### PR TITLE
fix: datepicker make the same width under wheel and normal mode

### DIFF
--- a/packages/semi-foundation/datePicker/datePicker.scss
+++ b/packages/semi-foundation/datePicker/datePicker.scss
@@ -20,6 +20,17 @@ $module-list: #{$prefix}-scrolllist;
                 height: 0;
             }
         }
+
+        .#{$module-list}-list-outer {
+            -ms-overflow-style: none; /* Internet Explorer 10+ */
+            scrollbar-width: none; /* Firefox */
+
+            &::-webkit-scrollbar {
+                display: none;
+                width: 0;
+                height: 0;
+            }
+        }
     }
 
     // 双月网格
@@ -174,11 +185,22 @@ $module-list: #{$prefix}-scrolllist;
                 }
             }
 
+            &-item {
+                & > ul > li {
+                    // add paddingRight to make the same width under wheel and normal mode
+                    min-width: $width-datepicker_panel_yam_scrolllist_li_min + $spacing-scrollList_item_wheel_list_outer-paddingRight;
+                }
+            }
+
             &-body {
                 padding: 0;
                 overflow: hidden;
 
                 .#{$prefix}-scrolllist-item-wheel {
+                    border: none;
+                }
+
+                .#{$prefix}-scrolllist-item {
                     border: none;
                 }
             }

--- a/packages/semi-foundation/datePicker/variables.scss
+++ b/packages/semi-foundation/datePicker/variables.scss
@@ -74,7 +74,7 @@ $spacing-datepicker_insetInput_wrapper-paddingX: 16px;
 $spacing-datepicker_insetInput_wrapper-paddingBottom: 0;
 $spacing-datepicker_insetInput_separator-paddingY: 0;
 $spacing-datepicker_insetInput_separator-paddingX: 4px;
-
+$spacing-scrollList_item_wheel_list_outer-paddingRight: 18px;
 
 // Color
 $color-datepicker_panel-bg-default: var(--semi-color-bg-3); // 日期选择器背景颜色


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 DatePicker type="month" 下 年月选择模式为 normal 和 wheel 时， 宽度不一致问题

---

🇺🇸 English
- Fix: fix the issue of inconsistent width when the year-month selection mode is normal and wheel under DatePicker type="month"


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
