### PR TITLE
fix(rating): allowhalf ui error when parent element set line-height

### DIFF
--- a/packages/semi-foundation/rating/rating.scss
+++ b/packages/semi-foundation/rating/rating.scss
@@ -56,6 +56,10 @@ $module: #{$prefix}-rating;
             font-size: $font-rating_item_default-fontSize;
         }
 
+        &-wrapper {
+            position: relative;
+        }
+
         &-first,
         &-second {
             color: $color-rating-bg-default;

--- a/packages/semi-ui/rating/item.tsx
+++ b/packages/semi-ui/rating/item.tsx
@@ -101,6 +101,7 @@ export default class Item extends PureComponent<RatingItemProps> {
                     aria-posinset={index + 1}
                     aria-setsize={count}
                     tabIndex={0}
+                    className={`${prefixCls}-wrapper`}
                 >
                     <div className={`${prefixCls}-first`} style={{ width: `${firstWidth * 100}%` }}>{content}</div>
                     <div className={`${prefixCls}-second`}>{content}</div>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #346 

### Changelog
🇨🇳 Chinese
- 修复 Rating 组件半星展示错误，当父级设置 line-height 时

---

🇺🇸 English
- Fix Rating component half star ui error, when parent element set line-height


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->

demo

```
<Rating allowHalf defaultValue={3.5} style={{lineHeight: 2}} />
```
![image](https://user-images.githubusercontent.com/16872030/144425450-2f8cfc29-6929-4be9-a589-2230b71786cd.png)
