### PR TITLE
fix: [Select] Fixed the problem that Select did not focus on the firs…

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -544,8 +544,14 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
     handleInputChange(sugInput: string) {
         // Input is a controlled component, so the value needs to be updated
         this._adapter.updateInputValue(sugInput);
-        const { options, isOpen } = this.getStates();
+        const { options, isOpen, focusIndex } = this.getStates();
         const { allowCreate, remote } = this.getProps();
+
+        // Hight first option when search
+        // if last focusIndex isn't first option, change focusIndex to 0(first option);
+        if (focusIndex !== 0) {
+            this._adapter.updateFocusIndex(0);
+        }
 
         let optionsAfterFilter = options;
         if (!remote) {


### PR DESCRIPTION
…t item when searching after the focused item was changed

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1128

### Changelog
🇨🇳 Chinese
- Fix: 修复 Select 中当 focused 非第一项时，搜索时没有高亮第一项的问题 #1128 

---

🇺🇸 English
- Fix: fix the problem that when the focused item is not the first item in Select, the first item is not highlighted when searching #1128 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
