### PR TITLE
fix: only when input is not null, select should notifySearch and upda…

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -523,16 +523,20 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
     }
 
     clearInput() {
-        this._adapter.updateInputValue('');
-        this._adapter.notifySearch('');
-        // reset options filter
-        const { options } = this.getStates();
-        const { remote } = this.getProps();
-        let optionsAfterFilter = options;
-        if (!remote) {
-            optionsAfterFilter = this._filterOption(options, '');
+        const { inputValue } = this.getStates();
+        // only when input is not null, select should notifySearch and updateOptions
+        if (inputValue !== ''){
+            this._adapter.updateInputValue('');
+            this._adapter.notifySearch('');
+            // reset options filter
+            const { options } = this.getStates();
+            const { remote } = this.getProps();
+            let optionsAfterFilter = options;
+            if (!remote) {
+                optionsAfterFilter = this._filterOption(options, '');
+            }
+            this._adapter.updateOptions(optionsAfterFilter);
         }
-        this._adapter.updateOptions(optionsAfterFilter);
     }
 
     focusInput() {


### PR DESCRIPTION
…teOptions

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Select 在filter为true, input框为空情况下，关闭面板后触发onSearch 问题

---

🇺🇸 English
- Fix: fix Select when the filter is true and the input box is empty, after closing panel trigger onSearch function issue


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
