### PR TITLE
fix: export some interface that has been exported in semi 1.x

### DIFF
--- a/content/input/form/index-en-US.md
+++ b/content/input/form/index-en-US.md
@@ -1516,10 +1516,10 @@ With Field did the following things.
 -   Insert Field's `<Form.Label>`above the field
 -   Insert Field's `<ErrorMessage>` under the field
 
-With Field Options specific configuration can be consulted [withFieldOption](#WithFieldOptions)
+With Field Options specific configuration can be consulted [withFieldOption](#WithFieldOption)
 
 ```jsx
-withField(YourComponent, withFieldOptions);
+withField(YourComponent, withFieldOption);
 ```
 
 ```jsx live=true dir="column"
@@ -1790,7 +1790,7 @@ const { ErrorMessage } = Form;
 | className  | Classname of ErrorMessage wrapper | string                   |         |
 | style      | Inline style                      | object                   |         |
 
-## withFieldOptions
+## withFieldOption
 
 | key               | Description                                                                                                                                                                                                                                                                                                                                                                 | Default    |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |

--- a/content/input/form/index.md
+++ b/content/input/form/index.md
@@ -1724,14 +1724,14 @@ withField 主要做了以下事情
 -   负责在表单控件下方插入 Field 的`<ErrorMessage>`
 -   负责在表单控件下方插入 Field 的 extraText
 
-withFieldOptions 具体配置可参考[withField Option](#withFieldOptions)
+withFieldOption 具体配置可参考[withField Option](#withFieldOption)
 
 你的自定义受控组件需要做以下事情：  
 值发生变化时，调用props.onChange并且将最新的值作为入参  
 响应props.value的变化，并更新你的组件UI渲染结果  
 
 ```jsx
-withField(YourComponent, withFieldOptions);
+withField(YourComponent, withFieldOption);
 ```
 
 ```jsx live=true dir="column" hideInDSM
@@ -2053,7 +2053,7 @@ const { ErrorMessage } = Form;
 | showValidateIcon | 自动加上 validateStatus 对应的 icon                       | boolean                  |
 | validateStatus   | 信息所属的校验状态，可选 default/error/warning/success(success一般建议与default样式相同) | boolean                  |
 
-## withFieldOptions
+## withFieldOption
 
 | key               | 描述                                                                                                                                                                                                                                          | 默认值     |
 | ----------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |

--- a/packages/semi-foundation/form/interface.ts
+++ b/packages/semi-foundation/form/interface.ts
@@ -79,7 +79,7 @@ export interface FieldState {
     status?: 'error' | 'success';
 }
 
-export interface withFieldOption {
+export interface WithFieldOption {
     valueKey?: string;
     onKeyChangeFnName?: string;
     valuePath?: string;

--- a/packages/semi-foundation/form/utils.ts
+++ b/packages/semi-foundation/form/utils.ts
@@ -3,7 +3,7 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import AsyncValidator from 'async-validator';
 import { cloneDeep, toPath } from 'lodash-es';
-import { FieldValidateTriggerType, BasicTriggerType, ComponentProps, withFieldOption } from './interface';
+import { FieldValidateTriggerType, BasicTriggerType, ComponentProps, WithFieldOption } from './interface';
 
 export function getDisplayName(WrappedComponent: React.ComponentType | any) {
     const originName = WrappedComponent.displayName || WrappedComponent.name;
@@ -61,7 +61,7 @@ function transformTrigger(trigger: FieldValidateTriggerType): Array<BasicTrigger
     return result;
 }
 
-export function mergeOptions(opts: withFieldOption, props: ComponentProps) {
+export function mergeOptions(opts: WithFieldOption, props: ComponentProps) {
     // Opts: different types of component identification value, value change callback function may be inconsistent, used to adapt 1, input, select 2, radio, checkbox 3, switch
     // valueKey: input, select class component control value props are value, and checkbox, switch is checked
     // eg：checkbox、radio   { valueKey: 'checked', onKeyChangeFnName: 'onChange', valuePath: 'target.value' }

--- a/packages/semi-ui/form/hoc/withField.tsx
+++ b/packages/semi-ui/form/hoc/withField.tsx
@@ -13,7 +13,7 @@ import ErrorMessage from '../errorMessage';
 import { isElement } from '../../_base/reactUtils';
 import Label from '../label';
 import { Col } from '../../grid';
-import { CallOpts, withFieldOption } from '@douyinfe/semi-foundation/form/interface';
+import { CallOpts, WithFieldOption } from '@douyinfe/semi-foundation/form/interface';
 import { CommonFieldProps, CommonexcludeType } from '../interface';
 import { Subtract } from 'utility-types';
 
@@ -29,7 +29,7 @@ const prefix = cssClasses.PREFIX;
 function withField<
     C extends React.ComponentType<React.ComponentProps<C>>,
     T extends React.ComponentType<Subtract<React.ComponentProps<C>, CommonexcludeType> & CommonFieldProps>
->(Component: C, opts?: withFieldOption): T {
+>(Component: C, opts?: WithFieldOption): T {
     let SemiField = (props: any, ref: React.MutableRefObject<any>) => {
         let {
             // condition,

--- a/packages/semi-ui/form/interface.ts
+++ b/packages/semi-ui/form/interface.ts
@@ -5,7 +5,7 @@ import { Subtract } from 'utility-types';
 import type { RuleItem } from 'async-validator';
 import { Options as scrollIntoViewOptions } from 'scroll-into-view-if-needed';
 
-import { BaseFormApi as FormApi, FormState } from '@douyinfe/semi-foundation/form/interface';
+import { BaseFormApi as FormApi, FormState, WithFieldOption } from '@douyinfe/semi-foundation/form/interface';
 import { SelectProps } from '../select/index';
 import Option from '../select/option';
 import OptGroup from '../select/optionGroup';
@@ -15,7 +15,7 @@ import { RadioProps } from '../radio/index';
 import { ErrorMessageProps, ReactFieldError as FieldError } from './errorMessage';
 import { LabelProps } from './label';
 
-export { FormState, FormApi };
+export { FormState, FormApi, WithFieldOption };
 
 export type CommonFieldProps = {
     /** Field is required (except Form. Checkbox within the Group, Form. Radio) */

--- a/packages/semi-ui/notification/index.tsx
+++ b/packages/semi-ui/notification/index.tsx
@@ -26,7 +26,8 @@ export interface NoticeReactProps extends NoticeProps{
 export {
     NoticeState,
     NotificationListProps,
-    NotificationListState
+    NotificationListState,
+    ConfigProps
 };
 
 export type NoticesInPosition = { top: NoticeInstance[];

--- a/packages/semi-ui/toast/index.tsx
+++ b/packages/semi-ui/toast/index.tsx
@@ -25,6 +25,7 @@ export interface ToastReactProps extends ToastProps{
 }
 
 export {
+    ConfigProps,
     ToastListProps,
     ToastListState,
     ToastState

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -15,6 +15,7 @@ import '@douyinfe/semi-foundation/upload/upload.scss';
 
 const prefixCls = cssClasses.PREFIX;
 
+export { BeforeUploadObjectResult, AfterUploadResult };
 
 export interface FileItem extends BaseFileItem {
     validateMessage?: ReactNode;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

### Changelog
🇨🇳 Chinese
- ts interface修改
  - Form增加 WithFieldOption 的导出
  - Notification增加 ConfigProps的导出
  - Toast增加 ConfigProps的导出
  - Upload增加 BeforeUploadObjectResult、AfterUploadResult的导出

- 文档修改
  - Form文档中WithFieldOption描述去掉s，保持与interface命名一致

---

🇺🇸 English


### Checklist
- [ ] Test or no need
- [x] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
