### PR TITLE
fix(datepicker): type=month can not select some date in US timeZone

### DIFF
--- a/packages/semi-foundation/datePicker/foundation.ts
+++ b/packages/semi-foundation/datePicker/foundation.ts
@@ -770,7 +770,8 @@ export default class DatePickerFoundation extends BaseFoundation<DatePickerAdapt
         const { currentMonth, currentYear } = item;
 
         if (typeof currentMonth === 'number' && typeof currentYear === 'number') {
-            const date = new Date(`${currentYear}-${currentMonth}`);
+            // Strings with only dates (e.g. "1970-01-01") will be treated as UTC instead of local time #1460
+            const date = new Date(currentYear, currentMonth - 1);
 
             this.handleSelectedChange([date]);
         }

--- a/packages/semi-ui/datePicker/__test__/datePicker.test.js
+++ b/packages/semi-ui/datePicker/__test__/datePicker.test.js
@@ -513,18 +513,17 @@ describe(`DatePicker`, () => {
     it('click presets disabled date should not trigger onChange', async () => {
         const onChange = sinon.spy();
         const defaultValue = '2021-04-12';
-        const disabeldValue = '2021-04-15';
+        const disabledValue = '2021-04-15';
         const notDisabledValue = '2021-04-30';
-        const defaultDate = new Date(defaultValue);
-        const disableDate = new Date(disabeldValue);
-        const notDisabeldDate = new Date(notDisabledValue);
+        const defaultDate = new Date(`${defaultValue} 00:00:00`);
+        const disableDate = new Date(`${disabledValue} 00:00:00`);
+        const notDisabledDate = new Date(`${notDisabledValue} 00:00:00`);
         let props = {
             open: true,
             motion: false,
             defaultValue,
             onChange,
-            disabledDate: dateStr => {
-                const date = new Date(dateStr);
+            disabledDate: date => {
                 const day = date.getDate();
                 if (day === 15) {
                     return true;
@@ -556,7 +555,7 @@ describe(`DatePicker`, () => {
         btns[1].click();
         await sleep();
         value = elem.state('value');
-        expect(value[0].getDate()).toEqual(notDisabeldDate.getDate());
+        expect(value[0].getDate()).toEqual(notDisabledDate.getDate());
         expect(onChange.called).toBeTruthy();
     });
 

--- a/packages/semi-ui/datePicker/_story/datePicker.stories.tsx
+++ b/packages/semi-ui/datePicker/_story/datePicker.stories.tsx
@@ -226,3 +226,4 @@ stories.add('Form.DatePicker', () => {
   return <Demo />;
 });
 
+stories.add('fix 1460', () => <DatePicker type={'month'} onChange={(date, dateString) => console.log('DatePicker changed: ', date, dateString)} />);


### PR DESCRIPTION
- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
Fixed DatePicker component type=month can not select some date in US timeZone

### Changelog
🇨🇳 Chinese
- 修复 DatePicker `type=month` 时，计算机设置为美东时区，无法选中日期问题

---

🇺🇸 English
- Fixed DatePicker component type=month can not select some date in US timeZone


### Checklist
- [x] Changelog
