### PR TITLE
fix(slider): onAfterChange triggered unexpectedly when value changed

### DIFF
--- a/packages/semi-foundation/slider/foundation.ts
+++ b/packages/semi-foundation/slider/foundation.ts
@@ -71,7 +71,7 @@ export interface SliderAdapter extends DefaultAdapter<SliderProps, SliderState>{
     isEventFromHandle: (e: any) => boolean;
     getOverallVars: () => OverallVars;
     updateDisabled: (disabled: SliderState['disabled']) => void;
-    transNewPropsToState: <K extends keyof SliderState>(stateObj: Pick<SliderState, K>, callback: () => void) => void;
+    transNewPropsToState: <K extends keyof SliderState>(stateObj: Pick<SliderState, K>, callback?: () => void) => void;
     notifyChange: (callbackValue: number | number[]) => void;
     setDragging: (value: boolean[]) => void;
     updateCurrentValue: (value: SliderState['currentValue']) => void;
@@ -447,7 +447,7 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
             resultState = disableState;
         }
         if (resultState) {
-            this._adapter.transNewPropsToState(resultState, () => this._adapter.onHandleUpAfter());
+            this._adapter.transNewPropsToState(resultState);
 
         }
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- 修复value受控改变时触发onAfterChange的问题

---

🇺🇸 English
- Fix onAfterChange triggered unexpectedly when value changed in control mode

### Checklist
- [X] Test or no need
- [X] Document or no need
- [X] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
