### PR TITLE
fix(table): fixed cell z-index is not higher than show type components

### DIFF
--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -104,7 +104,7 @@ $module: #{$prefix}-table;
 
                     &-left,
                     &-right {
-                        z-index: 1;
+                        z-index: $z-table_fixed_column;
                         position: sticky;
                         background-color: $color-table-bg-default;
 
@@ -247,7 +247,7 @@ $module: #{$prefix}-table;
 
                 &-left,
                 &-right {
-                    z-index: 1;
+                    z-index: $z-table_fixed_column;;
                     position: sticky;
                     background-color: $color-table-bg-default;
                 }

--- a/packages/semi-foundation/table/variables.scss
+++ b/packages/semi-foundation/table/variables.scss
@@ -82,3 +82,6 @@ $shadow-table_right: 3px 0 0 0 $color-table_shadow-bg-default; // 表格滚动�
 $border-table: #{$width-table_base_border} #{$border-table_base-borderStyle} $color-table-border-default; // 表格默认描边
 $border-table_head-bottom: #{$width-table_header_border} #{$border-table_base-borderStyle} $color-table_th-border-default; // 表头单元格描边 - 底部
 $border-table_resizer: $width-table_resizer_border solid $color-table_resizer-bg-default; // 表格拉伸标识描边
+
+$z-table-fixed: 101!default; // fixed列的zIndex值
+$z-table_fixed_column: $z-table-fixed; // fixed列的zIndex值

--- a/packages/semi-theme-default/scss/variables.scss
+++ b/packages/semi-theme-default/scss/variables.scss
@@ -31,6 +31,8 @@ $z-portal: 1; // 抽象插槽，适用于未经特殊定制的所有组件
 $z-affix: 10; // 固定位置的页面元素 z-index
 $z-backtop: 10; // 返回顶部 z-index
 $z-badge: 10; // badge z-index
+// $z-avatar-default: 100;
+$z-table-fixed: 101; // table fixed column
 $z-modal: 1000; // modal z-index
 $z-modal-mask: 1000; // modal 遮罩 z-index
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
Fixed Table fixed cell `z-index` is not higher than show type components(like Avatar etc)

### Changelog
🇨🇳 Chinese
- Table fixed 单元格的 z-index 调整为 101，之前为 1

---

🇺🇸 English
- Update Table fixed cell z-index from 1 to 101
