### PR TITLE
style: fix TagInput suffix color

### DIFF
--- a/packages/semi-foundation/tagInput/variables.scss
+++ b/packages/semi-foundation/tagInput/variables.scss
@@ -8,7 +8,7 @@ $color-tagInput-border-default: transparent; // 标签输入框描边颜色 - �
 $color-tagInput-border-hover: transparent ; // 标签输入框描边颜色 - 悬浮
 $color-tagInput-border-focus: var(--semi-color-focus-border); // 标签输入框描边颜色 - 选中态
 $color-tagInput_prefix-default: var(--semi-color-text-2); // 标签输入框 prefix 颜色
-$color-tagInput_suffix-default: var(--semi-color-text-1); // 标签输入框 suffix 颜色
+$color-tagInput_suffix-default: var(--semi-color-text-2); // 标签输入框 suffix 颜色
 
 $color-tagInput_default-bg-default: var(--semi-color-fill-0); // 标签输入框背景颜色 - 默认
 $color-tagInput_default-bg-hover: var(--semi-color-fill-1); // 标签输入框背景颜色 - 悬浮


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

TagInput 与 Input 等其他输入类组件对齐，保持 suffix 与 prefix 相同颜色，都是 --semi-color-text-2

- 修改前

![image](https://user-images.githubusercontent.com/26477537/175922266-8b69d157-cc82-49b2-9322-8b2c857e058f.png)

- 修改后

![image](https://user-images.githubusercontent.com/26477537/175922213-db572884-f275-4c83-9395-2ea51d470a03.png)


### Changelog
🇨🇳 Chinese
- Style: 修复 TagInput suffix 文本颜色，从 --semi-color-text-1 修改为 --semi-color-text-2

---

🇺🇸 English
- Style: Fix TagInput suffix text color, changed from --semi-color-text-1 to --semi-color-text-2


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
