### PR TITLE
fix: No 'default' in AvatarGroupSize TS value

### DIFF
--- a/packages/semi-ui/avatar/interface.ts
+++ b/packages/semi-ui/avatar/interface.ts
@@ -38,7 +38,7 @@ export interface AvatarProps extends BaseProps {
 }
 
 export type AvatarGroupShape = 'circle' | 'square';
-export type AvatarGroupSize = 'extra-extra-small' | 'extra-small' | 'small' | 'medium' | 'large' | 'extra-large';
+export type AvatarGroupSize = 'extra-extra-small' | 'extra-small' | 'small' | 'default' | 'medium' | 'large' | 'extra-large';
 export type AvatarGroupOverlapFrom = 'start' | 'end';
 
 export interface AvatarGroupProps {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes no 'default' in AvatarGroupSize TS value

### Changelog
🇨🇳 Chinese
- Fix: 修复 `AvatarGroup` 组件中 `size` 属性在 TS 定义中没有值 `default` 

---

🇺🇸 English
- Fix: fix `AvatarGroup` component `size` attribute has no `default` in TS define


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
