### PR TITLE
fix: [AutoComplete] Fix AutoComplete e.target is null in onBlur callback

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -413,7 +413,9 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         this._adapter.notifyFocus(e);
     }
 
-    handleBlur(e: FocusEvent) {
+    handleBlur(e: any) {
+        // https://reactjs.org/docs/legacy-event-pooling.html
+        e.persist();
         // In order to handle the problem of losing onClick binding when clicking on the padding area, the onBlur event is triggered first to cause the react view to be updated
         // internal-issues:1231
         setTimeout(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1172 

### Changelog
🇨🇳 Chinese
- Fix: 修复 AutoComplete 在 onBlur 回调中 e.target 是 null 的问题 #1172 

---

🇺🇸 English
- Fix: fix AutoComplete e.target is null in onBlur callback #1172 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
修复后
![image](https://user-images.githubusercontent.com/101110131/194759017-362c1b87-c6e1-4b2c-8ef2-8b868490a8f4.png)
