### PR TITLE
chore: remove a duplicate type

### DIFF
--- a/packages/semi-ui/tag/interface.ts
+++ b/packages/semi-ui/tag/interface.ts
@@ -38,15 +38,3 @@ export interface TagProps {
     'aria-label'?: React.AriaAttributes['aria-label'];
     tabIndex?: number; // use internal, when tag in taInput, we want to use left arrow and right arrow to control the tag focus, so the tabIndex need to be -1. 
 }
-
-export interface TagGroupProps {
-    style?: React.CSSProperties;
-    className?: string;
-    maxTagCount?: number;
-    tagList?: (TagProps | React.ReactNode)[];
-    size?: 'small' | 'large';
-    showPopover?: boolean;
-    popoverProps?: any; // TODO: 替换成PopoverProps
-    avatarShape?: AvatarShape;
-    mode?: string; // TODO: check 文档里没有这个api
-}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
#### chore:remove a duplicate type.
类型声明重复
Type `TagGroupProps` has been defined in `packages/semi-ui/tag/group.tsx`.So the type in "interface.ts" with Todoes is useless and duplicate.

### Changelog
🇨🇳 Chinese
- chore:删除了一个重复类型

---

🇺🇸 English
- chore:remove a duplicate type.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->