### PR TITLE
fix: fix the trigger in dropdown do not response the enter press problem

### DIFF
--- a/packages/semi-foundation/dropdown/foundation.ts
+++ b/packages/semi-foundation/dropdown/foundation.ts
@@ -34,7 +34,8 @@ export default class DropdownFoundation extends BaseFoundation<DropdownAdapter> 
             case ' ':
             case 'Enter':
                 event.target.click();
-                handlePrevent(event);
+                // user may use input to be the trigger and bind some key event on it, so do not stoppropagation
+                // handlePrevent(event);
                 break;
             case 'ArrowDown':
                 this.setFocusToFirstMenuItem(event.target);

--- a/packages/semi-foundation/dropdown/menuFoundation.ts
+++ b/packages/semi-foundation/dropdown/menuFoundation.ts
@@ -54,7 +54,8 @@ export default class DropdownMenuFoundation extends BaseFoundation<Partial<Defau
             case ' ':
             case 'Enter':
                 event.target.click();
-                handlePrevent(event);
+                // user may use input to be the trigger and bind some key event on it, so do not stoppropagation
+                // handlePrevent(event);
                 break;
             case 'Escape':
                 this.handleEscape(menu);

--- a/packages/semi-ui/dropdown/index.tsx
+++ b/packages/semi-ui/dropdown/index.tsx
@@ -247,7 +247,11 @@ class Dropdown extends BaseComponent<DropdownProps, DropdownState> {
                         }),
                         'aria-haspopup': true,
                         'aria-expanded': popVisible,
-                        onKeyDown: e => this.foundation.handleKeyDown(e)
+                        onKeyDown: e => {
+                            this.foundation.handleKeyDown(e);
+                            const childrenKeyDown = get(children, 'props.onKeyDown');
+                            childrenKeyDown && childrenKeyDown();
+                        }
                     }) :
                     children}
             </Tooltip>

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -720,7 +720,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                     ref.current = node;
                 }
             },
-            tabIndex:  (children as React.ReactElement).props.tabIndex || 0, // a11y keyboard, in some condition select's tabindex need to -1 or 0 
+            tabIndex: (children as React.ReactElement).props.tabIndex || 0, // a11y keyboard, in some condition select's tabindex need to -1 or 0 
             'data-popupid': id
         });
 

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -720,7 +720,8 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                     ref.current = node;
                 }
             },
-            tabIndex:  (children as React.ReactElement).props.tabIndex || 0 // a11y keyboard, in some condition select's tabindex need to -1 or 0 
+            tabIndex:  (children as React.ReactElement).props.tabIndex || 0, // a11y keyboard, in some condition select's tabindex need to -1 or 0 
+            'data-popupid': id
         });
 
         // If you do not add a layer of div, in order to bind the events and className in the tooltip, you need to cloneElement children, but this time it may overwrite the children's original ref reference


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1102 

### Changelog
🇨🇳 Chinese
- Fix: 修复在 DropDown 中使用 Input，Input onEnterPress 事件不生效问题

---

🇺🇸 English
- Fix:  fix the problem that Input onEnterPress event does not take effect when using Input in DropDown


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
