### PR TITLE
style: update --semi-color-secondary global style, Button,Badge,Dropd…

### DIFF
--- a/packages/semi-theme-default/scss/global.scss
+++ b/packages/semi-theme-default/scss/global.scss
@@ -14,13 +14,13 @@ body, body[theme-mode="dark"] .semi-always-light {
     --semi-color-primary-light-hover: rgba(var(--semi-blue-1), 1); // 浅版主要颜色悬浮态
     --semi-color-primary-light-active: rgba(var(--semi-blue-2), 1); // 浅版主要颜色激活态
 
-    --semi-color-secondary: rgba(var(--semi-blue-5), 1); // 次要颜色。强调作用次于主要颜色，但仍然具有强调作用。
-    --semi-color-secondary-hover: rgba(var(--semi-blue-6), 1); // 次要颜色悬浮态
-    --semi-color-secondary-active: rgba(var(--semi-blue-7), 1); // 次要颜色激活态
-    --semi-color-secondary-disabled: rgba(var(--semi-blue-2), 1); // 次要颜色禁用态
-    --semi-color-secondary-light-default: rgba(var(--semi-blue-0), 1); // 浅版次要颜色（多用于背景）。强调作用次于主要颜色，但仍然具有强调作用。
-    --semi-color-secondary-light-hover: rgba(var(--semi-blue-1), 1); // 浅版次要颜色悬浮态
-    --semi-color-secondary-light-active: rgba(var(--semi-blue-2), 1); // 浅版次要颜色激活态
+    --semi-color-secondary: rgba(var(--semi-light-blue-5), 1); // 次要颜色。强调作用次于主要颜色，但仍然具有强调作用。
+    --semi-color-secondary-hover: rgba(var(--semi-light-blue-6), 1); // 次要颜色悬浮态
+    --semi-color-secondary-active: rgba(var(--semi-light-blue-7), 1); // 次要颜色激活态
+    --semi-color-secondary-disabled: rgba(var(--semi-light-blue-2), 1); // 次要颜色禁用态
+    --semi-color-secondary-light-default: rgba(var(--semi-light-blue-0), 1); // 浅版次要颜色（多用于背景）。强调作用次于主要颜色，但仍然具有强调作用。
+    --semi-color-secondary-light-hover: rgba(var(--semi-light-blue-1), 1); // 浅版次要颜色悬浮态
+    --semi-color-secondary-light-active: rgba(var(--semi-light-blue-2), 1); // 浅版次要颜色激活态
 
     --semi-color-tertiary: rgba(var(--semi-grey-5), 1); // 第三颜色，可以在页面上多次使用
     --semi-color-tertiary-hover: rgba(var(--semi-grey-6), 1); // 第三颜色悬浮态
@@ -115,13 +115,13 @@ body[theme-mode="dark"], body .semi-always-dark {
     --semi-color-primary-light-default: rgba(var(--semi-blue-5), .2);
     --semi-color-primary-light-hover: rgba(var(--semi-blue-5), .3);
     --semi-color-primary-light-active: rgba(var(--semi-blue-5), .4);
-    --semi-color-secondary: rgba(var(--semi-blue-5), 1);
-    --semi-color-secondary-hover: rgba(var(--semi-blue-6), 1);
-    --semi-color-secondary-active: rgba(var(--semi-blue-7), 1);
-    --semi-color-secondary-disabled: rgba(var(--semi-blue-2), 1);
-    --semi-color-secondary-light-default: rgba(var(--semi-blue-5), .2);
-    --semi-color-secondary-light-hover: rgba(var(--semi-blue-5), .3);
-    --semi-color-secondary-light-active: rgba(var(--semi-blue-5), .4);
+    --semi-color-secondary: rgba(var(--semi-light-blue-5), 1);
+    --semi-color-secondary-hover: rgba(var(--semi-light-blue-6), 1);
+    --semi-color-secondary-active: rgba(var(--semi-light-blue-7), 1);
+    --semi-color-secondary-disabled: rgba(var(--semi-light-blue-2), 1);
+    --semi-color-secondary-light-default: rgba(var(--semi-light-blue-5), .2);
+    --semi-color-secondary-light-hover: rgba(var(--semi-light-blue-5), .3);
+    --semi-color-secondary-light-active: rgba(var(--semi-light-blue-5), .4);
     --semi-color-tertiary: rgba(var(--semi-grey-5), 1);
     --semi-color-tertiary-hover: rgba(var(--semi-grey-6), 1);
     --semi-color-tertiary-active: rgba(var(--semi-grey-7), 1);


### PR DESCRIPTION
…own,Steps used it

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Other, please describe: 样式变更


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

更新了 --semi-color-seconary 的色阶，之前引用的是 blue-xxx，修改后为 light-blue-xxx


![VIDdw391iI](https://user-images.githubusercontent.com/26477537/175510685-0b038703-afae-4222-84a2-8fab42803393.jpg)



### Changelog
🇨🇳 Chinese
- Style: 更新了 secondary 全局颜色变量，将引用的色阶由 blue 改为 light-blue，修改前 secondary 颜色变量与 primary 相同，修改后视觉上对比度弱于 primary。Button、Badge、Steps、Dropdown 组件受影响。

---

🇺🇸 English
- Style: Updated the secondary global color variable, and changed the referenced color scale from blue to light-blue. Before the modification, the secondary color variable was the same as the primary. After the modification, the visual contrast was weaker than the primary. Button, Badge, Steps, Dropdown components are affected.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
