### PR TITLE
fix: [Select] render when children is not full string character

### DIFF
--- a/packages/semi-ui/select/option.tsx
+++ b/packages/semi-ui/select/option.tsx
@@ -148,7 +148,7 @@ class Option extends PureComponent<OptionProps> {
                         <IconTick />
                     </div>
                 ) : null}
-                <div className={`${prefixCls}-text`}>{this.renderOptionContent({ children, config, inputValue, prefixCls })}</div>
+                {isString(children) ? <div className={`${prefixCls}-text`}>{this.renderOptionContent({ children, config, inputValue, prefixCls })}</div> : children}
             </div>
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
fix Select.Option children render

if children is string, then should wrap a option-text div
if children is ReactElement, then render children direct

### Changelog
🇨🇳 Chinese
- 修复 Select.Option children渲染逻辑

---

🇺🇸 English
- Fix Select.Option children rendering logic


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
