### PR TITLE
fix: (Typography) renderCopy function has bug when child element is r…

### DIFF
--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -9,7 +9,7 @@ import { IconSize as Size } from '../icons/index';
 import { isUndefined, omit, merge, isString } from 'lodash';
 import Tooltip from '../tooltip/index';
 import Popover from '../popover/index';
-import getRenderText from './util';
+import getRenderText, { mergedToString } from './util';
 import warning from '@douyinfe/semi-foundation/utils/warning';
 import isEnterPress from '@douyinfe/semi-foundation/utils/isEnterPress';
 import LocaleConsumer from '../locale/localeConsumer';
@@ -490,27 +490,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         if (!copyable) {
             return null;
         }
-        let copyContent: string;
-        let hasObject = false;
-        if (Array.isArray(children)) {
-            copyContent = '';
-            children.forEach(value => {
-                if (typeof value === 'object') {
-                    hasObject = true;
-                }
-                copyContent += String(value);
-            });
-        } else if (typeof children !== 'object') {
-            copyContent = String(children);
-        } else {
-            hasObject = true;
-            copyContent = String(children);
-        }
-
-        warning(
-            hasObject,
-            'Children in Typography is a object, it will case a [object Object] mistake when copy to clipboard.'
-        );
+        const copyContent: string = mergedToString(children);
         const copyConfig = {
             content: copyContent,
             duration: 3,

--- a/packages/semi-ui/typography/util.tsx
+++ b/packages/semi-ui/typography/util.tsx
@@ -1,5 +1,6 @@
 import ReactDOM from 'react-dom';
 import React from 'react';
+import { isString, isNumber } from 'lodash';
 
 /**
  * The logic of JS for text truncation is referenced from antd typography
@@ -136,5 +137,26 @@ const getRenderText = (
     ellipsisContainer.innerHTML = '';
     return resText;
 };
+
+const isSingleNode = (child: React.ReactNode) => {
+    return isString(child) || isNumber(child);
+};
+
+  
+export function mergedToString(children: any): string {
+    const mergedResult = [''];
+    React.Children.forEach(children, (child) => {
+        const prevIndex = mergedResult.length - 1;
+        const prevChild = mergedResult[prevIndex];
+  
+        if (isSingleNode(child) && isSingleNode(prevChild)) {
+            mergedResult[prevIndex] = `${prevChild}${child}`;
+        } else if (child?.props?.children) {
+            mergedResult.push(mergedToString(child.props.children));
+        }
+    });
+  
+    return mergedResult.join('');
+}
 
 export default getRenderText;


### PR DESCRIPTION
…eact node

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 ...
- 问题：
在Typography 组件中,如果要的点击复制文字按钮，复制的文字，如果是ReactNode类型会有bug，案例如下：
```javascript
// 点击copy的icon，实际上复制的文字是：“[object Object]”
<Paragraph copyable><span>复制的文字</span></Paragraph> 

// 或者如下，点击copy的icon，实际上复制的文字是：“复制文字[object Object]复制文字3”
<Paragraph copyable>复制文字<span>复制文字2<span>复制文字3</Paragraph>
```
解决方法：
我写了一个递归方法，逻辑是如果子元素，如上面的
```javascript
<span>复制的文字</span>
```
这个children元素如果不是string或者number，就继续往下找，方法如下（我也是arco design Typography组件的贡献者，这个方法没啥问题，arco也在用）：

```javascript

const isSingleNode = (child: React.ReactNode) => {
   // isString和isNumber是loadsh里的方法
    return isString(child) || isNumber(child);
};

  
export function mergedToString(children: any): string {
    const mergedResult = [''];
    React.Children.forEach(children, (child) => {
        const prevIndex = mergedResult.length - 1;
        const prevChild = mergedResult[prevIndex];
  
        if (isSingleNode(child) && isSingleNode(prevChild)) {
            mergedResult[prevIndex] = `${prevChild}${child}`;
        } else if (child?.props?.children) {
            mergedResult.push(mergedToString(child.props.children));
        }
    });
  
    return mergedResult.join('');
}
```
---

🇺🇸 English
- Fix: fix ...

- question:
In the Typography component, if you want to click the copy text icon, the copied text will have bugs if it is a ReactNode type. The case is as follows:
```javascript
// Click on the copy icon, the actual copied text is ：“[object Object]”
<Paragraph copyable><span>复制的文字</span></Paragraph> 
// Or as follows, click the icon of copy, the actual copied text is：“复制文字[object Object]复制文字3”
<Paragraph copyable>复制文字<span>复制文字2<span>复制文字3</Paragraph>

Solution:
I wrote a recursive method, the logic is that if the child element, such as 
```javascri[t
<span> copied text</span>
```
, if the children element is not a string or a number, continue to look down, the method is as follows (I am also arco designContributor of the Typography component, there is nothing wrong with this method, this method arco is also used):

```javascript

const isSingleNode = (child: React.ReactNode) => {
   // isString和isNumber是loadsh里的方法
    return isString(child) || isNumber(child);
};

  
export function mergedToString(children: any): string {
    const mergedResult = [''];
    React.Children.forEach(children, (child) => {
        const prevIndex = mergedResult.length - 1;
        const prevChild = mergedResult[prevIndex];
  
        if (isSingleNode(child) && isSingleNode(prevChild)) {
            mergedResult[prevIndex] = `${prevChild}${child}`;
        } else if (child?.props?.children) {
            mergedResult.push(mergedToString(child.props.children));
        }
    });
  
    return mergedResult.join('');
}
```
```
### Checklist
- [x] Test or no need
- [x] Document or no need
- [ ] Changelog or no need

### Other
- [] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
