### PR TITLE
fix: The form label of type ReactNode is not center aligned

### DIFF
--- a/packages/semi-foundation/form/form.scss
+++ b/packages/semi-foundation/form/form.scss
@@ -163,6 +163,10 @@ $rating: #{$prefix}-rating;
         display: flex;
 
         .#{$field}-label {
+
+            display: flex;
+            align-items: center;
+
             margin-bottom: $spacing-form_label_posLeft-marginBottom;
             margin-right: $spacing-form_label_posLeft-marginRight;
             // 增加padding-top：6px以达到与组件的第一行文本水平对齐

--- a/packages/semi-foundation/form/form.scss
+++ b/packages/semi-foundation/form/form.scss
@@ -78,7 +78,8 @@ $rating: #{$prefix}-rating;
         font-weight: $font-form_label-fontWeight;
         color: $color-form_label-text-default;
         margin-bottom: $spacing-form_label-marginBottom;
-        display: inline-block;
+        display: flex;
+        align-items: center;
         vertical-align: middle;
         @include font-size-regular;
         flex-shrink: 0;
@@ -91,7 +92,7 @@ $rating: #{$prefix}-rating;
         &-with-extra {
             .#{$field}-label-text,
             .#{$field}-label-extra {
-                display: inline-block;
+                display: flex;
             }
             .#{$field}-label-extra {
                 margin-left: $spacing-form_label_extra-marginLeft;

--- a/packages/semi-foundation/form/form.scss
+++ b/packages/semi-foundation/form/form.scss
@@ -78,8 +78,7 @@ $rating: #{$prefix}-rating;
         font-weight: $font-form_label-fontWeight;
         color: $color-form_label-text-default;
         margin-bottom: $spacing-form_label-marginBottom;
-        display: flex;
-        align-items: center;
+        display: inline-block;
         vertical-align: middle;
         @include font-size-regular;
         flex-shrink: 0;
@@ -148,7 +147,9 @@ $rating: #{$prefix}-rating;
         // display:
         .#{$field}-label {
             // make sure label height is correct
-            display: block;
+            //display: block;
+            display: flex;
+            align-items: center;
         }
         .#{$checkboxGroup},
         .#{$radioGroup} {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes [#324](https://github.com/DouyinFE/semi-design/issues/324)

### Changelog
🇨🇳 Chinese
- 修复 Form 组件中 label extra 中为 Icon时 ，文字与Icon 没有对齐

---

🇺🇸 English
- Fix The form label of type ReactNode is not center aligned


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
