### PR TITLE
Fix tooltip flashing react18, close #715

### DIFF
--- a/packages/semi-ui/tooltip/_story/tooltip.stories.js
+++ b/packages/semi-ui/tooltip/_story/tooltip.stories.js
@@ -1012,14 +1012,16 @@ export const autoFocusContentDemo = () => {
 
 export const FlashWithReact18 = () => {
   const [visible, setV] = useState(false);
+
+  const change = () => {
+    setV(false);
+  }
+
   return (<>
-    {/* <Tooltip content='test work with react 18' position='bottom' motion={false}>
-      <Button>semi with react 18 motion=false, all normal</Button>
-    </Tooltip> */}
     <Tooltip content='test work with react 18' position='bottom' trigger='custom' visible={visible}>
       <Button style={{ marginLeft: 10 }} onClick={() => setV(true)}>show, semi with react 18 motion=true, abnormal</Button>
     </Tooltip>
-    <Button style={{ marginLeft: 10 }} onClick={() => setV(false)}>hide</Button>
+    <Button style={{ marginLeft: 10 }} onClick={() => change()}>hide</Button>
 
   </>);
 }
@@ -1029,46 +1031,59 @@ export const FlashWithReact18 = () => {
 
 export const Transition = () => {
 
-  const [transitionState, setT] = useState('enter');
+  const [transitionState, setT] = useState('');
 
-  const [insert, setI] = useState(true);
+  const [insert, setInsert] = useState(false);
 
   const handleLeave = () => {
-    setI(false);
+    console.log('set insert false')
+    setInsert(false);
   }
 
-  const transitionDOM = (
-      <TooltipTransition didLeave={() => handleLeave()}>
-            {
-                transitionState === 'enter' ?
-                    ({ animateCls, animateStyle, animateEvents }) => {
-                        return (
-                        <div
-                            className={animateCls}
-                            style={{
-                                ...animateStyle,
-                            }}
-                            {...animateEvents}
-                        >
-                            {'我是content'}
-                        </div>
-                    )
-                } :
-                    null
-            }
-      </TooltipTransition>
-  );
+  const CommonDOM = () => {
+    const enterCls = `semi-tooltip-bounceIn`;
+    const leaveCls = `semi-tooltip-zoomOut`;
+    const animateStyle = {
+      animationDirection: 'normal',
+      animationName: transitionState === 'enter' ? enterCls : leaveCls,
+      animationDuration: '1000ms',
+    }
+
+    const handleEnd = () => {
+      if (transitionState === 'enter') {
+        console.log('animation end of show');
+      } else if (transitionState === 'leave') {
+        console.log('animation end of hide');
+        handleLeave();
+      }
+    }
+     
+    return <div style={{ ...animateStyle }} onAnimationEnd={handleEnd}>test</div>
+  };
+
+  const toggleShow = (insert) => {
+    if (!transitionState) {
+      setT('enter');
+      setInsert(insert);
+    } else if (transitionState === 'enter') {
+      setT('leave');
+    } else if (transitionState === 'leave') {
+      setT('enter');
+      setInsert(insert);
+    }
+  };
 
   return (
     <>
       <div style={{ width: 200, height: 90, border: '1px solid var(--semi-color-text-1)' }}>
-      {
-        insert ? (
-          transitionDOM
-        ) : null
-      }
+        {
+          insert ? (
+            <CommonDOM></CommonDOM>
+            ): null
+        }
       </div>
-      <Button onClick={() => setT(transitionState === 'enter' ? 'leave' : 'enter')}>change</Button>
+      <Button onClick={() => toggleShow(true)}>show</Button>
+      <Button onClick={() => toggleShow(false)}>hide</Button>
     </>
   )
 }

--- a/packages/semi-ui/tooltip/_story/tooltip.stories.js
+++ b/packages/semi-ui/tooltip/_story/tooltip.stories.js
@@ -24,6 +24,7 @@ import ArrowPointAtCenter from './ArrowPointAtCenter';
 import CustomContainer from './CustomContainer';
 import ContainerPosition from './ContainerPosition';
 import { IconList, IconSidebar, IconEdit } from '@douyinfe/semi-icons';
+import TooltipTransition from '../TooltipStyledTransition';
 
 export default {
   title: 'Tooltip',
@@ -1007,3 +1008,77 @@ export const autoFocusContentDemo = () => {
     </div>
   );
 };
+
+
+export const FlashWithReact18 = () => {
+  const [visible, setV] = useState(false);
+  return (<>
+    {/* <Tooltip content='test work with react 18' position='bottom' motion={false}>
+      <Button>semi with react 18 motion=false, all normal</Button>
+    </Tooltip> */}
+    <Tooltip content='test work with react 18' position='bottom' trigger='custom' visible={visible}>
+      <Button style={{ marginLeft: 10 }} onClick={() => setV(true)}>show, semi with react 18 motion=true, abnormal</Button>
+    </Tooltip>
+    <Button style={{ marginLeft: 10 }} onClick={() => setV(false)}>hide</Button>
+
+  </>);
+}
+
+
+
+
+export const Transition = () => {
+
+  const [transitionState, setT] = useState('enter');
+
+  const [insert, setI] = useState(true);
+
+  const handleLeave = () => {
+    setI(false);
+  }
+
+  const transitionDOM = (
+      <TooltipTransition didLeave={() => handleLeave()}>
+            {
+                transitionState === 'enter' ?
+                    ({ animateCls, animateStyle, animateEvents }) => {
+                        return (
+                        <div
+                            className={animateCls}
+                            style={{
+                                ...animateStyle,
+                            }}
+                            {...animateEvents}
+                        >
+                            {'我是content'}
+                        </div>
+                    )
+                } :
+                    null
+            }
+      </TooltipTransition>
+  );
+
+  return (
+    <>
+      <div style={{ width: 200, height: 90, border: '1px solid var(--semi-color-text-1)' }}>
+      {
+        insert ? (
+          transitionDOM
+        ) : null
+      }
+      </div>
+      <Button onClick={() => setT(transitionState === 'enter' ? 'leave' : 'enter')}>change</Button>
+    </>
+  )
+}
+
+export const TransitionDemo = () => {
+  const [key, setKey] = useState(1);
+  return (
+    <>
+    <Transition key={key} />
+    <Button onClick={() => setKey(Math.random())}>reset Demo</Button>
+  </>
+  )
+}

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -234,7 +234,10 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                 );
             },
             removePortal: () => {
-                this.setState({ isInsert: false, isPositionUpdated: false });
+                // fix issue 715, avoid flashing under react 18
+                ReactDOM.flushSync(() => {
+                    this.setState({ isInsert: false, isPositionUpdated: false });
+                });
             },
             getEventName: () => ({
                 mouseEnter: 'onMouseEnter',


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
All discussion detail refer to https://github.com/DouyinFE/semi-design/issues/715

### Changelog
🇨🇳 Chinese
- Fix: 修复Tooltip、Popover、Select等带浮层组件，在 React 18 下使用，关闭时会闪烁的问题 #715

---

🇺🇸 English
- Fix: Fix the problem that Tooltip, Popover, Select and other components with floating layers will flicker when they are used under React 18 #715


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
