### PR TITLE
feat: a11y - improve tooltip、popover aria #205

### DIFF
--- a/content/show/popover/index-en-US.md
+++ b/content/show/popover/index-en-US.md
@@ -478,7 +478,7 @@ Please refer to [Use with Tooltip/Popconfirm](/en-US/show/tooltip#%E6%90%AD%E9%8
 
 ## Accessibility
 
-### Aria
+### ARIA
 
 -  About role
    - If the trigger is set to `click`、`custom`, the PopoverContent element has role set to `dialog`.
@@ -488,7 +488,7 @@ Please refer to [Use with Tooltip/Popconfirm](/en-US/show/tooltip#%E6%90%AD%E9%8
 - Popover's children 
   - Will be automatically added [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attribute, when Popover is visible, the attribute value is `true`, when invisible Is `false`
   - Will be automatically added [aria-haspopup](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) attribute, which is `dialog`
-  - Will be automatically added [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls) and `aria-descriptionby` attribute, which is the id of the content wrapper
+  - Will be automatically added [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls) and `aria-describedby` attribute, which is the id of the content wrapper
 
 ## Design Tokens
 

--- a/content/show/popover/index-en-US.md
+++ b/content/show/popover/index-en-US.md
@@ -475,6 +475,21 @@ Please refer to [Use with Tooltip/Popconfirm](/en-US/show/tooltip#%E6%90%AD%E9%8
 | zIndex | Floating layer z-index value | number | 1030 |
 | onVisibleChange | A callback triggered when the pop-up layer is displayed / hidden | (isVisble: boolean) => void |  |
 | onClickOutSide  | Callback when the pop-up layer is in the display state and the non-Children, non-floating layer inner area is clicked (only valid when trigger is custom, click) | (e:event) => void | | **2.1.0** |
+
+## Accessibility
+
+### Aria
+
+-  About role
+   - If the trigger is set to `click`、`custom`, the PopoverContent element has role set to `dialog`.
+   - If the trigger is set to hover, it has role set to `tooltip`.
+- Popover's content
+   - The content wrapper will be automatically added with the id attribute
+- Popover's children 
+  - Will be automatically added [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) attribute, when Popover is visible, the attribute value is `true`, when invisible Is `false`
+  - Will be automatically added [aria-haspopup](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) attribute, which is `dialog`
+  - Will be automatically added [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls) and `aria-descriptionby` attribute, which is the id of the content wrapper
+
 ## Design Tokens
 
 <DesignToken/>

--- a/content/show/popover/index.md
+++ b/content/show/popover/index.md
@@ -478,7 +478,7 @@ function Demo() {
 
 ## Accessibility
 
-### Aria
+### ARIA
 
 -  关于 role
    - 当 Popover 的 trigger 为 click、custom时，Popover的 content 具有 `dialog` role
@@ -488,7 +488,7 @@ function Demo() {
 - Popover 的 children 
   - 会被自动添加 [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) 属性，当 Popover 可见时，属性值为 `true`，不可见时为 `false`
   - 会被自动添加 [aria-haspopup](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) 属性，为 `dialog`
-  - 会被自动添加 [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls) 与 `aria-descriptionby` 属性，为 content 的 wrapper 的 id
+  - 会被自动添加 [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls) 与 `aria-describedby` 属性，为 content 的 wrapper 的 id
 
 ## 设计变量
 <DesignToken/>

--- a/content/show/popover/index.md
+++ b/content/show/popover/index.md
@@ -475,5 +475,20 @@ function Demo() {
 | zIndex             | 弹出层 z-index 值                                                                                                                             | number                     | 1030                                        |            |
 | onVisibleChange    | 弹出层展示/隐藏时触发的回调                                                                                                                 | function(isVisble:boolean) |                                             |            |
 | onClickOutSide     | 当弹出层处于展示状态，点击非Children、非浮层内部区域时的回调（仅trigger为custom、click时有效）| function(e:event) |  | **2.1.0** |
+
+## Accessibility
+
+### Aria
+
+-  关于 role
+   - 当 Popover 的 trigger 为 click、custom时，Popover的 content 具有 `dialog` role
+   - 当trigger为hover时，Popover的content 具有 `tooltip` role
+- Popover 的 content
+   - content 的 wrapper 会被自动添加 `id` 属性
+- Popover 的 children 
+  - 会被自动添加 [aria-expanded](https://www.w3.org/TR/wai-aria-1.1/#aria-expanded) 属性，当 Popover 可见时，属性值为 `true`，不可见时为 `false`
+  - 会被自动添加 [aria-haspopup](https://www.w3.org/TR/wai-aria-1.1/#aria-haspopup) 属性，为 `dialog`
+  - 会被自动添加 [aria-controls](https://www.w3.org/TR/wai-aria-1.1/#aria-controls) 与 `aria-descriptionby` 属性，为 content 的 wrapper 的 id
+
 ## 设计变量
 <DesignToken/>

--- a/content/show/tooltip/index-en-US.md
+++ b/content/show/tooltip/index-en-US.md
@@ -403,18 +403,19 @@ import { Popconfirm, Tooltip, Button } from '@douyinfe/semi-ui';
 
 ## Accessibility
 
-### Aria
+### ARIA
 
 - Tooltip has a tooltip role, following the definition of Tooltip in the [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) specification
 - Tooltip's content and children
   - about content
-      - The wrapper of content will be automatically added with id attribute to match the `aria-descriptionby` of children and associate content with children
+      - The wrapper of content will be automatically added with id attribute to match the `aria-describedby` of children and associate content with children
   - about children
-       - There should be an explicit connection between the content of the Tooltip and its children. Tooltip will automatically add the aria-descriptionby attribute to the children element, the value is the id of the content wraper. Tooltip will automatically add the `aria-descriptionby` attribute to the children element, the value is the `id` of the content wraper
+       - There should be an explicit connection between the content of the Tooltip and its children. Tooltip will automatically add the `aria-describedby` attribute to the children element, the value is the id of the content wraper. 
        - If the children of your Tooltip are Icon and do not contain visible text, we recommend that you add the `aria-label` attribute to the children to describe accordingly 
 
 ```js
 // Good practices, add aria-label to description tooltip children
+/* eslint-disable */
 <Tooltip content={<p id='description'>Edit your setting</p>}>
     <IconSetting aria-label='Settings'> 
     </IconSetting>

--- a/content/show/tooltip/index-en-US.md
+++ b/content/show/tooltip/index-en-US.md
@@ -399,6 +399,29 @@ import { Popconfirm, Tooltip, Button } from '@douyinfe/semi-ui';
 | zIndex              | Bullet levels.                                                                                                                                                                                                                               | number                      | 1060                |            |
 | onVisibleChange     | A callback triggered when the pop-up layer is displayed/hidden                                                                                                                                                                               | (isVisble: boolean) => void |                     |            |
 | onClickOutSide      | Callback when the pop-up layer is in the display state and the non-Children, non-floating layer inner area is clicked (only valid when trigger is custom, click)                                                                             | (e:event) => void           |                     | **2.1.0** |
+
+
+## Accessibility
+
+### Aria
+
+- Tooltip has a tooltip role, following the definition of Tooltip in the [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) specification
+- Tooltip's content and children
+  - about content
+      - The wrapper of content will be automatically added with id attribute to match the `aria-descriptionby` of children and associate content with children
+  - about children
+       - There should be an explicit connection between the content of the Tooltip and its children. Tooltip will automatically add the aria-descriptionby attribute to the children element, the value is the id of the content wraper. Tooltip will automatically add the `aria-descriptionby` attribute to the children element, the value is the `id` of the content wraper
+       - If the children of your Tooltip are Icon and do not contain visible text, we recommend that you add the `aria-label` attribute to the children to describe accordingly 
+
+```js
+// Good practices, add aria-label to description tooltip children
+<Tooltip content={<p id='description'>Edit your setting</p>}>
+    <IconSetting aria-label='Settings'> 
+    </IconSetting>
+</Tooltip>
+```
+
+
 ## Design Tokens
 <DesignToken/>
 

--- a/content/show/tooltip/index.md
+++ b/content/show/tooltip/index.md
@@ -436,18 +436,19 @@ function Demo() {
 
 ## Accessibility
 
-### Aria
+### ARIA
 
 - Tooltip 具有 `tooltip` role，遵循 [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) 规范中对于 Tooltip 的定义
 - Tooltip 的 content 与 children
   - 关于 content
-      - content 的 wrapper 会被自动添加 id 属性，用于与 children 的 `aria-descriptionby` 匹配，关联 content 与 children
+      - content 的 wrapper 会被自动添加 id 属性，用于与 children 的 `aria-describedby` 匹配，关联 content 与 children
   - 关于 children
-       - Tooltip 的内容（content）与其触发器（children）之间应当具有显式联系。Tooltip 会自动为 children 元素添加 `aria-descriptionby` 属性，值为 content wraper的 id
+       - Tooltip 的内容（content）与其触发器（children）之间应当具有显式联系。Tooltip 会自动为 children 元素添加 `aria-describedby` 属性，值为 content wraper的 id
        - 若你 Tooltip的children 是Icon，不包含可见文本，我们推荐你在 children 上添加 `aria-label` 属性进行相应描述
 
 ```js
 // Good practices, add aria-label to description tooltip children
+/* eslint-disable */
 <Tooltip content={<p id='description'>Edit your setting</p>}>
     <IconSetting aria-label='Settings'> 
     </IconSetting>

--- a/content/show/tooltip/index.md
+++ b/content/show/tooltip/index.md
@@ -433,6 +433,28 @@ function Demo() {
 | zIndex | 弹层层级 | number | 1060 |  |
 | onVisibleChange | 弹出层展示/隐藏时触发的回调 | function(isVisible:boolean) |  |  |
 | onClickOutSide | 当弹出层处于展示状态，点击非Children、非浮层内部区域时的回调（仅trigger为custom、click时有效）| function(e:event) |  | **2.1.0** |
+
+## Accessibility
+
+### Aria
+
+- Tooltip 具有 `tooltip` role，遵循 [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) 规范中对于 Tooltip 的定义
+- Tooltip 的 content 与 children
+  - 关于 content
+      - 三content 的 wrapper 会被自动添加 id 属性，用于与 children 的 `aria-descriptionby` 匹配，关联 content 与 children
+  - 关于 children
+       - Tooltip 的内容（content）与其触发器（children）之间应当具有显式联系。Tooltip 会自动为 children 元素添加 `aria-descriptionby` 属性，值为 content wraper的 id
+       - 若你 Tooltip的children 是Icon，不包含可见文本，我们推荐你在 children 上添加 `aria-label` 属性进行相应描述
+
+
+```js
+// Good practices, add aria-label to description tooltip children
+<Tooltip content={<p id='description'>Edit your setting</p>}>
+    <IconSetting aria-label='Settings'> 
+    </IconSetting>
+</Tooltip>
+```
+
 ## 设计变量
 
 <DesignToken/>

--- a/content/show/tooltip/index.md
+++ b/content/show/tooltip/index.md
@@ -441,11 +441,10 @@ function Demo() {
 - Tooltip 具有 `tooltip` role，遵循 [WAI-ARIA](https://www.w3.org/TR/wai-aria-practices/#tooltip) 规范中对于 Tooltip 的定义
 - Tooltip 的 content 与 children
   - 关于 content
-      - 三content 的 wrapper 会被自动添加 id 属性，用于与 children 的 `aria-descriptionby` 匹配，关联 content 与 children
+      - content 的 wrapper 会被自动添加 id 属性，用于与 children 的 `aria-descriptionby` 匹配，关联 content 与 children
   - 关于 children
        - Tooltip 的内容（content）与其触发器（children）之间应当具有显式联系。Tooltip 会自动为 children 元素添加 `aria-descriptionby` 属性，值为 content wraper的 id
        - 若你 Tooltip的children 是Icon，不包含可见文本，我们推荐你在 children 上添加 `aria-label` 属性进行相应描述
-
 
 ```js
 // Good practices, add aria-label to description tooltip children

--- a/packages/semi-ui/popover/index.tsx
+++ b/packages/semi-ui/popover/index.tsx
@@ -118,6 +118,7 @@ class Popover extends React.PureComponent<PopoverProps, PopoverState> {
             arrowBounding,
             position,
             style,
+            trigger,
             ...attr
         } = this.props;
         let { spacing } = this.props;
@@ -136,9 +137,12 @@ class Popover extends React.PureComponent<PopoverProps, PopoverState> {
             spacing = showArrow ? numbers.SPACING_WITH_ARROW : numbers.SPACING;
         }
 
+        const role = trigger === 'click' || trigger === 'custom' ? 'dialog' : 'tooltip';
+
         return (
             <Tooltip
                 {...(attr as any)}
+                trigger={trigger}
                 position={position}
                 style={style}
                 content={popContent}
@@ -146,6 +150,7 @@ class Popover extends React.PureComponent<PopoverProps, PopoverState> {
                 spacing={spacing}
                 showArrow={arrow}
                 arrowBounding={arrowBounding}
+                role={role}
             >
                 {children}
             </Tooltip>

--- a/packages/semi-ui/tooltip/TriangleArrow.tsx
+++ b/packages/semi-ui/tooltip/TriangleArrow.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const TriangleArrow: React.FC<{ [key: string]: any }> = props => {
     const { className, style, ...restProps } = props;
     return (
-        <svg className={className} style={style} {...restProps} width="24" height="7" viewBox="0 0 24 7" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+        <svg aria-hidden className={className} style={style} {...restProps} width="24" height="7" viewBox="0 0 24 7" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
             <path d="M24 0V1C20 1 18.5 2 16.5 4C14.5 6 14 7 12 7C10 7 9.5 6 7.5 4C5.5 2 4 1 0 1V0H24Z" />
         </svg>
     );

--- a/packages/semi-ui/tooltip/TriangleArrowVertical.tsx
+++ b/packages/semi-ui/tooltip/TriangleArrowVertical.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 const TriangleArrowVertical: React.FC<{ [key: string]: any }> = props => {
     const { className, style, ...restProps } = props;
     return (
-        <svg className={className} style={style} {...restProps} width="7" height="24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
+        <svg aria-hidden className={className} style={style} {...restProps} width="7" height="24" xmlns="http://www.w3.org/2000/svg" fill="currentColor">
             <path d="M0 0L1 0C1 4, 2 5.5, 4 7.5S7,10 7,12S6 14.5, 4 16.5S1,20 1,24L0 24L0 0z" />
         </svg>
     );

--- a/packages/semi-ui/tooltip/_story/tooltip.stories.js
+++ b/packages/semi-ui/tooltip/_story/tooltip.stories.js
@@ -13,181 +13,185 @@ import ContainerPosition from './ContainerPosition';
 import { IconList, IconSidebar, IconEdit } from '@douyinfe/semi-icons';
 
 export default {
-  title: 'Tooltip',
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
-}
+    title: 'Tooltip',
+    parameters: {
+        chromatic: { disableSnapshot: true },
+    },
+};
 
 function test(visible) {
-  console.log('visible Change:' + visible);
+    console.log('visible Change:' + visible);
 }
 
 const ScrollDemo = function ScrollDemo(props = {}) {
-  const tops = [
-    ['topLeft', 'TL'],
-    ['top', 'Top'],
-    ['topRight', 'TR'],
-  ];
-  const lefts = [
-    ['leftTop', 'LT'],
-    ['left', 'Left'],
-    ['leftBottom', 'LB'],
-  ];
-  const rights = [
-    ['rightTop', 'RT'],
-    ['right', 'Right'],
-    ['rightBottom', 'RB'],
-  ];
-  const bottoms = [
-    ['bottomLeft', 'BL'],
-    ['bottom', 'Bottom'],
-    ['bottomRight', 'BR'],
-  ];
-  const { tagStyle, ...restProps } = props;
-  return (
-    <div
-      style={{
-        paddingLeft: 40,
-      }}
-    >
-      <div
-        style={{
-          marginLeft: 40,
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {tops.map((pos, index) => (
-          <Tooltip
-            content={
-              <article>
-                <p>hi bytedance</p>
-                <p>hi bytedance</p>
-              </article>
-            }
-            position={Array.isArray(pos) ? pos[0] : pos}
-            key={index}
-            trigger={'click'}
-            {...restProps}
-          >
-            <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
-          </Tooltip>
-        ))}
-      </div>
-      <div
-        style={{
-          width: 40,
-          float: 'left',
-        }}
-      >
-        {lefts.map((pos, index) => (
-          <Tooltip
-            content={
-              <article>
-                <p>hi bytedance</p>
-                <p>hi bytedance</p>
-              </article>
-            }
-            position={Array.isArray(pos) ? pos[0] : pos}
-            key={index}
-            trigger={'click'}
-            {...restProps}
-          >
-            <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
-          </Tooltip>
-        ))}
-      </div>
-      <div
-        style={{
-          width: 40,
-          marginLeft: 180,
-        }}
-      >
-        {rights.map((pos, index) => (
-          <Tooltip
-            content={
-              <article>
-                <p>hi bytedance</p>
-                <p>hi bytedance</p>
-              </article>
-            }
-            position={Array.isArray(pos) ? pos[0] : pos}
-            key={index}
-            trigger={'click'}
-            {...restProps}
-          >
-            <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
-          </Tooltip>
-        ))}
-      </div>
-      <div
-        style={{
-          marginLeft: 40,
-          clear: 'both',
-          whiteSpace: 'nowrap',
-        }}
-      >
-        {bottoms.map((pos, index) => (
-          <Tooltip
-            content={
-              <article>
-                <p>hi bytedance</p>
-                <p>hi bytedance</p>
-              </article>
-            }
-            position={Array.isArray(pos) ? pos[0] : pos}
-            key={index}
-            trigger={'click'}
-            {...restProps}
-          >
-            <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
-          </Tooltip>
-        ))}
-      </div>
-    </div>
-  );
+    const tops = [
+        ['topLeft', 'TL'],
+        ['top', 'Top'],
+        ['topRight', 'TR'],
+    ];
+    const lefts = [
+        ['leftTop', 'LT'],
+        ['left', 'Left'],
+        ['leftBottom', 'LB'],
+    ];
+    const rights = [
+        ['rightTop', 'RT'],
+        ['right', 'Right'],
+        ['rightBottom', 'RB'],
+    ];
+    const bottoms = [
+        ['bottomLeft', 'BL'],
+        ['bottom', 'Bottom'],
+        ['bottomRight', 'BR'],
+    ];
+    const { tagStyle, ...restProps } = props;
+    return (
+        <div
+            style={{
+                paddingLeft: 40,
+            }}
+        >
+            <div
+                style={{
+                    marginLeft: 40,
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                {tops.map((pos, index) => (
+                    <Tooltip
+                        content={
+                            <article>
+                                <p>hi bytedance</p>
+                                <p>hi bytedance</p>
+                            </article>
+                        }
+                        position={Array.isArray(pos) ? pos[0] : pos}
+                        key={index}
+                        trigger={'click'}
+                        {...restProps}
+                    >
+                        <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
+                    </Tooltip>
+                ))}
+            </div>
+            <div
+                style={{
+                    width: 40,
+                    float: 'left',
+                }}
+            >
+                {lefts.map((pos, index) => (
+                    <Tooltip
+                        content={
+                            <article>
+                                <p>hi bytedance</p>
+                                <p>hi bytedance</p>
+                            </article>
+                        }
+                        position={Array.isArray(pos) ? pos[0] : pos}
+                        key={index}
+                        trigger={'click'}
+                        {...restProps}
+                    >
+                        <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
+                    </Tooltip>
+                ))}
+            </div>
+            <div
+                style={{
+                    width: 40,
+                    marginLeft: 180,
+                }}
+            >
+                {rights.map((pos, index) => (
+                    <Tooltip
+                        content={
+                            <article>
+                                <p>hi bytedance</p>
+                                <p>hi bytedance</p>
+                            </article>
+                        }
+                        position={Array.isArray(pos) ? pos[0] : pos}
+                        key={index}
+                        trigger={'click'}
+                        {...restProps}
+                    >
+                        <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
+                    </Tooltip>
+                ))}
+            </div>
+            <div
+                style={{
+                    marginLeft: 40,
+                    clear: 'both',
+                    whiteSpace: 'nowrap',
+                }}
+            >
+                {bottoms.map((pos, index) => (
+                    <Tooltip
+                        content={
+                            <article>
+                                <p>hi bytedance</p>
+                                <p>hi bytedance</p>
+                            </article>
+                        }
+                        position={Array.isArray(pos) ? pos[0] : pos}
+                        key={index}
+                        trigger={'click'}
+                        {...restProps}
+                    >
+                        <Tag style={tagStyle}>{Array.isArray(pos) ? pos[1] : pos}</Tag>
+                    </Tooltip>
+                ))}
+            </div>
+        </div>
+    );
 };
 
 export const TooltipOnVisibleChange = () => {
-  const [visible, setVisible] = useState();
-  return (
-    <div className="demo">
-      <div>
-        <label>非受控</label>
-        <Tooltip
-          content={
-            <article>
-              <p>hi bytedance</p>
-              <p>hi bytedance</p>
-            </article>
-          }
-          position="rightBottom"
-          onVisibleChange={test}
-          trigger="click"
-        >
-          <Tag>demo</Tag>
-        </Tooltip>
-      </div>
-      <div>
-        <label>受控</label>
-        <Tooltip
-          content={
-            <article>
-              <p>hi bytedance</p>
-              <p>hi bytedance</p>
-            </article>
-          }
-          position="rightBottom"
-          onVisibleChange={setVisible}
-          trigger="click"
-          visible={visible}
-        >
-          <Tag>demo</Tag>
-        </Tooltip>
-      </div>
-      <br />
-      <br />
-      {/* <Tooltip
+    const [visible, setVisible] = useState(true);
+    return (
+        <div className="demo">
+            <div>
+                <label>受控</label>
+                <Tooltip
+                    content={
+                        <article>
+                            <p>hi bytedance</p>
+                            <p>hi bytedance</p>
+                        </article>
+                    }
+                    position="top"
+                    onVisibleChange={setVisible}
+                    trigger="click"
+                    visible={visible}
+                >
+                    <Tag>demo</Tag>
+                </Tooltip>
+            </div>
+
+            <br />
+            <br />
+            <div>
+                <label>非受控</label>
+                <Tooltip
+                    content={
+                        <article>
+                            <p>hi bytedance</p>
+                            <p>hi bytedance</p>
+                        </article>
+                    }
+                    position="leftTop"
+                    onVisibleChange={test}
+                    trigger="click"
+                >
+                    <Tag>demo</Tag>
+                </Tooltip>
+            </div>
+            <br />
+            <br />
+
+            {/* <Tooltip
        content={
            <article>
                <p>hi bytedance</p>
@@ -231,439 +235,439 @@ export const TooltipOnVisibleChange = () => {
     >
        <Tag>click</Tag>
     </Tooltip> */}
-    </div>
-  );
+        </div>
+    );
 };
 
 TooltipOnVisibleChange.story = {
-  name: 'tooltip onVisibleChange',
+    name: 'tooltip onVisibleChange',
 };
 
 export const GetPopupContainerDemo = () => (
-  <div className="demo">
-    <div className="content-layer" />
-    <Tooltip
-      content={
-        <article>
-          <p>hi bytedance</p> <p>hi bytedance</p>
-        </article>
-      }
-      position="bottom"
-      visible
-      trigger="custom"
-      getPopupContainer={() => document.querySelector('.content-layer')}
-    >
-      <Tag>指定弹出层的容器</Tag>
-      {/* <div className='content'></div> */}
-    </Tooltip>
-    <div>
-      <label>给定容器为window，看是否报错</label>
-      <Tooltip content={'单选'} position="top" getPopupContainer={() => window}>
-        <Radio style={{ display: 'inline-flex' }}>单选</Radio>
-      </Tooltip>
+    <div className="demo">
+        <div className="content-layer" />
+        <Tooltip
+            content={
+                <article>
+                    <p>hi bytedance</p> <p>hi bytedance</p>
+                </article>
+            }
+            position="bottom"
+            visible
+            trigger="custom"
+            getPopupContainer={() => document.querySelector('.content-layer')}
+        >
+            <Tag>指定弹出层的容器</Tag>
+            {/* <div className='content'></div> */}
+        </Tooltip>
+        <div>
+            <label>给定容器为window，看是否报错</label>
+            <Tooltip content={'单选'} position="top" getPopupContainer={() => window}>
+                <Radio style={{ display: 'inline-flex' }}>单选</Radio>
+            </Tooltip>
+        </div>
     </div>
-  </div>
 );
 
 GetPopupContainerDemo.story = {
-  name: 'tooltip指定弹出层的容器',
+    name: 'tooltip指定弹出层的容器',
 };
 
 export const TooltipAll = () => (
-  <div className="demo">
-    <ScrollDemo />
-    <div
-      style={{
-        padding: 120,
-      }}
-    >
-      <ScrollDemo
-        showArrow
-        tagStyle={{
-          height: 80,
-        }}
-      />
+    <div className="demo">
+        <ScrollDemo />
+        <div
+            style={{
+                padding: 120,
+            }}
+        >
+            <ScrollDemo
+                showArrow
+                tagStyle={{
+                    height: 80,
+                }}
+            />
+        </div>
     </div>
-  </div>
 );
 
 TooltipAll.story = {
-  name: 'tooltip All',
+    name: 'tooltip All',
 };
 
 export const NoContent = () => (
-  <div className="demo">
-    <div
-      style={{
-        padding: 120,
-      }}
-    >
-      <ScrollDemo showArrow content={''} />
+    <div className="demo">
+        <div
+            style={{
+                padding: 120,
+            }}
+        >
+            <ScrollDemo showArrow content={''} />
+        </div>
+        <div
+            style={{
+                padding: 120,
+            }}
+        >
+            <ScrollDemo
+                showArrow
+                tagStyle={{
+                    minHeight: 80,
+                    minWidth: 120,
+                }}
+                content={''}
+            />
+        </div>
     </div>
-    <div
-      style={{
-        padding: 120,
-      }}
-    >
-      <ScrollDemo
-        showArrow
-        tagStyle={{
-          minHeight: 80,
-          minWidth: 120,
-        }}
-        content={''}
-      />
-    </div>
-  </div>
 );
 
 NoContent.story = {
-  name: 'no content',
+    name: 'no content',
 };
 
 export const AdjustPosition = () => (
-  <>
-    <div className="adjust">
-      <div className="wrapper">
-        第一个滚动区域
-        <Tooltip
-          content={
-            <article>
-              <p>hi bytedance</p>
-              <p>hi bytedance</p>
-            </article>
-          }
-          position="rightBottom"
-          trigger="click"
-        >
-          {/* <Tag className='topLeft'>topleft</Tag> */}
-          <div>test</div>
-        </Tooltip>
-        <Tooltip
-          content={
-            <article>
-              <p>hi bytedance</p>
-              <p>hi bytedance</p>
-            </article>
-          }
-          position="topRight"
-          trigger="click"
-        >
-          <Tag className="topRight">topRight</Tag>
-        </Tooltip>
-        <Tooltip
-          content={
-            <article>
-              <p>hi bytedance</p>
-              <p>hi bytedance</p>
-            </article>
-          }
-          position="bottomLeft"
-          trigger="click"
-        >
-          <Tag className="bottomLeft">bottomLeft</Tag>
-        </Tooltip>
-        <Tooltip
-          content={
-            <article>
-              <p>hi bytedance</p>
-              <p>hi bytedance</p>
-            </article>
-          }
-          position="bottomRight"
-          trigger="click"
-        >
-          <Tag className="bottomRight">bottomRight</Tag>
-        </Tooltip>
-      </div>
-    </div>
-    <div className="adjust2">
-      <div className="wrapper2">第二个滚动区域</div>
-    </div>
-  </>
+    <>
+        <div className="adjust">
+            <div className="wrapper">
+                第一个滚动区域
+                <Tooltip
+                    content={
+                        <article>
+                            <p>hi bytedance</p>
+                            <p>hi bytedance</p>
+                        </article>
+                    }
+                    position="rightBottom"
+                    trigger="click"
+                >
+                    {/* <Tag className='topLeft'>topleft</Tag> */}
+                    <div>test</div>
+                </Tooltip>
+                <Tooltip
+                    content={
+                        <article>
+                            <p>hi bytedance</p>
+                            <p>hi bytedance</p>
+                        </article>
+                    }
+                    position="topRight"
+                    trigger="click"
+                >
+                    <Tag className="topRight">topRight</Tag>
+                </Tooltip>
+                <Tooltip
+                    content={
+                        <article>
+                            <p>hi bytedance</p>
+                            <p>hi bytedance</p>
+                        </article>
+                    }
+                    position="bottomLeft"
+                    trigger="click"
+                >
+                    <Tag className="bottomLeft">bottomLeft</Tag>
+                </Tooltip>
+                <Tooltip
+                    content={
+                        <article>
+                            <p>hi bytedance</p>
+                            <p>hi bytedance</p>
+                        </article>
+                    }
+                    position="bottomRight"
+                    trigger="click"
+                >
+                    <Tag className="bottomRight">bottomRight</Tag>
+                </Tooltip>
+            </div>
+        </div>
+        <div className="adjust2">
+            <div className="wrapper2">第二个滚动区域</div>
+        </div>
+    </>
 );
 
 AdjustPosition.story = {
-  name: '自适应'
-}
+    name: '自适应',
+};
 
 export const CompositeComponent = () => (
-  <div
-    style={{
-      padding: 50,
-    }}
-  >
-    <Tooltip
-      content={
-        <article>
-          <p>hi bytedance</p> <p>hi bytedance</p>
-        </article>
-      }
-      position="top"
+    <div
+        style={{
+            padding: 50,
+        }}
     >
-      <IconList />
-    </Tooltip>
-    <Tooltip content={'收起'} position="top">
-      <IconButton icon={<IconSidebar />} />
-    </Tooltip>
-    <Tooltip content={'开关'} position="top">
-      <Switch />
-    </Tooltip>
-    <Tooltip content={'选择框'} position="top">
-      <Checkbox
-        style={{
-          display: 'inline-flex',
-        }}
-      >
-        选择框
-      </Checkbox>
-    </Tooltip>
-    <Tooltip content={'单选'} position="top">
-      <Radio
-        style={{
-          display: 'inline-flex',
-        }}
-      >
-        单选
-      </Radio>
-    </Tooltip>
-  </div>
+        <Tooltip
+            content={
+                <article>
+                    <p>hi bytedance</p> <p>hi bytedance</p>
+                </article>
+            }
+            position="top"
+        >
+            <IconList />
+        </Tooltip>
+        <Tooltip content={'收起'} position="top">
+            <IconButton icon={<IconSidebar />} />
+        </Tooltip>
+        <Tooltip content={'开关'} position="top">
+            <Switch />
+        </Tooltip>
+        <Tooltip content={'选择框'} position="top">
+            <Checkbox
+                style={{
+                    display: 'inline-flex',
+                }}
+            >
+                选择框
+            </Checkbox>
+        </Tooltip>
+        <Tooltip content={'单选'} position="top">
+            <Radio
+                style={{
+                    display: 'inline-flex',
+                }}
+            >
+                单选
+            </Radio>
+        </Tooltip>
+    </div>
 );
 
 CompositeComponent.story = {
-  name: '复合组件'
-}
+    name: '复合组件',
+};
 
 export const WrapDisabledElems = () => (
-  <div
-    style={{
-      padding: 50,
-    }}
-  >
-    <Tooltip content="disabled">
-      <IconButton disabled icon={<IconEdit />} />
-    </Tooltip>
-    <Tooltip content="disabled">
-      <IconButton disabled icon={<IconEdit />} block />
-    </Tooltip>
-    <Tooltip content="disabled">
-      <Button disabled block>
-        编辑
-      </Button>
-    </Tooltip>
-    <Tooltip content="disabled">
-      <Button
-        disabled
+    <div
         style={{
-          display: 'block',
+            padding: 50,
         }}
-      >
-        编辑
-      </Button>
-    </Tooltip>
-  </div>
+    >
+        <Tooltip content="disabled">
+            <IconButton disabled icon={<IconEdit />} />
+        </Tooltip>
+        <Tooltip content="disabled">
+            <IconButton disabled icon={<IconEdit />} block />
+        </Tooltip>
+        <Tooltip content="disabled">
+            <Button disabled block>
+                编辑
+            </Button>
+        </Tooltip>
+        <Tooltip content="disabled">
+            <Button
+                disabled
+                style={{
+                    display: 'block',
+                }}
+            >
+                编辑
+            </Button>
+        </Tooltip>
+    </div>
 );
 
 WrapDisabledElems.story = {
-  name: 'wrap disabled elems',
+    name: 'wrap disabled elems',
 };
 
 export const InTable = () => (
-  <div
-    style={{
-      marginTop: 50,
-    }}
-  >
-    <InTableDemo />
-  </div>
+    <div
+        style={{
+            marginTop: 50,
+        }}
+    >
+        <InTableDemo />
+    </div>
 );
 
 InTable.story = {
-  name: 'in table',
+    name: 'in table',
 };
 
 export const _EdgeDemo = () => <EdgeDemo />;
 
 _EdgeDemo.story = {
-  name: 'edge demo',
+    name: 'edge demo',
 };
 
 export const ScrollTooltipDemo = () => <ScrollTooltip />;
 ScrollTooltipDemo.story = {
-  name: 'scroll demo and set popup container'
-}
+    name: 'scroll demo and set popup container',
+};
 export const DangerousHtmlDemo = () => <DangerousHtml />;
 DangerousHtmlDemo.story = {
-  name: 'in dangerous html'
-}
+    name: 'in dangerous html',
+};
 export const ArrowPointAtCenterDemo = () => <ArrowPointAtCenter />;
 ArrowPointAtCenterDemo.story = {
-  name: 'arrow point at center'
-}
+    name: 'arrow point at center',
+};
 export const CustomContainerDemo = () => <CustomContainer />;
 CustomContainerDemo.story = {
-  name: 'custom container'
-}
+    name: 'custom container',
+};
 export const ContainerPositionDemo = () => <ContainerPosition />;
 ContainerPositionDemo.story = {
-  name: 'container observer'
-}
+    name: 'container observer',
+};
 
 export const QuickMoveMouse = () => {
-  /**
-   * mouseEnterDelay, mouseLeaveDelay 默认都为 50
-   * mouseEnterDelay, mouseLeaveDelay 都为 0，快速滑动可能出现两个 tooltip 出现
-   */
-  const Demo = () => {
-    const props = {
-      mouseEnterDelay: 50,
-      mouseLeaveDelay: 0,
+    /**
+     * mouseEnterDelay, mouseLeaveDelay 默认都为 50
+     * mouseEnterDelay, mouseLeaveDelay 都为 0，快速滑动可能出现两个 tooltip 出现
+     */
+    const Demo = () => {
+        const props = {
+            mouseEnterDelay: 50,
+            mouseLeaveDelay: 0,
+        };
+        return (
+            <div className="demo">
+                <div>
+                    <Tooltip content={'1'} {...props}>
+                        aaaaaaaaaaa
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'2'} {...props}>
+                        bbbbbbbbbbb
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'3'} {...props}>
+                        ccccccccccc
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'4'} {...props}>
+                        aaaaaaaaaaa
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'5'} {...props}>
+                        bbbbbbbbbbb
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'6'} {...props}>
+                        ccccccccccc
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'7'} {...props}>
+                        aaaaaaaaaaa
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'8'} {...props}>
+                        bbbbbbbbbbb
+                    </Tooltip>
+                </div>
+                <div>
+                    <Tooltip content={'9'} {...props}>
+                        ccccccccccc
+                    </Tooltip>
+                </div>
+            </div>
+        );
     };
-    return (
-      <div className="demo">
-        <div>
-          <Tooltip content={'1'} {...props}>
-            aaaaaaaaaaa
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'2'} {...props}>
-            bbbbbbbbbbb
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'3'} {...props}>
-            ccccccccccc
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'4'} {...props}>
-            aaaaaaaaaaa
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'5'} {...props}>
-            bbbbbbbbbbb
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'6'} {...props}>
-            ccccccccccc
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'7'} {...props}>
-            aaaaaaaaaaa
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'8'} {...props}>
-            bbbbbbbbbbb
-          </Tooltip>
-        </div>
-        <div>
-          <Tooltip content={'9'} {...props}>
-            ccccccccccc
-          </Tooltip>
-        </div>
-      </div>
-    );
-  };
 
-  return <Demo />;
+    return <Demo />;
 };
 
 QuickMoveMouse.story = {
-  name: '快速移动鼠标可见性'
-}
+    name: '快速移动鼠标可见性',
+};
 
 export const MotionFalseFix1402 = () => {
-  function Demo() {
-    const Test = React.forwardRef((props, ref) => (
-      <span {...props} ref={ref}>
-        Test
-      </span>
-    ));
-    return (
-      <div>
-        <Tooltip content={'hi bytedance'} motion={false}>
-          <Test />
-        </Tooltip>
-        <br />
-        <br />
-        <Tooltip content={'hi bytedance'}>
-          <Test />
-        </Tooltip>
-      </div>
-    );
-  }
+    function Demo() {
+        const Test = React.forwardRef((props, ref) => (
+            <span {...props} ref={ref}>
+                Test
+            </span>
+        ));
+        return (
+            <div>
+                <Tooltip content={'hi bytedance'} motion={false}>
+                    <Test />
+                </Tooltip>
+                <br />
+                <br />
+                <Tooltip content={'hi bytedance'}>
+                    <Test />
+                </Tooltip>
+            </div>
+        );
+    }
 
-  return <Demo />;
+    return <Demo />;
 };
 
 MotionFalseFix1402.story = {
-  name: 'motion=false fix #1402',
+    name: 'motion=false fix #1402',
 };
 
 export const DisabledWrapperCls = () => (
-  <>
-    <Tooltip wrapperClassName="test" content={'hi bytedance'}>
-      <Button>按钮</Button>
-    </Tooltip>
-    <br />
-    <br />
-    <Tooltip wrapperClassName="test" content={'hi bytedance'}>
-      <Button disabled>禁用的单个按钮</Button>
-    </Tooltip>
-    <br />
-    <br />
-    <Tooltip wrapperClassName="test" content={'hi bytedance'}>
-      <Button>正常的多个按钮</Button>
-      <Button>正常的多个按钮</Button>
-    </Tooltip>
-    <br />
-    <br />
-    <Tooltip wrapperClassName="test" content={'hi bytedance'}>
-      <Select disabled placeholder="请选择业务线" style={{ width: 120 }}>
-        <Select.Option value="abc">抖音</Select.Option>
-        <Select.Option value="hotsoon">火山</Select.Option>
-        <Select.Option value="jianying" disabled>
-          剪映
-        </Select.Option>
-        <Select.Option value="xigua">西瓜视频</Select.Option>
-      </Select>
-    </Tooltip>
-    <br />
-    <br />
-  </>
+    <>
+        <Tooltip wrapperClassName="test" content={'hi bytedance'}>
+            <Button>按钮</Button>
+        </Tooltip>
+        <br />
+        <br />
+        <Tooltip wrapperClassName="test" content={'hi bytedance'}>
+            <Button disabled>禁用的单个按钮</Button>
+        </Tooltip>
+        <br />
+        <br />
+        <Tooltip wrapperClassName="test" content={'hi bytedance'}>
+            <Button>正常的多个按钮</Button>
+            <Button>正常的多个按钮</Button>
+        </Tooltip>
+        <br />
+        <br />
+        <Tooltip wrapperClassName="test" content={'hi bytedance'}>
+            <Select disabled placeholder="请选择业务线" style={{ width: 120 }}>
+                <Select.Option value="abc">抖音</Select.Option>
+                <Select.Option value="hotsoon">火山</Select.Option>
+                <Select.Option value="jianying" disabled>
+                    剪映
+                </Select.Option>
+                <Select.Option value="xigua">西瓜视频</Select.Option>
+            </Select>
+        </Tooltip>
+        <br />
+        <br />
+    </>
 );
 
 DisabledWrapperCls.story = {
-  name: 'disabledWrapperCls',
+    name: 'disabledWrapperCls',
 };
 
 export const ShowArrow = () => {
-  function Demo() {
-    const Test = React.forwardRef((props, ref) => (
-      <Tag {...props} ref={ref}>
-        Test
-      </Tag>
-    ));
-    return (
-      <div>
-        <h4>should show content and arrow when click</h4>
-        <Tooltip showArrow trigger="click" content={'hi bytedance'}>
-          <Test />
-        </Tooltip>
-      </div>
-    );
-  }
+    function Demo() {
+        const Test = React.forwardRef((props, ref) => (
+            <Tag {...props} ref={ref}>
+                Test
+            </Tag>
+        ));
+        return (
+            <div>
+                <h4>should show content and arrow when click</h4>
+                <Tooltip showArrow trigger="click" content={'hi bytedance'}>
+                    <Test />
+                </Tooltip>
+            </div>
+        );
+    }
 
-  return <Demo />;
+    return <Demo />;
 };
 
 ShowArrow.story = {
-  name: 'showArrow',
+    name: 'showArrow',
 };
 
 export const OnClickOutSideDemo = () => {
@@ -671,20 +675,20 @@ export const OnClickOutSideDemo = () => {
     let clickOutSide = () => {
         console.log('clickOutSide');
         setV(false);
-    }
+    };
     return (
         <>
-            <Tooltip onClickOutSide={() => clickOutSide()} content={'hi bytedance'} visible={v} trigger='custom'>
+            <Tooltip onClickOutSide={() => clickOutSide()} content={'hi bytedance'} visible={v} trigger="custom">
                 <Button onClick={() => setV(true)}>按钮</Button>
             </Tooltip>
             <br />
             <br />
-            <Tooltip onClickOutSide={() => console.log('clickOutSide')} content={'hi bytedance'} trigger='click'>
-                <Button >单个按钮</Button>
+            <Tooltip onClickOutSide={() => console.log('clickOutSide')} content={'hi bytedance'} trigger="click">
+                <Button>单个按钮</Button>
             </Tooltip>
         </>
     );
-}
+};
 OnClickOutSideDemo.story = {
-  name: 'OnClickOutSide',
+    name: 'OnClickOutSide',
 };

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -615,7 +615,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
 
         // eslint-disable-next-line prefer-const
         let ariaAttribute = {
-            'aria-descriptionby': id,
+            'aria-describedby': id,
         };
 
         // Take effect when used by Popover component

--- a/packages/semi-webpack/tsconfig.json
+++ b/packages/semi-webpack/tsconfig.json
@@ -21,5 +21,5 @@
         "skipLibCheck": true,
     },
     "include": ["**/*.ts"],
-    "exclude": ["node_modules"]
+    "exclude": ["node_modules", "lib"]
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
#### 改善 Tooltip a11y 
![image](https://user-images.githubusercontent.com/88709023/146170519-66f0b574-b040-46f1-a9b9-881b2f8d2e21.png)
 - props增加 role传入，便于Popover、Dropdown等使用时，可以二次定义 role，default值为 tooltip
 - tooltip箭头相关的svg，增加 aria-hidden属性
 - 为 Tooltip 的content wrapper 自动追加 id，用于与 children 的 aria-descriptionby 匹配，关联 content 与 children
 - children添加  aria-descriptionby，值为上面生成的id

#### 改善 Popover a11y 

![image](https://user-images.githubusercontent.com/88709023/146170555-06aadc58-22f0-4553-90d1-894eae2313ed.png)

- 向底层Tooltip 传入的props 增加 role，当trigger为custom、click时，role传dialog（W3C规范），当trigger为hover时，role传tooltip（参考chakra-ui，这个设定更合理一些）

- 当 Popover 向 Tooltip 传入的role为dialog时，trigger（即children）需要追加 Popover（dialog）特有的aria属性，如下：
   - aria-expanded：根据visible切换true or false
   - aria-haspopup，恒定为 dialog，标识当前 trigger是一个有弹出层的控件
   - aria-controls：与content wrapper的id相同，将 children 与 content 关联起来，表明 children具体控制的 content
![image](https://user-images.githubusercontent.com/88709023/146172115-b71158c2-f9f0-41e4-b470-0360a4b156a9.png)


#### 其他修改
- tooltip.stories.js：format了一次 tooltip 相关的story，无需关注
- semi-webpack/ts-config.json：eslint一直报错，将 lib 增加到 tsconfig.json的exclude中，对实际逻辑无影响



### Changelog
🇨🇳 Chinese
- 改善Tooltip、Popover 组件的 aria 相关 a11y  表现
---



### Checklist
- [ ] Test or no need
- [x] Document
   - en-us 文档待补充
- [x] Changelog
- [x]  Firefox A11y check
- [x]  Eslint A11y check

### Additional information


