### PR TITLE
Fix react18 strict mode error

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "useWorkspaces": true,
     "npmClient": "yarn",
-    "version": "2.10.1"
+    "version": "2.10.2-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "useWorkspaces": true,
     "npmClient": "yarn",
-    "version": "2.10.2-alpha.0"
+    "version": "2.10.2-alpha.1"
 }

--- a/packages/semi-animation-react/package.json
+++ b/packages/semi-animation-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@douyinfe/semi-animation-react",
-  "version": "2.10.1",
+  "version": "2.10.2-alpha.0",
   "description": "motion library for semi-ui-react",
   "keywords": [
     "motion",

--- a/packages/semi-animation-react/src/Animation.tsx
+++ b/packages/semi-animation-react/src/Animation.tsx
@@ -86,6 +86,12 @@ export default class Animation extends PureComponent<AnimationProps> {
 
         const { forwardInstance } = this.props;
 
+        if (this.animation === null) {
+            // didmount/willUnmount may be called twice when React.StrictMode is true in React 18, we need to ensure that this.animation is correct
+            this.initAnimation();
+            this.bindEvents();
+        }
+
         if (typeof forwardInstance === 'function') {
             forwardInstance(this.animation);
         }

--- a/packages/semi-ui/form/baseForm.tsx
+++ b/packages/semi-ui/form/baseForm.tsx
@@ -151,7 +151,6 @@ class Form extends BaseComponent<BaseFormProps, BaseFormState> {
 
     componentWillUnmount() {
         this.foundation.destroy();
-        this.foundation = null;
         this.formApi = null;
     }
 

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-ui",
-    "version": "2.10.2-alpha.0",
+    "version": "2.10.2-alpha.1",
     "description": "",
     "main": "lib/cjs/index.js",
     "module": "lib/es/index.js",

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-ui",
-    "version": "2.10.1",
+    "version": "2.10.2-alpha.0",
     "description": "",
     "main": "lib/cjs/index.js",
     "module": "lib/es/index.js",
@@ -15,7 +15,7 @@
     "dependencies": {
         "@babel/runtime-corejs3": "^7.15.4",
         "@douyinfe/semi-animation": "2.10.1",
-        "@douyinfe/semi-animation-react": "2.10.1",
+        "@douyinfe/semi-animation-react": "2.10.2-alpha.0",
         "@douyinfe/semi-foundation": "2.10.1",
         "@douyinfe/semi-icons": "2.10.1",
         "@douyinfe/semi-illustrations": "2.10.1",

--- a/packages/semi-ui/table/Body/BaseRow.tsx
+++ b/packages/semi-ui/table/Body/BaseRow.tsx
@@ -153,6 +153,21 @@ export default class TableRow extends BaseComponent<BaseRowProps, Record<string,
         this.foundation = new TableRowFoundation(this.adapter);
     }
 
+    componentDidMount() {
+        // fix #745
+        // didmount/willUnmount may be called twice when React.StrictMode is true in React 18, we need to ensure that this.cache.customRowProps is correct
+        const {
+            onRow,
+            index,
+            record,
+        } = this.props;
+        const customRowProps = this.adapter.getCache('customRowProps');
+        if (typeof customRowProps === 'undefined') {
+            const { className: customClassName, style: customStyle, ...rowProps } = onRow(record, index) || {};
+            this.adapter.setCache('customRowProps', { ...rowProps });
+        }
+    }
+
     shouldComponentUpdate(nextProps: BaseRowProps) {
         /**
           * Shallow comparison of incoming props to simulate PureComponent


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
#### 问题归因
由于 React 18 createRoot的严格模式下，会触发 componentDidMount、componentWillUnmount两次（详见：https://github.com/reactwg/react-18/discussions/19）
如果我们在willUnmount时执行了某些清除操作（例如将this对象上的某个键值对清空），而在 didMount中未初始化或还原（在Form、semi-animation-react中这类操作是在constructor阶段完成的），在第二次render时，就会导致读取不到对应的状态，从而触发 error

<img width="1932" alt="image" src="https://user-images.githubusercontent.com/88709023/168818557-4a2f19dc-0bdf-4b88-bd79-6b5bd84741e6.png">


#### 影响组件
- Form
- Tabs、Nav、SideSheet（用到了 @douyinfe/semi-animation-react的组件）

#### 修复思路
- semi-animation-react
   - 在didMount中进行判断，当前是否已执行过清空操作（即是否第二次触发 mounted）。如果是，则对this对象进行相应还原
- form
   - 直接去除 willUnmount 里对 foundation 的置null操作 （之前只是为了保险，这里去除理论无影响）
- Table 
   - didMount里判断如果 cacheRowProps是undefined，就执行一次onRow + 写cache的操作
  

### Changelog
🇨🇳 Chinese
- Fix: 修复 React 18 createRoot + strictMode 严格模式下，使用 Form、Tabs、Nav 、SideSheet 、Table 组件时提示 `can't get properties of undefined` 的问题 #745 #795 

---

🇺🇸 English
- Fix: Fix the problem that `can't get properties of undefined` is prompted when using Form, Tabs, and Nav components in React 18 createRoot + strictMode strict mode #745 #795 


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
