### PR TITLE
fix(button): fixed button focus style when clicked

### DIFF
--- a/packages/semi-foundation/button/button.scss
+++ b/packages/semi-foundation/button/button.scss
@@ -24,8 +24,16 @@ $module: #{$prefix}-button;
     vertical-align: middle;
     white-space: nowrap;
 
-    &:focus {
-        outline: $width-button-outline solid $color-button_primary-outline-focus;
+    // the specificity of `.#{$module}:focus-visible`  may lower than `reset.css` default `focus-visible` style
+    // so we add a class at the same level
+    &.#{$module}-primary,
+    &.#{$module}-secondary,
+    &.#{$module}-tertiary,
+    &.#{$module}-warning,
+    &.#{$module}-danger {
+        &:focus-visible {
+            outline: $width-button-outline solid $color-button_primary-outline-focus;
+        }
     }
 
     &-danger {
@@ -41,8 +49,8 @@ $module: #{$prefix}-button;
         &.#{$module}-borderless {
             color: $color-button_danger-bg-default;
         }
-        &:not(.#{$module}-borderless):not(.#{$module}-light):focus {
-            outline-color: $color-button_danger-outline-focus;
+        &:not(.#{$module}-borderless):not(.#{$module}-light):focus-visible {
+            outline: $width-button-outline solid $color-button_danger-outline-focus;
         }
     }
     &-warning {
@@ -58,8 +66,8 @@ $module: #{$prefix}-button;
         &.#{$module}-borderless {
             color: $color-button_warning-bg-default;
         }
-        &:not(.#{$module}-borderless):not(.#{$module}-light):focus {
-            outline-color: $color-button_warning-outline-focus;
+        &:not(.#{$module}-borderless):not(.#{$module}-light):focus-visible {
+            outline: $width-button-outline solid $color-button_warning-outline-focus;
         }
     }
     &-tertiary {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

使用 `focus-visible` 解决按钮点击后有聚焦样式问题，[storybook](https://semi-storybook.web.bytedance.net/?path=/story/button--combination-show)

- 2.6.0 ~ 目前，Button focus 在点击后会显示出来
- 修改后，点击不聚焦，切换 Tab 聚焦，但 Safari 15.3 和之前的版本没有效果（点击后不聚焦，切换 Tab 也不聚焦）。

![middle_img_v2_7db7cd14-47cc-406a-9177-7ab93365c37g](https://user-images.githubusercontent.com/26477537/160336708-f0b283fe-bb09-482c-8649-755f36bb2fbd.png)

### Changelog
🇨🇳 Chinese
- Fix: 修复 Button 点击后聚焦样式问题

---

🇺🇸 English
- Fix: Fixed focus style issue after Button is clicked


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
