### PR TITLE
style: Remove the padding-bottom from the last row of the descriptions

### DIFF
--- a/packages/semi-foundation/descriptions/descriptions.scss
+++ b/packages/semi-foundation/descriptions/descriptions.scss
@@ -24,6 +24,10 @@ $module: #{$prefix}-descriptions;
         vertical-align: top;
     }
 
+    & tr:last-child &-item {
+        padding-bottom: 0;
+    }
+
     &-key {
         font-weight: normal;
         @include font-size-regular;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

Remove the padding-bottom from the last row of the descriptions

### Changelog
🇨🇳 Chinese
- 移除描述列表最后一行的 padding-bottom

---

🇺🇸 English
- Remove the padding-bottom from the last row of the descriptions


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
