### PR TITLE
style: Add click hotspot for sorting

### DIFF
--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -409,7 +409,8 @@ $module: #{$prefix}-table;
             display: inline-flex;
             cursor: pointer;
             color: $color-table_filter-text-default;
-            vertical-align: middle;
+            // vertical-align: middle;
+            align-items: center;
 
             svg {
                 width: $width-table_column_filter-icon;

--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -371,9 +371,14 @@ $module: #{$prefix}-table;
             display: inline-block;
             width: $width-table_column_sorter-icon;
             height: $height-table_column_sorter-icon;
-            cursor: pointer;
             vertical-align: middle;
             text-align: center;
+
+            &-wrapper {
+                display: inline-flex;
+                align-items: center;
+                cursor: pointer;
+            }
 
             &-up,
             &-down {

--- a/packages/semi-foundation/table/variables.scss
+++ b/packages/semi-foundation/table/variables.scss
@@ -36,8 +36,8 @@ $radius-table_base: 4px;
 $width-table_column_selection: 48px; // 表格默认列宽
 $width-table_column_sorter-icon: 16px; // 表格排序按钮宽度
 $height-table_column_sorter-icon: 16px; // 表格排序按钮高度
-$width-table_column_filter-icon: 12px; // 表格过滤按钮宽度
-$height-table_column_filter-icon: 12px; // 表格过滤按钮高度
+$width-table_column_filter-icon: 16px; // 表格过滤按钮宽度
+$height-table_column_filter-icon: 16px; // 表格过滤按钮高度
 $width-table_cell_fixed_left_last: 1px; // 表格左上角单元格底部描边宽度
 $width-table_cell_fixed_right_first: 1px; // 表格左上角单元格右侧描边宽度
 $width-table_react_resizable_handle: 9px; // 表格伸缩列调节热区宽度

--- a/packages/semi-ui/table/ColumnFilter.tsx
+++ b/packages/semi-ui/table/ColumnFilter.tsx
@@ -164,6 +164,7 @@ export default function ColumnFilter(props: ColumnFilterProps = {}): React.React
     } else {
         iconElem = (
             <div className={finalCls}>
+                {'\u200b'/* ZWSP(zero-width space) */}
                 <IconFilter
                     role="button"
                     aria-label="Filter data with this column"

--- a/packages/semi-ui/table/ColumnFilter.tsx
+++ b/packages/semi-ui/table/ColumnFilter.tsx
@@ -169,7 +169,7 @@ export default function ColumnFilter(props: ColumnFilterProps = {}): React.React
                     aria-label="Filter data with this column"
                     aria-haspopup="listbox"
                     tabIndex={-1}
-                    size="small"
+                    size="default"
                 />
             </div>
         );

--- a/packages/semi-ui/table/ColumnSorter.tsx
+++ b/packages/semi-ui/table/ColumnSorter.tsx
@@ -15,6 +15,7 @@ export interface ColumnSorterProps {
     onClick?: (e: React.MouseEvent<HTMLDivElement>) => void;
     prefixCls?: string;
     sortOrder?: SortOrder;
+    title?: React.ReactNode;
 }
 
 export default class ColumnSorter extends PureComponent<ColumnSorterProps> {
@@ -33,9 +34,9 @@ export default class ColumnSorter extends PureComponent<ColumnSorterProps> {
     };
 
     render() {
-        const { prefixCls, onClick, sortOrder, style } = this.props;
+        const { prefixCls, onClick, sortOrder, style, title } = this.props;
 
-        const iconBtnSize = 'small';
+        const iconBtnSize = 'default';
 
         const upCls = cls(`${prefixCls}-column-sorter-up`, {
             on: sortOrder === strings.SORT_DIRECTIONS[0],
@@ -58,17 +59,22 @@ export default class ColumnSorter extends PureComponent<ColumnSorterProps> {
                 role='button'
                 {...ariaProps}
                 tabIndex={-1}
-                style={style}
-                className={`${prefixCls}-column-sorter`}
+                className={`${prefixCls}-column-sorter-wrapper`}
                 onClick={onClick}
                 onKeyPress={e => isEnterPress(e) && onClick(e as any)}
             >
-                <span className={`${upCls}`}>
-                    <IconCaretup size={iconBtnSize} />
-                </span>
-                <span className={`${downCls}`}>
-                    <IconCaretdown size={iconBtnSize} />
-                </span>
+                {title}
+                <div
+                    style={style}
+                    className={`${prefixCls}-column-sorter`}
+                >
+                    <span className={`${upCls}`}>
+                        <IconCaretup size={iconBtnSize} />
+                    </span>
+                    <span className={`${downCls}`}>
+                        <IconCaretdown size={iconBtnSize} />
+                    </span>
+                </div>
             </div>
         );
     }

--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -933,16 +933,22 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             const stateSortOrder = get(curQuery, 'sortOrder');
             const defaultSortOrder = get(curQuery, 'defaultSortOrder', false);
             const sortOrder = this.foundation.isSortOrderValid(stateSortOrder) ? stateSortOrder : defaultSortOrder;
+            const TitleNode = typeof rawTitle !== 'function' && <React.Fragment key={strings.DEFAULT_KEY_COLUMN_TITLE}>{rawTitle as React.ReactNode}</React.Fragment>;
             if (typeof column.sorter === 'function' || column.sorter === true) {
+                // In order to increase the click hot area of ​​sorting, when sorting is required & useFullRender is false,
+                // both the title and sorting areas are used as the click hot area for sorting。
                 const sorter = (
                     <ColumnSorter
                         key={strings.DEFAULT_KEY_COLUMN_SORTER}
                         sortOrder={sortOrder}
                         onClick={e => this.foundation.handleSort(column, e)}
+                        title={TitleNode}
                     />
                 );
                 useFullRender && (titleMap.sorter = sorter);
                 titleArr.push(sorter);
+            } else {
+                titleArr.push(TitleNode);
             }
 
             const stateFilteredValue = get(curQuery, 'filteredValue');
@@ -964,10 +970,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
 
             const newTitle =
                 typeof rawTitle === 'function' ?
-                    () => rawTitle(titleMap) :
-                    titleArr.unshift(
-                        <React.Fragment key={strings.DEFAULT_KEY_COLUMN_TITLE}>{rawTitle}</React.Fragment>
-                    ) && titleArr;
+                    () => rawTitle(titleMap) : titleArr;
 
             column = { ...column, title: newTitle };
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- style: 增加排序的点击热区

---

🇺🇸 English
- Fix: Add click hotspot for sorting


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
修改点：
1. icon 的 size 由 small （12*12）改为 default（16*16）；
2. 当有 sorting 排序时， 排序的点击热区为包含title和sorting的区域（ 此改动不影响完全自定义渲染）
https://user-images.githubusercontent.com/101110131/183805746-99b48e77-f7a3-4bca-ad36-a9c4c2543b56.mp4


