### PR TITLE
Fix: [Image] fix the drag and drop problem after the Image component is enlarged

### DIFF
--- a/content/show/dropdown/index-en-US.md
+++ b/content/show/dropdown/index-en-US.md
@@ -427,7 +427,7 @@ function DropdownEvents() {
 | children | Child elements wrapped by the drop layer | ReactNode |  |  |
 | clickToHide | Whether to close the drop-down layer automatically when clicking on the drop-down layer | boolean |  | **0.24.0** |
 | contentClassName | Drop-down menu root element class name | string |  |  |
-| getPopupContainer | Specifies the parent DOM, and the bullet layer will be rendered to the DOM, you need to set 'position: relative` | function():HTMLElement | () = > document.body |
+| getPopupContainer | Specifies the parent DOM, and the bullet layer will be rendered to the DOM, you need to set 'position: relative` | function():HTMLElement | () => document.body |
 | mouseEnterDelay | After the mouse is moved into the Trigger, the display time is delayed, in milliseconds (only effective when the trigger is hover/focus) | number | 50 |  |
 | mouseLeaveDelay | The time for the delay to disappear after the mouse moves out of the pop-up layer, in milliseconds (only effective when the trigger is hover/focus) | number | 50 |  |
 | menu | Menu content config | Array<DropdownMenuItem\> | [] | **1.12.0** |

--- a/content/show/image/index-en-US.md
+++ b/content/show/image/index-en-US.md
@@ -56,8 +56,12 @@ import { Image } from '@douyinfe/semi-ui';
             width={200}
             height={200}
             src="https://load-error.jpeg"
-            fallback="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMIAAADDCAYAAADQvc6UAAABRWlDQ1BJQ0MgUHJvZmlsZQAAKJFjYGASSSwoyGFhYGDIzSspCnJ3UoiIjFJgf8LAwSDCIMogwMCcmFxc4BgQ4ANUwgCjUcG3awyMIPqyLsis7PPOq3QdDFcvjV3jOD1boQVTPQrgSkktTgbSf4A4LbmgqISBgTEFyFYuLykAsTuAbJEioKOA7DkgdjqEvQHEToKwj4DVhAQ5A9k3gGyB5IxEoBmML4BsnSQk8XQkNtReEOBxcfXxUQg1Mjc0dyHgXNJBSWpFCYh2zi+oLMpMzyhRcASGUqqCZ16yno6CkYGRAQMDKMwhqj/fAIcloxgHQqxAjIHBEugw5sUIsSQpBobtQPdLciLEVJYzMPBHMDBsayhILEqEO4DxG0txmrERhM29nYGBddr//5/DGRjYNRkY/l7////39v///y4Dmn+LgeHANwDrkl1AuO+pmgAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAwqADAAQAAAABAAAAwwAAAAD9b/HnAAAHlklEQVR4Ae3dP3PTWBSGcbGzM6GCKqlIBRV0dHRJFarQ0eUT8LH4BnRU0NHR0UEFVdIlFRV7TzRksomPY8uykTk/zewQfKw/9znv4yvJynLv4uLiV2dBoDiBf4qP3/ARuCRABEFAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghgg0Aj8i0JO4OzsrPv69Wv+hi2qPHr0qNvf39+iI97soRIh4f3z58/u7du3SXX7Xt7Z2enevHmzfQe+oSN2apSAPj09TSrb+XKI/f379+08+A0cNRE2ANkupk+ACNPvkSPcAAEibACyXUyfABGm3yNHuAECRNgAZLuYPgEirKlHu7u7XdyytGwHAd8jjNyng4OD7vnz51dbPT8/7z58+NB9+/bt6jU/TI+AGWHEnrx48eJ/EsSmHzx40L18+fLyzxF3ZVMjEyDCiEDjMYZZS5wiPXnyZFbJaxMhQIQRGzHvWR7XCyOCXsOmiDAi1HmPMMQjDpbpEiDCiL358eNHurW/5SnWdIBbXiDCiA38/Pnzrce2YyZ4//59F3ePLNMl4PbpiL2J0L979+7yDtHDhw8vtzzvdGnEXdvUigSIsCLAWavHp/+qM0BcXMd/q25n1vF57TYBp0a3mUzilePj4+7k5KSLb6gt6ydAhPUzXnoPR0dHl79WGTNCfBnn1uvSCJdegQhLI1vvCk+fPu2ePXt2tZOYEV6/fn31dz+shwAR1sP1cqvLntbEN9MxA9xcYjsxS1jWR4AIa2Ibzx0tc44fYX/16lV6NDFLXH+YL32jwiACRBiEbf5KcXoTIsQSpzXx4N28Ja4BQoK7rgXiydbHjx/P25TaQAJEGAguWy0+2Q8PD6/Ki4R8EVl+bzBOnZY95fq9rj9zAkTI2SxdidBHqG9+skdw43borCXO/ZcJdraPWdv22uIEiLA4q7nvvCug8WTqzQveOH26fodo7g6uFe/a17W3+nFBAkRYENRdb1vkkz1CH9cPsVy/jrhr27PqMYvENYNlHAIesRiBYwRy0V+8iXP8+/fvX11Mr7L7ECueb/r48eMqm7FuI2BGWDEG8cm+7G3NEOfmdcTQw4h9/55lhm7DekRYKQPZF2ArbXTAyu4kDYB2YxUzwg0gi/41ztHnfQG26HbGel/crVrm7tNY+/1btkOEAZ2M05r4FB7r9GbAIdxaZYrHdOsgJ/wCEQY0J74TmOKnbxxT9n3FgGGWWsVdowHtjt9Nnvf7yQM2aZU/TIAIAxrw6dOnAWtZZcoEnBpNuTuObWMEiLAx1HY0ZQJEmHJ3HNvGCBBhY6jtaMoEiJB0Z29vL6ls58vxPcO8/zfrdo5qvKO+d3Fx8Wu8zf1dW4p/cPzLly/dtv9Ts/EbcvGAHhHyfBIhZ6NSiIBTo0LNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiEC/wGgKKC4YMA4TAAAAABJRU5ErkJggg=="
-        />
+            fallback={<Empty
+                image={<IllustrationFailure style={{ width: 150, height: 150 }} />}
+                darkModeImage={<IllustrationFailureDark style={{ width: 150, height: 150 }} />}
+                description={'加载失败'}
+            />}
+            />
     </div>
 );
 ```
@@ -144,7 +148,8 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
                         key={index} 
                         src={src} 
                         width={200} 
-                        alt={`lamp${index + 1}`} 
+                        alt={`lamp${index + 1}`}
+                        style={{ marginRight: 5 }} 
                     />
                 );
             })}
@@ -252,7 +257,8 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
                                 key={index} 
                                 src={src} 
                                 width={200} 
-                                alt={`lamp${index + 1}`} 
+                                alt={`lamp${index + 1}`}
+                                style={{ marginRight: 5 }} 
                             />
                         );
                     })}
@@ -359,7 +365,8 @@ import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, Ico
                         key={index} 
                         src={src} 
                         width={200} 
-                        alt={`lamp${index + 1}`} 
+                        alt={`lamp${index + 1}`}
+                        style={{ marginRight: 5 }} 
                     />
                 );
             })}
@@ -403,6 +410,7 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
                                 preview={{
                                     previewTitle: `lamp${index + 1}`,
                                 }} 
+                                style={{ marginRight: 5 }}
                             />
                         );
                     })}

--- a/content/show/image/index-en-US.md
+++ b/content/show/image/index-en-US.md
@@ -11,6 +11,8 @@ brief: Used to display and preview images.
 
 ### How to import
 
+Image, ImagePreview supported since v2.20.0
+
 ```jsx import
 import { Image, ImagePreview } from '@douyinfe/semi-ui';
 ```
@@ -73,12 +75,12 @@ import { Image, Button } from '@douyinfe/semi-ui';
     return (  
         <>
             <Image 
-                width={200}
+                width={300}
                 height={200}
-                src={`https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf.jpeg?${timestamp}`}
+                src={`https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-big.png?${timestamp}`}
                 placeholder={<Image 
-                    src='https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf-blur.jpeg'
-                    width={200}
+                    src='https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-small.jpeg'
+                    width={300}
                     height={200}
                     preview={false}
                 />}
@@ -106,12 +108,12 @@ import { Image } from '@douyinfe/semi-ui';
 
 () => {
      return ( 
-         <Image 
-             width={200}
+          <Image
+             width={300}
              height={200}
-             src={'https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf-blur.jpeg'}
+             src={'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-small.jpeg'}
              preview={{
-                 src: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf.jpeg'
+                 src: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-big.png'
              }}
          />
      );
@@ -267,8 +269,8 @@ The bottom action area of the preview can be customized using `renderPreviewMenu
 
 ```jsx live=true dir="column"
 import React, { useMemo, useCallback } from 'react';
-import { Image, ImagePreview, Button, Icon } from '@douyinfe/semi-ui';
-import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, IconDownload } from "@douyinfe/semi-icons";
+import { Image, ImagePreview, Button } from '@douyinfe/semi-ui';
+import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, IconDownload, IconRealSizeStroked, IconWindowAdaptionStroked } from "@douyinfe/semi-icons";
 
 () => {
     const srcList = useMemo(() => ([
@@ -276,26 +278,6 @@ import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, Ico
         "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/sky.jpg",
         "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/greenleaf.jpg",
     ]), []);
-
-    function RealSizeSvg() {
-        return <svg width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
-            <path fillRule="evenodd" clipRule="evenodd" d="M1 5C1 3.89543 1.89543 3 3 3H21C22.1046 3 23 3.89543 23 5V19C23 20.1046 22.1046 21 21 21H3C1.89543 21 1 20.1046 1 19V5ZM21 5L3 5V19H21V5Z" fill="white"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M5 9C5 8.44772 5.44772 8 6 8H7C7.55228 8 8 8.44772 8 9V15C8 15.5523 7.55228 16 7 16C6.44772 16 6 15.5523 6 15V10C5.44772 10 5 9.55228 5 9Z" fill="white"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M15 9C15 8.44772 15.4477 8 16 8H17C17.5523 8 18 8.44772 18 9V15C18 15.5523 17.5523 16 17 16C16.4477 16 16 15.5523 16 15V10C15.4477 10 15 9.55228 15 9Z" fill="white"/>
-            <path d="M13 10C13 10.5523 12.5523 11 12 11C11.4477 11 11 10.5523 11 10C11 9.44772 11.4477 9 12 9C12.5523 9 13 9.44772 13 10Z" fill="white"/>
-            <path d="M13 14C13 14.5523 12.5523 15 12 15C11.4477 15 11 14.5523 11 14C11 13.4477 11.4477 13 12 13C12.5523 13 13 13.4477 13 14Z" fill="white"/>
-        </svg>;
-    }
-
-    function AdaptionSvg() {
-        return <svg width="24" height="24" viewBox="0 0 24 24" fill="white" xmlns="http://www.w3.org/2000/svg">
-            <path fillRule="evenodd" clipRule="evenodd" d="M7 9C7 7.89543 7.89543 7 9 7H15C16.1046 7 17 7.89543 17 9V15C17 16.1046 16.1046 17 15 17H9C7.89543 17 7 16.1046 7 15V9ZM15 9H9V15H15V9Z" fill="white"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M15 3C15 2.44772 15.4477 2 16 2H21C21.5523 2 22 2.44772 22 3V8C22 8.55228 21.5523 9 21 9C20.4477 9 20 8.55228 20 8V4H16C15.4477 4 15 3.55228 15 3Z" fill="white"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M9 21C9 21.5523 8.55228 22 8 22L3 22C2.44772 22 2 21.5523 2 21L2 16C2 15.4477 2.44771 15 3 15C3.55228 15 4 15.4477 4 16L4 20L8 20C8.55228 20 9 20.4477 9 21Z" fill="white"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M3 9C2.44772 9 2 8.55228 2 8L2 3C2 2.44772 2.44771 2 3 2L8 2C8.55228 2 9 2.44771 9 3C9 3.55228 8.55228 4 8 4L4 4L4 8C4 8.55228 3.55228 9 3 9Z" fill="white"/>
-            <path fillRule="evenodd" clipRule="evenodd" d="M21 15C21.5523 15 22 15.4477 22 16L22 21C22 21.5523 21.5523 22 21 22L16 22C15.4477 22 15 21.5523 15 21C15 20.4477 15.4477 20 16 20L20 20L20 16C20 15.4477 20.4477 15 21 15Z" fill="white"/>
-        </svg>;
-    }
 
     const renderPreviewMenu = useCallback((props) => {
         const {
@@ -350,10 +332,7 @@ import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, Ico
                     disabled={disableZoomIn}
                 />
                 <Button
-                    icon={<Icon
-                        svg={ratio === "adaptation" ? <RealSizeSvg /> : <AdaptionSvg />}
-                        size="large"
-                    />}
+                    icon={ratio === "adaptation" ? <IconRealSizeStroked size="large" /> : <IconWindowAdaptionStroked size="large" />}
                     type="tertiary"
                     onClick={onRatioClick} 
                 />
@@ -440,86 +419,86 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
 
 | Properties       |Instructions                          | Type             | Default | Version |
 |------------------|--------------------------------------|------------------|---------|---------|
-| style            | custom style                         | CSSProperties     | - | |
-| className        | custom style class name              | string            | - | |
-| src              | Image acquisition address            | string            | - | |
-| width            | Image display width                  | number            | - | |
-| height           | Image display height                 | CSSProperties     | - | |
 | alt              | Image description                    | string            | - | |
-| placeholder      | Placeholder content when the image is not loaded | ReactNode | - | |
-| fallback         | Custom loading failed display content | string \|reactNode  | - | |
-| preview          | Preview parameter, when false, disable preview   | boolean \| ImagePreview | - | |
+| className        | custom style class name              | string            | - | |
 | crossOrigin      | Passthrough to the crossorigin of the native img tag | 'anonymous' \| 'use-credentials' |-| |
+| fallback         | Custom loading failed display content | ReactNode  | - | |
+| height           | Image display height                 | number            | - | |
 | onError          | Load error callback                  | (event: Event) => void | - | |
 | onLoad           | Load success callback                | (event: Event) => void | - | |
+| placeholder      | Placeholder content when the image is not loaded | ReactNode | - | |
+| preview          | Preview parameter, when false, disable preview   | boolean \| ImagePreview | - | |
+| src              | Image acquisition address            | string            | - | |
+| style            | custom style                         | CSSProperties     | - | |
+| width            | Image display width                  | number            | - | |
 
 ### ImagePreview
 
 | Properties       | Instructions            | Type            | Default | Version |
 |------------------|-------------------------|-----------------|---------|---------|
-| style            | Custom style            | CSSProperties   | - | |
-| className        | Custom style class name | string          | - | |
-| src              | Image list information  | string \| string[] | - | |
-| visible          | Controlled property, whether to preview  | boolean | - | |
-| defaultVisible   | Whether to open the preview for the first time | boolean | - | |
-| currentIndex     | Controlled property, the current preview image subscript | number | - | |
-| defaultCurrentIndex | First display image subscript | string \| number | - | |
-| infinite         | Whether to loop infinitely  | boolean        | - | |
-| closeOnEsc       | Hit esc to close the preview | boolean        | true | |
-| previewTitle     | Custom preview title     | ReactNode      | - | |
-| maskClosable     | Whether the mask can be closed by clicking | Boolean  | true | |
-| closable         | Whether to show the close button   | Boolean | true | |
-| zoomStep         | Image reduction/enlargement ratio each time | number | 0.1 | |
-| lazyLoad         | Whether to enable lazy loading ｜ boolean      | true | |
-| lazyLoadMargin   | Pass to the rootMargin parameter in options, refer to [Intersection Observer API](https://developer.mozilla.org/zh-CN/docs/Web/API/Intersection_Observer_API#interfaces) | string | "0px 100px 100px 0px" | |
-| preLoad          | Whether to enable preloading | boolean | true | |
-| preLoadGap       | Preloaded step size      | number         | 2 | |
-| viewerVisibleDelay | The length of time of inactivity before hiding the preview action button | number | 10000 | |
-| disableDownload  | Disable downloads        | boolean        | false | |
-| zIndex           | Preview layer hierarchy  | number        | 1070 | |
-| showTooltip      | Whether to display the bottom operation area prompt | boolean | false | |
-| prevTip          | Previous operation button prompt   | string  | "Previous" | |
-| nextTip          | Next action button prompt   | string  | "Next" | |
-| zoomInTip        | Zoom in on action button tips | string | "Zoom in" | |
-| zoomOutTip       | Zoom out action button prompt | string | "Zoom out" | |
-| rotate           | Rotate                   |string        | "Rotate" | |
-| downloadTip      | Download action button prompt | string  | "Download" | |
 | adaptiveTip      | Adapt to page action button prompts |string  | "Adapt to the page" | |
-| originTip        | Original Size Action Button Tips |string  | "Original size" | |
-| renderHeader     | Custom render preview top info  |(info: reactNode) => ReactNode  | null | |
-| renderPreviewMenu | Custom render preview bottom menu information | (props: MenuProps) => ReactNode; | - | |
+| className        | Custom style class name | string          | - | |
+| closable         | Whether to show the close button   | Boolean | true | |
+| closeOnEsc       | Hit esc to close the preview | boolean        | true | |
+| currentIndex     | Controlled property, the current preview image subscript | number | - | |
+| defaultCurrentIndex | First display image subscript | number | - | |
+| defaultVisible   | Whether to open the preview for the first time | boolean | - | |
+| disableDownload  | Disable downloads        | boolean        | false | |
+| downloadTip      | Download action button prompt | string  | "Download" | |
 | getPopupContainer | Specify the parent DOM, and the pop-up layer will be rendered into the DOM. For customization, you need to set container `position: relative`|() => HTMLElement;  | () => document.body | |
-| onVisibleChange  | Callback triggered by toggle visible state   | (visible: boolean, preVisible: boolean) => void  | - | |
+| infinite         | Whether to loop infinitely  | boolean        | false | |
+| lazyLoad         | Whether to enable lazy loading | boolean      | true | |
+| lazyLoadMargin   | Pass to the rootMargin parameter in options, refer to [Intersection Observer API](https://developer.mozilla.org/zh-CN/docs/Web/API/Intersection_Observer_API#interfaces) | string | "0px 100px 100px 0px" | |
+| maskClosable     | Whether the mask can be closed by clicking | Boolean  | true | |
+| nextTip          | Next action button prompt   | string  | "Next" | |
+| originTip        | Original size action button tips |string  | "Original size" | |
 | onChange         | Event triggered by switching pictures  | (index: number) => void | - | |
 | onClose          | The callback function when the close button is clicked  | () => void | - | |
+| onDownload       | Image download callback function  | (src: string, index: number) => void | - | |
+| onRotateLeft     | Callback for rotating the image     | (angle: number) => void | - | |
+| onNext           | Callback for switching pictures backwards   | (index: number) => void | - | |
+| onPrev           | Callback for switching the picture forward  | (index: number) => void | - | |
 | onZoomIn         | The callback function when the image is zoomed in  | (zoom: number) => void | - | |
 | onZoomOut        | The callback function when the image is zoomed out  | (zoom: number) => void | - | |
-| onDownload       | Image download callback function  | (src: string, index: number) => void | - | |
-| onPrev           | Callback for switching the picture forward  | (index: number) => void | - | |
-| onNext           | Callback for switching pictures backwards   | (index: number) => void | - | |
-| onRotateLeft     | Callback for rotating the image     | (angle: number) => void | - | |
+| onVisibleChange  | Callback triggered by toggle visible state   | (visible: boolean) => void  | - | |
+| preLoad          | Whether to enable preloading | boolean | true | |
+| preLoadGap       | Preloaded step size      | number         | 2 | |
+| previewTitle     | Custom preview title     | ReactNode      | - | |
+| prevTip          | Previous operation button prompt   | string  | "Previous" | |
+| renderHeader     | Custom render preview top info  |(info: reactNode) => ReactNode  | - | |
+| renderPreviewMenu | Custom render preview bottom menu information | (props: MenuProps) => ReactNode; | - | |
+| rotateTip        | Tips for rotating action buttons  |string        | "Rotate" | |
+| showTooltip      | Whether to display the bottom operation area prompt | boolean | false | |
+| src              | Image list information  | string \| string[] | - | |
+| style            | Custom style            | CSSProperties   | - | |
+| viewerVisibleDelay | The length of time of inactivity before hiding the preview action button | number | 10000 | |
+| visible          | Controlled property, whether to preview  | boolean | - | |
+| zIndex           | Preview layer hierarchy  | number        | 1070 | |
+| zoomInTip        | Zoom in action button tips | string | "Zoom in" | |
+| zoomOutTip       | Zoom out action button prompt | string | "Zoom out" | |
+| zoomStep         | Image reduction/enlargement ratio each time | number | 0.1 | |
 
 ### MenuProps
 
 | Properties       | Instructions            | Type             |
 |------------------|-------------------------|------------------|
-| zoom             | Current image magnification ratio    | number |
-| max              | The maximum ratio of image zoom      | number |
-| min              | The minimum ratio of image scaling   | number |
-| step             | Step size of scaling                 | number |
 | curPage          | Current image page subscript         | number |
-| totalNum         | The total number of images that can be previewed | number |
-| ratio            | Original size or Fit to page button state  | "adaptation" \| "realSize" |
 | disabledPrev     | Whether to disable the left toggle button  | boolean |
 | disabledNext     | Whether to disable the right toggle button | boolean |
 | disableDownload  | Whether to disable the download button     | boolean |
+| max              | The maximum ratio of image zoom      | number |
+| min              | The minimum ratio of image scaling   | number |
+| onDownload       | Call function when the image is downloaded | () => void |
 | onZoomIn         | Call function when the image is zoomed in  | () => void |
 | onZoomOut        | Call function when the image is zoomed out | () => void |
-| onDownload       | Call function when the image is downloaded | () => void |
 | onPrev           | Call function to switch the picture forward  | () => void |
 | onNext           | Call function to switch the picture backward | () => void |
 | onRotateLeft     | Call function to rotate the image counterclockwise | () => void |
 | onRotateRight    | Call function to rotate the image clockwise | () => void |
+| ratio            | Original size or Fit to page button state  | "adaptation" \| "realSize" |
+| step             | Step size of scaling                 | number |
+| totalNum         | The total number of images that can be previewed | number |
+| zoom             | Current image magnification ratio    | number |
 
 ## Design Token
 

--- a/content/show/image/index.md
+++ b/content/show/image/index.md
@@ -56,7 +56,11 @@ import { Image } from '@douyinfe/semi-ui';
             width={200}
             height={200}
             src="https://load-error.jpeg"
-            fallback="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAMIAAADDCAYAAADQvc6UAAABRWlDQ1BJQ0MgUHJvZmlsZQAAKJFjYGASSSwoyGFhYGDIzSspCnJ3UoiIjFJgf8LAwSDCIMogwMCcmFxc4BgQ4ANUwgCjUcG3awyMIPqyLsis7PPOq3QdDFcvjV3jOD1boQVTPQrgSkktTgbSf4A4LbmgqISBgTEFyFYuLykAsTuAbJEioKOA7DkgdjqEvQHEToKwj4DVhAQ5A9k3gGyB5IxEoBmML4BsnSQk8XQkNtReEOBxcfXxUQg1Mjc0dyHgXNJBSWpFCYh2zi+oLMpMzyhRcASGUqqCZ16yno6CkYGRAQMDKMwhqj/fAIcloxgHQqxAjIHBEugw5sUIsSQpBobtQPdLciLEVJYzMPBHMDBsayhILEqEO4DxG0txmrERhM29nYGBddr//5/DGRjYNRkY/l7////39v///y4Dmn+LgeHANwDrkl1AuO+pmgAAADhlWElmTU0AKgAAAAgAAYdpAAQAAAABAAAAGgAAAAAAAqACAAQAAAABAAAAwqADAAQAAAABAAAAwwAAAAD9b/HnAAAHlklEQVR4Ae3dP3PTWBSGcbGzM6GCKqlIBRV0dHRJFarQ0eUT8LH4BnRU0NHR0UEFVdIlFRV7TzRksomPY8uykTk/zewQfKw/9znv4yvJynLv4uLiV2dBoDiBf4qP3/ARuCRABEFAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghggQAQZQKAnYEaQBAQaASKIAQJEkAEEegJmBElAoBEgghgg0Aj8i0JO4OzsrPv69Wv+hi2qPHr0qNvf39+iI97soRIh4f3z58/u7du3SXX7Xt7Z2enevHmzfQe+oSN2apSAPj09TSrb+XKI/f379+08+A0cNRE2ANkupk+ACNPvkSPcAAEibACyXUyfABGm3yNHuAECRNgAZLuYPgEirKlHu7u7XdyytGwHAd8jjNyng4OD7vnz51dbPT8/7z58+NB9+/bt6jU/TI+AGWHEnrx48eJ/EsSmHzx40L18+fLyzxF3ZVMjEyDCiEDjMYZZS5wiPXnyZFbJaxMhQIQRGzHvWR7XCyOCXsOmiDAi1HmPMMQjDpbpEiDCiL358eNHurW/5SnWdIBbXiDCiA38/Pnzrce2YyZ4//59F3ePLNMl4PbpiL2J0L979+7yDtHDhw8vtzzvdGnEXdvUigSIsCLAWavHp/+qM0BcXMd/q25n1vF57TYBp0a3mUzilePj4+7k5KSLb6gt6ydAhPUzXnoPR0dHl79WGTNCfBnn1uvSCJdegQhLI1vvCk+fPu2ePXt2tZOYEV6/fn31dz+shwAR1sP1cqvLntbEN9MxA9xcYjsxS1jWR4AIa2Ibzx0tc44fYX/16lV6NDFLXH+YL32jwiACRBiEbf5KcXoTIsQSpzXx4N28Ja4BQoK7rgXiydbHjx/P25TaQAJEGAguWy0+2Q8PD6/Ki4R8EVl+bzBOnZY95fq9rj9zAkTI2SxdidBHqG9+skdw43borCXO/ZcJdraPWdv22uIEiLA4q7nvvCug8WTqzQveOH26fodo7g6uFe/a17W3+nFBAkRYENRdb1vkkz1CH9cPsVy/jrhr27PqMYvENYNlHAIesRiBYwRy0V+8iXP8+/fvX11Mr7L7ECueb/r48eMqm7FuI2BGWDEG8cm+7G3NEOfmdcTQw4h9/55lhm7DekRYKQPZF2ArbXTAyu4kDYB2YxUzwg0gi/41ztHnfQG26HbGel/crVrm7tNY+/1btkOEAZ2M05r4FB7r9GbAIdxaZYrHdOsgJ/wCEQY0J74TmOKnbxxT9n3FgGGWWsVdowHtjt9Nnvf7yQM2aZU/TIAIAxrw6dOnAWtZZcoEnBpNuTuObWMEiLAx1HY0ZQJEmHJ3HNvGCBBhY6jtaMoEiJB0Z29vL6ls58vxPcO8/zfrdo5qvKO+d3Fx8Wu8zf1dW4p/cPzLly/dtv9Ts/EbcvGAHhHyfBIhZ6NSiIBTo0LNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiECRCjUbEPNCRAhZ6NSiAARCjXbUHMCRMjZqBQiQIRCzTbUnAARcjYqhQgQoVCzDTUnQIScjUohAkQo1GxDzQkQIWejUogAEQo121BzAkTI2agUIkCEQs021JwAEXI2KoUIEKFQsw01J0CEnI1KIQJEKNRsQ80JECFno1KIABEKNdtQcwJEyNmoFCJAhELNNtScABFyNiqFCBChULMNNSdAhJyNSiEC/wGgKKC4YMA4TAAAAABJRU5ErkJggg=="
+            fallback={<Empty
+                image={<IllustrationFailure style={{ width: 150, height: 150 }} />}
+                darkModeImage={<IllustrationFailureDark style={{ width: 150, height: 150 }} />}
+                description={'加载失败'}
+            />}
         />
     </div>
 );
@@ -145,6 +149,7 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
                         src={src} 
                         width={200} 
                         alt={`lamp${index + 1}`} 
+                        style={{ marginRight: 5 }}
                     />
                 );
             })}
@@ -252,7 +257,8 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
                                 key={index} 
                                 src={src} 
                                 width={200} 
-                                alt={`lamp${index + 1}`} 
+                                alt={`lamp${index + 1}`}
+                                style={{ marginRight: 5 }} 
                             />
                         );
                     })}
@@ -360,6 +366,7 @@ import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, Ico
                         src={src} 
                         width={200} 
                         alt={`lamp${index + 1}`} 
+                        style={{ marginRight: 5 }}
                     />
                 );
             })}
@@ -402,7 +409,8 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
                                 alt={`lamp${index + 1}`} 
                                 preview={{
                                     previewTitle: `lamp${index + 1}`,
-                                }} 
+                                }}
+                                style={{ marginRight: 5 }} 
                             />
                         );
                     })}

--- a/content/show/image/index.md
+++ b/content/show/image/index.md
@@ -11,6 +11,8 @@ brief: 用于展示和预览图片。
 
 ### 如何引入
 
+Image, ImagePreview 从 v2.20.0 版本开始支持
+
 ```jsx import
 import { Image, ImagePreview } from '@douyinfe/semi-ui';
 ```
@@ -73,12 +75,12 @@ import { Image, Button } from '@douyinfe/semi-ui';
     return (  
         <>
             <Image 
-                width={200}
+                width={300}
                 height={200}
-                src={`https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf.jpeg?${timestamp}`}
+                src={`https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-big.png?${timestamp}`}
                 placeholder={<Image 
-                    src='https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf-blur.jpeg'
-                    width={200}
+                    src='https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-small.jpeg'
+                    width={300}
                     height={200}
                     preview={false}
                 />}
@@ -106,12 +108,12 @@ import { Image } from '@douyinfe/semi-ui';
 
 () => {
      return ( 
-         <Image 
-             width={200}
+         <Image
+             width={300}
              height={200}
-             src={'https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf-blur.jpeg'}
+             src={'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-small.jpeg'}
              preview={{
-                 src: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/9130eh7pltbfnuhog/leaf.jpeg'
+                 src: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract-big.png'
              }}
          />
      );
@@ -267,7 +269,7 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
 
 ```jsx live=true dir="column"
 import React, { useMemo, useCallback } from 'react';
-import { Image, ImagePreview, Button, Icon } from '@douyinfe/semi-ui';
+import { Image, ImagePreview, Button } from '@douyinfe/semi-ui';
 import { IconChevronLeft, IconChevronRight, IconMinus, IconPlus, IconRotate, IconDownload, IconRealSizeStroked, IconWindowAdaptionStroked } from "@douyinfe/semi-icons";
 
 () => {
@@ -417,86 +419,86 @@ import { Image, ImagePreview } from '@douyinfe/semi-ui';
 
 | 属性              | 说明                                    | 类型              | 默认值 | 版本 |
 |-------------------|---------------------------------------|-------------------|------|------|
-| style             | 自定义样式                              | CSSProperties     | - | |
-| className         | 自定义样式类名                           | string            | - | |
-| src               | 图片获取地址                             | string            | - | |
-| width             | 图片显示宽度                             | CSSProperties     | - | |
-| height            | 图片显示高度                             | CSSProperties     | - | |
 | alt               | 图像描述                                | string            | - | |
-| placeholder       | 图片未加载时候的占位内容                   | ReactNode         | - | |
-| fallback          | 加载失败容错地址或者自定义加载失败时的显示内容 | string \| reactNode  | - | |
-| preview           | 预览参数，为 false 时候禁用预览            | boolean \| ImagePreview | - | |
+| className         | 自定义样式类名                           | string            | - | |
 | crossOrigin       | 透传给原生 img 标签的 crossorigin         | 'anonymous'｜'use-credentials'| - | |
+| fallback          | 加载失败容错地址或者自定义加载失败时的显示内容 | ReactNode  | - | |
+| height            | 图片显示高度                             | number            | - | |
 | onError           | 加载错误回调                              | (event: Event) => void | - | |
 | onLoad            | 加载成功回调                              | (event: Event) => void | - | |
+| placeholder       | 图片未加载时候的占位内容                   | ReactNode         | - | |
+| preview           | 预览参数，为 false 时候禁用预览            | boolean \| ImagePreview | - | |
+| src               | 图片获取地址                             | string            | - | |
+| style             | 自定义样式                              | CSSProperties     | - | |
+| width             | 图片显示宽度                             | number            | - | |
 
 ### ImagePreview
 
 | 属性               | 说明                    | 类型              | 默认值 | 版本 |
 |-------------------|-------------------------|------------------|-------|-----|
-| style             | 自定义样式               | CSSProperties    | - | |
+| adaptiveTip       | 适应页面操作按钮提示       | string        | "适应页面" | |
 | className         | 自定义样式类名            | string           | - | |
-| src               | 图片列表信息              | string \| string[] | - | |
-| visible           | 受控属性，是否预览         | boolean         | - | |
-| defaultVisible    | 首次是否开启预览           | boolean         | - | |
+| closable          | 是否显示关闭按钮           | boolean        | true | |
+| closeOnEsc        | 点击 esc 关闭预览         | boolean        | true | |
 | currentIndex      | 受控属性，当前预览图片下标  | number               | - | |
 | defaultCurrentIndex | 首次展示图片下标        | number             | - | |
-| infinite          | 是否无限循环              | boolean       | - | |
-| closeOnEsc        | 点击 esc 关闭预览         | boolean        | true | |
-| previewTitle      | 自定义预览 title          | ReactNode      | - | |
-| maskClosable      | 点击遮罩是否可关闭         | boolean        | true | |
-| closable          | 是否显示关闭按钮           | boolean        | true | |
-| zoomStep          | 图片每次缩小/放大比例       | number        | 0.1 | |
+| defaultVisible    | 首次是否开启预览           | boolean         | - | |
+| disableDownload   | 禁用下载                  | boolean        | false | |
+| downloadTip       | 下载操作按钮提示          | string         | "下载" | |
+| getPopupContainer | 指定父级 DOM，弹层将会渲染至该 DOM 中，自定义需要设置 container `position: relative` | () => HTMLElement  | () => document.body | |
+| infinite          | 是否无限循环              | boolean       | false | |
 | lazyLoad          | 是否开启懒加载             | boolean      | true | |
 | lazyLoadMargin    | 传给 options 中的rootMargin 参数，参考 [Intersection Observer API](https://developer.mozilla.org/zh-CN/docs/Web/API/Intersection_Observer_API#interfaces) | string | "0px 100px 100px 0px" | |
-| preLoad           | 是否开启预加载             | boolean        | true | |
-| preLoadGap        | 预加载的步长               | number         | 2 | |
-| viewerVisibleDelay | 隐藏预览操作按钮前的无操作时长 | number         | 10000 | |
-| disableDownload   | 禁用下载                  | boolean        | false | |
-| zIndex            | 预览层层级                | number        | 1070 | |
-| showTooltip       | 是否展示底部操作区提示      | boolean        | false | |
-| prevTip           | 上一步操作按钮提示         | string         | "上一步" | |
+| maskClosable      | 点击遮罩是否可关闭         | boolean        | true | |
 | nextTip           | 下一步操作按钮提示         | string         | "下一步" | |
-| zoomInTip         | 放大操作按钮提示           | string         | "放大" | |
-| zoomOutTip        | 缩小操作按钮提示           | string        | "缩小" | |
-| rotate            | 旋转                    | string         | "旋转" | |
-| downloadTip       | 下载操作按钮提示          | string         | "下载" | |
-| adaptiveTip       | 适应页面操作按钮提示       | string        | "适应页面" | |
 | originTip         | 原始尺寸操作按钮提示       | string        | "原始尺寸" | |
-| renderHeader      | 自定义渲染预览顶部信息     | (info: ReactNode) => ReactNode  | - | |
-| renderPreviewMenu | 自定义渲染预览底部菜单信息  | (props: MenuProps) => ReactNode;| - | |
-| getPopupContainer | 指定父级 DOM，弹层将会渲染至该 DOM 中，自定义需要设置 container `position: relative` | () => HTMLElement;  | - | |
-| onVisibleChange   | 切换可见状态触发的回调   | (visible: boolean, preVisible: boolean) => void | - | |
 | onChange          | 切换图片触发的事件  | (index: number) => void | - | |
 | onClose           | 点击关闭按钮时的回调函数  | () => void | - | |
+| onDownload        | 图片下载回调函数     | (src: string, index: number) => void | - | |
+| onRotateLeft      | 旋转图片的回调      | (angle: number) => void | - | |
+| onNext            | 向后切换图片的回调   | (index: number) => void | - | |
+| onPrev            | 向前切换图片的回调   | (index: number) => void | - | |
 | onZoomIn          | 图片放大时的回调函数  | (zoom: number) => void | - | |
 | onZoomOut         | 图片缩小时的回调函数  | (zoom: number) => void | - | |
-| onDownload        | 图片下载回调函数     | (src: string, index: number) => void | - | |
-| onPrev            | 向前切换图片的回调   | (index: number) => void | - | |
-| onNext            | 向后切换图片的回调   | (index: number) => void | - | |
-| onRotateLeft      | 旋转图片的回调      | (angle: number) => void | - | |
+| onVisibleChange   | 切换可见状态触发的回调   | (visible: boolean) => void | - | |
+| preLoad           | 是否开启预加载             | boolean        | true | |
+| preLoadGap        | 预加载的步长               | number         | 2 | |
+| previewTitle      | 自定义预览 title          | ReactNode      | - | |
+| prevTip           | 上一步操作按钮提示         | string         | "上一步" | |
+| renderHeader      | 自定义渲染预览顶部信息     | (info: ReactNode) => ReactNode  | - | |
+| renderPreviewMenu | 自定义渲染预览底部菜单信息  | (props: MenuProps) => ReactNode;| - | |
+| rotateTip         | 旋转操作按钮提示                    | string         | "旋转" | |
+| showTooltip       | 是否展示底部操作区提示      | boolean        | false | |
+| src               | 图片列表信息              | string \| string[] | - | |
+| style             | 自定义样式               | CSSProperties    | - | |
+| viewerVisibleDelay | 隐藏预览操作按钮前的无操作时长 | number         | 10000 | |
+| visible           | 受控属性，是否预览         | boolean         | - | |
+| zIndex            | 预览层层级                | number        | 1070 | |
+| zoomInTip         | 放大操作按钮提示           | string         | "放大" | |
+| zoomOutTip        | 缩小操作按钮提示           | string        | "缩小" | |
+| zoomStep          | 图片每次缩小/放大比例       | number        | 0.1 | |
 
 ### MenuProps
 
 | 属性               | 说明                     | 类型    |
 |-------------------|--------------------------|--------|
-| zoom              | 当前图片缩放比例            | number |
-| max               | 图片缩放最大比例            | number |
-| min               | 图片缩放最小比例            | number |
-| step              | 缩放的比例步长              | number |
 | curPage           | 当前图片页下标              | number |
-| totalNum          | 可预览的总图片数            | number |
-| ratio             | 原始尺寸或适应页面按钮状态  | "adaptation" \| "realSize"|
 | disabledPrev      | 是否禁用向左切换按钮         | boolean |
 | disabledNext      | 是否禁用向右切换按钮         | boolean |
 | disableDownload   | 是否禁用下载按钮            | boolean |
+| max               | 图片缩放最大比例            | number |
+| min               | 图片缩放最小比例            | number |
+| onDownload        | 图片下载的调用函数           | () => void |
 | onZoomIn          | 图片放大时的调用函数         | () => void |
 | onZoomOut         | 图片缩小时的调用函数         | () => void |
-| onDownload        | 图片下载的调用函数           | () => void |
 | onPrev            | 向前切换图片的调用函数       | () => void |
 | onNext            | 向后切换图片的调用函数       | () => void |
 | onRotateLeft      | 逆时针旋转图片的调用函数     | () => void |
 | onRotateRight     | 顺时针旋转图片的调用函数     | () => void |
+| ratio             | 原始尺寸或适应页面按钮状态  | "adaptation" \| "realSize"|
+| step              | 缩放的比例步长              | number |
+| totalNum          | 可预览的总图片数            | number |
+| zoom              | 当前图片缩放比例            | number |
 
 ## 设计变量
 

--- a/packages/semi-foundation/image/image.scss
+++ b/packages/semi-foundation/image/image.scss
@@ -13,6 +13,7 @@ $module: #{$prefix}-image;
     &-img {
         vertical-align: middle;
         border-radius: inherit;
+        user-select: none;
 
         &-preview {
             cursor: zoom-in;
@@ -60,6 +61,7 @@ $module: #{$prefix}-image;
 
     .#{$module}-preview-hide {
         opacity: 0;
+        display: none;
     }
 
     &-icon {
@@ -135,6 +137,7 @@ $module: #{$prefix}-image;
         }
 
         &-page {
+            user-select: none;
             color: $color-image_preview_footer_icon;
             @include font-size-header-6;
             margin: $spacing-image_preview_footer_page-marginY $spacing-image_preview_footer_page-marginX;
@@ -192,6 +195,7 @@ $module: #{$prefix}-image;
             transform: scale3d($transform_scale3d-image_preview_image_img) $transform_rotate-image_preview_image_img;
             transition: transform $transition_duration-image_preview_image_img  $transition_delay-image_preview_image_img;
             z-index: 0;
+            user-select: none;
         }
 
         &-spin {

--- a/packages/semi-foundation/image/image.scss
+++ b/packages/semi-foundation/image/image.scss
@@ -61,7 +61,6 @@ $module: #{$prefix}-image;
 
     .#{$module}-preview-hide {
         opacity: 0;
-        display: none;
     }
 
     &-icon {

--- a/packages/semi-foundation/image/previewImageFoundation.ts
+++ b/packages/semi-foundation/image/previewImageFoundation.ts
@@ -220,16 +220,16 @@ export default class PreviewImageFoundation<P = Record<string, any>, S = Record<
     };
 
     handleMoveImage = (e: any): void => {
-        const { offset, width, height, left, top } = this.getStates();
-        const { rotation } = this.getProps();
+        const { offset, width, height } = this.getStates();
         const startMouseMove = this._adapter.getMouseMove();
         const startMouseOffset = this._adapter.getMouseOffset();
         const { canDragVertical, canDragHorizontal } = this.calcCanDragDirection();
         if (startMouseMove && (canDragVertical || canDragHorizontal)) {
-            const { pageX, pageY } = e;
+            const { clientX, clientY } = e;
+            const { left: containerLeft, top: containerTop } = this._getContainerBounds();
             const { left: extremeLeft, top: extremeTop } = this.calcExtremeBounds();
-            let newX = canDragHorizontal ? pageX - startMouseOffset.x : offset.x;
-            let newY = canDragVertical ? pageY - startMouseOffset.y : offset.y;
+            let newX = canDragHorizontal ? clientX - containerLeft - startMouseOffset.x : offset.x;
+            let newY = canDragVertical ? clientY - containerTop - startMouseOffset.y : offset.y;
             if (canDragHorizontal) {
                 newX = newX > 0 ? 0 : newX < extremeLeft ? extremeLeft : newX;
             }

--- a/packages/semi-foundation/image/previewInnerFoundation.ts
+++ b/packages/semi-foundation/image/previewInnerFoundation.ts
@@ -77,7 +77,11 @@ export default class PreviewInnerFoundation<P = Record<string, any>, S = Record<
         let couldClose = !isTargetEmit(e.nativeEvent, NOT_CLOSE_TARGETS);
         const { clientX, clientY } = e;
         const { x, y } = this._adapter.getStartMouseDown();
-        if (clientX !== x || y !== clientY) {
+        // 对鼠标移动做容错处理，当 x 和 y 方向在 mouseUp 的时候移动距离都小于等于 5px 时候就可以关闭预览
+        // Error-tolerant processing of mouse movement, when the movement distance in the x and y directions is less than or equal to 5px in mouseUp, the preview can be closed
+        // 不做容错处理的话，直接用 clientX !== x || y !== clientY 做判断，鼠标在用户点击时候无意识的轻微移动无法关闭预览，不符合用户预期
+        // If you do not do fault-tolerant processing, but directly use clientX !== x || y !== clientY to make judgments, the slight movement of the mouse when the user clicks will not be able to close the preview, which does not meet the user's expectations.
+        if (Math.abs(clientX - x) > 5 || Math.abs(y - clientY) > 5) {
             couldClose = false;
         }
         if (couldClose && maskClosable) {

--- a/packages/semi-foundation/image/utils.ts
+++ b/packages/semi-foundation/image/utils.ts
@@ -1,7 +1,9 @@
 export const isTargetEmit = (event, targetClasses): boolean => {
-    // e.path is the event-triggered bubbling path, which stores each node through which bubbling passes.
-    // e.path.length-4 is to remove elements above the root node, such as body, html, document, window
-    const isTarget = event?.path?.slice(0, event.path.length - 4).some((node): boolean => {
+    // event.path usage is discouraged, use event.composedPath() as it's standard and is more future-proof
+    // path is the event-triggered bubbling path, which stores each node through which bubbling passes.
+    // path.length-4 is to remove elements above the root node, such as body, html, document, window
+    const path = event?.composedPath();
+    const isTarget = path?.slice(0, path.length - 4).some((node): boolean => {
         if (node.className && typeof node.className === "string") {
             return targetClasses.some(c => node.className.includes(c));
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Image 预览放大后拖拽问题

---

🇺🇸 English
- Fix: fix the drag and drop problem after the Image preview is enlarged


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
本次提交的PR修改包含的内容：
1. 之前使用 pageX 计算拖拽后偏移的处理方式不太合理，pageX = clientX + 滚动条的距离，因此该用ClientX进行计算
2. Image 的 API 没有顺序没有根据字母顺序排列