### PR TITLE
fix: (InputNumber) value be formated when precision is set and defaultvalue is empty

### DIFF
--- a/packages/semi-foundation/inputNumber/foundation.ts
+++ b/packages/semi-foundation/inputNumber/foundation.ts
@@ -432,7 +432,7 @@ class InputNumberFoundation extends BaseFoundation<InputNumberAdapter> {
 
     _adjustPrec(num: string | number) {
         const precision = this.getProp('precision');
-        if (typeof precision === 'number') {
+        if (typeof precision === 'number' && num !== '') {
             num = Number(num).toFixed(precision);
         }
         return toString(num);

--- a/packages/semi-ui/inputNumber/_story/inputNumber.stories.js
+++ b/packages/semi-ui/inputNumber/_story/inputNumber.stories.js
@@ -63,6 +63,10 @@ export const _InputNumber = () => {
         />
         <br />
 
+        <label>小数（没有初始化值）</label>
+        <InputNumber precision={2} onChange={log} />
+        <br />
+
         <label>小数</label>
         <InputNumber defaultValue={10.08} precision={2} onChange={log} />
         <br />


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

InputNumber value be formated when precision is set and defaultvalue is empty

like this:
![image](https://user-images.githubusercontent.com/20662049/160241660-ad3d71a5-c757-44d5-a86b-d7de169038f8.png)

### Changelog
🇨🇳 Chinese
- Fix: 修复当inputnumber初始值为空时，如果设置了precision，内容会被初始化为0且进行精度格式化的问题

---

🇺🇸 English
- Fix: fix  InputNumber value be formated when precision is set and defaultvalue is empty


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
