### PR TITLE
fix: 修复transfer在groupList场景下,title属性传入reactElement节点导致key-warning

### DIFF
--- a/packages/semi-ui/transfer/index.tsx
+++ b/packages/semi-ui/transfer/index.tsx
@@ -445,10 +445,10 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         );
     }
 
-    renderGroupTitle(group: GroupItem) {
+    renderGroupTitle(group: GroupItem, index: number) {
         const groupCls = cls(`${prefixcls }-group-title`);
         return (
-            <div className={groupCls} key={group.title}>
+            <div className={groupCls} key={`title-${index}`}>
                 {group.title}
             </div>
         );
@@ -493,7 +493,7 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
                 // group content already insert
                 content.push(optionContent);
             } else if (parentGroup) {
-                const groupContent = this.renderGroupTitle(parentGroup);
+                const groupContent = this.renderGroupTitle(parentGroup, index);
                 groupStatus.set(parentGroup.title, true);
                 content.push(groupContent);
                 content.push(optionContent);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
当使用transfer组件时候，选择分组结构，并且因为个性化场景，需要修改定制title的时候，如果传入reactElement 会引起 key重复的warning
When using the transfer component, select the grouping structure, and because of the personalized scenario, when you need to modify the custom title, if you pass in the reactElement, it will cause the key to repeat the warning

### Changelog
🇨🇳 Chinese
- 修复 transfer在groupList场景下,title属性传入reactElement节点导致key-warning

---

🇺🇸 English
- Fix Transfer In the groupList scenario, the title attribute is passed into the reactElement node, resulting in key-warning


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

