### PR TITLE
fix: wrong type of nav.item['linkOptions']

### DIFF
--- a/packages/semi-ui/navigation/Item.tsx
+++ b/packages/semi-ui/navigation/Item.tsx
@@ -29,7 +29,7 @@ export interface NavItemProps extends ItemProps, BaseProps {
     itemKey?: React.ReactText;
     level?: number;
     link?: string;
-    linkOptions?: React.HTMLAttributes<HTMLLinkElement>;
+    linkOptions?: React.AnchorHTMLAttributes<HTMLAnchorElement>;
     text?: React.ReactNode;
     tooltipHideDelay?: number;
     tooltipShowDelay?: number;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #856

### Changelog
🇨🇳 Chinese
- Fix: 修复 Nav.Item['linkOptions'] 类型不正确

---

🇺🇸 English
- Fix: fix wrongly typed Nav.Item['linkOptions']


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
