### PR TITLE
fix: [select] using backspace to delete will cause the option to be invisible, close #444

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -785,15 +785,17 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
     }
 
     _removeInternalKey(option: BasicOptionProps) {
-        delete option._parentGroup;
-        delete option._show;
-        delete option._selected;
-        delete option._scrollIndex;
-        if ('_keyInOptionList' in option) {
-            option.key = option._keyInOptionList;
-            delete option._keyInOptionList;
+        // eslint-disable-next-line
+        let newOption = { ...option };
+        delete newOption._parentGroup;
+        delete newOption._show;
+        delete newOption._selected;
+        delete newOption._scrollIndex;
+        if ('_keyInOptionList' in newOption) {
+            newOption.key = newOption._keyInOptionList;
+            delete newOption._keyInOptionList;
         }
-        return option;
+        return newOption;
     }
 
     _notifySelect(value: BasicOptionProps['value'], option: BasicOptionProps) {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

#### 背景
Fixes #444 

#### 具体改动点
_removeInternalKey 增加一层浅复制，原有的逻辑中，对object的key进行delete操作，会导致意外修改 state 中的 options 的属性。  

如果当前defaultValue有值，然后使用键盘backspace键删除已选项后，上述行为会导致对应的option在下拉列表中不可见（直接原因：将原有的 _show：true 整个key移除掉了）  


调用链：_handleBackspaceKeyDown -> removeTag -> _notifyDeselect -> _removeInternalKey （这一步中意外修改了入参）

### Changelog
🇨🇳 Chinese
- 修复Select filter为true时，使用backspace移除已选项时，导致对应option在下拉列表中不可见的问题

---

🇺🇸 English
- Fix Select using backspace to delete will cause the option to be invisible


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
