### PR TITLE
fix: disabled input text invisible when setting some special color in…

### DIFF
--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -382,7 +382,8 @@ $module: #{$prefix}-input;
         // border: $border-thickness-control $color-input_disabled-border-default solid;
         color: $color-input_disabled-text-default;
         background-color: $color-input_disabled-bg-default;
-
+        // fix issue 670 in safari
+        -webkit-text-fill-color: $color-input_disabled-text-default;
         &:hover {
             background-color: $color-input_disabled-bg-default;
         }


### PR DESCRIPTION
… safari, close #670

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复disabled Input的文本颜色通过自定义css或者主题定制，将其设定为某些特定颜色时，在safari下无法显示disabled 文本的问题

---

🇺🇸 English
- Fix: Fixed the problem that the disabled text cannot be displayed in safari when the text color of disabled Input is customized by custom css or theme, and it is set to some specific color


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
