### PR TITLE
chore: add export type keyword for interface

### DIFF
--- a/packages/semi-foundation/calendar/foundation.ts
+++ b/packages/semi-foundation/calendar/foundation.ts
@@ -32,9 +32,8 @@ import {
     parseRangeAllDayEvent,
     DateObj,
     checkWeekend,
-    weeekStartsOnEnum
 } from './eventUtil';
-
+import type { weeekStartsOnEnum } from './eventUtil';
 
 export { weeekStartsOnEnum };
 export interface EventObject {

--- a/packages/semi-foundation/datePicker/foundation.ts
+++ b/packages/semi-foundation/datePicker/foundation.ts
@@ -12,12 +12,13 @@ import { getDefaultFormatTokenByType } from './_utils/getDefaultFormatToken';
 import { strings } from './constants';
 import { strings as inputStrings } from '../input/constants';
 
-import { Type, DateInputFoundationProps, InsetInputValue } from './inputFoundation';
-import { MonthsGridFoundationProps } from './monthsGridFoundation';
-import { WeekStartNumber } from './_utils/getMonthTable';
-import { ArrayElement, Motion } from '../utils/type';
 import getInsetInputFormatToken from './_utils/getInsetInputFormatToken';
 import getInsetInputValueFromInsetInputStr from './_utils/getInsetInputValueFromInsetInputStr';
+
+import type { ArrayElement, Motion } from '../utils/type';
+import type { Type, DateInputFoundationProps, InsetInputValue } from './inputFoundation';
+import type { MonthsGridFoundationProps } from './monthsGridFoundation';
+import type { WeekStartNumber } from './_utils/getMonthTable';
 
 export type ValidateStatus = ArrayElement<typeof strings.STATUS>;
 export type InputSize = ArrayElement<typeof strings.SIZE_SET>;
@@ -956,7 +957,7 @@ export default class DatePickerFoundation extends BaseFoundation<DatePickerAdapt
             if (insetInput) {
                 const insetInputFormatToken = getInsetInputFormatToken({ format, type });
                 const insetInputStr = this._isMultiple() ? this.formatMultipleDates(dates, undefined, insetInputFormatToken) : this.formatDates(dates, insetInputFormatToken);
-                insetInputValue = getInsetInputValueFromInsetInputStr({ inputValue: insetInputStr, type, rangeSeparator  });
+                insetInputValue = getInsetInputValueFromInsetInputStr({ inputValue: insetInputStr, type, rangeSeparator });
             }
             const isRangeTypeAndInputIncomplete = this._isRangeType() && !this._isRangeValueComplete(dates);
             /**

--- a/packages/semi-foundation/navigation/foundation.ts
+++ b/packages/semi-foundation/navigation/foundation.ts
@@ -188,7 +188,7 @@ export default class NavigationFoundation<P = Record<string, any>, S = Record<st
         return item;
     }
 
-    getShouldOpenKeys(itemKeysMap: ItemKey2ParentKeysMap = {}, selectedKeys: string | number[] = []) {
+    getShouldOpenKeys(itemKeysMap: ItemKey2ParentKeysMap = {}, selectedKeys: string | number[]= []) {
         const willOpenKeySet = new Set();
 
         if (Array.isArray(selectedKeys) && selectedKeys.length) {

--- a/packages/semi-ui/anchor/index.tsx
+++ b/packages/semi-ui/anchor/index.tsx
@@ -14,7 +14,7 @@ import ConfigContext, { ContextValue } from '../configProvider/context';
 
 const prefixCls = cssClasses.PREFIX;
 
-export { LinkProps } from './link';
+export type { LinkProps } from './link';
 
 export interface AnchorProps {
     autoCollapse?: boolean;

--- a/packages/semi-ui/backtop/index.tsx
+++ b/packages/semi-ui/backtop/index.tsx
@@ -102,6 +102,7 @@ export default class BackTop extends BaseComponent<BackTopProps, BackTopState> {
         );
         const backtopBtn = children ? children : this.renderDefault();
         const content = visible ? (
+            // eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions
             <div
                 {...others} 
                 className={preCls} 

--- a/packages/semi-ui/breadcrumb/index.tsx
+++ b/packages/semi-ui/breadcrumb/index.tsx
@@ -17,7 +17,7 @@ import { IconMore } from '@douyinfe/semi-icons';
 
 const clsPrefix = cssClasses.PREFIX;
 
-export { RouteProps, BreadcrumbItemProps, BreadcrumbItemInfo } from './item';
+export type { RouteProps, BreadcrumbItemProps, BreadcrumbItemInfo } from './item';
 export interface showToolTipProps {
     width?: string | number;
     ellipsisPos?: 'end' | 'middle';

--- a/packages/semi-ui/breadcrumb/item.tsx
+++ b/packages/semi-ui/breadcrumb/item.tsx
@@ -11,7 +11,7 @@ import { merge, isUndefined, isNull } from 'lodash';
 
 const clsPrefix = cssClasses.PREFIX;
 
-export { BreadcrumbItemInfo };
+export type { BreadcrumbItemInfo };
 
 export interface RouteProps extends Route {
     icon?: React.ReactNode;

--- a/packages/semi-ui/button/index.tsx
+++ b/packages/semi-ui/button/index.tsx
@@ -3,13 +3,13 @@ import React from 'react';
 import BaseButton, { ButtonProps as BaseButtonProps } from './Button';
 import IconButton, { IconButtonProps } from '../iconButton';
 
-export { ButtonProps as BaseButtonProps, HtmlType, Size, Theme, Type } from './Button';
+export type { ButtonProps as BaseButtonProps, HtmlType, Size, Theme, Type } from './Button';
 
-export { HorizontalPaddingType } from '../iconButton';
+export type { HorizontalPaddingType } from '../iconButton';
 
-export { ButtonGroupProps } from './buttonGroup';
+export type { ButtonGroupProps } from './buttonGroup';
 
-export { SplitButtonGroupProps } from './splitButtonGroup';
+export type { SplitButtonGroupProps } from './splitButtonGroup';
 
 // eslint-disable-next-line 
 export interface ButtonProps extends IconButtonProps {} // TODO check

--- a/packages/semi-ui/calendar/index.tsx
+++ b/packages/semi-ui/calendar/index.tsx
@@ -59,5 +59,5 @@ class Calendar extends BaseComponent<CalendarProps, {}> {
     }
 }
 
-export { EventObject };
+export type { EventObject };
 export default Calendar;

--- a/packages/semi-ui/calendar/interface.ts
+++ b/packages/semi-ui/calendar/interface.ts
@@ -1,7 +1,7 @@
-import { EventObject, weeekStartsOnEnum } from '@douyinfe/semi-foundation/calendar/foundation';
 import { strings } from '@douyinfe/semi-foundation/calendar/constants';
-import { ArrayElement } from '../_base/base';
-import { BaseProps } from '../_base/baseComponent';
+import type { ArrayElement } from '../_base/base';
+import type { BaseProps } from '../_base/baseComponent';
+import type { EventObject, weeekStartsOnEnum } from '@douyinfe/semi-foundation/calendar/foundation';
 
 export interface CalendarProps extends BaseProps {
     displayValue?: Date;

--- a/packages/semi-ui/card/index.tsx
+++ b/packages/semi-ui/card/index.tsx
@@ -13,9 +13,9 @@ const prefixcls = cssClasses.PREFIX;
 
 export type Shadows = 'hover' | 'always';
 
-export { MetaProps } from './meta';
+export type { MetaProps } from './meta';
 
-export { CardGroupProps } from './cardGroup';
+export type { CardGroupProps } from './cardGroup';
 
 export interface CardProps {
     /** Operation group at the bottom of the card content area */

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -31,8 +31,8 @@ import { Motion } from '../_base/base';
 import { isSemiIcon } from '../_utils';
 import { Position } from '../tooltip/index';
 
-export { CascaderType, ShowNextType } from '@douyinfe/semi-foundation/cascader/foundation';
-export { CascaderData, Entity, Data, CascaderItemProps } from './item';
+export type { CascaderType, ShowNextType } from '@douyinfe/semi-foundation/cascader/foundation';
+export type { CascaderData, Entity, Data, CascaderItemProps } from './item';
 
 export interface ScrollPanelProps extends BasicScrollPanelProps {
     activeNode: CascaderData;
@@ -402,7 +402,7 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                     ? (realValue as SimpleValueType[][])
                     : ([realValue] as SimpleValueType[][]);
             } else {
-                if (realValue !==  undefined) {
+                if (realValue !== undefined) {
                     normallizedValue = [[realValue]];
                 }
             }

--- a/packages/semi-ui/checkbox/index.tsx
+++ b/packages/semi-ui/checkbox/index.tsx
@@ -1,7 +1,7 @@
 import Checkbox, { CheckboxProps, CheckboxEvent } from './checkbox';
 import Group, { CheckboxGroupProps, CheckboxType, CheckboxDirection } from './checkboxGroup';
 
-export { CheckboxInnerProps } from './checkboxInner';
+export type { CheckboxInnerProps } from './checkboxInner';
 class CheckboxWithGroup extends Checkbox {
     static Group = Group;
 }
@@ -9,6 +9,9 @@ class CheckboxWithGroup extends Checkbox {
 export {
     CheckboxWithGroup,
     Checkbox,
+};
+
+export type {
     CheckboxProps,
     CheckboxGroupProps,
     CheckboxEvent,

--- a/packages/semi-ui/collapse/index.tsx
+++ b/packages/semi-ui/collapse/index.tsx
@@ -15,7 +15,7 @@ import { noop } from '@douyinfe/semi-foundation/utils/function';
 import { isEqual } from 'lodash';
 import CollapseContext from './collapse-context';
 
-export { CollapsePanelProps } from './item';
+export type { CollapsePanelProps } from './item';
 
 export interface CollapseReactProps extends CollapseProps{
     expandIcon?: React.ReactNode;
@@ -26,7 +26,7 @@ export interface CollapseReactProps extends CollapseProps{
 }
 
 
-export { CollapseState };
+export type { CollapseState };
 
 class Collapse extends BaseComponent<CollapseReactProps, CollapseState> {
     static Panel = CollapsePanel;

--- a/packages/semi-ui/datePicker/index.tsx
+++ b/packages/semi-ui/datePicker/index.tsx
@@ -7,12 +7,26 @@ import ConfigContext from '../configProvider/context';
 import LocaleConsumer from '../locale/localeConsumer';
 import { Locale } from '../locale/interface';
 
-export { DateInputProps } from './dateInput';
-export { DatePickerProps } from './datePicker';
-export { MonthProps } from './month';
-export { MonthsGridProps } from './monthsGrid';
-export { QuickControlProps } from './quickControl';
-export { YearAndMonthProps } from './yearAndMonth';
+export type {
+    BaseValueType,
+    DayStatusType,
+    DisabledDateOptions,
+    DisabledDateType,
+    DisabledTimeType,
+    InputSize,
+    Position,
+    PresetType,
+    PresetsType,
+    TriggerRenderProps,
+    ValidateStatus,
+    ValueType,
+} from '@douyinfe/semi-foundation/datePicker/foundation';
+export type { DateInputProps } from './dateInput';
+export type { DatePickerProps } from './datePicker';
+export type { MonthProps } from './month';
+export type { MonthsGridProps } from './monthsGrid';
+export type { QuickControlProps } from './quickControl';
+export type { YearAndMonthProps } from './yearAndMonth';
 
 export default forwardStatics(
     React.forwardRef<DatePicker, DatePickerProps>((props, ref) => {
@@ -69,18 +83,3 @@ export default forwardStatics(
     }),
     DatePicker
 );
-
-export {
-    BaseValueType,
-    DayStatusType,
-    DisabledDateOptions,
-    DisabledDateType,
-    DisabledTimeType,
-    InputSize,
-    Position,
-    PresetType,
-    PresetsType,
-    TriggerRenderProps,
-    ValidateStatus,
-    ValueType,
-} from '@douyinfe/semi-foundation/datePicker/foundation';

--- a/packages/semi-ui/descriptions/index.tsx
+++ b/packages/semi-ui/descriptions/index.tsx
@@ -7,7 +7,7 @@ import { isPlainObject } from 'lodash';
 import DescriptionsContext, { DescriptionsAlign, DescriptionsContextValue } from './descriptions-context';
 import Item from './item';
 
-export { DescriptionsItemProps } from './item';
+export type { DescriptionsItemProps } from './item';
 export type DescriptionsSize = 'small' | 'medium' | 'large';
 export interface Data {
     key?: React.ReactNode;

--- a/packages/semi-ui/dropdown/dropdownItem.tsx
+++ b/packages/semi-ui/dropdown/dropdownItem.tsx
@@ -2,10 +2,13 @@ import React from 'react';
 import cls from 'classnames';
 import PropTypes from 'prop-types';
 import { cssClasses as css, strings } from '@douyinfe/semi-foundation/dropdown/constants';
-import DropdownContext, { DropdownContextType } from './context';
-import BaseComponent, { BaseProps } from '../_base/baseComponent';
+import DropdownContext from './context';
+import BaseComponent from '../_base/baseComponent';
 import { IconTick } from '@douyinfe/semi-icons';
 import { noop } from 'lodash';
+
+import type { BaseProps } from '../_base/baseComponent';
+import type { DropdownContextType } from './context';
 
 export type Type = 'primary' | 'secondary' | 'tertiary' | 'warning' | 'danger';
 

--- a/packages/semi-ui/dropdown/index.tsx
+++ b/packages/semi-ui/dropdown/index.tsx
@@ -21,10 +21,10 @@ import { Motion } from '../_base/base';
 const positionSet = strings.POSITION_SET;
 const triggerSet = strings.TRIGGER_SET;
 
-export { DropdownDividerProps } from './dropdownDivider';
-export { DropdownItemProps, Type } from './dropdownItem';
-export { DropdownMenuProps } from './dropdownMenu';
-export { DropdownTitleProps } from './dropdownTitle';
+export type { DropdownDividerProps } from './dropdownDivider';
+export type { DropdownItemProps, Type } from './dropdownItem';
+export type { DropdownMenuProps } from './dropdownMenu';
+export type { DropdownTitleProps } from './dropdownTitle';
 
 export interface DropDownMenuItemItem extends DropdownItemProps {
     node: 'item';

--- a/packages/semi-ui/form/arrayField.tsx
+++ b/packages/semi-ui/form/arrayField.tsx
@@ -4,7 +4,7 @@ import { getUuidv4 } from '@douyinfe/semi-foundation/utils/uuid';
 import { cloneDeep, isUndefined } from 'lodash';
 import { FormUpdaterContext, ArrayFieldContext } from './context';
 import warning from '@douyinfe/semi-foundation/utils/warning';
-import { ArrayFieldStaff, FormUpdaterContextType } from '@douyinfe/semi-foundation/form/interface';
+import type { ArrayFieldStaff, FormUpdaterContextType } from '@douyinfe/semi-foundation/form/interface';
 
 export interface ArrayFieldProps {
     initValue?: any[];

--- a/packages/semi-ui/form/index.tsx
+++ b/packages/semi-ui/form/index.tsx
@@ -32,9 +32,9 @@ export {
 };
 
 export * from './interface';
-export { ArrayFieldProps } from './arrayField';
-export { ReactFieldError, ErrorMessageProps } from './errorMessage';
-export { InputGroupProps } from './group';
-export { LabelProps } from './label';
-export { SectionProps } from './section';
-export { SlotProps } from './slot';
+export type { ArrayFieldProps } from './arrayField';
+export type { ReactFieldError, ErrorMessageProps } from './errorMessage';
+export type { InputGroupProps } from './group';
+export type { LabelProps } from './label';
+export type { SectionProps } from './section';
+export type { SlotProps } from './slot';

--- a/packages/semi-ui/grid/index.tsx
+++ b/packages/semi-ui/grid/index.tsx
@@ -3,5 +3,5 @@ import Col from './col';
 
 export { Row, Col };
 
-export { ColSize, ColProps } from './col';
-export { Breakpoint, Gutter, RowProps } from './row';
+export type { ColSize, ColProps } from './col';
+export type { Breakpoint, Gutter, RowProps } from './row';

--- a/packages/semi-ui/icons/index.tsx
+++ b/packages/semi-ui/icons/index.tsx
@@ -1,5 +1,5 @@
 import Icon, { IconProps, IconSize } from '@douyinfe/semi-icons';
 
-export { IconProps, IconSize };
+export type { IconProps, IconSize };
 
 export default Icon;

--- a/packages/semi-ui/input/index.tsx
+++ b/packages/semi-ui/input/index.tsx
@@ -16,8 +16,8 @@ const sizeSet = strings.SIZE;
 const statusSet = strings.STATUS;
 const modeSet = strings.MODE;
 
-export { InputGroupProps } from './inputGroup';
-export { TextAreaProps } from './textarea';
+export type { InputGroupProps } from './inputGroup';
+export type { TextAreaProps } from './textarea';
 export type InputSize = 'small' | 'large' | 'default';
 export type InputMode = 'password';
 // still keep success as ValidateStatus optional value because form will pass success as props.validateStatus in sometime

--- a/packages/semi-ui/layout/index.tsx
+++ b/packages/semi-ui/layout/index.tsx
@@ -6,7 +6,7 @@ import '@douyinfe/semi-foundation/layout/layout.scss';
 import LayoutContext, { ContextType } from './layout-context';
 import Sider from './Sider';
 
-export { ResponsiveMap, SiderProps } from './Sider';
+export type { ResponsiveMap, SiderProps } from './Sider';
 
 const htmlTag = {
     Header: 'header',
@@ -20,8 +20,7 @@ function generator<P extends { type?: string; tagName?: string; role?: AriaRole;
     const typeName = type.toLowerCase();
     return (BasicComponent): ComponentClass<P> => class Adapter extends React.PureComponent<P> {
         render() {
-            return <BasicComponent role={this.props.role} aria-label={this.props['aria-label']} type={typeName}
-                tagName={tagName} {...this.props} />;
+            return <BasicComponent role={this.props.role} aria-label={this.props['aria-label']} type={typeName} tagName={tagName} {...this.props} />;
         }
     };
 }

--- a/packages/semi-ui/list/index.tsx
+++ b/packages/semi-ui/list/index.tsx
@@ -12,7 +12,7 @@ import Spin from '../spin';
 import ListContext, { Grid } from './list-context';
 import BaseComponent from '../_base/baseComponent';
 
-export { ListItemProps } from './item';
+export type { ListItemProps } from './item';
 
 export interface ListProps<T> {
     style?: React.CSSProperties;

--- a/packages/semi-ui/modal/Modal.tsx
+++ b/packages/semi-ui/modal/Modal.tsx
@@ -20,7 +20,7 @@ import { MotionObject } from "@douyinfe/semi-foundation/utils/type";
 export const destroyFns: any[] = [];
 export type ConfirmType = 'leftTop' | 'leftBottom' | 'rightTop' | 'rightBottom';
 export type Directions = 'ltr' | 'rtl';
-
+export type { ModalState };
 export interface ModalReactProps extends ModalProps {
     cancelButtonProps?: ButtonProps;
     children?: React.ReactNode;
@@ -38,9 +38,7 @@ export interface ModalReactProps extends ModalProps {
     onOk?: (e: React.MouseEvent) => void | Promise<any>;
 }
 
-export {
-    ModalState
-};
+
 
 class Modal extends BaseComponent<ModalReactProps, ModalState> {
 

--- a/packages/semi-ui/modal/index.tsx
+++ b/packages/semi-ui/modal/index.tsx
@@ -4,10 +4,10 @@ import { ModalState } from '@douyinfe/semi-foundation/modal/modalFoundation';
 import Modal from './Modal';
 import　{ ModalReactProps } from './Modal';
 
-export { ConfirmProps } from './confirm';
+export type { ConfirmProps } from './confirm';
 
 export type Directions = 'ltr' | 'rtl';
 
-export { ModalReactProps, ModalState };
+export type { ModalReactProps, ModalState };
 
 export default Modal;

--- a/packages/semi-ui/navigation/index.tsx
+++ b/packages/semi-ui/navigation/index.tsx
@@ -17,13 +17,13 @@ import LocaleConsumer from '../locale/localeConsumer';
 import '@douyinfe/semi-foundation/navigation/navigation.scss';
 import { Motion } from '../_base/base';
 
-export { CollapseButtonProps } from './CollapseButton';
-export { NavFooterProps } from './Footer';
-export { NavHeaderProps } from './Header';
-export { NavItemProps } from './Item';
-export { OpenIconTransitionProps } from './OpenIconTransition';
-export { ToggleIcon, SubNavProps } from './SubNav';
-export { SubNavTransitionProps } from './SubNavTransition';
+export type { CollapseButtonProps } from './CollapseButton';
+export type { NavFooterProps } from './Footer';
+export type { NavHeaderProps } from './Header';
+export type { NavItemProps } from './Item';
+export type { OpenIconTransitionProps } from './OpenIconTransition';
+export type { ToggleIcon, SubNavProps } from './SubNav';
+export type { SubNavTransitionProps } from './SubNavTransition';
 export type Mode = 'vertical' | 'horizontal';
 
 export interface OnSelectedData {

--- a/packages/semi-ui/notification/index.tsx
+++ b/packages/semi-ui/notification/index.tsx
@@ -18,12 +18,12 @@ import useNotification from './useNotification';
 import { NoticeInstance, NoticePosition, NoticeProps, NoticeState } from '@douyinfe/semi-foundation/notification/notificationFoundation';
 // TODO: Automatic folding + unfolding function when there are more than N
 
-export { NoticeTransitionProps } from './NoticeTransition';
+export type { NoticeTransitionProps } from './NoticeTransition';
 export interface NoticeReactProps extends NoticeProps{
     style?: CSSProperties;
 }
 
-export {
+export type {
     NoticeState,
     NotificationListProps,
     NotificationListState,

--- a/packages/semi-ui/overflowList/index.tsx
+++ b/packages/semi-ui/overflowList/index.tsx
@@ -17,7 +17,7 @@ const Boundary = strings.BOUNDARY_MAP;
 const OverflowDirection = strings.OVERFLOW_DIR;
 const RenderMode = strings.MODE_MAP;
 
-export { ReactIntersectionObserverProps } from './intersectionObserver';
+export type { ReactIntersectionObserverProps } from './intersectionObserver';
 export type OverflowItem = Record<string, any>;
 
 export interface OverflowListProps {

--- a/packages/semi-ui/pagination/index.tsx
+++ b/packages/semi-ui/pagination/index.tsx
@@ -67,7 +67,7 @@ export interface PaginationState {
 
 export type PaginationLocale = Locale['Pagination'];
 export type PopoverPosition = Position;
-export { PageList };
+export type { PageList };
 
 export default class Pagination extends BaseComponent<PaginationProps, PaginationState> {
     static contextType = ConfigContext;

--- a/packages/semi-ui/popover/index.tsx
+++ b/packages/semi-ui/popover/index.tsx
@@ -10,7 +10,8 @@ import { BaseProps } from '../_base/baseComponent';
 import { Motion } from '../_base/base';
 import { isFunction, noop } from 'lodash';
 
-export { ArrowProps } from './Arrow';
+import type { ArrowProps } from './Arrow';
+export type { ArrowProps };
 declare interface ArrowStyle {
     borderColor?: string;
     backgroundColor?: string;

--- a/packages/semi-ui/radio/index.tsx
+++ b/packages/semi-ui/radio/index.tsx
@@ -7,6 +7,6 @@ class RadioWithGroup extends Radio {
 
 export default RadioWithGroup;
 export { RadioWithGroup, Radio };
-export { RadioInnerMode, RadioInnerProps } from './radioInner';
-export { RadioGroupProps, OptionItem } from './radioGroup';
-export { RadioDisplayMode, RadioType, RadioProps, RadioChangeEvent } from './radio';
+export type { RadioInnerMode, RadioInnerProps } from './radioInner';
+export type { RadioGroupProps, OptionItem } from './radioGroup';
+export type { RadioDisplayMode, RadioType, RadioProps, RadioChangeEvent } from './radio';

--- a/packages/semi-ui/radio/radio.tsx
+++ b/packages/semi-ui/radio/radio.tsx
@@ -55,7 +55,7 @@ export interface RadioState {
     checked?: boolean;
 }
 
-export { RadioChangeEvent };
+export type { RadioChangeEvent };
 
 class Radio extends BaseComponent<RadioProps, RadioState> {
     static contextType = Context;

--- a/packages/semi-ui/rating/index.tsx
+++ b/packages/semi-ui/rating/index.tsx
@@ -12,7 +12,7 @@ import RatingFoundation, { RatingAdapter } from '@douyinfe/semi-foundation/ratin
 
 import '@douyinfe/semi-foundation/rating/rating.scss';
 
-export { RatingItemProps } from './item';
+export type { RatingItemProps } from './item';
 export interface RatingProps {
     'aria-describedby'?: string;
     'aria-errormessage'?: string;
@@ -270,7 +270,7 @@ export default class Rating extends BaseComponent<RatingProps, RatingState> {
     }
 
     getItemList = (ariaLabelPrefix: string) => {
-        const { count, allowHalf, prefixCls, disabled,  character, size, tooltips } =this.props;
+        const { count, allowHalf, prefixCls, disabled, character, size, tooltips } =this.props;
         const { value, hoverValue, focused } = this.state;
         // index == count is for Empty rating
         const itemList = [...Array(count + 1).keys()].map(ind => {

--- a/packages/semi-ui/scrollList/index.tsx
+++ b/packages/semi-ui/scrollList/index.tsx
@@ -8,7 +8,7 @@ import Foundation from '@douyinfe/semi-foundation/scrollList/foundation';
 
 import '@douyinfe/semi-foundation/scrollList/scrollList.scss';
 
-export { ScrollItemProps } from './scrollItem';
+export type { ScrollItemProps } from './scrollItem';
 export interface ScrollListProps extends BaseProps {
     header?: React.ReactNode;
     footer?: React.ReactNode;

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -34,9 +34,9 @@ import '@douyinfe/semi-foundation/select/select.scss';
 import { Locale } from '../locale/interface';
 import { Position, TooltipProps } from '../tooltip';
 
-export { OptionProps } from './option';
-export { OptionGroupProps } from './optionGroup';
-export { VirtualRowProps } from './virtualRow';
+export type { OptionProps } from './option';
+export type { OptionGroupProps } from './optionGroup';
+export type { VirtualRowProps } from './virtualRow';
 
 const prefixcls = cssClasses.PREFIX;
 

--- a/packages/semi-ui/sideSheet/index.tsx
+++ b/packages/semi-ui/sideSheet/index.tsx
@@ -20,8 +20,8 @@ const prefixCls = cssClasses.PREFIX;
 const defaultWidthList = strings.WIDTH;
 const defaultHeight = strings.HEIGHT;
 
-export { SideSheetContentProps } from './SideSheetContent';
-export { SideSheetTransitionProps } from './SideSheetTransition';
+export type { SideSheetContentProps } from './SideSheetContent';
+export type { SideSheetTransitionProps } from './SideSheetTransition';
 
 export interface SideSheetReactProps extends SideSheetProps {
     bodyStyle?: CSSProperties;
@@ -34,7 +34,7 @@ export interface SideSheetReactProps extends SideSheetProps {
     onCancel?: (e: React.MouseEvent | React.KeyboardEvent) => void;
 }
 
-export {
+export type {
     SideSheetState
 };
 

--- a/packages/semi-ui/skeleton/index.tsx
+++ b/packages/semi-ui/skeleton/index.tsx
@@ -5,7 +5,7 @@ import { cssClasses } from '@douyinfe/semi-foundation/skeleton/constants';
 import '@douyinfe/semi-foundation/skeleton/skeleton.scss';
 import { Avatar, Image, Title, Button, Paragraph } from './item';
 
-export { ParagraphProps, AvatarProps, GenericProps } from './item';
+export type { ParagraphProps, AvatarProps, GenericProps } from './item';
 
 const prefixCls = cssClasses.PREFIX;
 

--- a/packages/semi-ui/slider/index.tsx
+++ b/packages/semi-ui/slider/index.tsx
@@ -18,7 +18,7 @@ export interface SliderProps extends BasicSliceProps {
     railStyle?: CSSProperties;
 }
 
-export {
+export type {
     SliderState
 };
 
@@ -464,7 +464,7 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                         onKeyDown={e =>{
                             this.foundation.handleKeyDown(e, 'max');
                         }}
-                        onFocus={e =>  {
+                        onFocus={e => {
                             this.foundation.onFocus(e, 'max');
                         }}
                         onBlur={(e) => {
@@ -566,7 +566,7 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
 
 
     render() {
-        const { disabled, currentValue, min, max  } = this.state;
+        const { disabled, currentValue, min, max } = this.state;
         const { vertical, verticalReverse, style, railStyle, range, className } = this.props;
         const wrapperClass = cls(
             `${prefixCls}-wrapper`,

--- a/packages/semi-ui/steps/index.tsx
+++ b/packages/semi-ui/steps/index.tsx
@@ -8,13 +8,13 @@ import BasicSteps, { BasicStepsProps } from './basicSteps';
 import NavSteps, { NavStepsProps } from './navSteps';
 import Context from './context';
 
-export { Status, Size, BasicStepProps } from './basicStep';
-export { Direction, BasicStepsProps } from './basicSteps';
-export { FillStepProps } from './fillStep';
-export { FillStepsProps } from './fillSteps';
-export { NavStepProps } from './navStep';
-export { NavStepsProps } from './navSteps';
-export { StepProps } from './step';
+export type { Status, Size, BasicStepProps } from './basicStep';
+export type { Direction, BasicStepsProps } from './basicSteps';
+export type { FillStepProps } from './fillStep';
+export type { FillStepsProps } from './fillSteps';
+export type { NavStepProps } from './navStep';
+export type { NavStepsProps } from './navSteps';
+export type { StepProps } from './step';
 
 export interface FillStepsAllProps extends FillStepsProps {
     type?: 'fill';

--- a/packages/semi-ui/timePicker/index.tsx
+++ b/packages/semi-ui/timePicker/index.tsx
@@ -1,21 +1,19 @@
 import React from 'react';
 import LocaleConsumer from '../locale/localeConsumer';
 import BaseTimePicker, { TimePickerProps as BasePickerProps, BaseValueType } from './TimePicker';
-import { ValidateStatus } from '../_base/baseComponent';
-import { ScrollItemProps } from '../scrollList/scrollItem';
 import ConfigContext from '../configProvider/context';
 import { get } from 'lodash';
 import { Locale } from '../locale/interface';
+import type { ValidateStatus } from '../_base/baseComponent';
+import type { ScrollItemProps } from '../scrollList/scrollItem';
 
-export { TimeInputProps } from './TimeInput';
-export { TimePickerProps } from './TimePicker';
-
-export {
+export type { TimeInputProps } from './TimeInput';
+export type { TimePickerProps } from './TimePicker';
+export type {
     BaseValueType,
     ScrollItemProps,
     ValidateStatus
 };
-
 export type LocalePickerProps = BasePickerProps;
 
 export default class LocaleTimePicker extends React.PureComponent<LocalePickerProps> {

--- a/packages/semi-ui/timeline/index.tsx
+++ b/packages/semi-ui/timeline/index.tsx
@@ -6,7 +6,7 @@ import { cssClasses, strings } from '@douyinfe/semi-foundation/timeline/constant
 import ConfigContext from '../configProvider/context';
 import Item, { TimelineItemProps } from './item';
 
-export { TimelineItemProps } from './item';
+export type { TimelineItemProps } from './item';
 
 export interface Data extends TimelineItemProps {
     content: React.ReactNode;

--- a/packages/semi-ui/toast/index.tsx
+++ b/packages/semi-ui/toast/index.tsx
@@ -17,7 +17,7 @@ import useToast from './useToast';
 import { ConfigProps, ToastInstance, ToastProps, ToastState } from '@douyinfe/semi-foundation/toast/toastFoundation';
 import { Motion } from '../_base/base';
 
-export { ToastTransitionProps } from './ToastTransition';
+export type { ToastTransitionProps } from './ToastTransition';
 export interface ToastReactProps extends ToastProps{
     id?: string;
     style?: CSSProperties;
@@ -25,7 +25,7 @@ export interface ToastReactProps extends ToastProps{
     content: React.ReactNode;
 }
 
-export {
+export type {
     ConfigProps,
     ToastListProps,
     ToastListState,

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -26,9 +26,9 @@ import TooltipTransition from './TooltipStyledTransition';
 import ArrowBoundingShape from './ArrowBoundingShape';
 import { Motion } from '../_base/base';
 
-export { TooltipTransitionProps } from './TooltipStyledTransition';
+export type { TooltipTransitionProps } from './TooltipStyledTransition';
 export type Trigger = ArrayElement<typeof strings.TRIGGER_SET>;
-
+export type { Position };
 export interface ArrowBounding {
     offsetX?: number;
     offsetY?: number;
@@ -734,5 +734,3 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         );
     }
 }
-
-export { Position };

--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -45,7 +45,7 @@ import {
 import CheckboxGroup from '../checkbox/checkboxGroup';
 
 export * from './interface';
-export { AutoSizerProps } from './autoSizer';
+export type { AutoSizerProps } from './autoSizer';
 
 const prefixcls = cssClasses.PREFIX;
 

--- a/packages/semi-ui/typography/index.tsx
+++ b/packages/semi-ui/typography/index.tsx
@@ -15,10 +15,10 @@ Typography.Title = Title;
 Typography.Paragraph = Paragraph;
 
 
-export { BaseTypographyProps } from './base';
-export { CopyableProps } from './copyable';
-export { TitleProps } from './title';
-export { TextProps } from './text';
-export { ParagraphProps } from './paragraph';
+export type { BaseTypographyProps } from './base';
+export type { CopyableProps } from './copyable';
+export type { TitleProps } from './title';
+export type { TextProps } from './text';
+export type { ParagraphProps } from './paragraph';
 export * from './interface';
 export default Typography;

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -3,15 +3,10 @@ import React, { ReactNode, CSSProperties, RefObject, ChangeEvent, DragEvent } fr
 import cls from 'classnames';
 import PropTypes from 'prop-types';
 import { noop, pick } from 'lodash';
-import UploadFoundation, {
-    CustomFile,
-    UploadAdapter,
-    BeforeUploadObjectResult,
-    AfterUploadResult,
-} from '@douyinfe/semi-foundation/upload/foundation';
+import UploadFoundation from '@douyinfe/semi-foundation/upload/foundation';
 import { strings, cssClasses } from '@douyinfe/semi-foundation/upload/constants';
 import FileCard from './fileCard';
-import BaseComponent, { ValidateStatus } from '../_base/baseComponent';
+import BaseComponent from '../_base/baseComponent';
 import LocaleConsumer from '../locale/localeConsumer';
 import { IconUpload } from '@douyinfe/semi-icons';
 import {
@@ -27,6 +22,14 @@ import {
 } from './interface';
 import { Locale } from '../locale/interface';
 import '@douyinfe/semi-foundation/upload/upload.scss';
+
+import type {
+    CustomFile,
+    UploadAdapter,
+    BeforeUploadObjectResult,
+    AfterUploadResult,
+} from '@douyinfe/semi-foundation/upload/foundation';
+import type { ValidateStatus } from '../_base/baseComponent';
 
 const prefixCls = cssClasses.PREFIX;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description


### Changelog
🇨🇳 Chinese
- Chore:  对组件中的 interface 导出，增加 type 关键字，避免storybook、gatsby等将 interface 识别为 js module而导致的 warning
```diff
- export { xxInterface, xxProps };
+ export type  { xxInterface, xxProps };
```

![b77c71b0-bd0a-48ae-9779-31e81cf257c9](https://user-images.githubusercontent.com/88709023/191903223-7d24193d-d233-44eb-9928-638d9baef524.jpeg)

---

🇺🇸 English
- Chore: add type keyword on interface export


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
