### PR TITLE
Select component same label bug

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -462,7 +462,7 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
     updateOptionsActiveStatus(selections: Map<any, any>, options: BasicOptionProps[] = this.getState('options')) {
         const { allowCreate } = this.getProps();
         const newOptions = options.map(option => {
-            if (selections.has(option.label)) {
+            if (selections.has(option.label) && selections.get(option.label).value === option.value) {
                 option._selected = true;
                 if (allowCreate) {
                     delete option._inputCreateOnly;

--- a/packages/semi-ui/form/arrayField.tsx
+++ b/packages/semi-ui/form/arrayField.tsx
@@ -9,7 +9,17 @@ import { ArrayFieldStaff, FormUpdaterContextType } from '@douyinfe/semi-foundati
 export interface ArrayFieldProps {
     initValue?: any[];
     field?: string;
-    children?: ({ }) => React.ReactNode;
+    children?: (props: ArrayFieldChildrenProps) => React.ReactNode;
+}
+
+export interface ArrayFieldChildrenProps {
+    arrayFields: {
+        key: string;
+        field: string;
+        remove: () => void;
+    }[];
+    add: () => void;
+    addWithInitValue: (lineObject: Record<string, any>) => void;
 }
 
 export interface ArrayFieldState {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #216 

### Changelog
🇨🇳 Chinese
- 修复了当多个option名字相同时会重复选中的情况，通过select.option的value作为唯一判断依据。

---

🇺🇸 English
- Fix when select component has multiple Select.Option component with the same label, all of them will be checked bug.Only select when the value is equal to the clicked item.


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
