### PR TITLE
feat(tooltip): leftTopOver position support autoAdjustOverflow (#294)

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,3 +1,4 @@
 {
-  "projectId": "k83u7j"
+  "projectId": "k83u7j",
+  "scrollBehavior": false
 }

--- a/cypress/integration/tooltip.spec.js
+++ b/cypress/integration/tooltip.spec.js
@@ -1,0 +1,25 @@
+// tooltip.spec.js created with Cypress
+//
+// Start writing your Cypress tests below!
+// If you're unfamiliar with how Cypress works,
+// check out the link below and learn how to write your first test:
+// https://on.cypress.io/writing-first-test
+
+/**
+ * Cypress will default scroll element into view
+ * @see https://docs.cypress.io/guides/core-concepts/interacting-with-elements#Scrolling
+ */
+describe('tooltip', () => {
+    it('leftTopOver', () => {
+        cy.visit('http://127.0.0.1:6009/iframe.html?id=tooltip--left-top-over-demo&args=&viewMode=story');
+        cy.get('[data-cy="leftTopOver"]').click();
+        cy.get('[x-placement="leftBottomOver"]').should('have.length', 2);
+        cy.get('#root > div').click({force: true}); // click outside
+        cy.get('[x-placement="leftBottomOver"]').should('have.length', 1);
+        cy.get('[data-cy="leftTopOver"]').scrollIntoView();
+        cy.get('[data-cy="leftTopOver"]').click();
+        cy.get('[x-placement="leftTopOver"]').should('have.length', 2);
+        cy.get('#root > div').click({force: true}); // click outside
+        cy.get('[x-placement="leftTopOver"]').should('have.length', 1);
+    });
+});

--- a/packages/semi-foundation/tooltip/constants.ts
+++ b/packages/semi-foundation/tooltip/constants.ts
@@ -20,6 +20,7 @@ const strings = {
         'bottomRight',
         'leftTopOver',
         'rightTopOver',
+        'leftBottomOver'
     ],
     TRIGGER_SET: ['hover', 'focus', 'click', 'custom'],
     STATUS_DISABLED: 'disabled',

--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -434,6 +434,10 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 top = triggerRect.top;
                 translateX = -1;
                 break;
+            case 'leftBottomOver':
+                left = triggerRect.left;
+                top = triggerRect.bottom;
+                translateY = -1;
             default:
                 break;
         }
@@ -604,6 +608,8 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
             const shouldReverseLeft = clientLeft < wrapperRect.width + spacing && restClientRight > wrapperRect.width + spacing;
             const sholdReverseBottom = restClientBottom < wrapperRect.height + spacing && clientTop > wrapperRect.height + spacing;
             const shouldReverseRight = restClientRight < wrapperRect.width + spacing && clientLeft > wrapperRect.width + spacing;
+            const shouldReverseTopOver = restClientTop < wrapperRect.height + spacing && clientBottom > wrapperRect.height + spacing;
+            const shouldReverseBottomOver = clientBottom < wrapperRect.height + spacing && restClientTop > wrapperRect.height + spacing;
 
             const shouldReverseTopSide = restClientTop < wrapperRect.height && clientBottom > wrapperRect.height;
             const shouldReverseBottomSide = clientBottom < wrapperRect.height && restClientTop > wrapperRect.height;
@@ -692,6 +698,16 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                         position = this._reversePos(position);
                     }
                     if (shouldReverseBottomSide && heightIsBigger) {
+                        position = this._reversePos(position, true);
+                    }
+                    break;
+                case 'leftTopOver':
+                    if (shouldReverseTopOver) {
+                        position = this._reversePos(position, true);
+                    }
+                    break;
+                case 'leftBottomOver':
+                    if (shouldReverseBottomOver) {
                         position = this._reversePos(position, true);
                     }
                     break;

--- a/packages/semi-ui/tooltip/_story/tooltip.stories.js
+++ b/packages/semi-ui/tooltip/_story/tooltip.stories.js
@@ -1,7 +1,7 @@
 import React, { useState, useMemo } from 'react';
 import Tooltip from '../index';
 import './story.scss';
-import { Tag, Icon, IconButton, Switch, Checkbox, Radio, Button, Select, InputNumber } from '@douyinfe/semi-ui';
+import { Tag, Icon, IconButton, Switch, Checkbox, Radio, Button, Select, InputNumber, Space } from '@douyinfe/semi-ui';
 
 import InTableDemo from './InTable';
 import EdgeDemo from './Edge';
@@ -736,3 +736,37 @@ export const AutoAdjustWithSpacing = () => {
 AutoAdjustWithSpacing.story = {
   name: 'AutoAdjustWithSpacing',
 };
+
+export const leftTopOverDemo = () => {
+    const content = (
+        <div style={{ height: 200, width: 200 }}>
+            Semi Design
+        </div>
+    );
+
+    return (
+        <div style={{ height: '200vh' }}>
+            <div style={{ position: 'absolute', bottom: 0 }}>
+                <Space style={{ marginBottom: 10 }}>
+                    <Tooltip content={content} trigger="click" position='leftTopOver' spacing={1}  showArrow={false}>
+                        <Button data-cy='leftTopOver'>leftTopOver</Button>
+                    </Tooltip>
+                    <Tooltip content={content} trigger="click" position='bottom' showArrow={false}>
+                        <Button data-cy='bottom'>bottom（对照组）</Button>
+                    </Tooltip>
+                    <Tooltip content={content} trigger="click" position='leftBottomOver' showArrow={false}>
+                        <Button data-cy='leftBottomOver'>leftBottomOver</Button>
+                    </Tooltip>
+                    <Tooltip content={content} trigger="click" position='top' showArrow={false}>
+                        <Button data-cy='top'>top（对照组）</Button>
+                    </Tooltip>
+                    <Tooltip content={content} trigger="custom" visible={true}  position='leftTopOver' spacing={1}  showArrow={false}>
+                        <Button data-cy='leftTopOver-visible'>leftTopOver</Button>
+                    </Tooltip>
+                </Space>
+            </div>
+        </div>
+    )
+};
+leftTopOverDemo.storyName = `leftTopOver autoAdjustOverflow`;
+leftTopOverDemo.parameters = { chromatic: { disableSnapshot: false }};


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Feature


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

DatePicker 优化需要支持 Tooltip 原地展开，查看了下，已支持 leftTopOverflow，但是不能自动调整位置。本次更新 leftTopOverflow 自动调整位置的支持。

leftTopOverflow 的调整位置只包括上下，不包括左右，且 `spacing` 对 leftTopOverflow 没有效果。

![tooltip-leftTopOver-autoAdjustOverlfow](https://user-images.githubusercontent.com/26477537/150115369-8462c21d-0ef6-4f68-8e3a-7501bac15a62.gif)

### Changelog
🇨🇳 Chinese
- Feat: Tooltip `leftTopOver` 位置支持自动调整位置

---

🇺🇸 English
- Feat:  Tooltip `leftTopOver` position supports `autoAdjustOverflow`


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
