### PR TITLE
fix: 修复collapsible组件展开样式

### DIFF
--- a/packages/semi-ui/collapsible/index.tsx
+++ b/packages/semi-ui/collapsible/index.tsx
@@ -90,7 +90,7 @@ const Collapsible = (props: CollapsibleProps) => {
         const wrapperCls = cls(`${cssClasses.PREFIX}-wrapper`, className);
         return (
             <div style={wrapperstyle} className={wrapperCls} ref={ref}>
-                <div ref={setHeight}>{children}</div>
+                <div ref={setHeight} style={{display: 'inline-block'}}>{children}</div>
             </div>
         );
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
由于collapsible的children节点有浏览器默认的padding样式导致父元素margin合并，现将父元素设置成内联块元素解决children margin问题
![col](https://user-images.githubusercontent.com/24850162/139855974-2643b17a-59b6-479b-8d17-b1df2fa88b17.gif)


### Changelog
🇨🇳 Chinese
- 修复 collapsible 组件展开动画闪烁问题

---


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
