### PR TITLE
fix(rating): size props working error when set number #356

### DIFF
--- a/packages/semi-ui/rating/item.tsx
+++ b/packages/semi-ui/rating/item.tsx
@@ -88,7 +88,10 @@ export default class Item extends PureComponent<RatingItemProps> {
             height: size,
             fontSize: size
         } : {};
-        const iconSize = size === 'small' ? 'default' : 'extra-large';
+        
+        // when set custom size, no need a builtin style for icon, so here wo set iconSize a empty value.
+        const iconSize = isCustomSize ? 'empty-value' : (size === 'small' ? 'default' : 'extra-large');
+        // @ts-ignore 
         const content = character ? character : <IconStar size={iconSize} />;
         return (
             <li className={starCls} style={{ ...sizeStyle }}>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #356 

### Changelog
🇨🇳 Chinese
- 修复 Rating 组件设置 size 为 number 后 UI 错误

---

🇺🇸 English
- Fix Rating UI error when set size number


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Additional information

demo
```
<Rating defaultValue={5} size={50}/>
```
