### PR TITLE
Fix: when radio-group's value is NaN, "Maimum update depth exceeded" is triggered

### DIFF
--- a/packages/semi-ui/radio/__test__/radioGroup.test.jsx
+++ b/packages/semi-ui/radio/__test__/radioGroup.test.jsx
@@ -196,4 +196,12 @@ describe('RadioGroup', () => {
         expect(middleRadio.exists(`.${BASE_CLASS_PREFIX}-radio-addon-buttonRadio-middle`)).toEqual(true);
         expect(largeRadio.exists(`.${BASE_CLASS_PREFIX}-radio-addon-buttonRadio-large`)).toEqual(true);
     });
+
+    it('does not trigger Maximum update exceeded when setting radio-group\'s value to NaN', () => {
+        const radioGroup = mount(
+            createRadioGroup({ value: NaN }),
+        );
+
+        expect(radioGroup.exists(`${BASE_CLASS_PREFIX}-radio-checked`)).toEqual(false);
+    });
 });

--- a/packages/semi-ui/radio/radioGroup.tsx
+++ b/packages/semi-ui/radio/radioGroup.tsx
@@ -97,9 +97,13 @@ class RadioGroup extends BaseComponent<RadioGroupProps, RadioGroupState> {
     }
 
     componentDidUpdate(prevProps: RadioGroupProps) {
-        if (typeof prevProps.value === 'number' && isNaN(prevProps.value)) {
-            // `prevProps.value` could be NaN, and `NaN === NaN` returns false
-            // This will fail the next if check, therefore short-circuiting here
+        if (typeof prevProps.value === 'number'
+            && isNaN(prevProps.value)
+            && typeof this.props.value === 'number'
+            && isNaN(this.props.value)
+        ) {
+            // `NaN === NaN` returns false, and this will fail the next if check
+            // therefore triggering an infinite loop
             return;
         }
         if (prevProps.value !== this.props.value) {

--- a/packages/semi-ui/radio/radioGroup.tsx
+++ b/packages/semi-ui/radio/radioGroup.tsx
@@ -97,9 +97,8 @@ class RadioGroup extends BaseComponent<RadioGroupProps, RadioGroupState> {
     }
 
     componentDidUpdate(prevProps: RadioGroupProps) {
-        if ((typeof prevProps.value === 'number' && isNaN(prevProps.value))
-            || (typeof this.props.value === 'number' && isNaN(this.props.value))) {
-            // `props.value` could be NaN, and `NaN === NaN` returns false
+        if (typeof prevProps.value === 'number' && isNaN(prevProps.value)) {
+            // `prevProps.value` could be NaN, and `NaN === NaN` returns false
             // This will fail the next if check, therefore short-circuiting here
             return;
         }

--- a/packages/semi-ui/radio/radioGroup.tsx
+++ b/packages/semi-ui/radio/radioGroup.tsx
@@ -97,6 +97,12 @@ class RadioGroup extends BaseComponent<RadioGroupProps, RadioGroupState> {
     }
 
     componentDidUpdate(prevProps: RadioGroupProps) {
+        if ((typeof prevProps.value === 'number' && isNaN(prevProps.value))
+            || (typeof this.props.value === 'number' && isNaN(this.props.value))) {
+            // `props.value` could be NaN, and `NaN === NaN` returns false
+            // This will fail the next if check, therefore short-circuiting here
+            return;
+        }
         if (prevProps.value !== this.props.value) {
             this.foundation.handlePropValueChange(this.props.value);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #712

### Changelog
🇨🇳 Chinese
- Fix: RadioGroup value 为 NaN 时，触发 Maximum update depth exceeded

---

🇺🇸 English
- Fix: when radio-group's value is NaN, "Maimum update depth exceeded" is triggered


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
