### PR TITLE
fix: alias not work after config semi-next in next.js project, close …

### DIFF
--- a/packages/semi-next/src/index.ts
+++ b/packages/semi-next/src/index.ts
@@ -9,7 +9,7 @@ export default function(options: SemiNextOptions = {}) {
     return (nextConfig: NextConfig = {}) => {
         const actualConfig: NextConfig = {
             ...nextConfig,
-            webpack(config, { isServer, webpack }) {
+            webpack(config, { isServer, webpack, ...rest }) {
                 config.plugins.push(new SemiWebpackPlugin({
                     omitCss: options.omitCss === undefined ? true : options.omitCss,
                     webpackContext: {
@@ -38,6 +38,9 @@ export default function(options: SemiNextOptions = {}) {
                             }
                         ];
                     }
+                }
+                if (typeof nextConfig.webpack === 'function') {
+                    return nextConfig.webpack(config, { isServer, webpack, ...rest });
                 }
                 return config;
             }


### PR DESCRIPTION
…#630

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
修复 next.js 项目使用 @douyinfe/semi-next 插件后，webpack.resolve.alias配置失效的问题 ，原有写法，如果用户在 next.config.js 中又单独配置了webpack，semi-next中的配置会将自定义配置覆盖掉。

### Changelog
🇨🇳 Chinese
- Fix: 修复 next.js 项目使用 @douyinfe/semi-next 插件后，webpack.resolve.alias配置失效的问题 #630

---

🇺🇸 English
- Fix: Fix the problem that the configuration of webpack.resolve.alias is invalid after the @douyinfe/semi-next plugin is used in the next.js project #630


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
