### PR TITLE
fix: set the outer div's props tabindex to -1, and when value change …

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -153,6 +153,9 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         this._adapter.notifySearch(inputValue);
         this._adapter.notifyChange(inputValue);
         this._modifyFocusIndex(inputValue);
+        if (!this.isPanelOpen){
+            this.openDropdown();
+        }
     }
 
     handleSelect(option: StateOptionItem, optionIndex?: number): void {
@@ -389,7 +392,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         if (!visible){
             this.openDropdown();
         } else {
-            if (focusIndex !== undefined  && focusIndex !== -1 && options.length !== 0) {
+            if (focusIndex !== undefined && focusIndex !== -1 && options.length !== 0) {
                 const visibleOptions = options.filter((item: StateOptionItem) => item.show);
                 const selectedOption = visibleOptions[focusIndex];
                 this.handleSelect(selectedOption, focusIndex);

--- a/packages/semi-ui/autoComplete/index.tsx
+++ b/packages/semi-ui/autoComplete/index.tsx
@@ -361,6 +361,8 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
             ref: this.triggerRef,
             id,
             ...keyboardEventSet,
+            // tooltip give tabindex 0 to children by default, autoComplete just need the input get focus, so outer div's tabindex set to -1
+            tabIndex: -1
         };
 
         const innerProps = {


### PR DESCRIPTION
…open the panel

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### Changelog
🇨🇳 Chinese
- Fix: 修复 AutoComplete 通过 tab 聚焦或者 autoFocus 聚焦后，输入值改变不打开面板问题

---

🇺🇸 English
- Fix: fix AutoComplete focus by tab or autoFocus, the input value change does not open the panel problem


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
