### PR TITLE
fix: fix the problem when react 18 and strict mode useFormApi get null

### DIFF
--- a/packages/semi-ui/form/baseForm.tsx
+++ b/packages/semi-ui/form/baseForm.tsx
@@ -151,7 +151,6 @@ class Form extends BaseComponent<BaseFormProps, BaseFormState> {
 
     componentWillUnmount() {
         this.foundation.destroy();
-        this.formApi = null;
     }
 
     get adapter(): BaseFormAdapter<BaseFormProps, BaseFormState> {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
由于 React 18 createRoot的严格模式下，会触发 componentDidMount、componentWillUnmount两次（详见：https://github.com/reactwg/react-18/discussions/19%EF%BC%89
如果我们在willUnmount时执行了某些清除操作（例如将this对象上的某个键值对清空），而在 didMount中未初始化或还原（在Form、semi-animation-react中这类操作是在constructor阶段完成的），在第二次render时，就会导致读取不到对应的状态，从而触发 error

### Changelog
🇨🇳 Chinese
- Fix: 修复 React 18 createRoot + strictMode 严格模式下， 使用 useFormApi 得到空值问题 #1063 

---

🇺🇸 English
- Fix: fix  use useFormApi to get null value problem under React 18 createRoot + strictMode #1063


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
