### PR TITLE
fix(switch): 解决点击 switch 边缘无法触发 change 的问题, resolve #992

### DIFF
--- a/packages/semi-foundation/switch/switch.scss
+++ b/packages/semi-foundation/switch/switch.scss
@@ -103,8 +103,8 @@ $module: #{$prefix}-switch;
     &-native-control {
 
         &[type="checkbox"] {
-            width: 100%;
-            height: 100%;
+            width: inherit;
+            height: inherit;
         }
         width: 100%;
         height: 100%;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #992 

### Changelog
🇨🇳 Chinese
- Fix: 修复点击 switch 边缘无法触发 change 的问题

---

🇺🇸 English
- Fix: fix click on the edge of the switch can not trigger the change problem


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
造成这个问题的原因是因为，用来触发 change 事件的 input 的高度采用的 height 100%，而父元素有设置 1px 的 border，导致用户了 input 的高度会比 父元素少 2px，用户点击到时边缘时，会点击到父元素因此会有动画，但是并没有点击到 input，所以没有触发 change 事件，采用 inherit 就可以避免这个 border 造成的高度问题，可以看下面的前后高度对比
<!-- You can provide screenshot/video or some additional information -->
<img width="935" alt="image" src="https://user-images.githubusercontent.com/78683712/182011754-8da1ec71-deb4-4c6e-aeeb-d6b2683c3037.png">
