### PR TITLE
fix: make collapse icon fixed to avoid the collapse tabs flush in some width

### DIFF
--- a/cypress/integration/tabs.spec.js
+++ b/cypress/integration/tabs.spec.js
@@ -23,7 +23,7 @@ describe('tabs', () => {
         cy.get('.semi-tabs-content').contains('关于');
     });
 
-    it.only('collapse', () => {
+    it('collapse', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?id=tabs--collapse-tabs&args=&viewMode=story');
         cy.viewport(800, 800);
         cy.get('.semi-tabs-content').eq(0).contains('Content of card tab 0');

--- a/cypress/integration/tabs.spec.js
+++ b/cypress/integration/tabs.spec.js
@@ -23,16 +23,16 @@ describe('tabs', () => {
         cy.get('.semi-tabs-content').contains('关于');
     });
 
-    it('collapse', () => {
+    it.only('collapse', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?id=tabs--collapse-tabs&args=&viewMode=story');
         cy.viewport(800, 800);
         cy.get('.semi-tabs-content').eq(0).contains('Content of card tab 0');
-        cy.get('.semi-button').eq(0).trigger('mouseover');
+        cy.get('.semi-button').eq(1).trigger('mouseover');
         cy.get('.semi-dropdown').contains('Tab-6').click();
         cy.get('.semi-tabs-content').eq(0).contains('Content of card tab 6');
 
         // Tab-10 visible
-        cy.get('.semi-button').eq(0).click();
+        cy.get('.semi-button').eq(0).click({ force: true });
         cy.get('.semi-tabs-tab').contains('Tab-10').click({ force: true });
         cy.get('.semi-tabs-content').eq(0).contains('Content of card tab 10');
     });

--- a/packages/semi-ui/tabs/TabBar.tsx
+++ b/packages/semi-ui/tabs/TabBar.tsx
@@ -147,7 +147,13 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
 
     renderCollapse = (items: Array<OverflowItem>, icon: ReactNode, pos: 'start' | 'end'): ReactNode => {
         if (isEmpty(items)) {
-            return null;
+            return (
+                <Button
+                    disabled={true}
+                    icon={icon}
+                    theme="borderless"
+                />
+            );
         }
         const { dropdownClassName, dropdownStyle } = this.props;
         const { rePosKey } = this.state;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1039 
详细修复过程看这里～https://bytedance.feishu.cn/docx/doxcndFl24VU3Gl7Kthxxtc2Cjf

bug表现可见视频：https://lf3-static.bytednsdoc.com/obj/eden-cn/slepweh7nupqpognuhbo/41209.mp4
#### 问题归因
可折叠tabs底层依赖的是Semi的`OverflowList`，`OverflowList`在滚动（scroll）模式下依赖于`IntersectionObserver`。`IntersectionObserver`对象在其监听到目标元素的可见部分穿过了一个或多个`thresholds`时，会执行指定的回调函数，默认的`threshold`为0.75。
在`OverflowList`内每当有目标元素的可见部分超过或者低于`threshold`时，就会触发对元素数组`visibleState`的重新评估。我们根据该数组第一个和最后一个可见元素的位置，将元素数组分为两个部分，分别代表左侧不可见元素和右侧不可见元素。
在tabBar侧，我们会根据左右不可见元素数组的长度判断是否渲染箭头按钮。
所以**反复横跳**的横跳过程大概如下图所示
![image](https://user-images.githubusercontent.com/101160769/186796629-1d6ddb7f-fb4d-4d98-9f96-efeeedb8154f.png)


####  修复思路
只要可折叠tabs的箭头是动态渲染的，这个“反复横跳”的问题就必然存在。题解真正的奥义就是让icon按钮常驻，无遮挡元素时禁用按钮。
Solution: Make the icon button permanent, and disable the button when there is no occluded element

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tabs collapse模式在某些宽度下会反复横跳，导致闪烁不停的问题 #1039 

---

🇺🇸 English
- Fix: fix tabs collapse mode will flush in some screen #1039


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
