### PR TITLE
fix: [Cascader] When multiple and onChangeWithObject, the defaultValue passed into object[] does not take effect#184

### DIFF
--- a/packages/semi-ui/cascader/__test__/cascader.test.js
+++ b/packages/semi-ui/cascader/__test__/cascader.test.js
@@ -873,5 +873,44 @@ describe('Cascader', () => {
         // check checkedKeys
         expect(cascaderWithDisable.state().checkedKeys.size).toEqual(5); 
         cascaderWithDisable.unmount();
-    })
+    });
+
+    it('multiple + onChangeWithObject', () => {
+        const cascader = render({
+            multiple: true,
+            onChangeWithObject: true,
+            defaultValue: [
+                {
+                    label: '北美洲',
+                    value: 'Beimeizhou',
+                    key: 'beimeizhou',
+                    children: [
+                        {
+                            label: '美国',
+                            value: 'Meiguo',
+                            key: 'meiguo',
+                        },
+                        {
+                            label: '加拿大',
+                            value: 'Jianada',
+                            key: 'jianada',
+                        },
+                    ],
+                },
+                {
+                    label: '美国',
+                    value: 'Meiguo',
+                    key: 'meiguo',
+                }
+            ]
+        });
+        const tags = cascader.find(`.${BASE_CLASS_PREFIX}-cascader-selection .${BASE_CLASS_PREFIX}-tag`)
+        expect(tags.length).toEqual(1);
+        expect(
+            tags
+            .find(`.${BASE_CLASS_PREFIX}-tag-content`)
+            .getDOMNode()
+            .textContent
+        ).toEqual('美国');
+    });
 });

--- a/packages/semi-ui/cascader/_story/cascader.stories.js
+++ b/packages/semi-ui/cascader/_story/cascader.stories.js
@@ -1062,3 +1062,73 @@ stories.add('loadData with defaultValue', () => {
         </div>
     );
 });
+
+stories.add('onChangeWithObject', () => (
+    <>
+        <div>单选 + onChangeWithObject + defaultValue 为 string []</div>
+        <Cascader
+            onChangeWithObject
+            style={{ width: 300 }}
+            treeData={treeData4}
+            placeholder="请选择所在地区"
+            defaultValue={['zhejiang', 'hangzhou', 'xihu']}
+        />
+        <br /><br />
+        <div>多选 + onChangeWithObject + defaultValue 为 string []</div>
+        <Cascader
+            multiple
+            changeOnSelect
+            onChangeWithObject
+            style={{ width: 300 }}
+            treeData={treeData4}
+            placeholder="请选择所在地区"
+            defaultValue={'zhejiang'}
+        />
+        <br /><br />
+        <div>单选 + onChangeWithObject + defaultValue 为 object []</div>
+        <Cascader
+            onChangeWithObject
+            changeOnSelect
+            style={{ width: 300 }}
+            treeData={treeData2}
+            placeholder="请选择所在地区"
+            defaultValue={{
+                label: '北美洲',
+                value: 'beimeizhou',
+                children: [
+                    {
+                        label: '美国',
+                        value: 'meiguo',
+                    },
+                    {
+                        label: '加拿大',
+                        value: 'jianada',
+                    },
+                ],
+            }}
+        />
+        <br /><br />
+        <div>多选 + onChangeWithObject + defaultValue 为 object []</div>
+        <Cascader
+            multiple
+            onChangeWithObject
+            style={{ width: 300 }}
+            treeData={treeData2}
+            placeholder="请选择所在地区"
+            defaultValue={{
+                label: '北美洲',
+                value: 'beimeizhou',
+                children: [
+                    {
+                        label: '美国',
+                        value: 'meiguo',
+                    },
+                    {
+                        label: '加拿大',
+                        value: 'jianada',
+                    },
+                ],
+            }}
+        />
+    </>
+));

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -378,15 +378,17 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                     let normallizedValue: SimpleValueType[][] = [];
                     const realValue = needUpdate('value') ? value : defaultValue;
                     // eslint-disable-next-line max-depth
-                    if (!isEmpty(realValue)) {
+                    if (Array.isArray(realValue)) {
                         normallizedValue = Array.isArray(realValue[0]) ?
                             realValue as SimpleValueType[][] :
                             [realValue] as SimpleValueType[][];
+                    } else {
+                        normallizedValue = [[realValue]];
                     }
                     // formatValuePath is used to save value of valuePath
                     const formatValuePath: (string | number)[][] = [];
                     normallizedValue.forEach((valueItem: SimpleValueType[]) => {
-                        const formatItem: (string | number)[] = onChangeWithObject && !isEmpty(prevProps) ?
+                        const formatItem: (string | number)[] = onChangeWithObject ?
                             valueItem.map((i: CascaderData) => i.value) :
                             valueItem as (string | number)[];
                         formatValuePath.push(formatItem);


### PR DESCRIPTION


<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- 修复.Cascader 多选且开启 onChangeWithObject，defaultValue 为 object[] 没有生效的问题 

---

🇺🇸 English
- When multiple and onChangeWithObject, fix the defaultValue passed into object[] does not take effect


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
