### PR TITLE
[form] using formApi.setValues to reset ArrayField not work when pass empty object

### DIFF
--- a/packages/semi-foundation/form/foundation.ts
+++ b/packages/semi-foundation/form/foundation.ts
@@ -384,11 +384,7 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
         if (this.registeredArrayField.size) {
             const arrayFieldPaths = [...this.registeredArrayField.keys()];
             arrayFieldPaths.forEach(path => {
-                // if values includes arrayField's fieldPath as key
-                const pathVal = ObjectUtil.get(values, path);
-                if (pathVal) {
-                    this.updateArrayField(path, { updateKey: new Date().valueOf() });
-                }
+                this.updateArrayField(path, { updateKey: new Date().valueOf() });
             });
         }
         // When isOverrid is true, there may be a non-existent field in the values passed in, directly synchronized to formState.values

--- a/packages/semi-ui/form/_story/DynamicField/arrayFieldDemo.jsx
+++ b/packages/semi-ui/form/_story/DynamicField/arrayFieldDemo.jsx
@@ -241,13 +241,13 @@ class ArrayFieldDemo extends React.Component {
                     // {},
                     // {},
                     { name: 'sugar', time: '3min' },
-                    { name: 'bacon', time: '6min', key: 'c2' },
+                    // { name: 'bacon', time: '6min', key: 'c2' },
+                    { name: 'bacon', time: '6min' },
                 ],
             },
             flag: true
         };
         this.getFormApi = this.getFormApi.bind(this);
-        this.change = this.change.bind(this);
     }
 
     change = () => {
@@ -257,6 +257,12 @@ class ArrayFieldDemo extends React.Component {
             time: `${i}-time`
         }));
         this.formApi.setValue('effects', newData);
+    }
+
+    clear = () => {
+        // this.formApi.setValues({ number: 3 });
+        // this.formApi.setValues({}, { isOverride: true });
+        this.formApi.setValues({ number: 3 }, { isOverride: true });
     }
 
     getFormApi(formApi) {
@@ -275,6 +281,7 @@ class ArrayFieldDemo extends React.Component {
                             {({ add, arrayFields }) => (
                                 <React.Fragment>
                                     <Button onClick={add} type="primary">Add</Button>
+                                    <Button onClick={this.clear} type="primary">Clear by setValues empty Object</Button>
                                     {
                                         arrayFields.map(({ field, key, remove }, i) => (
                                             <div key={key}>
@@ -294,7 +301,7 @@ class ArrayFieldDemo extends React.Component {
                                 </React.Fragment>
                             )}
                         </ArrayField>
-                        {/* <Form.InputNumber field="number" label="期望个数" /> */}
+                        <Form.InputNumber field="number" label="期望个数" />
                         <Space>
                             <Button onClick={this.change}>改变</Button>
                             <Button htmlType="submit">submit</Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fix #211 

### Changelog
🇨🇳 Chinese
- 修复 Form 通过 setValues 重置 ArrayField时，formState已生效，UI渲染未同步更新的问题
---

🇺🇸 English
- Fix the issue that when Form resets ArrayField through setValues, formState has taken effect and UI rendering is not updated synchronously

### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
