### PR TITLE
fix(textarea): set cursor attribute to text when textarea is readonly

### DIFF
--- a/packages/semi-foundation/input/textarea.scss
+++ b/packages/semi-foundation/input/textarea.scss
@@ -55,10 +55,6 @@ $module: #{$prefix}-input;
         }
     }
 
-    &-readonly {
-        cursor: default;
-    }
-
     &-disabled, &-readonly {
         cursor: not-allowed;
         // border: $border-thickness-control $color-input_disabled-border-default solid;

--- a/packages/semi-foundation/input/textarea.scss
+++ b/packages/semi-foundation/input/textarea.scss
@@ -60,7 +60,7 @@ $module: #{$prefix}-input;
     }
 
     &-disabled {
-        cursor: not-allowed;
+        cursor: text;
         // border: $border-thickness-control $color-input_disabled-border-default solid;
         color: $color-input_disabled-text-default;
         background-color: $color-input_disabled-bg-default;
@@ -168,7 +168,7 @@ $module: #{$prefix}-input;
     &-autosize {
         overflow: hidden;
     }
-    
+
     &-counter {
         @include font-size-small;
         display: flex;

--- a/packages/semi-foundation/input/textarea.scss
+++ b/packages/semi-foundation/input/textarea.scss
@@ -59,8 +59,8 @@ $module: #{$prefix}-input;
         cursor: default;
     }
 
-    &-disabled {
-        cursor: text;
+    &-disabled, &-readonly {
+        cursor: not-allowed;
         // border: $border-thickness-control $color-input_disabled-border-default solid;
         color: $color-input_disabled-text-default;
         background-color: $color-input_disabled-bg-default;
@@ -72,6 +72,10 @@ $module: #{$prefix}-input;
         &::placeholder {
             color: $color-input_disabled-text-default;
         }
+    }
+
+    &-readonly {
+        cursor: text;
     }
 
     &-error {
@@ -151,7 +155,7 @@ $module: #{$prefix}-input;
         padding-right: $spacing-textarea_withShowClear-paddingRight;
     }
 
-    &-disabled {
+    &-disabled, &-readonly {
         cursor: not-allowed;
         color: $color-input_disabled-text-default;
         background-color: transparent;
@@ -163,6 +167,10 @@ $module: #{$prefix}-input;
         &::placeholder {
             color: $color-input_disabled-text-default;
         }
+    }
+
+    &-readonly {
+        cursor: text;
     }
 
     &-autosize {

--- a/packages/semi-ui/input/textarea.tsx
+++ b/packages/semi-ui/input/textarea.tsx
@@ -295,7 +295,8 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             className,
             `${prefixCls}-textarea-wrapper`,
             {
-                [`${prefixCls}-textarea-wrapper-disabled`]: disabled || readonly,
+                [`${prefixCls}-textarea-wrapper-disabled`]: disabled,
+                [`${prefixCls}-textarea-wrapper-readonly`]: readonly,
                 [`${prefixCls}-textarea-wrapper-${validateStatus}`]: Boolean(validateStatus),
                 [`${prefixCls}-textarea-wrapper-focus`]: isFocus,
                 // [`${prefixCls}-textarea-wrapper-resize`]: !autosize && resize,
@@ -305,7 +306,8 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         const itemCls = cls(
             `${prefixCls}-textarea`,
             {
-                [`${prefixCls}-textarea-disabled`]: disabled || readonly,
+                [`${prefixCls}-textarea-disabled`]: disabled,
+                [`${prefixCls}-textarea-readonly`]: readonly,
                 [`${prefixCls}-textarea-autosize`]: autosize,
                 [`${prefixCls}-textarea-showClear`]: showClear,
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 TextArea readonly 模式下光标显示为禁用问题 [@chenc041](https://github.com/chenc041)  [#535](https://github.com/DouyinFE/semi-design/issues/535)

---

🇺🇸 English
- Fix: Fixed TextArea readonly hover cursor style bug [@chenc041](https://github.com/chenc041)  [#535](https://github.com/DouyinFE/semi-design/issues/535)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
