### PR TITLE
fix(input): 修复 windows edge 浏览器 password input 默认 icon 的问题

### DIFF
--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -445,6 +445,11 @@ $module: #{$prefix}-input;
     background-color: transparent;
     box-sizing: border-box;
 
+    &[type="password"]::-ms-reveal, 
+    &[type="password"]::-ms-clear {
+        display: none;
+    }
+
     &::placeholder {
         color: $color-input_placeholder-text-default;
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1004 

### Changelog
🇨🇳 Chinese
- Fix: 修复 windows edge 浏览器 password input 默认 icon 的问题

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
按照 issue 的解法实现，已经验证了 windows edge 浏览器可修复
![image](https://user-images.githubusercontent.com/78683712/182430766-c1b58742-ff4d-49e5-9160-1cf68e7fc750.png)

<!-- You can provide screenshot/video or some additional information -->
