### PR TITLE
fix: Empty component darkmode judge

### DIFF
--- a/packages/semi-ui/empty/index.tsx
+++ b/packages/semi-ui/empty/index.tsx
@@ -79,17 +79,17 @@ export default class Empty extends BaseComponent<EmptyProps, EmptyState> {
         const { className, image, description, style, title, imageStyle, children, layout, darkModeImage } = this.props;
 
         const alt = typeof description === 'string' ? description : 'empty';
-        const imgSrc = this.state.mode && darkModeImage ? darkModeImage : image;
+        const imgSrc = ((this.state.mode === 'dark') && darkModeImage) ? darkModeImage : image;
         let imageNode = null;
         if (typeof imgSrc === 'string') {
-            imageNode = <img alt={alt} src={imgSrc} />;
+            imageNode = <img alt={alt} src={imgSrc}/>;
         } else if (imgSrc && 'id' in (imgSrc as any)) {
             imageNode = (
                 <svg
                     // className={iconCls}
                     aria-hidden="true"
                 >
-                    <use xlinkHref={`#${(imgSrc as any).id}`} />
+                    <use xlinkHref={`#${(imgSrc as any).id}`}/>
                 </svg>
             );
         } else {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Empty 组件在 body theme-mode attribute 为非预期值时意外判定为暗色模式的问题

---

🇺🇸 English
- Fix: Fix the problem that the Empty component is unexpectedly judged as dark mode when the body theme-mode attribute is unexpected


### Checklist
- [X] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
