### PR TITLE
feat: allowCreate时，传入不存在的value时，自动创建option

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -463,6 +463,21 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
     // Update the selected item in the drop-down box
     updateOptionsActiveStatus(selections: Map<any, any>, options: BasicOptionProps[] = this.getState('options')) {
         const { allowCreate } = this.getProps();
+        const createOptions = allowCreate ?
+            [...selections].reduce((opts, [k, v]) => {
+                if (v._notExist) {
+                    const newOpt = {
+                        _show: true,
+                        _selected: true,
+                        value: k,
+                        label: k,
+                        ...omit(v, '_notExist'),
+                    };
+                    opts.push(newOpt);
+                    return opts;
+                }
+                return opts;
+            }, []) : [];
         const newOptions = options.map(option => {
             if (selections.has(option.label)) {
                 option._selected = true;
@@ -477,7 +492,7 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
             }
             return option;
         });
-        this._adapter.updateOptions(newOptions);
+        this._adapter.updateOptions([...newOptions, ...createOptions]);
     }
 
     removeTag(item: BasicOptionProps) {


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

- [ ] Bugfix
- [x] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Test Case
- [ ] TypeScript definition update
- [ ] Document improve
- [ ] CI/CD improve
- [ ] Branch sync
- [ ] Other, please describe:


### PR 描述
<!--
相关issue, 背景, 以及 reviewer 需要关注的地方
-->
Fixes #

### 更新日志
🇨🇳 Chinese
- 修复 ...
  allowCreate时，传入不存在的value时，自动创建option
---

🇺🇸 English
- Fix ...


### 检查清单
- [ ] 已增加测试用例或无须增加
- [ ] 已补充文档或无须补充
- [ ] Changelog已提供或无须提供

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->
![image](https://user-images.githubusercontent.com/45666106/146336739-38242d8d-54fa-4133-8041-ef68b4e5a319.png)
