### PR TITLE
fix(tabs): onChange triggers unexpectly when click active tab

### DIFF
--- a/packages/semi-foundation/tabs/foundation.ts
+++ b/packages/semi-foundation/tabs/foundation.ts
@@ -20,12 +20,19 @@ class TabsFoundation<P = Record<string, any>, S = Record<string, any>> extends B
 
     destroy = noop;
 
+    _notifyChange(activeKey: string): void {
+        const { activeKey: stateActiveKey } = this.getStates();
+        if (stateActiveKey !== activeKey) {
+            this._adapter.notifyChange(activeKey);
+        }
+    }
+
     handleTabClick(activeKey: string, event: any): void {
         const isControledComponent = this._isInProps('activeKey');
         if (isControledComponent) {
-            this._adapter.notifyChange(activeKey);
+            this._notifyChange(activeKey);
         } else {
-            this._adapter.notifyChange(activeKey);
+            this._notifyChange(activeKey);
             this.handleNewActiveKey(activeKey);
         }
         this._adapter.notifyTabClick(activeKey, event);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix

### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #208 

### Changelog
🇨🇳 Chinese
- 修复 Tabs 点击激活状态的 `tab` 仍触发 `onChange` 的问题

---

🇺🇸 English
- Fix Tabs `onChange` triggers unexpectly when click active `tab`


### Checklist
- [X] Test or no need
- [X] Document or no need
- [X] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
