### PR TITLE
fix(slider): when `value` is controlled, click on track not trigger `onAfterChange`

### DIFF
--- a/packages/semi-foundation/slider/foundation.ts
+++ b/packages/semi-foundation/slider/foundation.ts
@@ -79,7 +79,7 @@ export interface SliderAdapter extends DefaultAdapter<SliderProps, SliderState>{
     getMinHandleEl: () => { current: HTMLElement };
     getMaxHandleEl: () => { current: HTMLElement };
     onHandleDown: (e: any) => any;
-    onHandleMove: (mousePos: number, isMin: boolean, stateChangeCallback?: () => void) => boolean | void;
+    onHandleMove: (mousePos: number, isMin: boolean, stateChangeCallback?: () => void, clickTrack?: boolean) => boolean | void;
     setEventDefault: (e: any) => void;
     setStateVal: (state: keyof SliderState, value: any) => void;
     onHandleEnter: (position: SliderState['focusPos']) => void;
@@ -568,7 +568,7 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
         const mousePos = this.handleMousePos(e.pageX, e.pageY);
         const position = vertical ? mousePos.y : mousePos.x;
         const isMin = this.checkWhichHandle(position);
-        this.setHandlePos(position, isMin);
+        this.setHandlePos(position, isMin, true);
     };
 
     /**
@@ -576,8 +576,8 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
      *
      * @memberof SliderFoundation
      */
-    setHandlePos = (position: number, isMin: boolean) => {
-        this._adapter.onHandleMove(position, isMin, () => this._adapter.onHandleUpAfter());
+    setHandlePos = (position: number, isMin: boolean, clickTrack = false) => {
+        this._adapter.onHandleMove(position, isMin, () => this._adapter.onHandleUpAfter(), clickTrack);
     };
 
     /**

--- a/packages/semi-ui/slider/index.tsx
+++ b/packages/semi-ui/slider/index.tsx
@@ -194,7 +194,7 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                 this._addEventListener(document.body, 'mouseup', this.foundation.onHandleUp, false);
                 this._addEventListener(document.body, 'touchmove', this.foundation.onHandleTouchMove, false);
             },
-            onHandleMove: (mousePos: number, isMin: boolean, stateChangeCallback = noop): boolean | void => {
+            onHandleMove: (mousePos: number, isMin: boolean, stateChangeCallback = noop, clickTrack = false): boolean | void => {
 
                 const sliderDOMIsInRenderTree = this.foundation.checkAndUpdateIsInRenderTreeState();
                 if (!sliderDOMIsInRenderTree) {
@@ -211,7 +211,8 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                 const { currentValue } = this.state;
                 if (!isEqual(this.foundation.outPutValue(currentValue), outPutValue)) {
                     onChange(outPutValue);
-                    if (this.foundation.valueFormatIsCorrect(value)) {
+                    if (!clickTrack && this.foundation.valueFormatIsCorrect(value)) {
+                        // still require afterChangeCallback when click on the track directly, need skip here
                         return false;
                     }
                     this.setState({


### PR DESCRIPTION


<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix

### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
修复 Slider `value` 受控时点击轨道未触发 `onAfterChange` 的问题

### Changelog
🇨🇳 Chinese
- 修复 Slider `value` 受控时点击轨道未触发 `onAfterChange` 的问题

---

🇺🇸 English
- Fix Slider when `value` is controlled, click on track not trigger `onAfterChange`


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
