### PR TITLE
fix: timepicker make the same width under wheel and normal mode

### DIFF
--- a/packages/semi-foundation/timePicker/timePicker.scss
+++ b/packages/semi-foundation/timePicker/timePicker.scss
@@ -6,8 +6,13 @@ $module-list: #{$prefix}-scrolllist;
     display: inline-block;
 
     &-panel {
+        .#{$module-list}-header {
+            padding: $spacing-timePicker_range_panel_scrolllist_header_body-padding;
+        }
+
         .#{$module-list}-body {
             height: $height-timePicker_panel_body;
+            padding: $spacing-timePicker_range_panel_scrolllist_header_body-padding;
 
             .#{$module-list}-item-wheel .#{$module-list}-list-outer-nocycle,
             .#{$module-list}-item {
@@ -20,6 +25,15 @@ $module-list: #{$prefix}-scrolllist;
 
             .#{$module-list}-item,
             .#{$module-list}-item-wheel .#{$module-list}-list-outer {
+                -ms-overflow-style: none; /* Internet Explorer 10+ */
+                scrollbar-width: none; /* Firefox */
+
+                &::-webkit-scrollbar {
+                    display: none;
+                    width: 0;
+                    height: 0;
+                }
+
                 & > ul {
                     padding-bottom: ($height-timePicker_panel_body - $height-scrollList_item) * 0.5;
                 }
@@ -28,7 +42,7 @@ $module-list: #{$prefix}-scrolllist;
             .#{$module-list}-item {
                 -ms-overflow-style: none; /* Internet Explorer 10+ */
                 scrollbar-width: none; /* Firefox */
-                
+
                 &::-webkit-scrollbar {
                     display: none;
                     width: 0;

--- a/packages/semi-foundation/timePicker/timePicker.scss
+++ b/packages/semi-foundation/timePicker/timePicker.scss
@@ -6,13 +6,9 @@ $module-list: #{$prefix}-scrolllist;
     display: inline-block;
 
     &-panel {
-        .#{$module-list}-header {
-            padding: $spacing-timePicker_range_panel_scrolllist_header_body-padding;
-        }
 
         .#{$module-list}-body {
             height: $height-timePicker_panel_body;
-            padding: $spacing-timePicker_range_panel_scrolllist_header_body-padding;
 
             .#{$module-list}-item-wheel .#{$module-list}-list-outer-nocycle,
             .#{$module-list}-item {

--- a/packages/semi-foundation/timePicker/timePicker.scss
+++ b/packages/semi-foundation/timePicker/timePicker.scss
@@ -6,7 +6,6 @@ $module-list: #{$prefix}-scrolllist;
     display: inline-block;
 
     &-panel {
-
         .#{$module-list}-body {
             height: $height-timePicker_panel_body;
 

--- a/packages/semi-foundation/timePicker/variables.scss
+++ b/packages/semi-foundation/timePicker/variables.scss
@@ -4,8 +4,8 @@ $color-timePicker_range_panel-border: rgba(0, 0, 0, .1); // 时间选择器描�
 
 // Width/Height
 $width-timePicker_range_panel-border: 1px; // 时间选择器菜单分割线宽度
-$height-scrollList_item: 36px;
-$height-timePicker_panel_body: $height-scrollList_item * 7 + $spacing-tight * 2 - 2px; // 时间选择器菜单高度, 最多6 + 1行，再加上padding，默认266px
+$height-timePicker_panel_body: 252px; // 时间选择器菜单高度
+$height-scrollList_item: 36px; 
 $width-timePicker_panel_list_ampm: 72px; // 时间选择器菜单中列宽度 - 上午下午
 $width-timePicker_panel_list_hour: 64px; // 时间选择器菜单中列宽度 - 小时
 $width-timePicker_panel_list_minute: 64px; // 时间选择器菜单中列宽度 - 分钟

--- a/packages/semi-foundation/timePicker/variables.scss
+++ b/packages/semi-foundation/timePicker/variables.scss
@@ -4,8 +4,8 @@ $color-timePicker_range_panel-border: rgba(0, 0, 0, .1); // 时间选择器描�
 
 // Width/Height
 $width-timePicker_range_panel-border: 1px; // 时间选择器菜单分割线宽度
-$height-timePicker_panel_body: 252px; // 时间选择器菜单高度
-$height-scrollList_item: 36px; 
+$height-scrollList_item: 36px;
+$height-timePicker_panel_body: $height-scrollList_item * 7 + $spacing-tight * 2 - 2px; // 时间选择器菜单高度, 最多6 + 1行，再加上padding，默认266px
 $width-timePicker_panel_list_ampm: 72px; // 时间选择器菜单中列宽度 - 上午下午
 $width-timePicker_panel_list_hour: 64px; // 时间选择器菜单中列宽度 - 小时
 $width-timePicker_panel_list_minute: 64px; // 时间选择器菜单中列宽度 - 分钟


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 TimePicker 选择模式为 normal 和 wheel 时， 滚动条表现不一致问题

---

🇺🇸 English
- Fix: fix the problem that the scroll bar behaves inconsistently when the TimePicker selection mode is normal and wheel

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
