### PR TITLE
fix: [Tree/TreeSelect] remove the padding and margin of loading Spin #181

### DIFF
--- a/packages/semi-foundation/tree/tree.scss
+++ b/packages/semi-foundation/tree/tree.scss
@@ -55,7 +55,6 @@ $module: #{$prefix}-tree;
     }
 
     li > .#{$module}-option-label {
-        // box-sizing: border-box;
         list-style-type: none;
         padding: 0;
     }
@@ -66,10 +65,8 @@ $module: #{$prefix}-tree;
         width: $width-tree_emptyIcon;
         color: $color-tree_option-icon-default;
         margin-right: $spacing-tree_icon-marginRight;
-        // padding: 4px 0;
         display: flex;
         flex-shrink: 0;
-        // align-self: start;
     }
 
     .#{$module}-option {
@@ -110,7 +107,6 @@ $module: #{$prefix}-tree;
 
         &-label-text,
         .#{$prefix}-checkbox-addon {
-            // padding: 2px 4px;
             border-radius: $radius-tree_checkbox_addon;
 
             &:hover {
@@ -318,7 +314,6 @@ $module: #{$prefix}-tree;
 
         &-spin-icon {
             display: flex;
-            // box-sizing: content-box;
             & svg {
                 width: $width-tree_spinIcon;
                 height: $width-tree_spinIcon;

--- a/packages/semi-foundation/tree/tree.scss
+++ b/packages/semi-foundation/tree/tree.scss
@@ -323,9 +323,7 @@ $module: #{$prefix}-tree;
                 width: $width-tree_spinIcon;
                 height: $width-tree_spinIcon;
             }
-            margin-right: $spacing-tree_icon-marginRight;
             color: $color-tree_option_loading-icon-default;
-            padding: $spacing-tree_spinIcon-paddingY $spacing-tree_spinIcon-paddingX;
         }
 
         &-selected {

--- a/packages/semi-foundation/tree/variables.scss
+++ b/packages/semi-foundation/tree/variables.scss
@@ -41,8 +41,8 @@ $spacing-tree_icon-marginRight: 8px; // 树选项图标右侧外边距
 $spacing-tree_label_withIcon-marginRight: 8px; // 树选项图标右侧外边距
 $spacing-tree_option_draggable-paddingY: 3px; // 可拖拽的树选项垂直内边距
 $spacing-tree_option_draggable-paddingX: 0; // 可拖拽的树选项水平内边距
-$spacing-tree_spinIcon-paddingY: 4px; // 树选项加载 spin 垂直内边距
-$spacing-tree_spinIcon-paddingX: 0; // 树选项加载 spin 水平内边距
+$spacing-tree_spinIcon-paddingY: 4px; // 树选项加载 spin 垂直内边距 (已废弃)
+$spacing-tree_spinIcon-paddingX: 0; // 树选项加载 spin 水平内边距 (已废弃)
 
 $width-tree-border: 1px; // 树选项描边宽度
 $width-tree_arrow: 32px; // 树选项箭头宽度


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- 修复 Tree / TreeSelect 在异步加载 loading 时，选项高度会变高的问题

---

🇺🇸 English
- Fix the problem that the height of the option will become higher when the Tree / TreeSelect is loaded asynchronously

### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
