### PR TITLE
fix: [TreeSelect] In single-selection search, after selecting a item, its child items will be expanded and Popover will be closed immediately (#78)

### DIFF
--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -241,10 +241,6 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
         return this.getProp('expandedKeys');
     }
 
-    _isFilterable() {
-        return Boolean(this.getProp('filterTreeNode')); // filter can be boolean or function
-    }
-
     _isSelectToClose() {
         return !this.getProp('expandAction');
     }
@@ -402,9 +398,6 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
         this._adapter.closeMenu();
         this._adapter.unregisterClickOutsideHandler();
         this._notifyBlur(e);
-        if (this._isFilterable()) {
-            this.clearInput();
-        }
         if (this.getProp('motionExpand')) {
             this._adapter.updateState({ motionKeys: new Set([]) } as any);
         }

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -1125,6 +1125,14 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         return key;
     };
 
+    /* Event handler function after popover is closed */
+    handlePopoverClose = isVisible => {
+        const { filterTreeNode } = this.props;
+        if (isVisible === false && Boolean(filterTreeNode)) {
+            this.foundation.clearInput();
+        }
+    }
+
     renderTreeNode = (treeNode: FlattenNode, ind: number, style: React.CSSProperties) => {
         const { data } = treeNode;
         // eslint-disable-next-line @typescript-eslint/no-shadow
@@ -1281,6 +1289,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 autoAdjustOverflow={autoAdjustOverflow}
                 mouseLeaveDelay={mouseLeaveDelay}
                 mouseEnterDelay={mouseEnterDelay}
+                onVisibleChange={this.handlePopoverClose}
             >
                 {selection}
             </Popover>


### PR DESCRIPTION
- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述
Fixes #78 

### 更新日志
Chinese
- 修复 TreeSelect 单选搜索时，选中某个节点后，会展开其子孙节点并立即关闭 Popover，从而造成了视觉上的闪烁感
---

English
- Fix TreeSelect in single-selection search, after selecting a node, it will expand its descendants and immediately close Popover, thus causing a visual flicker


### 检查清单
- [x] 已增加测试用例或无须增加
- [x] 已补充文档或无须补充
- [x] Changelog已提供或无须提供

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->