### PR TITLE
fix: fix timePicker defaultValue and clear after select up

### DIFF
--- a/packages/semi-foundation/timePicker/foundation.ts
+++ b/packages/semi-foundation/timePicker/foundation.ts
@@ -185,7 +185,6 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
             if (this.getState('isAM')[index] !== result.isAM){
                 this.setState({ isAM } as any);
             }
-
             if (!this._isControlledComponent('value')) {
                 const invalid = this.validateDates(value);
                 this.setState({

--- a/packages/semi-foundation/timePicker/foundation.ts
+++ b/packages/semi-foundation/timePicker/foundation.ts
@@ -11,7 +11,7 @@ import {
     isTimeFormatLike
 } from './utils';
 import { split } from 'lodash';
-import { isValid, format } from 'date-fns';
+import { isValid, format, getHours } from 'date-fns';
 import { utcToZonedTime, zonedTimeToUtc } from '../utils/date-fns-extra';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
 
@@ -125,6 +125,11 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
             }
         });
 
+        const isAM = [true, false];
+        parsedValues.map((item, idx)=>{
+            isAM[idx]= getHours(item) < 12;
+        });
+
         if (parsedValues.length === value.length) {
             value = parsedValues;
         } else {
@@ -142,6 +147,7 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
         }
 
         this.setState({
+            isAM,
             value,
             inputValue,
             invalid,
@@ -175,6 +181,10 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
             value[index] = date;
             isAM[index] = panelIsAM;
             const inputValue = this.formatValue(value);
+
+            if (this.getState('isAM')[index] !== result.isAM){
+                this.setState({ isAM } as any);
+            }
 
             if (!this._isControlledComponent('value')) {
                 const invalid = this.validateDates(value);
@@ -307,7 +317,7 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
 
     validateStr(inputValue = '') {
         const dates = this.parseInput(inputValue);
-
+    
         return this.validateDates(dates);
     }
 

--- a/packages/semi-ui/scrollList/scrollItem.tsx
+++ b/packages/semi-ui/scrollList/scrollItem.tsx
@@ -329,7 +329,7 @@ export default class ScrollItem<T extends Item> extends BaseComponent<ScrollItem
         const { wrapper } = this;
         const wrapperHeight = wrapper.offsetHeight;
         const itemHeight = this.getItmHeight(node);
-        const targetTop = node.offsetTop - (wrapperHeight - itemHeight) / 2;
+        const targetTop =  (node.offsetTop || this.list.children.length * itemHeight / 2 )  - (wrapperHeight - itemHeight) / 2;
 
         this.scrollToPos(targetTop, duration);
     };

--- a/packages/semi-ui/timePicker/_story/timepicker.stories.js
+++ b/packages/semi-ui/timePicker/_story/timepicker.stories.js
@@ -1,6 +1,6 @@
 import React, { Component, useState } from 'react';
 import TimePickerPanel from '../index';
-import { TimePicker as BasicTimePicker, Button } from '../../index';
+import { TimePicker as BasicTimePicker, Button, Form } from '../../index';
 import { strings } from '@douyinfe/semi-foundation/timePicker/constants';
 import { get } from 'lodash';
 
@@ -44,6 +44,12 @@ const init = () => {
 init();
 
 export const TimePickerPanelDefault = () => {
+   const initValues = {
+    testRange: [
+      new Date("2022-04-17T15:00:00"),
+      new Date("2022-04-17T18:00:00"),
+    ],
+  };
   return (
     <div>
       <TimePicker panelHeader={'Time Select'} onChange={val => console.log(val)} />
@@ -53,6 +59,19 @@ export const TimePickerPanelDefault = () => {
         defaultOpen={true}
         scrollItemProps={{ cycled: false }}
       />
+      <TimePicker use12Hours defaultValue={"上午 10:32:33"}/>
+      <br/><br/>
+      <TimePicker type="timeRange" use12Hours format="a h:mm"  defaultValue={["下午 08:11", "上午 11:21"]} />
+      <Form initValues={initValues}>
+      <pre>{JSON.stringify(initValues)}</pre>
+      <Form.TimePicker
+        use12Hours
+        field="testRange"
+        label="Time Range"
+        type="timeRange"
+        format="a hh:mm"
+      />
+    </Form>
     </div>
   );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
[TimePicker - use12Hours 设置initValue 受控情况下无法正常设置am/pm](https://bytedance.feishu.cn/docx/doxcnnvpJPJuu6R1UNDx2VMYrqh)
[TimePicker - use12Hours传入 defaultValue无法设为下午](https://bytedance.feishu.cn/docx/doxcnrkZ1ceW2L1XVD1Ff8gTUBg)
[TimePicker - 向上滑动选择时间，清除时间，时间不会回到00:00:00，而是回到03:03:03](https://bytedance.feishu.cn/docx/doxcnPQKcahhg8lymRUFKh18EXb)


### Changelog
🇨🇳 Chinese
- Fix:   修复TimePicker组件use12Hours下，pm/am无法正确设置问题 https://github.com/DouyinFE/semi-design/issues/776 ；修复TimePicker组件向上选择选项后点击清除无法回到预期位置问题

---

🇺🇸 English
- Fix: fix the problem that pm/am could not be set correctly under the TimePicker component use12Hours https://github.com/DouyinFE/semi-design/issues/776, fix the problem that the TimePicker component could not return to the expected position after selecting the option upwards and clicking clear


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
