### PR TITLE
fix: spin darkmode rect

### DIFF
--- a/packages/semi-ui/spin/icon.tsx
+++ b/packages/semi-ui/spin/icon.tsx
@@ -40,7 +40,7 @@ function Icon(props: IconProps = {}) {
                 </linearGradient>
             </defs>
             <g stroke="none" strokeWidth="1" fill="none" fillRule="evenodd">
-                <rect fillOpacity="0.01" fill="#FFFFFF" x="0" y="0" width="36" height="36" />
+                <rect fillOpacity="0.01" fill="none" x="0" y="0" width="36" height="36" />
                 <path
                     d="M34,18 C34,9.163444 26.836556,2 18,2 C11.6597233,2 6.18078805,5.68784135 3.59122325,11.0354951"
                     stroke={`url(#${id})`}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Spin 组件在暗色模式下个别场景内容物有黑色矩形的问题

---

🇺🇸 English
- Fix: Fix the issue that the Spin component has black rectangles in some scene contents in dark mode


### Checklist
- [X] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
