### PR TITLE
fix: [Cascader] Fix when motion is false, after searching for the sel…

### DIFF
--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -522,7 +522,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
         this._adapter.notifyDropdownVisibleChange(false);
         this._adapter.unregisterClickOutsideHandler();
         if (this._isFilterable()) {
-            const { selectedKeys } = this.getStates();
+            const { selectedKeys, isSearching } = this.getStates();
             let inputValue = '';
             if (key && !multiple) {
                 inputValue = this.renderDisplayText(key);
@@ -532,6 +532,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
             this._adapter.updateStates({ inputValue });
             !multiple && this.toggle2SearchInput(false);
             !multiple && this._adapter.updateFocusState(false);
+            isSearching && this._adapter.updateStates({ isSearching: false });
         }
         this._notifyBlur(e);
     }


### PR DESCRIPTION
…ected value, the panel display is still the searched option after the panel is collapsed and then opened

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1199 

### Changelog
🇨🇳 Chinese
- Fix: 修复当motion为false时，搜索选中值后，在面板收起后再打开面板显示仍然是搜索后的选项 #1199 

---

🇺🇸 English
- Fix: fix when motion is false, after searching for the selected value, the panel display is still the searched option after the panel is collapsed and then opened #1199 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
