### PR TITLE
fix: Fix the redundant box-shadow in the fixed column on the left whe…

### DIFF
--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -405,7 +405,6 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             hoveredRowKey: null,
         });
 
-        this.setScrollPosition('left');
         this.debouncedWindowResize = debounce(this.handleWindowResize, 150);
 
         this.cachedFilteredSortedDataSource = [];
@@ -473,6 +472,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
 
     componentDidMount() {
         super.componentDidMount();
+        this.setScrollPosition('left');
 
         if (this.adapter.isAnyColumnFixed() || (this.props.showHeader && this.adapter.useFixedHeader())) {
             this.handleWindowResize();


### PR DESCRIPTION
…n entering the virtual list for the first time

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1134 

### Changelog
🇨🇳 Chinese
- Fix:  修复虚拟化表格在有左边固定列时，首次渲染左边固定列会有多余的box-shadow问题 #1134 

---

🇺🇸 English
- Fix: fix the problem that when the virtual table has a fixed column on the left, there will be an extra box-shadow when rendering the fixed column on the left for the first time #1134 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
