### PR TITLE
fix: [Cascader] fix typeError when value is undefined while onChangeWithObject and mutiple #905

### DIFF
--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -412,13 +412,15 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                             realValue as SimpleValueType[][] :
                             [realValue] as SimpleValueType[][];
                     } else {
-                        normallizedValue = [[realValue]];
+                        if (realValue !==  undefined) {
+                            normallizedValue = [[realValue]];
+                        }
                     }
                     // formatValuePath is used to save value of valuePath
                     const formatValuePath: (string | number)[][] = [];
                     normallizedValue.forEach((valueItem: SimpleValueType[]) => {
                         const formatItem: (string | number)[] = onChangeWithObject ?
-                            (valueItem as CascaderData[]).map(i => i.value) :
+                            (valueItem as CascaderData[]).map(i => i?.value) :
                             valueItem as (string | number)[];
                         formatValuePath.push(formatItem);
                     });


### PR DESCRIPTION
…WithObject and multiple

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #905

### Changelog
🇨🇳 Chinese
- Fix: 修复当设置onChangeWithObject，mutiple后，value传入的值为undefined时时，Cascader 崩溃的问题。（影响范围 v2.0.4 - v 2.12.0） #905
---

🇺🇸 English
- Fix:  Fixed the problem that Cascader crashes when the value passed in is undefined after setting onChange WithObject, multiple, #905

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
