### PR TITLE
feat: add support for `onChangeWithDateFirst` API

### DIFF
--- a/content/input/timepicker/index-en-US.md
+++ b/content/input/timepicker/index-en-US.md
@@ -316,6 +316,7 @@ function Demo(props = {}) {
 | value | Current time | Date\|timeStamp\|string (array when type = "timeRange") |  |
 | onBlur | Callback when focus is lost | (e: domEvent) => void | () => {} | **1.0.0** |
 | onChange | A callback in time. | (time: Date\|Date[], timeString: string\|string[]) => void |  |
+| onChangeWithDateFirst | Set the order of parameter in `onChange`, `true`: (string, Date); `false`: (Date, string) | boolean | true | **2.4.0** |
 | onFocus | Callback when focus is obtained | (e: domEvent) => void | () => {} | **1.0.0** |
 | onOpenChange | A callback when the panel is on / off | (isOpen: boolean) => void |  |
 

--- a/content/input/timepicker/index-en-US.md
+++ b/content/input/timepicker/index-en-US.md
@@ -316,7 +316,7 @@ function Demo(props = {}) {
 | value | Current time | Date\|timeStamp\|string (array when type = "timeRange") |  |
 | onBlur | Callback when focus is lost | (e: domEvent) => void | () => {} | **1.0.0** |
 | onChange | A callback in time. | (time: Date\|Date[], timeString: string\|string[]) => void |  |
-| onChangeWithDateFirst | Set the order of parameter in `onChange`, `true`: (string, Date); `false`: (Date, string) | boolean | true | **2.4.0** |
+| onChangeWithDateFirst | Set the order of parameter in `onChange`, `true`: (Date, string); `false`: (string, Date) | boolean | true | **2.4.0** |
 | onFocus | Callback when focus is obtained | (e: domEvent) => void | () => {} | **1.0.0** |
 | onOpenChange | A callback when the panel is on / off | (isOpen: boolean) => void |  |
 

--- a/content/input/timepicker/index.md
+++ b/content/input/timepicker/index.md
@@ -301,7 +301,7 @@ function Demo(props = {}) {
 | value               | 当前时间                                               | Date\|timeStamp\|String（type="timeRange"时为数组）                               |                                                                   |                    |
 | onBlur              | 失去焦点时的回调                                       | (e: domEvent) => void                                                             | () => {}                                                          | **1.0.0**          |
 | onChange            | 时间发生变化的回调                                     | Function(time: Date, timeString: string): void （type="timeRange"时入参皆为数组） | 无                                                                |                    |
-| onChangeWithDateFirst | 设置为 `true` 时 onChange 的入参顺序为 (string, Date), `false` 时为 (Date, string) | boolean | true | **2.4.0** |
+| onChangeWithDateFirst | 设置为 `true` 时 onChange 的入参顺序为 (Date, string), `false` 时为 (string, Date) | boolean | true | **2.4.0** |
 | onFocus             | 获得焦点时的回调                                       | (e: domEvent) => void                                                             | () => {}                                                          | **1.0.0**          |
 | onOpenChange        | 面板打开/关闭时的回调                                  | Function(isOpen: boolean): void                                                   | 无                                                                |                    |
 

--- a/content/input/timepicker/index.md
+++ b/content/input/timepicker/index.md
@@ -301,6 +301,7 @@ function Demo(props = {}) {
 | value               | 当前时间                                               | Date\|timeStamp\|String（type="timeRange"时为数组）                               |                                                                   |                    |
 | onBlur              | 失去焦点时的回调                                       | (e: domEvent) => void                                                             | () => {}                                                          | **1.0.0**          |
 | onChange            | 时间发生变化的回调                                     | Function(time: Date, timeString: string): void （type="timeRange"时入参皆为数组） | 无                                                                |                    |
+| onChangeWithDateFirst | 设置为 `true` 时 onChange 的入参顺序为 (string, Date), `false` 时为 (Date, string) | boolean | true | **2.4.0** |
 | onFocus             | 获得焦点时的回调                                       | (e: domEvent) => void                                                             | () => {}                                                          | **1.0.0**          |
 | onOpenChange        | 面板打开/关闭时的回调                                  | Function(isOpen: boolean): void                                                   | 无                                                                |                    |
 

--- a/packages/semi-foundation/timePicker/foundation.ts
+++ b/packages/semi-foundation/timePicker/foundation.ts
@@ -37,7 +37,8 @@ export interface TimePickerAdapter<P = Record<string, any>, S = Record<string, a
     setInputValue: (inputValue: string, cb?: () => void) => void;
     unregisterClickOutSide: () => void;
     notifyOpenChange: (open: boolean) => void;
-    notifyChange: (value: Date | Date[], input: string | string[]) => void;
+    notifyChange(value: Date | Date[], input: string | string[]): void;
+    notifyChange(input: string | string[], value: Date | Date[]): void;
     notifyFocus: (e: any) => void;
     notifyBlur: (e: any) => void;
     isRangePicker: () => boolean;
@@ -413,8 +414,12 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
                 str = format(_value, formatToken);
             }
         }
-
-        this._adapter.notifyChange(_value, str);
+        const onChangeWithDateFirst = this.getProp('onChangeWithDateFirst');
+        if (onChangeWithDateFirst) {
+            this._adapter.notifyChange(_value, str);
+        } else {
+            this._adapter.notifyChange(str, _value);
+        }
     }
 
     _hasChanged(dates: Date[] = [], oldDates: Date[] = []) {

--- a/packages/semi-ui/timePicker/TimePicker.tsx
+++ b/packages/semi-ui/timePicker/TimePicker.tsx
@@ -90,6 +90,7 @@ export type TimePickerProps = {
     zIndex?: number | string;
     onBlur?: React.FocusEventHandler<HTMLInputElement>;
     onChange?: TimePickerAdapter['notifyChange'];
+    onChangeWithDateFirst?: boolean;
     onFocus?: React.FocusEventHandler<HTMLInputElement>;
     onOpenChange?: (open: boolean) => void;
 };
@@ -187,6 +188,7 @@ export default class TimePicker extends BaseComponent<TimePickerProps, TimePicke
         onFocus: noop,
         onBlur: noop,
         onChange: noop,
+        onChangeWithDateFirst: true,
         use12Hours: false,
         focusOnOpen: false,
         onKeyDown: noop,
@@ -257,7 +259,7 @@ export default class TimePicker extends BaseComponent<TimePickerProps, TimePicke
                 }
             },
             notifyOpenChange: (...args) => this.props.onOpenChange(...args),
-            notifyChange: (...args) => this.props.onChange && this.props.onChange(...args),
+            notifyChange: (agr1, arg2) => this.props.onChange && this.props.onChange(agr1, arg2),
             notifyFocus: (...args) => this.props.onFocus && this.props.onFocus(...args),
             notifyBlur: (...args) => this.props.onBlur && this.props.onBlur(...args),
             isRangePicker: () => this.props.type === strings.TYPE_TIME_RANGE_PICKER,

--- a/packages/semi-ui/timePicker/__test__/timePicker.test.js
+++ b/packages/semi-ui/timePicker/__test__/timePicker.test.js
@@ -22,11 +22,13 @@ describe(`TimePicker`, () => {
         const defaultMinute = 24;
         const defaultSeconds = 18;
 
-        const onFoucs = sinon.spy();
+        const onFocus = sinon.spy();
+        const onChange = sinon.spy();
 
         const elem = mount(
             <TimePicker
-                onFocus={onFoucs}
+                onChange={onChange}
+                onFocus={onFocus}
                 panelHeader={<strong>Select Time</strong>}
                 locale={Locale.TimePicker}
                 localeCode={Locale.code}
@@ -59,7 +61,7 @@ describe(`TimePicker`, () => {
         // focus
         elem.find(`input`).simulate('focus');
         await sleep(200);
-        expect(onFoucs.calledOnce).toBeTruthy();
+        expect(onFocus.calledOnce).toBeTruthy();
 
         // input value
         const newInputHour = 10;
@@ -82,6 +84,11 @@ describe(`TimePicker`, () => {
 
         await sleep(200);
         expect(elem.state('open')).toBe(false);
+
+        expect(onChange.called).toBeTruthy();
+        const args = onChange.getCall(0).args;
+        expect(args[0] instanceof Date).toBe(true);
+        expect(typeof args[1]).toBe('string');
     });
 
     it(`test controlled value`, async () => {
@@ -279,5 +286,29 @@ describe(`TimePicker`, () => {
         const args = onChange.getCall(0).args;
         expect(args[0]).toBe(undefined);
         expect(args[1]).toBe('');
+    });
+
+    it('test onChangeWithDateFirst=false', async () => {
+        const onChange = sinon.spy();
+        let props = {
+            defaultValue: "10:23:15",
+            onChange,
+            defaultOpen: true,
+            onChangeWithDateFirst: false,
+            autofocus: true,
+            locale: Locale.TimePicker,
+            localeCode: Locale.code
+        };
+        const elem = mount(<TimePicker {...props} />);
+        // click minute
+        const minuteUl = elem.find(`.${BASE_CLASS_PREFIX}-timepicker-panel-list-minute .${BASE_CLASS_PREFIX}-scrolllist-list-outer ul`);
+        const minuteLis = minuteUl.find(`li`);
+
+        minuteUl.simulate('click', { target: minuteLis.at(0).getDOMNode(), nativeEvent: null });
+
+        expect(onChange.called).toBeTruthy();
+        const args = onChange.getCall(0).args;
+        expect(typeof args[0]).toBe('string');
+        expect(args[1] instanceof Date).toBe(true);
     });
 });

--- a/packages/semi-ui/timePicker/_story/timepicker.stories.js
+++ b/packages/semi-ui/timePicker/_story/timepicker.stories.js
@@ -262,3 +262,21 @@ export const ShowClear = () => (
     />
   </>
 );
+
+
+export const TimePickerWithOnChangeWithDateFirst = () => {
+  return (
+    <div>
+      onChangeWithDateFirst=true (default)
+      <TimePicker onChange={(...val) => console.log(...val)} />
+      <br />
+      onChangeWithDateFirst=false
+      <TimePicker onChangeWithDateFirst={false} onChange={(...val) => console.log(...val)} />
+      
+    </div>
+  );
+};
+
+TimePickerWithOnChangeWithDateFirst.story = {
+  name: 'OnChangeWithDateFirst',
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Feature


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
close #555 

### Changelog
🇨🇳 Chinese
- feat: TimePicker 支持 `onChangeWithDateFirst` API #555 

---

🇺🇸 English
- Fix: TimePicker add support for `onChangeWithDateFirst` API #555 

### Checklist
- [X] Test or no need
- [X] Document or no need
- [X] Changelog or no need


### Additional information
<!-- You can provide screenshot/video or some additional information -->
