### PR TITLE
fix: (nav) limitIndent should not work when collapsed

### DIFF
--- a/content/navigation/navigation/index-en-US.md
+++ b/content/navigation/navigation/index-en-US.md
@@ -523,7 +523,6 @@ class NavApp extends React.Component {
         return (
             <Nav
                 limitIndent={false}
-                toggleIconPosition={'left'}
                 defaultOpenKeys={['job']}
                 bodyStyle={{ height: 320 }}
                 items={[

--- a/content/navigation/navigation/index.md
+++ b/content/navigation/navigation/index.md
@@ -525,7 +525,6 @@ class NavApp extends React.Component {
         return (
             <Nav
                 limitIndent={false}
-                toggleIconPosition={'left'}
                 defaultOpenKeys={['job']}
                 bodyStyle={{ height: 320 }}
                 items={[

--- a/packages/semi-ui/navigation/Item.tsx
+++ b/packages/semi-ui/navigation/Item.tsx
@@ -195,7 +195,7 @@ export default class NavItem extends BaseComponent<NavItemProps, NavItemState> {
             itemChildren = children;
         } else {
             let placeholderIcons = null;
-            if (mode === strings.MODE_VERTICAL && !limitIndent) {
+            if (mode === strings.MODE_VERTICAL && !limitIndent && !isCollapsed) {
                 const iconAmount = (icon && !indent) ? level : level - 1;
                 placeholderIcons = times(iconAmount, () => this.renderIcon(null, strings.ICON_POS_RIGHT, false));
             }

--- a/packages/semi-ui/navigation/SubNav.tsx
+++ b/packages/semi-ui/navigation/SubNav.tsx
@@ -237,7 +237,7 @@ export default class SubNav extends BaseComponent<SubNavProps, SubNavState> {
         }
 
         let placeholderIcons = null;
-        if (mode === strings.MODE_VERTICAL && !limitIndent) {
+        if (mode === strings.MODE_VERTICAL && !limitIndent && !isCollapsed) {
             /* Different icons' amount means different indents.*/
             const iconAmount = (icon && !indent) ? level : level - 1;
             placeholderIcons = times(iconAmount, index => this.renderIcon(null, strings.ICON_POS_RIGHT, false, undefined, index));


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

before：
![image](https://user-images.githubusercontent.com/88709023/152985887-812cfed9-3074-4bf2-bf9b-92d12596d2a5.png)


after：
![image](https://user-images.githubusercontent.com/88709023/152985768-e3ab7616-43c8-4fd3-a73d-f5bf354d91e8.png)


### Changelog
🇨🇳 Chinese
- Fix: 修复 Nav limitIndent 在折叠态后，子菜单通过 dropdown 形式展示时，也被消费，从而导致了多余的空白间隔的问题

---

🇺🇸 English
- Fix: Fix Nav limitIndent in the collapsed state, when the submenu is displayed in the form of dropdown, it is also consumed, which leads to the problem of redundant blank space


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
