### PR TITLE
fix(popover): select in popover close bug #818

### DIFF
--- a/cypress/integration/popover.spec.js
+++ b/cypress/integration/popover.spec.js
@@ -91,4 +91,14 @@ describe('popover', () => {
         cy.get('[data-cy=pop-focusable-first]').type('{esc}', { force: true });
         cy.get('[data-cy=returnFocusOnClose-false]').should('not.be.focused');
     });
+
+    it('click select option in popover ', () => {
+        cy.visit('http://localhost:6006/iframe.html?id=popover--fix-nested-popover&args=&viewMode=story');
+        cy.get('[data-cy=fix-nested-popover] .semi-tag').click();
+        cy.get('[data-cy=select-in-popover] .semi-select').click();
+        cy.get('[data-cy=select-in-popover] .semi-select').click();
+        cy.get('.semi-select-option').contains('西瓜视频').click();
+        cy.get('[data-cy=select-in-popover] .semi-select').should('be.visible');
+        cy.get('.semi-select-option').contains('西瓜视频').should('be.not.exist')
+    })
 });

--- a/packages/semi-ui/popover/_story/popover.stories.js
+++ b/packages/semi-ui/popover/_story/popover.stories.js
@@ -2,13 +2,15 @@ import React, { useState } from 'react';
 
 import Popover from '../index';
 import { strings } from '@douyinfe/semi-foundation/tooltip/constants';
-import { Button, Input, Table, IconButton, Modal, Tag, Space } from '@douyinfe/semi-ui';
+import { Button, Input, Table, IconButton, Modal, Tag, Space, Select } from '@douyinfe/semi-ui';
 import SelectInPopover from './SelectInPopover';
 import BtnClose from './BtnClose';
 import PopRight from './PopRight';
 import NestedPopover from './NestedPopover';
 import ArrowPointAtCenter from './ArrowPointAtCenter';
 import { IconDelete } from '@douyinfe/semi-icons';
+
+const Option = Select.Option;
 
 export default {
   title: 'Popover',
@@ -646,3 +648,37 @@ export const A11yKeyboard = () => {
   );
 };
 A11yKeyboard.storyName = "a11y keyboard and focus";
+
+/**
+ * fix 嵌套 popover 的弹出层会导致外部 popover 关闭问题
+ * 
+ * @see https://github.com/DouyinFE/semi-design/issues/818
+ * @see https://github.com/facebook/react/issues/4335#issuecomment-421705171
+ */
+export const FixNestedPopover = () => {
+    return (
+        <div data-cy="fix-nested-popover" style={{ paddingLeft: 100 }}>
+            <Popover
+                content={(
+                    <div data-cy="select-in-popover" style={{ padding: 20 }}>
+                        <Select
+                            defaultValue="abc"
+                            style={{ width: 120 }}
+                        >
+                            <Option value="abc">抖音</Option>
+                            <Option value="hotsoon">火山</Option>
+                            <Option value="pipixia" disabled>
+                                皮皮虾
+                            </Option>
+                            <Option value="xigua">西瓜视频</Option>
+                        </Select>
+                    </div>
+                )}
+                trigger="click"
+                showArrow
+            >
+                <Tag>点击此处</Tag>
+            </Popover>
+        </div>
+    );
+}

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -343,11 +343,11 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                         cb();
                     }
                 };
-                document.addEventListener('mousedown', this.clickOutsideHandler, { capture: true });
+                window.addEventListener('mousedown', this.clickOutsideHandler);
             },
             unregisterClickOutsideHandler: () => {
                 if (this.clickOutsideHandler) {
-                    document.removeEventListener('mousedown', this.clickOutsideHandler, { capture: true });
+                    window.removeEventListener('mousedown', this.clickOutsideHandler);
                     this.clickOutsideHandler = null;
                 }
             },
@@ -528,6 +528,12 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         }
     };
 
+    handlePortalMouseDown = (e: React.MouseEvent) => {
+        if (this.props.stopPropagation) {
+            stopPropagation(e);
+        }
+    }
+
     handlePortalInnerKeyDown = (e: React.KeyboardEvent) => {
         this.foundation.handleContainerKeydown(e);
     }
@@ -595,6 +601,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                     style={portalInnerStyle}
                     ref={this.setContainerEl}
                     onClick={this.handlePortalInnerClick}
+                    onMouseDown={this.handlePortalMouseDown}
                     onKeyDown={this.handlePortalInnerKeyDown}
                 >
                     {inner}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #818

问题：

- react16 事件委托在 document，我们的 Tooltip 同时在 document 监听原生事件 mousedown 以处理 clickoutside。#818 属于嵌套弹出层场景，预期是点击内部 Select 不关闭外部 Popover。

![image](https://user-images.githubusercontent.com/26477537/167258732-f8c571d5-0d58-4321-8f4f-977d991810a4.png)

代码实现上我们想在弹出层的 react 处理函数中取消冒泡以不触发外层 document 上的处理函数。但是这依赖于 document 上监听事件的时机晚于 react 绑定事件的时机。

- react17 以后，react 事件委托在 root 节点，其实不会有这个问题~

更新：

- 这里我们为了兼容 16 将 document 监听 clickoutside 修改为 window 监听。
- 同时取消了在 capture 阶段监听。capture 阶段监听无法处理嵌套场景。


处理办法参考 react issue ： https://github.com/facebook/react/issues/4335#issuecomment-421705171

### Changelog
🇨🇳 Chinese
- Fix: 修复 Popover 中嵌套 Select，点击 Select Option 会关闭 Popover 问题 #818

---

🇺🇸 English
- Fix: Fix the nested Select in Popover, click Select Option will close the Popover problem #818


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
