### PR TITLE
fix(tooltip): motion visible bug #69

### DIFF
--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -267,9 +267,9 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
 
         this._adapter.insertPortal(content, position);
 
-        if (trigger === 'custom') {
-            this._togglePortalVisible(true);
-        }
+        // if (trigger === 'custom') {
+        //     this._togglePortalVisible(true);
+        // }
 
         /**
          * trigger类型是click时，仅当portal被插入显示后，才绑定clickOutsideHandler

--- a/packages/semi-foundation/utils/Event.ts
+++ b/packages/semi-foundation/utils/Event.ts
@@ -1,3 +1,5 @@
+import isNullOrUndefined from '@douyinfe/semi-foundation/utils/isNullOrUndefined';
+
 export default class Event {
     _eventMap = new Map<string, Array<(...arg: any) => void>>();
 
@@ -32,7 +34,8 @@ export default class Event {
                         callbacks.splice(index, 1);
                     }
                 }
-            } else if (callback === null) {
+                // fix bug in ts refactor
+            } else if (isNullOrUndefined(callback)) {
                 this._eventMap.delete(event);
             }
         }

--- a/packages/semi-ui/_portal/index.tsx
+++ b/packages/semi-ui/_portal/index.tsx
@@ -3,6 +3,7 @@ import { createPortal } from 'react-dom';
 import { BASE_CLASS_PREFIX } from '@douyinfe/semi-foundation/base/constants';
 import PropTypes from 'prop-types';
 import classnames from 'classnames';
+import { get } from 'lodash-es';
 import ConfigContext from '../configProvider/context';
 import '@douyinfe/semi-foundation/_portal/portal.scss';
 
@@ -77,7 +78,7 @@ class Portal extends PureComponent<PortalProps, PortalState> {
 
     componentWillUnmount() {
         const { container } = this.state;
-        if (container) {
+        if (container && get(this.el, 'parentNode') === container) {
             container.removeChild(this.el);
         }
     }

--- a/packages/semi-ui/dropdown/__test__/dropdown.test.js
+++ b/packages/semi-ui/dropdown/__test__/dropdown.test.js
@@ -2,6 +2,7 @@ import { Icon, Dropdown, Tag } from '../../index';
 import { string } from 'prop-types';
 import { noop, drop } from 'lodash-es';
 import { BASE_CLASS_PREFIX } from '../../../semi-foundation/base/constants';
+import { sleep } from '../../_test_/utils';
 
 const defaultItems = [{ children: 'Menu Item 1' }, { children: 'Menu Item 2' }, { children: 'Menu Item 3' }];
 
@@ -76,7 +77,7 @@ describe('Dropdown', () => {
         expect(Number(document.querySelector(`.${BASE_CLASS_PREFIX}-portal`).style.zIndex)).toEqual(zIndex);
     });
 
-    it('Dropdown-trigger-hover', () => {
+    it('Dropdown-trigger-hover', async () => {
         let props = {
             trigger: 'hover',
         };
@@ -89,6 +90,8 @@ describe('Dropdown', () => {
         expect(dropdown.find(el_item)).toHaveLength(3);
         // auto hide
         dropdown.find(`.${BASE_CLASS_PREFIX}-tag`).simulate('mouseLeave', {});
+        await sleep(200);
+        dropdown.update();
         expect(dropdown.exists(el_portal_inner)).toEqual(false);
         expect(dropdown.find(el_item)).toHaveLength(0);
     });

--- a/packages/semi-ui/select/__test__/select.test.js
+++ b/packages/semi-ui/select/__test__/select.test.js
@@ -5,6 +5,7 @@ const OptGroup = Select.OptGroup;
 import { IconClear, IconChevronDown } from '@douyinfe/semi-icons';
 import { BASE_CLASS_PREFIX } from '../../../semi-foundation/base/constants';
 import keyCode from '../../../semi-foundation/utils/keyCode';
+import { sleep } from '../../_test_/utils';
 
 const defaultList = [
     { value: 'abc', label: 'Abc' },
@@ -457,7 +458,7 @@ describe('Select', () => {
         expect(select.exists(`.${BASE_CLASS_PREFIX}-select-option-list`)).toEqual(false);
     });
 
-    it('onDropdownVisibleChange & clickToHide', () => {
+    it('onDropdownVisibleChange & clickToHide', async () => {
         let onDropdownVisible = () => {};
         let spyOnDV = sinon.spy(onDropdownVisible);
         const props = {
@@ -470,6 +471,8 @@ describe('Select', () => {
         expect(spyOnDV.calledOnce).toEqual(true);
         expect(spyOnDV.calledWithMatch(true)).toEqual(true);
         select.find(`.${BASE_CLASS_PREFIX}-select`).simulate('click', {});
+        await sleep(200);
+        select.update();
         expect(select.exists(`.${BASE_CLASS_PREFIX}-select-option-list`)).toEqual(false);
         expect(spyOnDV.calledWithMatch(false)).toEqual(true);
     });
@@ -999,7 +1002,7 @@ describe('Select', () => {
         expect(select.find('.semi-select-option').length).toEqual(defaultList.length);
     });
 
-    it('test keyboard press', () => {
+    it('test keyboard press', async () => {
         let props = {
             defaultOpen: true,
         };
@@ -1012,6 +1015,8 @@ describe('Select', () => {
         expect(select.find(`.${BASE_CLASS_PREFIX}-select-option`).at(defaultList.length-1).hasClass(`${BASE_CLASS_PREFIX}-select-option-focused`)).toBe(true);
         // press ESC
         select.find(`.${BASE_CLASS_PREFIX}-select`).simulate('keydown', { keyCode: keyCode.ESC });
+        await sleep(100);
+        select.update();
         expect(select.find(`.${BASE_CLASS_PREFIX}-select-option`).exists()).toBe(false);
         // reopen select, press ⬇️ and ENTER, the first option should be selected
         select.find(`.${BASE_CLASS_PREFIX}-select`).simulate('click', {});

--- a/packages/semi-ui/tooltip/_story/tooltip.stories.js
+++ b/packages/semi-ui/tooltip/_story/tooltip.stories.js
@@ -2,7 +2,7 @@ import React, { useState, useMemo } from 'react';
 import { storiesOf } from '@storybook/react';
 import Tooltip from '../index';
 import './story.scss';
-import { Tag, Icon, IconButton, Switch, Checkbox, Radio, Button, Select } from '@douyinfe/semi-ui';
+import { Tag, Icon, IconButton, Switch, Checkbox, Radio, Button, Select, ButtonGroup, Button, DatePicker, Popover } from '@douyinfe/semi-ui';
 
 import InTableDemo from './InTable';
 import EdgeDemo from './Edge';
@@ -453,7 +453,7 @@ stories.add('快速移动鼠标可见性', () => {
      */
     const Demo = () => {
         const props = {
-            mouseEnterDelay: 50,
+            mouseEnterDelay: 0,
             mouseLeaveDelay: 0,
         }
         return (
@@ -566,4 +566,64 @@ stories.add('showArrow', () => {
     }
       
     return <Demo />
-})
+});
+
+stories.add('fix 69', () => {
+
+    function Demo() {
+        const [visible, setVisible] = useState(false);
+
+        return (
+            <div style={{ height: '200vh', position: 'relative' }}>
+                <div style={{ position: 'absolute', top: '40%' }}>
+                    <Tooltip
+                        content={'hi bytedance'}
+                        trigger="custom"
+                        visible={visible}
+                    >
+                        <span style={{ display: 'inline-block' }}>
+                            <ButtonGroup>
+                                <Button onClick={() => setVisible(true)}>受控显示</Button>
+                                <Button onClick={() => setVisible(false)}>受控隐藏</Button>
+                            </ButtonGroup>
+                        </span>
+                    </Tooltip>
+                    <div>
+                        <DatePicker motion={true} style={{ marginTop: 20 }} />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+      
+    return <Demo />
+});
+
+stories.add('fix hover and scroll', () => {
+
+    function Demo() {
+        const Test = React.forwardRef((props, ref) => (
+            <span {...props} ref={ref}>
+                Test
+            </span>
+        ));
+        return (
+            <div style={{ height: '200vh', position: 'relative' }}>
+                <div style={{ position: 'absolute', top: '40%', left: 100 }}>
+                    <Popover
+                        content={
+                            <article style={{ padding: 12 }}>
+                                Hi ByteDancer, this is a popover.
+                                <br /> We have 2 lines.
+                            </article>
+                        }
+                    >
+                        <Tag>悬停此处</Tag>
+                    </Popover>
+                </div>
+            </div>
+        );
+    }
+      
+    return <Demo />
+});

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -76,6 +76,7 @@ interface TooltipState {
     isInsert: boolean;
     placement: Position;
     transitionStyle: Record<string, any>;
+    isPositionUpdated: boolean; // mark whether is second insert portal
 }
 
 const prefix = cssClasses.PREFIX;
@@ -164,6 +165,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             isInsert: false,
             placement: props.position || 'top',
             transitionStyle: {},
+            isPositionUpdated: false,
         };
         this.foundation = new TooltipFoundation(this.adapter);
         this.eventManager = new Event();
@@ -200,12 +202,15 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                          * Hiding portal will remove portalInserted event listener(normal process)
                          * then portal can't hide because _togglePortalVisible(false) will found isVisible=false and nowVisible=false(bug here)
                          */
-                        this.eventManager.emit('portalInserted');
+                        setTimeout(() => {
+                            // waiting child component mounted
+                            this.eventManager.emit('portalInserted');
+                        }, 0);
                     }
                 );
             },
             removePortal: () => {
-                this.setState({ isInsert: false });
+                this.setState({ isInsert: false, isPositionUpdated: false });
             },
             getEventName: () => ({
                 mouseEnter: 'onMouseEnter',
@@ -272,7 +277,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             getDocumentElementBounding: () => document.documentElement.getBoundingClientRect(),
             setPosition: ({ position, ...style }: { position: Position }) => {
                 this.setState(
-                    { containerStyle: { ...this.state.containerStyle, ...style }, placement: position },
+                    { containerStyle: { ...this.state.containerStyle, ...style }, placement: position, isPositionUpdated: true },
                     () => {
                         this.eventManager.emit('positionUpdated');
                     }
@@ -418,16 +423,17 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         return false;
     };
 
-    willEnter = () => {
-        this.foundation.calcPosition();
-        /**
-         * Dangerous: remove setState in motion fix #1379
-         * because togglePortalVisible callback function will use visible state to notifyVisibleChange
-         * if visible state is old value, then notifyVisibleChange function will not be called
-         * we should ensure that after calling togglePortalVisible, callback function can get right visible value
-         */
-        // this.setState({ visible: true });
-    };
+    // no need calcPosition in motion
+    // willEnter = () => {
+    //     this.foundation.calcPosition();
+    //     /**
+    //      * Dangerous: remove setState in motion fix #1379
+    //      * because togglePortalVisible callback function will use visible state to notifyVisibleChange
+    //      * if visible state is old value, then notifyVisibleChange function will not be called
+    //      * we should ensure that after calling togglePortalVisible, callback function can get right visible value
+    //      */
+    //     // this.setState({ visible: true });
+    // };
 
     didLeave = () => {
         this.adapter.unregisterClickOutsideHandler();
@@ -485,7 +491,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
     };
 
     renderPortal = () => {
-        const { containerStyle = {}, visible, portalEventSet, placement, transitionState } = this.state;
+        const { containerStyle = {}, visible, portalEventSet, placement, transitionState, isPositionUpdated } = this.state;
         const { prefixCls, content, showArrow, style, motion, zIndex } = this.props;
         const { className: propClassName } = this.props;
         const direction = this.context.direction;
@@ -498,15 +504,15 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         const icon = this.renderIcon();
         const portalInnerStyle = omit(containerStyle, motion ? ['transformOrigin'] : undefined);
         const transformOrigin = get(containerStyle, 'transformOrigin');
-        const inner = motion ? (
-            <TooltipTransition position={placement} willEnter={this.willEnter} didLeave={this.didLeave} motion={motion}>
+        const inner = motion && isPositionUpdated ? (
+            <TooltipTransition position={placement} didLeave={this.didLeave} motion={motion}>
                 {
                     transitionState === 'enter' ?
                         ({ animateCls, animateStyle, animateEvents }) => (
                             <div
                                 className={classNames(className, animateCls)}
                                 style={{
-                                    visibility: 'visible',
+                                    // visibility: 'visible', // even with motion, we should control visibility with visible state #69
                                     ...animateStyle,
                                     transformOrigin,
                                     ...style,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix

### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #69

When DatePicker is at the edge of the screen, the pop-up will flicker. The reason is to rely on the Tooltip component to set visibility to true when it is in motion.

With this change, motion will not be used when Portal is inserted for the first time, and motion will only be used when Portal is inserted for the second time. This can also bring performance improvements.

DatePicker 在屏幕边缘时，弹出会出现闪烁。原因是依赖 Tooltip 组件在 motion 时会把 visibility 设置为 true。

此次变更会在 Portal 第一次插入时不使用 motion，第二次插入时才使用 motion。这样也可以带来性能的提升。

### Changelog
🇨🇳 Chinese
- 修复 Tooltip 在自动调整位置时可能会出现闪烁情况 #69

---

🇺🇸 English
- Fix Tooltip may flicker when automatically adjusting position #69


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Additional information

bug demo
https://user-images.githubusercontent.com/26477537/139371878-c43a9543-7cd8-453c-9db1-fd447899c1c6.mp4

Number of Components based Tooltip are huge, review it carefully! Thanks!!



