### PR TITLE
feat: add `onNavite` API to Nav and NavItem

### DIFF
--- a/content/navigation/navigation/index-en-US.md
+++ b/content/navigation/navigation/index-en-US.md
@@ -2,7 +2,7 @@
 localeCode: en-US
 order: 39
 category: Navigation
-title:  Navigation
+title: Navigation
 subTitle: Navigation
 icon: doc-navigation
 width: 650px
@@ -17,6 +17,7 @@ brief: A menu list that provides navigation for pages and features.
 ```jsx
 import { Nav } from '@douyinfe/semi-ui';
 ```
+
 ### Basic Usage
 
 By passing `items` Parameters, you can quickly get a navigation bar.
@@ -38,7 +39,8 @@ class NavApp extends React.Component {
     render() {
         return (
             <Nav
-                Body Style={{ height: 320 }}
+                Body
+                Style={{ height: 320 }}
                 items={[
                     { itemKey: 'user', text: 'User Management', icon: <IconUser /> },
                     { itemKey: 'union', text: 'Union Center', icon: <IconStar /> },
@@ -76,14 +78,14 @@ class NavApp extends React.Component {
         return (
             <Nav
                 bodyStyle={{ height: 320 }}
-                defaultOpenKeys={[ 'task' ]}
+                defaultOpenKeys={['task']}
                 items={[
                     { itemKey: 'user', text: 'User Management' },
                     { itemKey: 'union', text: 'User Center' },
                     {
                         itemKey: 'union-management',
                         text: 'Union Management',
-                        items: ['Announcement Settings', 'Union Inquiries', 'Entry information']
+                        items: ['Announcement Settings', 'Union Inquiries', 'Entry information'],
                     },
                     {
                         text: 'Task Platform',
@@ -130,8 +132,10 @@ class NavApp extends React.Component {
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Live Platform'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Live Platform',
                 }}
                 footer={{
                     collapseButton: true,
@@ -178,8 +182,10 @@ class NavApp extends React.Component {
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Live Platform'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Live Platform',
                 }}
                 footer={{
                     collapseButton: true,
@@ -208,7 +214,12 @@ class NavApp extends React.Component {
                 onSelect={data => console.log('trigger onSelect: ', data)}
                 onClick={data => console.log('trigger onClick: ', data)}
             >
-                <Nav.Header logo={<img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />} text={'Live Platform'} />
+                <Nav.Header
+                    logo={
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    }
+                    text={'Live Platform'}
+                />
                 <Nav.Item itemKey={'union'} text={'Union Center'} icon={<IconStar />} />
                 <Nav.Sub itemKey={'user'} text="User Management" icon={<IconUser />}>
                     <Nav.Item itemKey={'golder'} text={'Gold Master Management'} />
@@ -224,7 +235,6 @@ class NavApp extends React.Component {
         );
     }
 }
-
 ```
 
 ### Navigation Direction
@@ -262,7 +272,7 @@ class NavApp extends React.Component {
                             itemKey: 'union-management',
                             text: 'Union Management',
                             icon: <IconUserGroup />,
-                            items: ['Announcement Settings', 'Union Query', 'Entry Information']
+                            items: ['Announcement Settings', 'Union Query', 'Entry Information'],
                         },
                         {
                             text: 'Task Platform',
@@ -273,8 +283,10 @@ class NavApp extends React.Component {
                     ]}
                     onSelect={key => console.log(key)}
                     header={{
-                        logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                        text: 'Live Platform'
+                        logo: (
+                            <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                        ),
+                        text: 'Live Platform',
                     }}
                     footer={{
                         collapseButton: true,
@@ -311,12 +323,9 @@ class NavApp extends React.Component {
                                 {
                                     itemKey: 'operation-management',
                                     text: 'Operations Management',
-                                    items: [
-                                        'Personnel Management',
-                                        'Personnel Change'
-                                    ]
-                                }
-                            ]
+                                    items: ['Personnel Management', 'Personnel Change'],
+                                },
+                            ],
                         },
                         {
                             text: 'Task Platform',
@@ -327,8 +336,10 @@ class NavApp extends React.Component {
                     ]}
                     onSelect={key => console.log(key)}
                     header={{
-                        logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                        text: 'Live Platform'
+                        logo: (
+                            <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                        ),
+                        text: 'Live Platform',
                     }}
                     footer={
                         <Dropdown
@@ -340,7 +351,9 @@ class NavApp extends React.Component {
                                 </Dropdown.Menu>
                             }
                         >
-                            <Avatar size="small" color='light-blue' style={{margin: 4}}>BD</Avatar>
+                            <Avatar size="small" color="light-blue" style={{ margin: 4 }}>
+                                BD
+                            </Avatar>
                             <span>Bytedancer</span>
                         </Dropdown>
                     }
@@ -369,7 +382,7 @@ class NavApp extends React.Component {
                 itemKey: 'union-management',
                 text: 'Union Management',
                 icon: <IconUserGroup />,
-                items: ['Announcement Settings', 'Union Query', 'Entry Information']
+                items: ['Announcement Settings', 'Union Query', 'Entry Information'],
             },
             {
                 itemKey: 'approve-management',
@@ -380,12 +393,9 @@ class NavApp extends React.Component {
                     {
                         itemKey: 'operation-management',
                         text: 'Operations Management',
-                        items: [
-                            'Personnel Management',
-                            'Personnel Change'
-                        ]
-                    }
-                ]
+                        items: ['Personnel Management', 'Personnel Change'],
+                    },
+                ],
             },
             {
                 text: 'Task Platform',
@@ -405,16 +415,22 @@ class NavApp extends React.Component {
                 mode={'horizontal'}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Live Platform'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Live Platform',
                 }}
                 footer={
                     <>
-                        <Select defaultValue='English' style={{ width: 120, marginRight: 10 }} insetLabel={<IconLanguage />}>
-                            <Select.Option value='Chinese'>中文</Select.Option>
-                            <Select.Option value='English'>English</Select.Option>
-                            <Select.Option value='Korean'>한국어</Select.Option>
-                            <Select.Option value='Japanese'>日本語</Select.Option>
+                        <Select
+                            defaultValue="English"
+                            style={{ width: 120, marginRight: 10 }}
+                            insetLabel={<IconLanguage />}
+                        >
+                            <Select.Option value="Chinese">中文</Select.Option>
+                            <Select.Option value="English">English</Select.Option>
+                            <Select.Option value="Korean">한국어</Select.Option>
+                            <Select.Option value="Japanese">日本語</Select.Option>
                         </Select>
                         <Button style={{ marginRight: 10 }}>Switch to Overseas Version</Button>
                         <Dropdown
@@ -426,7 +442,9 @@ class NavApp extends React.Component {
                                 </Dropdown.Menu>
                             }
                         >
-                            <Avatar size="small" color='light-blue' style={{margin: 4}}>BD</Avatar>
+                            <Avatar size="small" color="light-blue" style={{ margin: 4 }}>
+                                BD
+                            </Avatar>
                             <span>Bytedancer</span>
                         </Dropdown>
                     </>
@@ -476,19 +494,21 @@ class NavApp extends React.Component {
                 defaultOpenKeys={['job']}
                 bodyStyle={{ height: 320 }}
                 items={[
-                    {itemKey:'user', text:'User Management', icon: <IconUser /> },
-                    {itemKey:'union', text:'guild center', icon: <IconStar /> },
+                    { itemKey: 'user', text: 'User Management', icon: <IconUser /> },
+                    { itemKey: 'union', text: 'guild center', icon: <IconStar /> },
                     {
-                        text:'Task platform',
+                        text: 'Task platform',
                         icon: <IconSetting />,
-                        itemKey:'job',
-                        items: ['task management','user task query'],
+                        itemKey: 'job',
+                        items: ['task management', 'user task query'],
                     },
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text:'Live broadcast operation background'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Live broadcast operation background',
                 }}
                 footer={{
                     collapseButton: true,
@@ -500,6 +520,7 @@ class NavApp extends React.Component {
 ```
 
 ### Indentation limit
+
 No indentation by default. If you need to indent the navigation items according to the level, please set limitIndent to false
 
 When using Nav.Item to pass navigation items in React Jsx mode, please pass level props to Nav.Item manually.
@@ -521,28 +542,36 @@ class NavApp extends React.Component {
                 defaultOpenKeys={['job']}
                 bodyStyle={{ height: 320 }}
                 items={[
-                    {itemKey:'user', text:'User Management', icon: <IconUser /> },
+                    { itemKey: 'user', text: 'User Management', icon: <IconUser /> },
                     {
-                        text:'Task platform',
+                        text: 'Task platform',
                         icon: <IconSetting />,
-                        itemKey:'job',
-                        items: ['Task Management', {
-                            text:'Task 1',
-                            icon: <IconSetting />,
-                            itemKey:'mission1',
-                            items: ['Task 2',{
-                                text:'Task 3 disassembly',
+                        itemKey: 'job',
+                        items: [
+                            'Task Management',
+                            {
+                                text: 'Task 1',
                                 icon: <IconSetting />,
-                                itemKey:'mission3',
-                                items: ['Subtask 1','Subtask 2'],
-                            }, ],
-                        },],
+                                itemKey: 'mission1',
+                                items: [
+                                    'Task 2',
+                                    {
+                                        text: 'Task 3 disassembly',
+                                        icon: <IconSetting />,
+                                        itemKey: 'mission3',
+                                        items: ['Subtask 1', 'Subtask 2'],
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text:'Live broadcast operation background'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Live broadcast operation background',
                 }}
                 footer={{
                     collapseButton: true,
@@ -552,7 +581,6 @@ class NavApp extends React.Component {
     }
 }
 ```
-
 
 ### Uncontrolled Properties
 
@@ -582,7 +610,7 @@ class NavApp extends React.Component {
                         itemKey: 'union-management',
                         text: 'Union Management',
                         icon: <IconUserGroup />,
-                        items: ['Announcement Settings', 'Union Query', 'Entry Information']
+                        items: ['Announcement Settings', 'Union Query', 'Entry Information'],
                     },
                     {
                         text: 'Task Platform',
@@ -592,17 +620,18 @@ class NavApp extends React.Component {
                     },
                 ]}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Live Platform'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Live Platform',
                 }}
                 footer={{
-                    collapseButton: true
+                    collapseButton: true,
                 }}
             />
         );
     }
 }
-
 ```
 
 ### Controlled Properties
@@ -626,7 +655,7 @@ import React, { useMemo } from 'react';
 import { Nav } from '@douyinfe/semi-ui';
 import { IconUser, IconStar, IconUserGroup, IconSetting } from '@douyinfe/semi-icons';
 
-function NavApp (props = {}) {
+function NavApp(props = {}) {
     const [openKeys, setOpenKeys] = useState(['union-management', 'job']);
     const [selectedKeys, setSelectedKeys] = useState(['User Task Query']);
     const [isCollapsed, setIsCollapsed] = useState(true);
@@ -644,22 +673,25 @@ function NavApp (props = {}) {
         setIsCollapsed(isCollapsed);
     };
 
-    const items = useMemo(() => [
-        { itemKey: 'user', text: 'User Management', icon: <IconUser /> },
-        { itemKey: 'union', text: 'Union Center', icon: <IconStar /> },
-        {
-            itemKey: 'union-management',
-            text: 'Union Management',
-            icon: <IconUserGroup />,
-            items: ['Announcement Settings', 'Union Query', 'Entry Information']
-        },
-        {
-            text: 'Task Platform',
-            icon: <IconSetting />,
-            itemKey: 'job',
-            items: ['Task Management', 'User Task Query'],
-        },
-    ], []);
+    const items = useMemo(
+        () => [
+            { itemKey: 'user', text: 'User Management', icon: <IconUser /> },
+            { itemKey: 'union', text: 'Union Center', icon: <IconStar /> },
+            {
+                itemKey: 'union-management',
+                text: 'Union Management',
+                icon: <IconUserGroup />,
+                items: ['Announcement Settings', 'Union Query', 'Entry Information'],
+            },
+            {
+                text: 'Task Platform',
+                icon: <IconSetting />,
+                itemKey: 'job',
+                items: ['Task Management', 'User Task Query'],
+            },
+        ],
+        []
+    );
 
     return (
         <Nav
@@ -669,11 +701,13 @@ function NavApp (props = {}) {
             bodyStyle={{ height: 360 }}
             items={items}
             header={{
-                logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                text: 'Live Platform'
+                logo: (
+                    <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                ),
+                text: 'Live Platform',
             }}
             footer={{
-                collapseButton: true
+                collapseButton: true,
             }}
             onCollapseChange={onCollapseChange}
             onOpenChange={onOpenChange}
@@ -683,97 +717,132 @@ function NavApp (props = {}) {
 }
 ```
 
+### Proxy Routeing by 3P Libs
+
+Most React SPAs use `react-router-dom` to route among inner pages. In this case, all routing actions should be handled by `react-router-dom` APIs.
+
+However, if you just use `<NavItem link="/eg" />`, you will get a `<a href="/eg" />` tag and it will cause your page jump and reload instead of routing inside the APP by `react-router-dom`.
+
+It's true that you can go through this by rendering `<NavItem>` by yourself or pass extra parameters to `a` tag to let `react-router-dom` to proxy it's behavior, but it's too complicated to worth it。
+
+Now introducing the `onNavigate` API. It's an interface for the callback handler triggered when a nav item with `link` property is clicked and it's first parameter will be the target link. And when it's provided, the `preventDefault()` will be automatically added to the `onclick` event handler of the `a` tag rendered. So you can easily integrate any third routing libraries with Semi `Nav` component by just listening this interface.
+
+```jsx live=false
+import React from 'react';
+import { Nav } from '@douyinfe/semi-ui';
+import { useNavigate } from 'react-router-dom';
+
+const NavApp = () => {
+    const navigate = useNavigate();
+
+    return (
+        <Nav
+            items={[
+                { itemKey: 'user', text: 'User mgmt', link: '/eg/1' },
+                { itemKey: 'union', text: 'The union', link: '/eg/2' },
+            ]}
+            onNavigate={targetLink => navigate(targetLink)}
+        />
+    );
+};
+```
+
+By the way, for a better semantic and friendlier SEO, you should add your target link to the `href` property of `a` tag instead of just listen to the `onclick` event without using `href` property. That's why we provide this `onNavigate` API instead of just letting you use `onClick` API.
+
 ## API Reference
 
 ### Nav
 
-| Properties          | Type                                                                                                                                                                                       | Description                                                                                                                      | Default    |
-| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| bodyStyle           | Custom style for navigation item list                                                                                                                                                      | object                                                                                                                           |            |
-| className           | Style name of outermost element                                                                                                                                                            | boolean                                                                                                                          |            |
-| defaultIsCollapsed  | Whether the default is put away, valid only when `mode = "vertical"`                                                                                                                       | boolean                                                                                                                          | false      |
-| defaultOpenKeys     | Initially open sub navigation `itemKey` array, valid only `mode = "vertical"`and the sidebar is in an expanded state                                                                       | string[]                                                                                                                         | []         |
-| defaultSelectedKeys | Originally selected navigation item `itemKey` array                                                                                                                                        | string[]                                                                                                                         | []         |
-| footer              | The bottom area configure objects or elements, see [Nav.Footer](#Nav.Footer)                                                                                                               | object\|ReactNode                                                                                                                |            |
-| header              | Head area configuration objects or elements, see [Nav.Header](#Nav.Header)                                                                                                                 | object\|ReactNode                                                                                                                |            |
-| isCollapsed         | A controlled attribute of whether it is in a put-away state, valid only when `mode = "vertical"`                                                                                           | boolean                                                                                                                          |            |
-| items               | Navigate the list of items, each item can continue with the items property. If it is a string array, each item is taken as text and itemKey                                                | object\|string[]\|[Item](#Nav.Item)[]\|[Sub](#Nav.Sub)[]                                                                         |            |
-| mode                | Navigation type, currently supports horizontal and vertical, optional value: `vertical`\|`horizontal`                                                                                      | string                                                                                                                           | `vertical` |
-| onClick             | Trigger when clicking on any navigation item                                                                                                                                               | ({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) => void                                                             | () = > {}  |
-| onCollapseChange    | The callback when the state changes.                                                                                                                                                       | (is Collapsed: boolean) => void                                                                                                  | () = > {}  |
-| onOpenChange        | Triggers when switching the hidden state of a sub navigation project                                                                                                                       | ({ itemKey: string, openKeys: string[], domEvent: MouseEvent, isOpen: boolean }) => void                                         | () = > {}  |
-| onSelect            | Triggers the first time you select an optional navigation project, where the selected Items field version > = 0.17.0 is supported                                                          | ({ itemKey: string, selectedKeys: string[], selectedItems: [Item](#Nav.Item)[], domEvent: MouseEvent, isOpen: boolean }) => void | () = > {}  |
-| openKeys            | Controlled open sub navigation `itemKey` array, expanded with `onOpenChange` callback control sub navigation items, valid only `mode = "vertical"`and the sidebar is in an unfolding state | string[]                                                                                                                         |            |
-| selectedKeys        | Controlled navigation item `itemKey` array, with `onSelect` callback control navigation item selection                                                                                     | string[]                                                                                                                         |            |
-| style               | Custom styles for outermost elements                                                                                                                                                       | object                                                                                                                           |            |
-| subNavCloseDelay    | Delay of sub navigation floating layer closure. Effective when the limit is true or mode is "limit" in MS                                                                                  | number                                                                                                                           | 100        |
-| subNavOpenDelay     | The delay displayed by the sub navigation floating layer. Effective when the input is true or mode is "selected" in MS                                                                     | number                                                                                                                           | 0          |
-| tooltipHideDelay    | The latency hidden by tooltip is valid when it is true in MS                                                                                                                               | number                                                                                                                           | 100        |
-| tooltipShowDelay    | The delay displayed by tooltip is valid when it is true in MS                                                                                                                              | number                                                                                                                           | 0          |
-| limitIndent         | To lift the indentation limit, you can use level to customize the indentation of navigation items. The horizontal mode can only be true >=1.27.0                                           | boolean                                                                                                                          | true       |
-| toggleIconPosition  | Parent navigation item arrow position with child navigation items >=1.27.0                                                                                                                 | 'left' \| 'right'                                                                                                                | 'right'    |
+| Properties | Description | Type | Default |
+| --- | --- | --- | --- |
+| bodyStyle | Custom style for navigation item list | object |  |
+| className | Style name of outermost element | boolean |  |
+| defaultIsCollapsed | Whether the default is put away, valid only when `mode = "vertical"` | boolean | false |
+| defaultOpenKeys | Initially open sub navigation `itemKey` array, valid only `mode = "vertical"`and the sidebar is in an expanded state | string[] | [] |
+| defaultSelectedKeys | Originally selected navigation item `itemKey` array | string[] | [] |
+| footer | The bottom area configure objects or elements, see [Nav.Footer](#Nav.Footer) | object\|ReactNode |  |
+| header | Head area configuration objects or elements, see [Nav.Header](#Nav.Header) | object\|ReactNode |  |
+| isCollapsed | A controlled attribute of whether it is in a put-away state, valid only when `mode = "vertical"` | boolean |  |
+| items | Navigate the list of items, each item can continue with the items property. If it is a string array, each item is taken as text and itemKey | object\|string[]\|[Item](#Nav.Item)[]\|[Sub](#Nav.Sub)[] |  |
+| mode | Navigation type, currently supports horizontal and vertical, optional value: `vertical`\|`horizontal` | string | `vertical` |
+| onClick | Trigger when clicking on any navigation item | ({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) => void | () = > {} |
+| onCollapseChange | The callback when the state changes. | (is Collapsed: boolean) => void | () = > {} |
+| onOpenChange | Triggers when switching the hidden state of a sub navigation project | ({ itemKey: string, openKeys: string[], domEvent: MouseEvent, isOpen: boolean }) => void | () = > {} |
+| onSelect | Triggers the first time you select an optional navigation project, where the selected Items field version > = 0.17.0 is supported | ({ itemKey: string, selectedKeys: string[], selectedItems: [Item](#Nav.Item)[], domEvent: MouseEvent, isOpen: boolean }) => void | () = > {} |
+| openKeys | Controlled open sub navigation `itemKey` array, expanded with `onOpenChange` callback control sub navigation items, valid only `mode = "vertical"`and the sidebar is in an unfolding state | string[] |  |
+| selectedKeys | Controlled navigation item `itemKey` array, with `onSelect` callback control navigation item selection | string[] |  |
+| style | Custom styles for outermost elements | object |  |
+| subNavCloseDelay | Delay of sub navigation floating layer closure. Effective when the limit is true or mode is "limit" in MS | number | 100 |
+| subNavOpenDelay | The delay displayed by the sub navigation floating layer. Effective when the input is true or mode is "selected" in MS | number | 0 |
+| tooltipHideDelay | The latency hidden by tooltip is valid when it is true in MS | number | 100 |
+| tooltipShowDelay | The delay displayed by tooltip is valid when it is true in MS | number | 0 |
+| limitIndent | To lift the indentation limit, you can use level to customize the indentation of navigation items. The horizontal mode can only be true >=1.27.0 | boolean | true |
+| toggleIconPosition | Parent navigation item arrow position with child navigation items >=1.27.0 | 'left' \| 'right' | 'right' |
+| onNavigate | Triggered when a nav item with `link` property is clicked. The jumping action of `a` tag will be prevented when provided. Will be passed to all sub nav items. | (link: string) => unknown | |
 
 ### Nav.Item
 
-| Properties   | Description                                                                                                       | Type                                                                 | Default  | Version |
-| ------------ | ----------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- | -------- | ------- |
-| disabled     | Disabled state                                                                                                    | boolean                                                              | false    | 1.17.0  |
-| icon         | Navigation project icon name or component                                                                         | ReactNode                                                            |          |         |
-| indent       | If the icon is empty, keep its space or not. Only effective for first level navigation                            | boolean                                                              | false    |         |
-| itemKey      | Navigation project only key                                                                                       | string                                                               | ""       |         |
-| level        | The nesting level of the current item. When limitIndent is true, it is used to customize the indentation position | number                                                               |          | 1.27.0  |
-| link         | Navigation item href link, when imported, the navigation item will be wrapped with an a tag                       | string                                                               | -        | 1.0.0   |
-| linkOptions  | Parameters transparently passed to the a tag                                                                      | object                                                               | -        | 1.0.0   |
-| text         | Navigation project copy or element                                                                                | string \| ReactNode                                                  | ""       |         |
-| onClick      | Callback of click                                                                                                 | function({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) | () => {} |
-| onMouseEnter | Callback of mouse enter event                                                                                     | function(e) => {}                                                    | () => {} |
-| onMouseLeave | Callback of mouse leave event                                                                                     | function(e) => {}                                                    | () => {} |
+| Properties | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| disabled | Disabled state | boolean | false | 1.17.0 |
+| icon | Navigation project icon name or component | ReactNode |  |  |
+| indent | If the icon is empty, keep its space or not. Only effective for first level navigation | boolean | false |  |
+| itemKey | Navigation project only key | string | "" |  |
+| level | The nesting level of the current item. When limitIndent is true, it is used to customize the indentation position | number |  | 1.27.0 |
+| link | Navigation item href link, when imported, the navigation item will be wrapped with an a tag | string | - | 1.0.0 |
+| linkOptions | Parameters transparently passed to the a tag | object | - | 1.0.0 |
+| text | Navigation project copy or element | string \| ReactNode | "" |  |
+| onClick | Callback of click | function({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) | () => {} |
+| onMouseEnter | Callback of mouse enter event | function(e) => {} | () => {} |
+| onMouseLeave | Callback of mouse leave event | function(e) => {} | () => {} |
+| onNavigate | Triggered when it's clicked and has `link` property. The jumping action of `a` tag will be prevented when provided. | (link: string) => unknown | |
 
 ### Nav.Sub
 
-| Properties    | Description                                                                                                       | Type                | Default  |
-| ------------- | ----------------------------------------------------------------------------------------------------------------- | ------------------- | -------- |
-| disabled      | Disabled state                                                                                                    | boolean             | false    | 1.17.0 |
-| dropdownStyle | Style of dropdown layer                                                                                           | CSSProperties       |          |        |
-| icon          | Navigation project icon name or component                                                                         | ReactNode           |          |
-| indent        | If the icon is empty, keep its space or not. Only effective for first level navigation                            | boolean             | false    |
-| isCollapsed   | Whether it is a controlled attribute in the collapsed state, only `mode = "vertical"`                             | boolean             | false    |
-| isOpen        | Control open state                                                                                                | boolean             | false    |
-| itemKey       | Navigation project only key                                                                                       | string              | ""       |
-| level         | The nesting level of the current item. When limitIndent is true, it is used to customize the indentation position | number              | 1.27.0   |
-| maxHeight     | max height                                                                                                        | number              | 999      |
-| text          | Navigation project copy or component                                                                              | string \| ReactNode | ""       |
-| onMouseEnter  | Callback of mouse enter event                                                                                     | function(e) => {}   | () => {} |
-| onMouseLeave  | Callback of mouse leave event                                                                                     | function(e) => {}   | () => {} |
+| Properties | Description | Type | Default |
+| --- | --- | --- | --- |
+| disabled | Disabled state | boolean | false | 1.17.0 |
+| dropdownStyle | Style of dropdown layer | CSSProperties |  |  |
+| icon | Navigation project icon name or component | ReactNode |  |
+| indent | If the icon is empty, keep its space or not. Only effective for first level navigation | boolean | false |
+| isCollapsed | Whether it is a controlled attribute in the collapsed state, only `mode = "vertical"` | boolean | false |
+| isOpen | Control open state | boolean | false |
+| itemKey | Navigation project only key | string | "" |
+| level | The nesting level of the current item. When limitIndent is true, it is used to customize the indentation position | number | 1.27.0 |
+| maxHeight | max height | number | 999 |
+| text | Navigation project copy or component | string \| ReactNode | "" |
+| onMouseEnter | Callback of mouse enter event | function(e) => {} | () => {} |
+| onMouseLeave | Callback of mouse leave event | function(e) => {} | () => {} |
 
 ### Nav.Header
 
-| Properties  | Description                                                                                 | Type                | Default | Version |
-| ----------- | ------------------------------------------------------------------------------------------- | ------------------- | ------- | ------- |
-| children    | Sub element                                                                                 | ReactNode           |         |         |
-| className   | Outermost style name                                                                        | string              |         |         |
-| link        | Navigation item href link, when imported, the navigation item will be wrapped with an a tag | string              | -       | 1.0.0   |
-| linkOptions | Parameters transparently passed to the a tag                                                | object              | -       | 1.0.0   |
-| logo        | Logo, can be a string or component                                                          | string \| ReactNode |         |         |
-| style       | Outermost style                                                                             | object              |         |         |
-| text        | Logo copy, which can be a string or component                                               | string \| ReactNode |         |         |
+| Properties | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| children | Sub element | ReactNode |  |  |
+| className | Outermost style name | string |  |  |
+| link | Navigation item href link, when imported, the navigation item will be wrapped with an a tag | string | - | 1.0.0 |
+| linkOptions | Parameters transparently passed to the a tag | object | - | 1.0.0 |
+| logo | Logo, can be a string or component | string \| ReactNode |  |  |
+| style | Outermost style | object |  |  |
+| text | Logo copy, which can be a string or component | string \| ReactNode |  |  |
 
 ### Nav.Footer
 
-| Properties     | Description                                                                                                                       | Type                                      | Default | Version |
-| -------------- | --------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------- | ------- | ------- |
-| children       | Sub element                                                                                                                       | ReactNode                                 |         |         |
-| className      | Outermost style name                                                                                                              | string                                    |         |         |
-| collapseButton | Do you show the bottom "put away the sidebar" button, mode = "vertical" and the child parameter of the Footer component is empty? | boolean\|ReactNode                        | false   |         |
-| collapseText   | Title of the collapse button                                                                                                      | (collapsed:boolean) => string\|ReactNode |         | 0.35.0  |
-| style          | Outermost style                                                                                                                   | object                                    |         |         |
+| Properties | Description | Type | Default | Version |
+| --- | --- | --- | --- | --- |
+| children | Sub element | ReactNode |  |  |
+| className | Outermost style name | string |  |  |
+| collapseButton | Do you show the bottom "put away the sidebar" button, mode = "vertical" and the child parameter of the Footer component is empty? | boolean\|ReactNode | false |  |
+| collapseText | Title of the collapse button | (collapsed:boolean) => string\|ReactNode |  | 0.35.0 |
+| style | Outermost style | object |  |  |
 
 ## Content Guidelines
 
-- Navigation bar menu uses sentence case format
-- Keep it as simple as possible
+-   Navigation bar menu uses sentence case format
+-   Keep it as simple as possible
 
 ## Design Tokens
+
 <DesignToken/>
 
 <!-- ## Related Material
@@ -782,9 +851,9 @@ function NavApp (props = {}) {
 ``` -->
 
 ## FAQ
-- **Lost animation in navigation bar?**
+
+-   **Lost animation in navigation bar?**
 
     When using functional components, you should give items with useState or useMemo, because passing an array directly to items will trigger component rerendering.
 
-- **Lost item when subNav is too height >=999px ?**
-    Please refer to [this issue](https://github.com/DouyinFE/semi-design/issues/563)
+-   **Lost item when subNav is too height >=999px ?** Please refer to [this issue](https://github.com/DouyinFE/semi-design/issues/563)

--- a/content/navigation/navigation/index.md
+++ b/content/navigation/navigation/index.md
@@ -2,13 +2,12 @@
 localeCode: zh-CN
 order: 39
 category: 导航类
-title:  Navigation 导航
+title: Navigation 导航
 icon: doc-navigation
 width: 650px
 dir: column
 brief: 为页面和功能提供导航的菜单列表。
 ---
-
 
 ## 代码演示
 
@@ -56,9 +55,7 @@ class NavApp extends React.Component {
         );
     }
 }
-
 ```
-
 
 ### 导航缩进
 
@@ -79,14 +76,14 @@ class NavApp extends React.Component {
         return (
             <Nav
                 bodyStyle={{ height: 320 }}
-                defaultOpenKeys={[ 'job' ]}
+                defaultOpenKeys={['job']}
                 items={[
                     { itemKey: 'user', text: '用户管理' },
                     { itemKey: 'union', text: '公会中心' },
                     {
                         itemKey: 'union-management',
                         text: '公会管理',
-                        items: ['公告设置', '公会查询', '信息录入']
+                        items: ['公告设置', '公会查询', '信息录入'],
                     },
                     {
                         text: '任务平台',
@@ -133,8 +130,10 @@ class NavApp extends React.Component {
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Semi 运营后台'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Semi 运营后台',
                 }}
                 footer={{
                     collapseButton: true,
@@ -181,8 +180,10 @@ class NavApp extends React.Component {
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Semi 运营后台'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Semi 运营后台',
                 }}
                 footer={{
                     collapseButton: true,
@@ -211,7 +212,12 @@ class NavApp extends React.Component {
                 onSelect={data => console.log('trigger onSelect: ', data)}
                 onClick={data => console.log('trigger onClick: ', data)}
             >
-                <Nav.Header logo={<img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />} text={'Semi 运营后台'} />
+                <Nav.Header
+                    logo={
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    }
+                    text={'Semi 运营后台'}
+                />
                 <Nav.Item itemKey={'union'} text={'公会中心'} icon={<IconStar />} />
                 <Nav.Sub itemKey={'user'} text="用户管理" icon={<IconUser />}>
                     <Nav.Item itemKey={'golder'} text={'金主管理'} />
@@ -227,7 +233,6 @@ class NavApp extends React.Component {
         );
     }
 }
-
 ```
 
 ### 导航方向
@@ -265,7 +270,7 @@ class NavApp extends React.Component {
                             itemKey: 'union-management',
                             text: '公会管理',
                             icon: <IconUserGroup />,
-                            items: ['公告设置', '公会查询', '信息录入']
+                            items: ['公告设置', '公会查询', '信息录入'],
                         },
                         {
                             text: '任务平台',
@@ -276,8 +281,10 @@ class NavApp extends React.Component {
                     ]}
                     onSelect={key => console.log(key)}
                     header={{
-                        logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                        text: 'Semi 运营后台'
+                        logo: (
+                            <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                        ),
+                        text: 'Semi 运营后台',
                     }}
                     footer={{
                         collapseButton: true,
@@ -314,12 +321,9 @@ class NavApp extends React.Component {
                                 {
                                     itemKey: 'operation-management',
                                     text: '运营管理',
-                                    items: [
-                                        '人员管理',
-                                        '人员变更'
-                                    ]
-                                }
-                            ]
+                                    items: ['人员管理', '人员变更'],
+                                },
+                            ],
                         },
                         {
                             text: '任务平台',
@@ -330,8 +334,10 @@ class NavApp extends React.Component {
                     ]}
                     onSelect={key => console.log(key)}
                     header={{
-                        logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                        text: 'Semi 运营后台'
+                        logo: (
+                            <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                        ),
+                        text: 'Semi 运营后台',
                     }}
                     footer={
                         <Dropdown
@@ -343,7 +349,9 @@ class NavApp extends React.Component {
                                 </Dropdown.Menu>
                             }
                         >
-                            <Avatar size="small" color='light-blue' style={{margin: 4}}>BD</Avatar>
+                            <Avatar size="small" color="light-blue" style={{ margin: 4 }}>
+                                BD
+                            </Avatar>
                             <span>Bytedancer</span>
                         </Dropdown>
                     }
@@ -372,7 +380,7 @@ class NavApp extends React.Component {
                 itemKey: 'union-management',
                 text: '公会管理',
                 icon: <IconUserGroup />,
-                items: ['公告设置', '公会查询', '信息录入']
+                items: ['公告设置', '公会查询', '信息录入'],
             },
             {
                 itemKey: 'approve-management',
@@ -383,12 +391,9 @@ class NavApp extends React.Component {
                     {
                         itemKey: 'operation-management',
                         text: '运营管理',
-                        items: [
-                            '人员管理',
-                            '人员变更'
-                        ]
-                    }
-                ]
+                        items: ['人员管理', '人员变更'],
+                    },
+                ],
             },
             {
                 text: '任务平台',
@@ -408,16 +413,22 @@ class NavApp extends React.Component {
                 mode={'horizontal'}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Semi 运营后台'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Semi 运营后台',
                 }}
                 footer={
                     <>
-                        <Select defaultValue='Chinese' style={{ width: 120, marginRight: 10 }} insetLabel={<IconLanguage />}>
-                            <Select.Option value='Chinese'>中文</Select.Option>
-                            <Select.Option value='English'>English</Select.Option>
-                            <Select.Option value='Korean'>한국어</Select.Option>
-                            <Select.Option value='Japanese'>日本語</Select.Option>
+                        <Select
+                            defaultValue="Chinese"
+                            style={{ width: 120, marginRight: 10 }}
+                            insetLabel={<IconLanguage />}
+                        >
+                            <Select.Option value="Chinese">中文</Select.Option>
+                            <Select.Option value="English">English</Select.Option>
+                            <Select.Option value="Korean">한국어</Select.Option>
+                            <Select.Option value="Japanese">日本語</Select.Option>
                         </Select>
                         <Button style={{ marginRight: 10 }}>切换至海外版</Button>
                         <Dropdown
@@ -429,7 +440,9 @@ class NavApp extends React.Component {
                                 </Dropdown.Menu>
                             }
                         >
-                            <Avatar size="small" color='light-blue' style={{margin: 4}}>BD</Avatar>
+                            <Avatar size="small" color="light-blue" style={{ margin: 4 }}>
+                                BD
+                            </Avatar>
                             <span>Bytedancer</span>
                         </Dropdown>
                     </>
@@ -490,8 +503,10 @@ class NavApp extends React.Component {
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Semi 运营后台'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Semi 运营后台',
                 }}
                 footer={{
                     collapseButton: true,
@@ -503,6 +518,7 @@ class NavApp extends React.Component {
 ```
 
 ### 缩进限制
+
 默认无缩进，需要导航项依据层级缩进请将 limitIndent 设置为 false
 
 React Jsx 方式用 Nav.Item 传入导航项时 请手动给 Nav.Item 传入 `level` props。
@@ -529,23 +545,31 @@ class NavApp extends React.Component {
                         text: '任务平台',
                         icon: <IconSetting />,
                         itemKey: 'job',
-                        items: ['任务管理', {
-                            text: '任务1',
-                            icon: <IconSetting />,
-                            itemKey: 'mission1',
-                            items: ['任务2',{
-                                text: '任务3拆解',
+                        items: [
+                            '任务管理',
+                            {
+                                text: '任务1',
                                 icon: <IconSetting />,
-                                itemKey: 'mission3',
-                                items: ['子任务1', '子任务2'],
-                            }, ],
-                        },],
+                                itemKey: 'mission1',
+                                items: [
+                                    '任务2',
+                                    {
+                                        text: '任务3拆解',
+                                        icon: <IconSetting />,
+                                        itemKey: 'mission3',
+                                        items: ['子任务1', '子任务2'],
+                                    },
+                                ],
+                            },
+                        ],
                     },
                 ]}
                 onSelect={key => console.log(key)}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Semi 运营后台'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Semi 运营后台',
                 }}
                 footer={{
                     collapseButton: true,
@@ -555,7 +579,6 @@ class NavApp extends React.Component {
     }
 }
 ```
-
 
 ### 非受控属性
 
@@ -585,7 +608,7 @@ class NavApp extends React.Component {
                         itemKey: 'union-management',
                         text: '公会管理',
                         icon: <IconUserGroup />,
-                        items: ['公告设置', '公会查询', '信息录入']
+                        items: ['公告设置', '公会查询', '信息录入'],
                     },
                     {
                         text: '任务平台',
@@ -595,17 +618,18 @@ class NavApp extends React.Component {
                     },
                 ]}
                 header={{
-                    logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                    text: 'Semi 运营后台'
+                    logo: (
+                        <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                    ),
+                    text: 'Semi 运营后台',
                 }}
                 footer={{
-                    collapseButton: true
+                    collapseButton: true,
                 }}
             />
         );
     }
 }
-
 ```
 
 ### 受控属性
@@ -629,7 +653,7 @@ import React, { useMemo, useState } from 'react';
 import { Nav } from '@douyinfe/semi-ui';
 import { IconUser, IconStar, IconUserGroup, IconSetting } from '@douyinfe/semi-icons';
 
-function NavApp (props = {}) {
+function NavApp(props = {}) {
     const [openKeys, setOpenKeys] = useState(['union-management', 'job']);
     const [selectedKeys, setSelectedKeys] = useState(['用户任务查询']);
     const [isCollapsed, setIsCollapsed] = useState(true);
@@ -647,22 +671,25 @@ function NavApp (props = {}) {
         setIsCollapsed(isCollapsed);
     };
 
-    const items = useMemo(() => [
-        { itemKey: 'user', text: '用户管理', icon: <IconUser /> },
-        { itemKey: 'union', text: '公会中心', icon: <IconStar /> },
-        {
-            itemKey: 'union-management',
-            text: '公会管理',
-            icon: <IconUserGroup />,
-            items: ['公告设置', '公会查询', '信息录入']
-        },
-        {
-            text: '任务平台',
-            icon: <IconSetting />,
-            itemKey: 'job',
-            items: ['任务管理', '用户任务查询'],
-        },
-    ], []);
+    const items = useMemo(
+        () => [
+            { itemKey: 'user', text: '用户管理', icon: <IconUser /> },
+            { itemKey: 'union', text: '公会中心', icon: <IconStar /> },
+            {
+                itemKey: 'union-management',
+                text: '公会管理',
+                icon: <IconUserGroup />,
+                items: ['公告设置', '公会查询', '信息录入'],
+            },
+            {
+                text: '任务平台',
+                icon: <IconSetting />,
+                itemKey: 'job',
+                items: ['任务管理', '用户任务查询'],
+            },
+        ],
+        []
+    );
 
     return (
         <Nav
@@ -672,11 +699,13 @@ function NavApp (props = {}) {
             bodyStyle={{ height: 360 }}
             items={items}
             header={{
-                logo: <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />,
-                text: 'Semi 运营后台'
+                logo: (
+                    <img src="https://sf6-cdn-tos.douyinstatic.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/webcast_logo.svg" />
+                ),
+                text: 'Semi 运营后台',
             }}
             footer={{
-                collapseButton: true
+                collapseButton: true,
             }}
             onCollapseChange={onCollapseChange}
             onOpenChange={onOpenChange}
@@ -686,105 +715,138 @@ function NavApp (props = {}) {
 }
 ```
 
+### 由第三方库托管路由
+
+大部分 React SPA 都使用了 `react-router-dom` 之类的路由库实现 SPA 内导航。此时，导航都应该由 `react-router-dom` 的 API 实现。
+
+而如果你直接使用 `<NavItem link="/eg" />`，则会渲染一个 `<a href="/eg" />` 标签，点击则会直接跳转，不走 `react-router-dom`，造成页面刷新。
+
+之前解决方案，可以自己渲染 `<NavItem>` 内容，也可以控制 `a` 标签参数让其行为被 `react-router-dom` 代理。（例如监听 `onclick` 事件并在其回调中添加 `e.preventDefault()`）。
+
+现在我们有了新的 API `onNavigate`，其回调函数第一个参数为目标地址，而且当你传入回调函数时，它会自动为你添加 `preventDefault()`。监听此端口即可直接方便地将路由托管给第三方库。
+
+```jsx live=false
+import React from 'react';
+import { Nav } from '@douyinfe/semi-ui';
+import { useNavigate } from 'react-router-dom';
+
+const NavApp = () => {
+    const navigate = useNavigate();
+
+    return (
+        <Nav
+            items={[
+                { itemKey: 'user', text: '用户管理', link: '/eg/1' },
+                { itemKey: 'union', text: '公会中心', link: '/eg/2' },
+            ]}
+            onNavigate={targetLink => navigate(targetLink)}
+        />
+    );
+};
+```
+
+温馨提示：为了提升网页语义化程度、提高 SEO 友好度，建议将目标路径写入 `a` 标签的 `href` 属性中。这就是为什么上述例子中要使用 `href` 配合 `preventDefault()` 而非放弃 `href` 属性并仅监听其 `onclick` 事件。
+
 ## API 参考
 
 ### Nav
 
-| 属性                | 类型                                                                                                                             | 描述                                                                                                                           | 默认值     |
-| ------------------- | -------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------ | ---------- |
-| bodyStyle           | 导航项列表的自定义样式                                                                             | object                                                                                                                           |           |
-| className           | 最外层元素的样式名                                                                               | boolean                                                                                                                          |           |
-| defaultIsCollapsed  | 默认是否处于收起状态，仅 `mode = "vertical"` 时有效                                                    | boolean                                                                                                                          | false     |
-| defaultOpenKeys     | 初始打开的子导航 `itemKey` 数组，仅 `mode = "vertical"` 且侧边栏处于展开状态时有效                               | string[]                                                                                                                         | []        |
-| defaultSelectedKeys | 初始选中的导航项 `itemKey` 数组                                                                   | string[]                                                                                                                         | []        |
-| footer              | 底部区域配置对象或元素，详见 [Nav.Footer](#Nav.Footer)                                                | object\| ReactNode |                      |
-| header              | 头部区域配置对象或元素，详见 [Nav.Header](#Nav.Header)                                                | object\| ReactNode |                      |
-| isCollapsed         | 是否处于收起状态的受控属性，仅 `mode = "vertical"` 时有效                                                 | boolean                                                                                                                          |           |
-| items               | 导航项目列表，每一项可以继续带有 items 属性。如果为 string 数组，则会取每一项作为 text 和 itemKey                         | object\| string[] \| [Item](#Nav.Item)[] \| [Sub](#Nav.Sub)[] |  |
-| limitIndent         | 解除缩进限制，可使用 level 自定义导航项缩进，水平模式只能为true >=1.27.0                                          | boolean                                                                                                                          | true      |
-| mode                | 导航类型，目前支持横向与竖直，可选值：`vertical`\                                                          | `horizontal`                                                                                                                     | string    | `vertical`           |
-| openKeys            | 受控的打开的子导航 `itemKey` 数组，配合 `onOpenChange` 回调控制子导航项展开，仅 `mode = "vertical"` 且侧边栏处于展开状态时有效 | string[]                                                                                                                         |           |
-| prefixCls           | 类名前缀                                                                                    | string                                                                                                                           | `semi`    |
-| selectedKeys        | 受控的导航项 `itemKey` 数组，配合 `onSelect` 回调控制导航项选择                                             | string[]                                                                                                                         |           |
-| style               | 最外层元素的自定义样式                                                                             |         CSSProperties                                                                                                                         |           |
-| subNavCloseDelay    | 子导航浮层关闭的延迟。collapse 为 true 或 mode 为 "horizontal" 时有效，单位为 ms                             | number                                                                                                                           | 100       |
-| subNavMotion        | 子导航折叠动画                                                                                 | boolean                                                                                                                          | true      |
-| subNavOpenDelay     | 子导航浮层显示的延迟。collapse 为 true 或 mode 为 "horizontal" 时有效，单位为 ms                             | number                                                                                                                           | 0         |
-| toggleIconPosition  | 带有子导航项的的父级导航项箭头位置 >=1.27.0                                                              | 'left' \| 'right'   | 'right'              |
-| tooltipHideDelay    | tooltip 隐藏的延迟，collapse 为 true 时有效，单位为 ms                                                | number                                                                                                                           | 100       |
-| tooltipShowDelay    | tooltip 显示的延迟，collapse 为 true 时有效，单位为 ms                                                | number                                                                                                                           | 0         |
-| onClick             | 点击任意导航项时触发                                                                              | ({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) => {}                                                               | () => {}  |
-| onCollapseChange    | 收起状态变化时的回调                                                                              | (isCollapsed: boolean) => {}                                                                                                     | () => {}  |
-| onOpenChange        | 切换某个子导航项目显隐状态时触发                                                                        | ({ itemKey: string, openKeys: string[], domEvent: MouseEvent, isOpen: boolean }) => {}                                           | () => {}  |
-| onSelect            | 第一次选中某个可选中导航项目时触发，其中 selectedItems 这个字段版本 >= 0.17.0 后才支持 | ({ itemKey: string, selectedKeys: string[], selectedItems: [Item](#Nav.Item)[], domEvent: MouseEvent, isOpen: boolean }) => {} | () => {}  |
+| 属性 | 描述 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| bodyStyle | 导航项列表的自定义样式 | object |  |
+| className | 最外层元素的样式名 | boolean |  |
+| defaultIsCollapsed | 默认是否处于收起状态，仅 `mode = "vertical"` 时有效 | boolean | false |
+| defaultOpenKeys | 初始打开的子导航 `itemKey` 数组，仅 `mode = "vertical"` 且侧边栏处于展开状态时有效 | string[] | [] |
+| defaultSelectedKeys | 初始选中的导航项 `itemKey` 数组 | string[] | [] |
+| footer | 底部区域配置对象或元素，详见 [Nav.Footer](#Nav.Footer) | object\| ReactNode |  |
+| header | 头部区域配置对象或元素，详见 [Nav.Header](#Nav.Header) | object\| ReactNode |  |
+| isCollapsed | 是否处于收起状态的受控属性，仅 `mode = "vertical"` 时有效 | boolean |  |
+| items | 导航项目列表，每一项可以继续带有 items 属性。如果为 string 数组，则会取每一项作为 text 和 itemKey | object\| string[] \| [Item](#Nav.Item)[] \| [Sub](#Nav.Sub)[] |  |
+| limitIndent | 解除缩进限制，可使用 level 自定义导航项缩进，水平模式只能为 true >=1.27.0 | boolean | true |
+| mode | 导航类型，目前支持横向与竖直，可选值：`vertical`\  | `horizontal` | string | `vertical` |
+| openKeys | 受控的打开的子导航 `itemKey` 数组，配合 `onOpenChange` 回调控制子导航项展开，仅 `mode = "vertical"` 且侧边栏处于展开状态时有效 | string[] |  |
+| prefixCls | 类名前缀 | string | `semi` |
+| selectedKeys | 受控的导航项 `itemKey` 数组，配合 `onSelect` 回调控制导航项选择 | string[] |  |
+| style | 最外层元素的自定义样式 | CSSProperties |  |
+| subNavCloseDelay | 子导航浮层关闭的延迟。collapse 为 true 或 mode 为 "horizontal" 时有效，单位为 ms | number | 100 |
+| subNavMotion | 子导航折叠动画 | boolean | true |
+| subNavOpenDelay | 子导航浮层显示的延迟。collapse 为 true 或 mode 为 "horizontal" 时有效，单位为 ms | number | 0 |
+| toggleIconPosition | 带有子导航项的的父级导航项箭头位置 >=1.27.0 | 'left' \| 'right' | 'right' |
+| tooltipHideDelay | tooltip 隐藏的延迟，collapse 为 true 时有效，单位为 ms | number | 100 |
+| tooltipShowDelay | tooltip 显示的延迟，collapse 为 true 时有效，单位为 ms | number | 0 |
+| onClick | 点击任意导航项时触发 | ({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) => {} | () => {} |
+| onCollapseChange | 收起状态变化时的回调 | (isCollapsed: boolean) => {} | () => {} |
+| onOpenChange | 切换某个子导航项目显隐状态时触发 | ({ itemKey: string, openKeys: string[], domEvent: MouseEvent, isOpen: boolean }) => {} | () => {} |
+| onSelect | 第一次选中某个可选中导航项目时触发，其中 selectedItems 这个字段版本 >= 0.17.0 后才支持 | ({ itemKey: string, selectedKeys: string[], selectedItems: [Item](#Nav.Item)[], domEvent: MouseEvent, isOpen: boolean }) => {} | () => {} |
+| onNavigate | 点击有 `link` 参数的导航项时触发。此值不为空时还会阻止 `a` 标签的自动跳转。会透传给所有子项。 | (link: string) => unknown | |
 
 ### Nav.Item
 
-| 属性        | 描述                                               | 类型              | 默认值 | 版本          |
-|-------------|--------------------------------------------------|-------------------|--------|---------------|
-| disabled    | 是否禁用                                           | boolean | false     | 1.17.0              |
-| icon        | 导航项目图标                             | ReactNode |      |               |
-| indent      | 如果 icon 为空，是否保留其占位，仅对一级导航生效       | boolean           | false  |               |
-| itemKey     | 导航项目唯一 key                                   | string            | ""     |               |
-| level       | 当前项所在嵌套层级，limitIndent 为 true时，用于自定义缩进位置| number | | 1.27.0 | 
-| link        | 导航项 href 链接，传入时导航项整体会包裹一个 a 标签 | string            | -      | 1.0.0 |
-| linkOptions | 透传给 a 标签的参数                                | object            | -      | 1.0.0 |
-| text        | 导航项目文案或元素                                 | string\|ReactNode | ""     |               |
-| onClick     | 点击任意导航项时触发 |function({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) |  () => {}   | 
-| onMouseEnter| mouse enter 时触发 |function(e) => {} | () => {}   | 
-| onMouseLeave| mouse leave 时触发 |function(e) => {} | () => {}   | 
+| 属性 | 描述 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| disabled | 是否禁用 | boolean | false | 1.17.0 |
+| icon | 导航项目图标 | ReactNode |  |  |
+| indent | 如果 icon 为空，是否保留其占位，仅对一级导航生效 | boolean | false |  |
+| itemKey | 导航项目唯一 key | string | "" |  |
+| level | 当前项所在嵌套层级，limitIndent 为 true 时，用于自定义缩进位置 | number |  | 1.27.0 |
+| link | 导航项 href 链接，传入时导航项整体会包裹一个 a 标签 | string | - | 1.0.0 |
+| linkOptions | 透传给 a 标签的参数 | object | - | 1.0.0 |
+| text | 导航项目文案或元素 | string\|ReactNode | "" |  |
+| onClick | 点击任意导航项时触发 | function({ itemKey: string, domEvent: MouseEvent, isOpen: boolean }) | () => {} |
+| onMouseEnter | mouse enter 时触发 | function(e) => {} | () => {} |
+| onMouseLeave | mouse leave 时触发 | function(e) => {} | () => {} |
+| onNavigate | 若有 `link` 参数，则点击时触发；此值不为空时还会阻止 `a` 标签的自动跳转。 | (link: string) => unknown | |
 
 ### Nav.Sub
 
-| 属性    | 描述                           | 类型              | 默认值 |
-| ------- | ------------------------------ | ----------------- | ------ |
-| disabled    | 是否禁用                                           | boolean | false     | 1.17.0             |
-| dropdownStyle | 弹出层的 style                                           | CSSProperties |     |              |
-| icon    | 导航项目图标       | ReactNode |      |
-| indent  | 如果 icon 为空，是否保留其占位，仅对一级导航生效 | boolean           | false  |
-| isCollapsed         |  是否处于收起状态的受控属性，仅 `mode = "vertical"`      | boolean  |    false        |
-| isOpen         |  是否打开      | boolean  |    false        |
-| itemKey | 导航项目唯一 key               | string            | ""     |
-| level       | 当前项所在嵌套层级，limitIndent 为 true时，用于自定义缩进位置| number | 0 | 1.27.0 |
-| maxHeight       | 最大高度 | number | 999 |
-| text    | 导航项目文案或组件             | string\|ReactNode | ""     |
-| onMouseEnter| mouse enter 时触发 |function(e) => {} | () => {}   | 
-| onMouseLeave| mouse leave 时触发 |function(e) => {} | () => {}   | 
+| 属性          | 描述                                                           | 类型              | 默认值   |
+| ------------- | -------------------------------------------------------------- | ----------------- | -------- |
+| disabled      | 是否禁用                                                       | boolean           | false    | 1.17.0 |
+| dropdownStyle | 弹出层的 style                                                 | CSSProperties     |          |  |
+| icon          | 导航项目图标                                                   | ReactNode         |          |
+| indent        | 如果 icon 为空，是否保留其占位，仅对一级导航生效               | boolean           | false    |
+| isCollapsed   | 是否处于收起状态的受控属性，仅 `mode = "vertical"`             | boolean           | false    |
+| isOpen        | 是否打开                                                       | boolean           | false    |
+| itemKey       | 导航项目唯一 key                                               | string            | ""       |
+| level         | 当前项所在嵌套层级，limitIndent 为 true 时，用于自定义缩进位置 | number            | 0        | 1.27.0 |
+| maxHeight     | 最大高度                                                       | number            | 999      |
+| text          | 导航项目文案或组件                                             | string\|ReactNode | ""       |
+| onMouseEnter  | mouse enter 时触发                                             | function(e) => {} | () => {} |
+| onMouseLeave  | mouse leave 时触发                                             | function(e) => {} | () => {} |
 
 ### Nav.Header
 
-| 属性        | 描述                                               | 类型              | 默认值 | 版本          |
-|-------------|--------------------------------------------------|-------------------|--------|---------------|
-| children    | 子元素                                             | ReactNode         |        |               |
-| className   | 最外层样式名                                       | string            |        |               |
-| link        | 导航项 href 链接，传入时导航项整体会包裹一个 a 标签 | string            | -      | 1.0.0 |
-| linkOptions | 透传给 a 标签的参数                                | object            | -      | 1.0.0 |
-| logo        | Logo                         | ReactNode |        |               |
-| style       | 最外层样式                                         | CSSProperties            |        |               |
-| text        | Logo 文案                       | ReactNode |        |               |
+| 属性        | 描述                                                | 类型          | 默认值 | 版本  |
+| ----------- | --------------------------------------------------- | ------------- | ------ | ----- |
+| children    | 子元素                                              | ReactNode     |        |       |
+| className   | 最外层样式名                                        | string        |        |       |
+| link        | 导航项 href 链接，传入时导航项整体会包裹一个 a 标签 | string        | -      | 1.0.0 |
+| linkOptions | 透传给 a 标签的参数                                 | object        | -      | 1.0.0 |
+| logo        | Logo                                                | ReactNode     |        |       |
+| style       | 最外层样式                                          | CSSProperties |        |       |
+| text        | Logo 文案                                           | ReactNode     |        |       |
 
 ### Nav.Footer
 
-| 属性           | 描述                                                                                     | 类型                                      | 默认值 | 版本           |
-| -------------- | ---------------------------------------------------------------------------------------- | ----------------------------------------- | ------ | -------------- |
-| children       | 子元素                                                                                   | ReactNode                                 |        |                |
-| className      | 最外层样式名                                                                             | string                                    |        |                |
-| collapseButton | 是否展示底部“收起侧边栏”按钮，mode="vertical" 且 Footer 组件的 children 参数为空才有效果 | boolean\|ReactNode                        | false  |                |
-| collapseText   | “收起”按钮的文案                                                                         | (collapsed:boolean) => string\|ReactNode |        | 0.35.0 |
-| style          | 最外层样式                                                                               | CSSProperties                                    |        |                |
-
+| 属性 | 描述 | 类型 | 默认值 | 版本 |
+| --- | --- | --- | --- | --- |
+| children | 子元素 | ReactNode |  |  |
+| className | 最外层样式名 | string |  |  |
+| collapseButton | 是否展示底部“收起侧边栏”按钮，mode="vertical" 且 Footer 组件的 children 参数为空才有效果 | boolean\|ReactNode | false |  |
+| collapseText | “收起”按钮的文案 | (collapsed:boolean) => string\|ReactNode |  | 0.35.0 |
+| style | 最外层样式 | CSSProperties |  |  |
 
 ## 文案规范
 
-- 导航栏菜单使用句子大小写格式
-- 尽量精简
+-   导航栏菜单使用句子大小写格式
+-   尽量精简
 
-| ✅ 推荐用法 | ❌ 不推荐用法 |   
-| --- | --- | 
+| ✅ 推荐用法   | ❌ 不推荐用法 |
+| ------------- | ------------- |
 | Appeal center | Appeal Center |
 
-
 ## 设计变量
+
 <DesignToken/>
 
 <!-- ## 相关物料
@@ -797,5 +859,4 @@ function NavApp (props = {}) {
 -   **导航动画丢失？**  
     在使用函数式组件时，应该用 useState 或者 useMemo 包裹一下 items，原因是 items 直接传一个数组会触发组件重新渲染。
 
--   **当子菜单高度超过999px，部分导航消失？**
-    请查看 [此 issue](https://github.com/DouyinFE/semi-design/issues/563)
+-   **当子菜单高度超过 999px，部分导航消失？** 请查看 [此 issue](https://github.com/DouyinFE/semi-design/issues/563)

--- a/packages/semi-ui/navigation/Item.tsx
+++ b/packages/semi-ui/navigation/Item.tsx
@@ -33,6 +33,7 @@ export interface NavItemProps extends ItemProps, BaseProps {
     text?: React.ReactNode;
     tooltipHideDelay?: number;
     tooltipShowDelay?: number;
+    onNavigate?(link?: string): unknown;
     onClick?(clickItems: SelectedData): void;
     onMouseEnter?: React.MouseEventHandler<HTMLLIElement>;
     onMouseLeave?: React.MouseEventHandler<HTMLLIElement>;
@@ -55,6 +56,7 @@ export default class NavItem extends BaseComponent<NavItemProps, NavItemState> {
         onClick: PropTypes.func,
         onMouseEnter: PropTypes.func,
         onMouseLeave: PropTypes.func,
+        onNavigate: PropTypes.func,
         children: PropTypes.node,
         icon: PropTypes.oneOfType([PropTypes.node]),
         className: PropTypes.string,
@@ -217,7 +219,20 @@ export default class NavItem extends BaseComponent<NavItemProps, NavItemState> {
 
         if (typeof link === 'string') {
             itemChildren = (
-                <a className={`${prefixCls}-item-link`} href={link} {...(linkOptions as any)}>
+                <a
+                    className={`${prefixCls}-item-link`}
+                    href={link}
+                    {...(linkOptions as any)}
+                    onClick={e => {
+                        if (this.props.onNavigate && link) {
+                            e.preventDefault();
+                            this.handleClick(e);
+                            this.props.onNavigate(link);
+                        } else {
+                            this.handleClick(e);
+                        }
+                    }}
+                >
                     {itemChildren}
                 </a>
             );

--- a/packages/semi-ui/navigation/_story/LinkNavByOnNavigate/index.jsx
+++ b/packages/semi-ui/navigation/_story/LinkNavByOnNavigate/index.jsx
@@ -1,0 +1,40 @@
+import React, { useMemo } from 'react';
+import { IconClose, IconTick } from '@douyinfe/semi-icons';
+import { Nav, Typography, Space } from '../../../index';
+
+export default function Demo() {
+    const navItems = useMemo(
+        () => [
+            { itemKey: 'item-without-link', text: '无 link 选项', icon: <IconClose /> },
+            { itemKey: 'item-with-link', text: '有 link 选项', link:'/test-link', icon: <IconTick /> },
+        ],
+        []
+    );
+
+    return (
+        <Space vertical align="start" spacing="loose">
+            <Typography.Title heading={1}>阻止自动跳转的导航栏</Typography.Title>
+            <Typography.Paragraph>不使用 <code>onNavigate</code> 时，如果选项中配置了 <code>link</code> 属性则会渲染带 <code>href</code> 属性的 <code>a</code> 标签。此时点击则会发生页面跳转，不利于使用诸如 <code>react-router-dom</code> 等库的 SPA 进行导航。</Typography.Paragraph>
+            <Typography.Paragraph>使用 <code>onNavigate</code> 后，会自动在 <code>a</code> 标签的 <code>onClick</code> 事件中添加 <code>e.preventDefault()</code>，并触发 <code>onNavigate</code> API，其回调函数的第一个参数为目标地址。使用 <code>react-router-dom</code> 等库的同学可以监听此端口进行导航。</Typography.Paragraph>
+            <Space spacing="loose">
+                <Space vertical align="start">
+                    <Typography.Title heading={3}>使用 <code>onNavigate</code></Typography.Title>
+                    <Nav
+                        items={navItems}
+                        onClick={clickParams => console.log('[Semi.Nav] onClick triggered:', clickParams)}
+                        onSelect={selectParams => console.log('[Semi.Nav] onSelect triggered:', selectParams)}
+                        onNavigate={link => console.log('[Semi.Nav] onNavigate triggered:', link)}
+                    />
+                </Space>
+                <Space vertical align="start">
+                    <Typography.Title heading={3}>不使用 <code>onNavigate</code></Typography.Title>
+                    <Nav
+                        items={navItems}
+                        onClick={clickParams => console.log('[Semi.Nav] onClick triggered:', clickParams)}
+                        onSelect={selectParams => console.log('[Semi.Nav] onSelect triggered:', selectParams)}
+                    />
+                </Space>
+            </Space>
+        </Space>
+    );
+}

--- a/packages/semi-ui/navigation/_story/navigation.stories.js
+++ b/packages/semi-ui/navigation/_story/navigation.stories.js
@@ -5,6 +5,7 @@ import Switch from '../../switch';
 import AutoOpenDemo from './AutoOpen';
 import ControlledSelectedKeys from './ControlledSelectedKeys';
 import LinkNavDemo from './LinkNav';
+import LinkNavByOnNavigateDemo from './LinkNavByOnNavigate';
 import MountUnmount from './MountUnmount';
 import WithRouter from './WithRouter';
 import WithChildren from './WithChildren';
@@ -297,6 +298,11 @@ AutoOpen.story = {
 export const LinkNav = () => <LinkNavDemo />;
 LinkNav.story = {
   name: 'link nav',
+}
+
+export const LinkNavWithOnNavigate = () => <LinkNavByOnNavigateDemo />;
+LinkNavWithOnNavigate.story = {
+  name: 'link nav with onNavigate',
 }
 
 export const MountUnmountDemo = () => <MountUnmount />;

--- a/packages/semi-ui/navigation/index.tsx
+++ b/packages/semi-ui/navigation/index.tsx
@@ -71,6 +71,7 @@ export interface NavProps extends BaseProps {
     onDeselect?: (data?: any) => void;
     onOpenChange?: (data: { itemKey: (string | number); openKeys: (string | number)[]; domEvent: MouseEvent; isOpen: boolean }) => void;
     onSelect?: (data: OnSelectedData) => void;
+    onNavigate?: (link: string) => unknown;
 }
 
 export interface NavState {
@@ -124,6 +125,8 @@ class Nav extends BaseComponent<NavProps, NavState> {
         mode: PropTypes.oneOf([...strings.MODE]),
         // Triggered when selecting a navigation item
         onSelect: PropTypes.func,
+        // Triggered when clicking a navigation item, will prevent default a tag jumping
+        onNavigate: PropTypes.func,
         // Triggered when clicking a navigation item
         onClick: PropTypes.func,
         // SubNav expand/close callback
@@ -271,7 +274,7 @@ class Nav extends BaseComponent<NavProps, NavState> {
                             </SubNav>
                         );
                     } else {
-                        return <Item key={item.itemKey || String(level) + idx} {...item as NavItemPropsWithItems} level={level} />;
+                        return <Item key={item.itemKey || String(level) + idx} {...item as NavItemPropsWithItems} level={level} onNavigate={this.props.onNavigate} />;
                     }
                 })}
             </>


### PR DESCRIPTION
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
**新增特性**：给 `Nav` 和 `NavItem` 组件新增了 `onNavigate` API，在有 `link` 属性的叶子结点被点击时触发，回调入参传入目标链接。传入此项后，会给渲染的 `a` 标签的 `onclick` 事件回调中自动添加 `preventDefault()` 以避免页面跳转刷新。此改动是为了在保持页面语义化和 SEO 友好的前提下更方便集成 `react-router-dom` 等第三方路由库。在 `Nav` 组件传入的 `onNavigate` 回调会被透传给所有子项。

**New feature**: Introducing `onNavigate` API to `Nav` and `NavItem`. `onNavigate` is an interface for the callback handler triggered when a nav item with `link` property is clicked and its first parameter will be the target link. And when it's provided, the `preventDefault()` will be automatically added to the `onclick` event handler of the `a` tag rendered. So you can easily integrate any third routing libraries with Semi `Nav` component by just listening this interface. Notice: when it's provided to `Nav` component, it will be passed to all sub nav items.

```jsx
<a
    className={`${prefixCls}-item-link`}
    href={link}
    {...(linkOptions as any)}
    onClick={e => {
        if (this.props.onNavigate && link) {
            e.preventDefault();
            this.handleClick(e);
            this.props.onNavigate(link);
        } else {
            this.handleClick(e);
        }
    }}
>
    {itemChildren}
</a>
```

### Change-log

- **特性**：为 `Nav` 和 `NavItem` 组件新增 `onNavigate` API。

---

- **Feat**: Introducing `onNavigate` API to `Nav` and `NavItem`.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Change-log or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
