### PR TITLE
fix: fix modal afterClose exec time

### DIFF
--- a/packages/semi-ui/modal/Modal.tsx
+++ b/packages/semi-ui/modal/Modal.tsx
@@ -188,10 +188,10 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
         if (props.visible && prevState.displayNone) {
             newState.displayNone = false;
         }
-
-        if (!props.visible && !props.motion && !prevState.displayNone) {
-            newState.displayNone = true;
-        }
+        //
+        // if (!props.visible && !props.motion && !prevState.displayNone) {
+        //     newState.displayNone = true;
+        // }
 
 
         return newState;
@@ -250,14 +250,14 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
         if (!prevProps.visible && this.props.visible) {
             this.foundation.beforeShow();
         }
-        // show => hide
-        if (prevProps.visible && !this.props.visible) {
-            this.foundation.afterHide();
-        }
 
         const shouldRender = this.props.visible || (this.props.keepDOM && (!this.props.lazyRender || this._haveRendered));
         if (shouldRender === true && this.state.shouldRender === false) {
             this.foundation.setShouldRender(true);
+        }
+
+        if (!prevState.displayNone && this.state.displayNone){
+            this.foundation.afterHide();
         }
     }
 

--- a/packages/semi-ui/modal/useModal/HookModal.tsx
+++ b/packages/semi-ui/modal/useModal/HookModal.tsx
@@ -1,12 +1,10 @@
 import React, { PropsWithChildren } from 'react';
 import ConfirmModal from '../ConfirmModal';
-import { get } from 'lodash';
 import { ConfirmProps } from '../confirm';
 
 interface HookModalProps {
     afterClose: (...args: any[]) => void;
-    config: ConfirmProps;
-    motion?: boolean
+    config: ConfirmProps
 }
 
 export interface HookModalRef {
@@ -33,28 +31,15 @@ const HookModal = ({ afterClose, config, ...props }: PropsWithChildren<HookModal
         },
     }));
 
-    const { motion } = props;
-    /* istanbul ignore next */
-    const mergedMotion =
-        typeof motion === 'undefined' || motion ?
-            {
-                ...(motion as any),
-                didLeave: (...args: any[]) => {
-                    const didLeave = get(props.motion, 'didLeave');
-
-                    if (typeof didLeave === 'function') {
-                        didLeave(...args);
-                    }
-                    afterClose();
-                },
-            } :
-            false;
-
+    const mergeAfterClose = () => {
+        config?.afterClose?.();
+        afterClose();
+    }; 
     return (
         <ConfirmModal
             {...innerConfig}
+            afterClose={mergeAfterClose}
             // visible={!visible ? visible : undefined}
-            motion={mergedMotion}
         />
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

修复 modal afterClose 在 js2css 改造时 在有动画时执行时机提前的问题，因 js2css 尚未发包，无需 changelog

### Changelog
🇨🇳 Chinese
- Fix: 修复 ...

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [X] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
