### PR TITLE
fix: fix the problem that it does not take effect when the noHorizont…

### DIFF
--- a/packages/semi-ui/iconButton/index.tsx
+++ b/packages/semi-ui/iconButton/index.tsx
@@ -80,6 +80,9 @@ class IconButton extends PureComponent<IconButtonProps> {
         } else if (noHorizontalPadding === true) {
             style.paddingLeft = 0;
             style.paddingRight = 0;
+        } else if (typeof noHorizontalPadding === 'string') {
+            noHorizontalPadding === 'left' && (style.paddingLeft = 0);
+            noHorizontalPadding === 'right' && (style.paddingRight = 0);
         }
 
         let finalChildren = null;


### PR DESCRIPTION
…alPadding parameter type of Button is string

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复当Button的noHorizontalPadding参数类型为string时不生效问题

---

🇺🇸 English
- Fix: fix the problem that it does not take effect when the noHorizontalPadding parameter type of Button is string


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
