### PR TITLE
feat: [TagInput] Support drag and drop sorting

### DIFF
--- a/content/input/form/index-en-US.md
+++ b/content/input/form/index-en-US.md
@@ -348,7 +348,7 @@ class BasicDemoWithInit extends React.Component {
                         <TagInput 
                             field="product"
                             label='Product（TagInput）'
-                            defaultValue={['abc','hotsoon']}
+                            initValue={['abc','hotsoon']}
                             style={style}
                         />
                     </Col>

--- a/content/input/form/index.md
+++ b/content/input/form/index.md
@@ -358,7 +358,7 @@ class BasicDemoWithInit extends React.Component {
                             <TagInput 
                                 field="product"
                                 label='产品（TagInput）'
-                                defaultValue={['abc','ulikeCam']}
+                                initValue={['abc','ulikeCam']}
                                 placeholder='请输入产品'
                                 style={style}
                             />

--- a/content/input/taginput/index-en-US.md
+++ b/content/input/taginput/index-en-US.md
@@ -214,7 +214,7 @@ import { TagInput } from '@douyinfe/semi-ui';
         <TagInput 
             maxLength={5} 
             placeholder='maxLength = 5'  
-            style={{marginTop:12}}
+            style={{ marginTop: 12 }}
             onChange={v => console.log(v)}
             onInputExceed={v => {
                 Toast.warning('Exceeds maxLength');
@@ -344,7 +344,7 @@ class TagInputDemo extends React.Component {
         return (
             <>
                 <TagInput defaultValue={['Semi','Hotsoon']} ref={this.ref} />
-                <Button style={{marginTop:10}} onClick={this.handleTagInputFocus}>
+                <Button style={{ marginTop: 10 }} onClick={this.handleTagInputFocus}>
                     focus
                 </Button>
             </>
@@ -368,10 +368,10 @@ class CustomRender extends React.Component {
             value : ['xiakeman']
         };
         this.list = [
-            { "name": "xiakeman", "avatar":  "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/dy.png"},
-            { "name": "shenyue",  "avatar":  "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg"},
-            { "name": "quchenyi", "avatar":  "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg"},
-            { "name": "wenjiamao", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/7abf810ff060ac3387bd027ead92c4e0.jpg"},
+            { "name": "xiakeman", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/avatarDemo.jpeg" },
+            { "name": "shenyue", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bf8647bffab13c38772c9ff94bf91a9d.jpg" },
+            { "name": "quchenyi", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/dbf7351bb779433d17c4f50478cf42f7.jpg" },
+            { "name": "wenjiamao", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/7abf810ff060ac3387bd027ead92c4e0.jpg" },
         ];
         this.mapList = new Map(this.list.map( item => [item.name,item]));
     }
@@ -381,7 +381,7 @@ class CustomRender extends React.Component {
         return (
             <div 
                 key={index} 
-                style={{display: 'flex', alignItems: 'center', fontSize: 14, marginRight: 10}}
+                style={{ display: 'flex', alignItems: 'center', fontSize: 14, marginRight: 10 }}
             >
                 <Avatar 
                     alt='avatar'
@@ -400,7 +400,7 @@ class CustomRender extends React.Component {
         return (
             <TagInput 
                 value={value} 
-                onChange={value=>this.setState({value})}
+                onChange={value=>this.setState({ value })}
                 renderTagItem={(value,index)=>this.renderTagItem(value,index)}
             />
         );
@@ -408,6 +408,27 @@ class CustomRender extends React.Component {
 }
 ``` 
 
+### Drag to sort
+
+Set `draggable` to true to enable drag and drop sorting. Supported since v2.17.0. Adding the same Tag is not allowed under drag and drop sorting, 
+so you need to set `allowDuplicates` to false. After the drag and drop function is enabled, clicking any area in TagInput except the 
+clear icon of Tag and the clear icon of clear all Tags will make the Tag in TagInput draggable. Click anywhere outside the TagInput, 
+and the Tag in the TagInput will be restored to not be draggable.
+
+```jsx live=true
+import React from 'react';
+import { TagInput } from '@douyinfe/semi-ui';
+
+() => (
+    <TagInput
+        draggable
+        allowDuplicates={false}
+        defaultValue={['Semi','Hotsoon','Pipixia']}
+        placeholder='please enter...'
+        onChange={v => console.log(v)}
+    />
+);
+```
 
 ## API Reference
 
@@ -437,14 +458,16 @@ class CustomRender extends React.Component {
 |suffix        |Suffix                                            |ReactNode                                                        |-         |1.19.0|
 |validateStatus|Validate status for styling only, one of  `default`、`warning`、`error`|string                                       |`default` |1.19.0|
 |value         |Controlled tag value                              |string[] \| undefined                                                         | -        |1.19.0|
+|draggable     |Set whether to drag and drop                      |boolean                         |false      |2.17.0| 
+|expandRestTagsOnClick| Without dragging，whether to expand redundant tags after TagInput is clicked     |boolean                          |true       |2.17.0| 
 |onAdd         |Callback invoked when tags are added             |(addedValue: string[]) => void                                   | -        |1.19.0|
-|onBlur        |Callback invoked when input loses focus          |(e:React.MouseEvent<HTMLInputElement\>) => void                  | -        |1.19.0|
+|onBlur        |Callback invoked when input loses focus          |(e:React.MouseEvent) => void                  | -        |1.19.0|
 |onChange      |Callback invoked when tags changes               |(value:string[]) => void                                         | -        |1.19.0|
 |onExceed      |Callback invoked when max is exceeded    |(value:string[]) => void                                         | -        |1.19.0|
-|onFocus       |Callback invoked when input gets focus           |(e:React.MouseEvent<HTMLInputElement\>) => void                  | -        |1.19.0|
-|onInputChange |Callback invoked when input changes              |(value:string,e: React.KeyboardEvent<HTMLInputElement\>) => void)| -        |1.19.0|
+|onFocus       |Callback invoked when input gets focus           |(e:React.MouseEvent) => void                  | -        |1.19.0|
+|onInputChange |Callback invoked when input changes              |(value:string,e: React.KeyboardEvent) => void)| -        |1.19.0|
 |onInputExceed |Callback invoked when maxLength is exceeded      |(value:string) => void                                           | -        |1.19.0|
-|onKeyDown    |Callback invoked when keydown                     |(e: React.KeyboardEvent<HTMLInputElement\>) => void          | -        |2.1.0|
+|onKeyDown    |Callback invoked when keydown                     |(e: React.KeyboardEvent) => void          | -        |2.1.0|
 |onRemove      |Callback invoked when tags are removed           |(removedValue: string, idx: number) => void                                 | -        |1.19.0|
 
 ## Methods

--- a/content/input/taginput/index-en-US.md
+++ b/content/input/taginput/index-en-US.md
@@ -411,9 +411,8 @@ class CustomRender extends React.Component {
 ### Drag to sort
 
 Set `draggable` to true to enable drag and drop sorting. Supported since v2.17.0. Adding the same Tag is not allowed under drag and drop sorting, 
-so you need to set `allowDuplicates` to false. After the drag and drop function is enabled, clicking any area in TagInput except the 
-clear icon of Tag and the clear icon of clear all Tags will make the Tag in TagInput draggable. Click anywhere outside the TagInput, 
-and the Tag in the TagInput will be restored to not be draggable.
+so you need to set `allowDuplicates` to false. After the drag function is enabled, click TagInput, and the Tag can be dragged. Click anywhere 
+outside the TagInput, the Tag cannot be dragged.
 
 ```jsx live=true
 import React from 'react';

--- a/content/input/taginput/index.md
+++ b/content/input/taginput/index.md
@@ -411,8 +411,7 @@ class CustomRender extends React.Component {
 ### 拖拽排序
 
 将 `draggable`设为 true，开启拖拽排序功能。v2.17.0 后支持。拖拽排序下不允许添加相同 Tag， 因此需要将 `allowDuplicates` 设置为 false。
-拖拽功能开启后，点击 TagInput 中除 Tag 的清除 icon， 清除所有 Tag 的清除 icon 外的任一区域将使 TagInput 中的 Tag 变成能够拖拽的 Tag 。
-点击 TagInput 外任意区域，TagInput 中的 Tag 将恢复不可拖拽的状态。
+拖拽功能开启后，点击 TagInput，Tag 可拖拽。点击 TagInput 外任意区域，Tag 不可拖拽。
 
 ```jsx live=true
 import React from 'react';
@@ -422,7 +421,7 @@ import { TagInput } from '@douyinfe/semi-ui';
     <TagInput
         draggable
         allowDuplicates={false}
-        defaultValue={['抖音','火山','西瓜视频']}
+        defaultValue={['抖音', '火山', '西瓜视频']}
         placeholder='请输入...'
         onChange={v => console.log(v)}
     />

--- a/content/input/taginput/index.md
+++ b/content/input/taginput/index.md
@@ -211,7 +211,7 @@ import { TagInput } from '@douyinfe/semi-ui';
         <TagInput 
             maxLength={5} 
             placeholder='单个标签长度不超过5...'  
-            style={{marginTop:12}}
+            style={{ marginTop: 12 }}
             onChange={v => console.log(v)}
             onInputExceed={v => {
                 Toast.warning('超过 maxLength');
@@ -344,7 +344,7 @@ class TagInputDemo extends React.Component {
         return (
             <>
                 <TagInput defaultValue={['抖音','火山']} ref={this.ref} />
-                <Button style={{marginTop:10}} onClick={this.handleTagInputFocus}>
+                <Button style={{ marginTop:10 }} onClick={this.handleTagInputFocus}>
                     点击按钮聚焦
                 </Button>
             </>
@@ -368,10 +368,10 @@ class CustomRender extends React.Component {
             value : ['夏可漫']
         };
         this.list = [
-            { "name": "夏可漫", "avatar":  "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/dy.png"},
-            { "name": "申悦",  "avatar":  "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg"},
-            { "name": "曲晨一", "avatar":  "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg"},
-            { "name": "文嘉茂", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/7abf810ff060ac3387bd027ead92c4e0.jpg"},
+            { "name": "夏可漫", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/avatarDemo.jpeg" },
+            { "name": "申悦", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bf8647bffab13c38772c9ff94bf91a9d.jpg" },
+            { "name": "曲晨一", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/dbf7351bb779433d17c4f50478cf42f7.jpg" },
+            { "name": "文嘉茂", "avatar":  "https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/7abf810ff060ac3387bd027ead92c4e0.jpg" },
         ];
         this.mapList = new Map(this.list.map( item => [item.name,item]));
     }
@@ -381,7 +381,7 @@ class CustomRender extends React.Component {
         return (
             <div 
                 key={index} 
-                style={{display: 'flex', alignItems: 'center', fontSize: 14, marginRight: 10}}
+                style={{ display: 'flex', alignItems: 'center', fontSize: 14, marginRight: 10 }}
             >
                 <Avatar 
                     alt='avatar'
@@ -400,13 +400,34 @@ class CustomRender extends React.Component {
         return (
             <TagInput 
                 value={value} 
-                onChange={value=>this.setState({value})}
-                renderTagItem={(value,index)=>this.renderTagItem(value,index)}
+                onChange={value => this.setState({ value })}
+                renderTagItem={(value,index) => this.renderTagItem(value,index)}
             />
         );
     }
 }
 ``` 
+
+### 拖拽排序
+
+将 `draggable`设为 true，开启拖拽排序功能。v2.17.0 后支持。拖拽排序下不允许添加相同 Tag， 因此需要将 `allowDuplicates` 设置为 false。
+拖拽功能开启后，点击 TagInput 中除 Tag 的清除 icon， 清除所有 Tag 的清除 icon 外的任一区域将使 TagInput 中的 Tag 变成能够拖拽的 Tag 。
+点击 TagInput 外任意区域，TagInput 中的 Tag 将恢复不可拖拽的状态。
+
+```jsx live=true
+import React from 'react';
+import { TagInput } from '@douyinfe/semi-ui';
+
+() => (
+    <TagInput
+        draggable
+        allowDuplicates={false}
+        defaultValue={['抖音','火山','西瓜视频']}
+        placeholder='请输入...'
+        onChange={v => console.log(v)}
+    />
+);
+```
 
 
 ## API 参考
@@ -437,15 +458,18 @@ class CustomRender extends React.Component {
 |suffix       |后缀标签                                           |ReactNode                      |-         |1.19.0|
 |validateStatus|设置校验状态样式,可选: `default`、`warning`、`error` |string                          |`default` |1.19.0|
 |value        |当前标签，配合 onChange 实现受控                     |string[] \| undefined                       | -        |1.19.0|
+|draggable    |设置是否可拖拽                                      |boolean                         |false      |2.17.0| 
+|expandRestTagsOnClick| 在不可拖拽的情况下，在 TagInput 被点击后是否展开多余的 Tag        |boolean                          |true       |2.17.0| 
 |onAdd        |添加标签时的回调                                     |(addedValue: string[]) => void     | -        |1.19.0|
-|onBlur       |输入框失去焦点时的回调           |(e:React.MouseEvent<HTMLInputElement\>) => void                 | -        |1.19.0|
+|onBlur       |输入框失去焦点时的回调           |(e:React.MouseEvent) => void                 | -        |1.19.0|
 |onChange     |标签变化时的回调                                     |(value:string[]) => void | -        |1.19.0|
 |onExceed     |超过 max 时的回调                           |(value:string[]) => void        | -        |1.19.0|
-|onFocus      |输入框获取焦点时的回调                                |(e:React.MouseEvent<HTMLInputElement\>) => void               | -        |1.19.0|
-|onInputChange|输入框内容变化时的回调                                |(value:string,e: React.KeyboardEvent<HTMLInputElement\>) => void)  | -        |1.19.0|
+|onFocus      |输入框获取焦点时的回调                                |(e:React.MouseEvent) => void               | -        |1.19.0|
+|onInputChange|输入框内容变化时的回调                                |(value:string,e: React.KeyboardEvent) => void)  | -        |1.19.0|
 |onInputExceed|超过 maxLength 时的回调                             |(value:string) => void          | -        |1.19.0|
-|onKeyDown    |keydown 回调                             |(e: React.KeyboardEvent<HTMLInputElement\>) => void          | -        |2.1.0|
+|onKeyDown    |keydown 回调                             |(e: React.KeyboardEvent) => void          | -        |2.1.0|
 |onRemove     |移除标签时的回调                                     |(removedValue: string, idx: number) => void     | -        |1.19.0|
+
 ## 方法
 
 |名称    |描述   |版本     |

--- a/packages/semi-foundation/tagInput/tagInput.scss
+++ b/packages/semi-foundation/tagInput/tagInput.scss
@@ -11,6 +11,19 @@ $module: #{$prefix}-tagInput;
     width: 100%;
     box-sizing: border-box;
     
+    &-drag {
+
+        &-item {
+            display: flex;
+            align-items: center;
+        }
+
+        &-handler {
+            margin-right: $spacing-tagInput_drag_handler-marginRight;
+            cursor: move;
+        }
+    }
+
     &-hover {
         background-color: $color-tagInput_default-bg-hover;
         border: $width-tagInput-border-hover $color-tagInput-border-hover solid;
@@ -103,6 +116,10 @@ $module: #{$prefix}-tagInput;
                     margin-top: $spacing-tagInput_large-Y;
                     margin-bottom: $spacing-tagInput_large-Y;
                 }
+            }
+            
+            &-icon {
+                padding-left: $spacing-tagInput_tag_icon_paddingLeft;
             }
         }
 

--- a/packages/semi-foundation/tagInput/variables.scss
+++ b/packages/semi-foundation/tagInput/variables.scss
@@ -32,6 +32,8 @@ $spacing-tagInput_small-Y: 1px; // 小尺寸标签输入框标签顶部外边距
 $spacing-tagInput_default-Y: $spacing-super-tight; // 默认尺寸标签输入框标签顶部外边距
 $spacing-tagInput_large-Y: 3px; // 大尺寸标签输入框标签顶部外边距
 $spacing-tagInput_wrapper_n_paddingX: $spacing-tight; //标签输入框标签容器水平内边距
+$spacing-tagInput_drag_handler-marginRight: 4px; // 拖拽handler icon的右外边距 
+$spacing-tagInput_tag_icon_paddingLeft: 4px; // tag中有handler icon时tag的左内边距
 
 $height-tagInput-large: $height-control-large; // 大尺寸标签输入框高度
 $height-tagInput-default: $height-control-default; // 默认尺寸标签输入框高度

--- a/packages/semi-foundation/transfer/foundation.ts
+++ b/packages/semi-foundation/transfer/foundation.ts
@@ -3,6 +3,7 @@ import BaseFoundation, { DefaultAdapter } from '../base/foundation';
 import { BasicValue as BasicTreeValue } from '../tree/foundation';
 import { strings } from './constants';
 import { _generateGroupedData, _generateTreeData } from './transferUtils';
+import arrayMove from '../utils/arrayMove';
 
 export interface BasicDataItem {
     [x: string]: any;
@@ -217,7 +218,7 @@ export default class TransferFoundation<P = Record<string, any>, S = Record<stri
         const { oldIndex, newIndex } = callbackProps;
         const selectedItems = this._adapter.getSelected();
         let selectedArr = [...selectedItems.values()];
-        selectedArr = this._arrayMove(selectedArr, oldIndex, newIndex);
+        selectedArr = arrayMove(selectedArr, oldIndex, newIndex);
         let newSelectedItems = new Map();
         selectedArr.forEach(option => {
             newSelectedItems = newSelectedItems.set(option.key, option);
@@ -226,9 +227,4 @@ export default class TransferFoundation<P = Record<string, any>, S = Record<stri
         this._notifyChange(newSelectedItems);
     }
 
-    _arrayMove(array: Array<BasicDataItem>, from: number, to: number) {
-        const newArray = array.slice();
-        newArray.splice(to < 0 ? newArray.length + to : to, 0, newArray.splice(from, 1)[0]);
-        return newArray;
-    }
 }

--- a/packages/semi-foundation/utils/arrayMove.ts
+++ b/packages/semi-foundation/utils/arrayMove.ts
@@ -1,0 +1,5 @@
+export default function arrayMove(array: Array<any>, from: number, to: number) {
+    const newArray = array.slice();
+    newArray.splice(to < 0 ? newArray.length + to : to, 0, newArray.splice(from, 1)[0]);
+    return newArray;
+}

--- a/packages/semi-ui/tagInput/_story/tagInput.stories.js
+++ b/packages/semi-ui/tagInput/_story/tagInput.stories.js
@@ -78,6 +78,24 @@ ShowClear.story = {
   name: 'showClear',
 };
 
+export const Draggable = () => (
+  <>
+    <TagInput draggable defaultValue={['抖音', '火山', '西瓜视频', 'AI Lab', '花亦山', '水之月','轻颜','醒图']} showClear style={style} />
+    <br />
+    <TagInput 
+      draggable
+      defaultValue={['抖音', '火山', '西瓜视频', 'AI Lab', '花亦山', '水之月','轻颜','醒图']} 
+      maxTagCount={5} 
+      showClear 
+      style={style} 
+    />
+  </>
+);
+
+Draggable.story = {
+  name: 'draggable',
+};
+
 export const MaxExceed = () => (
   <>
     <TagInput

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'lodash';
 import { cssClasses, strings } from '@douyinfe/semi-foundation/tagInput/constants';
 import '@douyinfe/semi-foundation/tagInput/tagInput.scss';
-import TagInputFoundation, { TagInputAdapter } from '@douyinfe/semi-foundation/tagInput/foundation';
+import TagInputFoundation, { TagInputAdapter, OnSortEndProps } from '@douyinfe/semi-foundation/tagInput/foundation';
 import { ArrayElement } from '../_base/base';
 import { isSemiIcon } from '../_utils';
 import BaseComponent from '../_base/baseComponent';
@@ -19,11 +19,26 @@ import Tag from '../tag';
 import Input from '../input';
 import Popover, { PopoverProps } from '../popover';
 import Paragraph from '../typography/paragraph';
-import { IconClear } from '@douyinfe/semi-icons';
+import { IconClear, IconHandle } from '@douyinfe/semi-icons';
+import { SortableContainer, SortableElement, SortableHandle } from 'react-sortable-hoc';
 
 export type Size = ArrayElement<typeof strings.SIZE_SET>;
 export type RestTagsPopoverProps = PopoverProps;
 type ValidateStatus = "default" | "error" | "warning";
+
+const SortableItem = SortableElement(props => props.item);
+
+const SortableList = SortableContainer(
+    ({ items }) => {
+        return (
+            <div style={{ display: 'flex', flexFlow: 'row wrap', }}>
+                {items.map((item, index) => (
+                    // @ts-ignore skip SortableItem type check
+                    <SortableItem key={item.key} index={index} item={item.item}></SortableItem>
+                ))}
+            </div>
+        );
+    });
 
 export interface TagInputProps {
     className?: string;
@@ -38,6 +53,8 @@ export interface TagInputProps {
     showContentTooltip?: boolean;
     allowDuplicates?: boolean;
     addOnBlur?: boolean;
+    draggable?: boolean;
+    expandRestTagsOnClick?: boolean;
     onAdd?: (addedValue: string[]) => void;
     onBlur?: (e: React.MouseEvent<HTMLInputElement>) => void;
     onChange?: (value: string[]) => void;
@@ -69,6 +86,7 @@ export interface TagInputState {
     inputValue?: string;
     focusing?: boolean;
     hovering?: boolean;
+    active?: boolean;
 }
 
 const prefixCls = cssClasses.PREFIX;
@@ -93,6 +111,8 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         separator: PropTypes.oneOfType([PropTypes.string, PropTypes.array]),
         showClear: PropTypes.bool,
         addOnBlur: PropTypes.bool,
+        draggable: PropTypes.bool,
+        expandRestTagsOnClick: PropTypes.bool,
         autoFocus: PropTypes.bool,
         renderTagItem: PropTypes.func,
         onBlur: PropTypes.func,
@@ -118,6 +138,8 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         allowDuplicates: true,
         showRestTagsPopover: true,
         autoFocus: false,
+        draggable: false,
+        expandRestTagsOnClick: true,
         showContentTooltip: true,
         separator: ',',
         size: 'default' as const,
@@ -134,7 +156,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
     };
 
     inputRef: React.RefObject<HTMLInputElement>;
+    tagInputRef: React.RefObject<HTMLDivElement>;
     foundation: TagInputFoundation;
+    clickOutsideHandler: any;
 
     constructor(props: TagInputProps) {
         super(props);
@@ -143,9 +167,12 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             tagsArray: props.defaultValue || [],
             inputValue: '',
             focusing: false,
-            hovering: false
+            hovering: false,
+            active: false,
         };
         this.inputRef = React.createRef();
+        this.tagInputRef = React.createRef();
+        this.clickOutsideHandler = null;
     }
 
     static getDerivedStateFromProps(nextProps: TagInputProps, prevState: TagInputState) {
@@ -190,6 +217,12 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             setHovering: (hovering: boolean) => {
                 this.setState({ hovering });
             },
+            setActive: (active: boolean) => {
+                this.setState({ active });
+            },
+            getClickOutsideHandler: () => {
+                return this.clickOutsideHandler;
+            },
             notifyBlur: (e: React.MouseEvent<HTMLInputElement>) => {
                 this.props.onBlur(e);
             },
@@ -211,6 +244,21 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             notifyKeyDown: e => {
                 this.props.onKeyDown(e);
             },
+            registerClickOutsideHandler: cb => {
+                const clickOutsideHandler = (e: Event) => {
+                    const tagInputDom = this.tagInputRef && this.tagInputRef.current;
+                    const target = e.target as Element;
+                    if (tagInputDom && !tagInputDom.contains(target)) {
+                        cb(e);
+                    }
+                };
+                this.clickOutsideHandler = clickOutsideHandler;
+                document.addEventListener('click', clickOutsideHandler, false);
+            },
+            unregisterClickOutsideHandler: () => {
+                document.removeEventListener('click', this.clickOutsideHandler, false);
+                this.clickOutsideHandler = null;
+            },
         };
     }
 
@@ -218,7 +266,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         const { disabled, autoFocus, preventScroll } = this.props;
         if (!disabled && autoFocus) {
             this.inputRef.current.focus({ preventScroll });
+            this.foundation.handleClick();
         }
+        this.foundation.init();
     }
 
     handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -252,6 +302,10 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
 
     handleInputMouseLeave = (e: React.MouseEvent<HTMLDivElement>) => {
         this.foundation.handleInputMouseLeave();
+    };
+
+    handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
+        this.foundation.handleClick(e);
     };
 
     handleInputMouseEnter = (e: React.MouseEvent<HTMLDivElement>) => {
@@ -338,34 +392,37 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         );
     }
 
-    renderTags() {
+    getAllTags = () => {
         const {
             size,
             disabled,
             renderTagItem,
-            maxTagCount,
             showContentTooltip,
-            showRestTagsPopover,
-            restTagsPopoverProps = {},
+            draggable,
         } = this.props;
-        const { tagsArray } = this.state;
+        const { tagsArray, active } = this.state;
+        const showIconHandler = active && draggable;
         const tagCls = cls(`${prefixCls}-wrapper-tag`, {
             [`${prefixCls}-wrapper-tag-size-${size}`]: size,
+            [`${prefixCls}-wrapper-tag-icon`]: showIconHandler,
         });
         const typoCls = cls(`${prefixCls}-wrapper-typo`, {
-            [`${prefixCls}-wrapper-typo-disabled`]: disabled
+            [`${prefixCls}-wrapper-typo-disabled`]: disabled,
         });
-        const restTagsCls = cls(`${prefixCls}-wrapper-n`, {
-            [`${prefixCls}-wrapper-n-disabled`]: disabled
+        const itemWrapperCls = cls({
+            [`${prefixCls}-drag-item`]: showIconHandler,
+            [`${prefixCls}-wrapper-tag-icon`]: showIconHandler,
         });
-        const restTags: Array<React.ReactNode> = [];
-        const tags: Array<React.ReactNode> = [];
-        tagsArray.forEach((value, index) => {
-            let item = null;
+        const DragHandle = SortableHandle(() => <IconHandle className={`${prefixCls}-drag-handler`}></IconHandle>);
+        return tagsArray.map((value, index) => {
+            const elementKey = showIconHandler ? value : `${index}${value}`;
             if (isFunction(renderTagItem)) {
-                item = renderTagItem(value, index);
+                return showIconHandler? (<div className={itemWrapperCls} key={elementKey}>
+                    <DragHandle />
+                    {renderTagItem(value, index)}
+                </div>) : renderTagItem(value, index);
             } else {
-                item = (
+                return (
                     <Tag
                         className={tagCls}
                         color="white"
@@ -375,10 +432,11 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
                             !disabled && this.handleTagClose(index);
                         }}
                         closable={!disabled}
-                        key={`${index}${value}`}
+                        key={elementKey}
                         visible
                         aria-label={`${!disabled ? 'Closable ' : ''}Tag: ${value}`}
                     >
+                        {showIconHandler && <DragHandle />}
                         <Paragraph
                             className={typoCls}
                             ellipsis={{ showTooltip: showContentTooltip, rows: 1 }}
@@ -388,17 +446,47 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
                     </Tag>
                 );
             }
-            if (maxTagCount && index >= maxTagCount) {
-                restTags.push(item);
-            } else {
-                tags.push(item);
-            }
         });
+    }
 
+    onSortEnd = (callbackProps: OnSortEndProps) => {
+        this.foundation.handleSortEnd(callbackProps);
+    }
+
+    renderTags() {
+        const {
+            disabled,
+            maxTagCount,
+            showRestTagsPopover,
+            restTagsPopoverProps = {},
+            draggable,
+            expandRestTagsOnClick,
+        } = this.props;
+        const { tagsArray, active } = this.state;
+        const restTagsCls = cls(`${prefixCls}-wrapper-n`, {
+            [`${prefixCls}-wrapper-n-disabled`]: disabled,
+        });
+        const allTags = this.getAllTags();
+        let restTags: Array<React.ReactNode> = [];
+        let tags: Array<React.ReactNode> = [...allTags];
+        if (( !active || !expandRestTagsOnClick) && maxTagCount && maxTagCount < allTags.length){
+            tags = allTags.slice(0, maxTagCount);
+            restTags = allTags.slice(maxTagCount);
+        }
+    
         const restTagsContent = (
             <span className={restTagsCls}>+{tagsArray.length - maxTagCount}</span>
         );
 
+        const sortableListItems = allTags.map((item, index) => ({
+            item: item,
+            key: tagsArray[index],
+        }));
+
+        if (active && draggable && sortableListItems.length > 0) {
+            // @ts-ignore skip SortableItem type check
+            return <SortableList useDragHandle items={sortableListItems} onSortEnd={this.onSortEnd} axis={"xy"} />;
+        } 
         return (
             <>
                 {tags}
@@ -426,11 +514,17 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
 
     blur() {
         this.inputRef.current.blur();
+        // unregister clickOutside event 
+        this.foundation.clickOutsideCallBack();
     }
 
     focus() {
-        const { preventScroll } = this.props;
+        const { preventScroll, disabled } = this.props;
         this.inputRef.current.focus({ preventScroll });
+        if (!disabled) {
+            // register clickOutside event 
+            this.foundation.handleClick();
+        }
     }
 
     render() {
@@ -447,11 +541,12 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             focusing,
             hovering,
             tagsArray,
-            inputValue
+            inputValue,
+            active,
         } = this.state;
 
         const tagInputCls = cls(prefixCls, className, {
-            [`${prefixCls}-focus`]: focusing,
+            [`${prefixCls}-focus`]: focusing || active,
             [`${prefixCls}-disabled`]: disabled,
             [`${prefixCls}-hover`]: hovering && !disabled,
             [`${prefixCls}-error`]: validateStatus === 'error',
@@ -463,7 +558,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         const wrapperCls = cls(`${prefixCls}-wrapper`);
 
         return (
+            // eslint-disable-next-line 
             <div
+                ref={this.tagInputRef}
                 style={style}
                 className={tagInputCls}
                 aria-disabled={disabled}
@@ -474,6 +571,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
                 }}
                 onMouseLeave={e => {
                     this.handleInputMouseLeave(e);
+                }}
+                onClick={e => {   
+                    this.handleClick(e);
                 }}
             >
                 {this.renderPrefix()}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Feat: TagInput 支持拖拽排序。

---

🇺🇸 English
- Feat: TagInput supports drag and drop sorting.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
新增两个API，draggable 和 expandRestTagsOnClick。
draggable用于设置是否可拖拽， 默认false；
expandRestTagsOnClick用于在不可拖拽的情况下，在 TagInput 被点击后是否展开多余的 Tag， 默认为true。