### PR TITLE
fix: setting RadioGroup value prop to NaN does not cause errors #712

### DIFF
--- a/packages/semi-ui/radio/__test__/radioGroup.test.jsx
+++ b/packages/semi-ui/radio/__test__/radioGroup.test.jsx
@@ -196,4 +196,11 @@ describe('RadioGroup', () => {
         expect(middleRadio.exists(`.${BASE_CLASS_PREFIX}-radio-addon-buttonRadio-middle`)).toEqual(true);
         expect(largeRadio.exists(`.${BASE_CLASS_PREFIX}-radio-addon-buttonRadio-large`)).toEqual(true);
     });
+
+    it('setting RadioGroup value prop to NaN does not cause errors', () => {
+        const radioGroup = mount(
+            createRadioGroup({ value: NaN }),
+        );
+        expect(radioGroup.exists(`${BASE_CLASS_PREFIX}-radio-checked`)).toEqual(false);
+    });
 });

--- a/packages/semi-ui/radio/radioGroup.tsx
+++ b/packages/semi-ui/radio/radioGroup.tsx
@@ -11,6 +11,7 @@ import BaseComponent from '../_base/baseComponent';
 import { ArrayElement } from '../_base/base';
 import Radio, { RadioType } from './radio';
 import Context, { RadioGroupButtonSize, RadioMode } from './context';
+import Logger from '@douyinfe/semi-foundation/utils/Logger';
 
 export interface OptionItem {
     label?: React.ReactNode;
@@ -48,6 +49,8 @@ export type RadioGroupProps = {
 export interface RadioGroupState {
     value?: any;
 }
+
+const logger = new Logger('[@douyinfe/semi-ui RadioGroup]');
 
 class RadioGroup extends BaseComponent<RadioGroupProps, RadioGroupState> {
     static propTypes = {
@@ -97,6 +100,10 @@ class RadioGroup extends BaseComponent<RadioGroupProps, RadioGroupState> {
     }
 
     componentDidUpdate(prevProps: RadioGroupProps) {
+        if (isNaN(this.props.value as number)){
+            logger.warn('plase do not use NaN as value');
+            return;
+        }
         if (prevProps.value !== this.props.value) {
             this.foundation.handlePropValueChange(this.props.value);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 RadioGroup 组件值为NaN时报错的问题

---

🇺🇸 English
- Fix: Fix the problem of reporting errors when the value of radiogroup component is NaN


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
