### PR TITLE
fix: [AutoComplete] Fix AutoComplete e.target is null in onBlur callback 

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -415,7 +415,9 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         this._adapter.notifyFocus(e);
     }
 
-    handleBlur(e: FocusEvent) {
+    handleBlur(e: any) {
+        // https://reactjs.org/docs/legacy-event-pooling.html
+        e.persist();
         // In order to handle the problem of losing onClick binding when clicking on the padding area, the onBlur event is triggered first to cause the react view to be updated
         // internal-issues:1231
         setTimeout(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 AutoComplete 在 onBlur 回调中 e.target 是 null 的问题

---

🇺🇸 English
- Fix: fix AutoComplete e.target is null in onBlur callback


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
该修改的 commit 已经合入 main 分支，但是提 issue 的用户同时使用了2.21.0-beta版本上的一个 feature，因此再合入 release， 发个patch