### PR TITLE
fix: (InputNumber) inputnumber will be validate when form init

### DIFF
--- a/packages/semi-foundation/inputNumber/foundation.ts
+++ b/packages/semi-foundation/inputNumber/foundation.ts
@@ -382,7 +382,7 @@ class InputNumberFoundation extends BaseFoundation<InputNumberAdapter> {
         this._adapter.setNumber(number);
         this._adapter.setValue(formattedValue);
 
-        if (isString(formattedValue) && formattedValue !== String(propsValue)) {
+        if (isString(formattedValue) && formattedValue !== String(propsValue ?? '')) {
             this.notifyChange(formattedValue, null);
         }
     }

--- a/packages/semi-ui/inputNumber/__test__/inputNumber.test.js
+++ b/packages/semi-ui/inputNumber/__test__/inputNumber.test.js
@@ -412,9 +412,8 @@ describe(`InputNumber`, () => {
             <InputNumber min={1} value={value} onChange={spyChange} />
         );
         inputNumber.setProps({ value: 0 });
-        expect(spyChange.calledTwice).toBe(true);
-        expect(spyChange.getCall(0).args[0]).toEqual('');
-        expect(spyChange.getCall(1).args[0]).toEqual(1);
+        expect(spyChange.calledOnce).toBe(true);
+        expect(spyChange.getCall(0).args[0]).toEqual(1);
     });
 
     it('fix controlled min value form field', () => {

--- a/packages/semi-ui/inputNumber/_story/inputNumber.stories.js
+++ b/packages/semi-ui/inputNumber/_story/inputNumber.stories.js
@@ -712,3 +712,32 @@ export const FixPrecision786 = () => {
   );
 }
 FixPrecision786.storyName = 'fix precision 删除后输入非法值会显示 0.00';
+
+
+ export const FixFormValidate = () => {
+  return (
+      <div data-cy="fix-precision-786">
+          <Form  >
+              <Form.InputNumber
+                  field="inputnumber"
+                  label='inputnumber' 
+                  rules={[
+                      {
+                          required: true,
+                      },
+                  ]}
+              />
+              <Form.Input
+                  field="input"
+                  label='input'
+                  rules={[
+                      {
+                          required: true,
+                      },
+                  ]}
+              />
+          </Form>
+      </div>
+  );
+}
+FixFormValidate.storyName = 'fix form validate';


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复InputNumber如果设置了必填验证在表单中初始化时会触发验证，这与其他表单不一致

---

🇺🇸 English
- Fix: fix inputnumber will be validate when form init if it required


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
