### PR TITLE
fix: [TreeSelect]maxTagCount does not take effect when searchPosition…

### DIFF
--- a/packages/semi-ui/treeSelect/__test__/treeMultiple.test.js
+++ b/packages/semi-ui/treeSelect/__test__/treeMultiple.test.js
@@ -632,7 +632,12 @@ describe('TreeSelect', () => {
             searchPosition: 'trigger',
             filterTreeNode: true,
             multiple: true,
+            maxTagCount: 1,
+            defaultValue: ['Zhongguo', 'Meiguo']
         });
+        const selection = treeSelect.find(`.${BASE_CLASS_PREFIX}-tree-select .${BASE_CLASS_PREFIX}-tree-select-selection`);
+        expect(selection.find(`.${BASE_CLASS_PREFIX}-tagInput .${BASE_CLASS_PREFIX}-tag`).length).toEqual(1);
+        expect(selection.find(`.${BASE_CLASS_PREFIX}-tagInput .${BASE_CLASS_PREFIX}-tagInput-wrapper-n`).at(0).getDOMNode().textContent).toEqual('+1');
         const input = treeSelect.find(`.${BASE_CLASS_PREFIX}-tree-select .${BASE_CLASS_PREFIX}-tagInput .${BASE_CLASS_PREFIX}-input`);
         const searchValue = '北';
         const event = { target: { value: searchValue } };

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.js
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.js
@@ -299,6 +299,18 @@ export const SearchPosition = () => (
       placeholder="searchAutoFocus"
       searchAutoFocus
     />
+    <br />
+    <br />
+    <TreeSelect
+      searchPosition="trigger"
+      style={{ width: 300 }}
+      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+      treeData={treeData2}
+      multiple
+      filterTreeNode
+      maxTagCount={1}
+      placeholder="maxTagCount=1"
+    />
   </>
 );
 

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -979,6 +979,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             size,
             searchAutoFocus,
             placeholder,
+            maxTagCount,
         } = this.props;
         const {
             keyEntities,
@@ -988,6 +989,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const keyList = normalizeKeyList(checkedKeys, keyEntities, leafOnly);
         return (
             <TagInput
+                maxTagCount={maxTagCount}
                 disabled={disabled}
                 onInputChange={v => this.search(v)}
                 ref={this.tagInputRef}


### PR DESCRIPTION
… is trigger #498

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- 修复 TreeSelect 当 searchPosition 为 trigger 时，maxTagCount 不生效的问题 #498 

---

🇺🇸 English
- fix: TreeSelect maxTagCount does not take effect when searchPosition is trigger #498 


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Additional information
<!-- You can provide screenshot/video or some additional information -->
