### PR TITLE
fix: fix modal esc trigger close callback after close

### DIFF
--- a/packages/semi-foundation/modal/modalContentFoundation.ts
+++ b/packages/semi-foundation/modal/modalContentFoundation.ts
@@ -48,7 +48,7 @@ export default class ModalContentFoundation extends BaseFoundation<ModalContentA
         this._adapter.notifyDialogMouseUp();
     }
 
-    handleKeyDown(e: any) {
+    handleKeyDown = (e: any) => {
         const { closeOnEsc } = this.getProps();
         if (closeOnEsc && e.keyCode === KeyCode.ESC) {
             e.stopPropagation();

--- a/packages/semi-ui/modal/ModalContent.tsx
+++ b/packages/semi-ui/modal/ModalContent.tsx
@@ -79,12 +79,12 @@ export default class ModalContent extends BaseComponent<ModalContentReactProps, 
             },
             addKeyDownEventListener: () => {
                 if (this.props.closeOnEsc) {
-                    document.addEventListener('keydown', this.foundation.handleKeyDown.bind(this.foundation));
+                    document.addEventListener('keydown', this.foundation.handleKeyDown);
                 }
             },
             removeKeyDownEventListener: () => {
                 if (this.props.closeOnEsc) {
-                    document.removeEventListener('keydown', this.foundation.handleKeyDown.bind(this.foundation));
+                    document.removeEventListener('keydown', this.foundation.handleKeyDown);
                 }
             },
             getMouseState: () => this.state.dialogMouseDown,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Modal 在 关闭后 esc 触发事件回调的问题。

---

🇺🇸 English
- Fix: fix Modal esc key trigger event callback after closed.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
