### PR TITLE
fix: after update the anchor click area, a11y offset should be internal

### DIFF
--- a/packages/semi-foundation/anchor/anchor.scss
+++ b/packages/semi-foundation/anchor/anchor.scss
@@ -18,8 +18,6 @@ $module: #{$prefix}-anchor;
         left: $spacing-anchor_slide-left;
         top: $spacing-anchor_slide-top;
         height: 100%;
-        box-sizing: border-box;
-        padding: $width-anchor-outline 0;
 
         &-muted {
             display: none;
@@ -66,11 +64,6 @@ $module: #{$prefix}-anchor;
 
     &-link {
 
-        &-wrapper {
-            padding-right: $width-anchor-outline;
-            margin: $width-anchor-outline 0;
-        }
-
         &-title {
             cursor: pointer;
             color: $color-anchor_title-text-default;
@@ -92,6 +85,7 @@ $module: #{$prefix}-anchor;
 
             &:focus-visible {
                 outline: $width-anchor-outline solid $color-anchor_title-outline-focus;
+                outline-offset: $width-anchor-outlineOffset;
             }
 
             &-disabled {

--- a/packages/semi-foundation/anchor/variables.scss
+++ b/packages/semi-foundation/anchor/variables.scss
@@ -30,4 +30,5 @@ $radius-anchor_slide: 1px; // 滑轨圆角
 
 // Witdh
 $width-anchor-outline: 2px; // anchor轮廓宽度
+$width-anchor-outlineOffset: -2px; // anchor轮廓 outline-offset 宽度
 $width-anchor-outline_border_radius: 3px; // anchor轮廓圆角


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Anchor 间距可触发选中后，键盘聚焦样式被遮挡问题

---

🇺🇸 English
- Fix: fix the issue that the keyboard focus style is blocked after the Anchor spacing can trigger the selection


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
