### PR TITLE
style: [Cascader] The right icon in the Cascader menu item increases …

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -408,6 +408,21 @@ $module: #{$prefix}-cascader;
             &-empty {
                 margin-right: $spacing-cascader_empty_icon-marginRight;
             }
+
+            &-left {
+                margin-left: $spacing-cascader_option-icon-marginLeft;
+            }
+        }
+
+        &-spin-icon {
+            width: $width-cascader-icon;
+            height: $width-cascader-icon;
+            line-height: 0;
+
+            & svg {
+                width: $width-cascader-icon;
+                height: $width-cascader-icon;
+            }
         }
 
         &-label {

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -51,6 +51,7 @@ $spacing-cascader_selection_tagInput-marginLeft: - $spacing-extra-tight; // 级�
 $spacing-cascader_selection_input-marginLeft: $spacing-extra-tight; // 级联选择触发器多选搜索时输入框的左外边距
 $spacing-cascader_selection_n-marginRight: $spacing-extra-tight; // 超出 maxTagCount 后，+n 的右外边距
 $spacing-cascader_clearBtn-marginRight: 12px; // 级联选择触发器清空按钮右侧外边距
+$spacing-cascader_option-icon-marginLeft: 8px; // 级联选择菜单项图标左侧外边距
 
 $color-cascader_selection_n-text-default: var(--semi-color-text-0); // 超出 maxTagCount 后，+n 的文字默认颜色
 $color-cascader_selection_n-text-disabled: var(--semi-color-disabled-text); // 超出 maxTagCount 后，+n 的文字disabled颜色

--- a/packages/semi-ui/cascader/item.tsx
+++ b/packages/semi-ui/cascader/item.tsx
@@ -139,16 +139,19 @@ export default class Item extends PureComponent<CascaderItemProps> {
         return state;
     };
 
-    renderIcon = (type: string) => {
+    renderIcon = (type: string, havePaddingLeft = false) => {
+        const finalStyle = (style: string) => {
+            return style + (havePaddingLeft ? ` ${prefixcls}-icon-left` : '');
+        };
         switch (type) {
             case 'child':
-                return (<IconChevronRight className={`${prefixcls}-icon ${prefixcls}-icon-expand`} />);
+                return (<IconChevronRight className={finalStyle(`${prefixcls}-icon ${prefixcls}-icon-expand`)} />);
             case 'tick':
-                return (<IconTick className={`${prefixcls}-icon ${prefixcls}-icon-active`} />);
+                return (<IconTick className={finalStyle(`${prefixcls}-icon ${prefixcls}-icon-active`)} />);
             case 'loading':
-                return <Spin wrapperClassName={`${prefixcls}-spin-icon`} />;
+                return <Spin wrapperClassName={finalStyle(`${prefixcls}-spin-icon`)} />;
             case 'empty':
-                return (<span aria-hidden={true} className={`${prefixcls}-icon ${prefixcls}-icon-empty`} />);
+                return (<span aria-hidden={true} className={finalStyle(`${prefixcls}-icon ${prefixcls}-icon-empty`)} />);
             default:
                 return null;
         }
@@ -273,7 +276,7 @@ export default class Item extends PureComponent<CascaderItemProps> {
                                 )}
                                 <span>{label}</span>
                             </span>
-                            {showExpand ? this.renderIcon(loading ? 'loading' : 'child') : null}
+                            {showExpand ? this.renderIcon(loading ? 'loading' : 'child', true) : null}
                         </li>
                     );
                 })}

--- a/packages/semi-ui/cascader/item.tsx
+++ b/packages/semi-ui/cascader/item.tsx
@@ -139,19 +139,19 @@ export default class Item extends PureComponent<CascaderItemProps> {
         return state;
     };
 
-    renderIcon = (type: string, havePaddingLeft = false) => {
-        const finalStyle = (style: string) => {
-            return style + (havePaddingLeft ? ` ${prefixcls}-icon-left` : '');
+    renderIcon = (type: string, haveMarginLeft = false) => {
+        const finalCls = (style: string) => {
+            return style + (haveMarginLeft ? ` ${prefixcls}-icon-left` : '');
         };
         switch (type) {
             case 'child':
-                return (<IconChevronRight className={finalStyle(`${prefixcls}-icon ${prefixcls}-icon-expand`)} />);
+                return (<IconChevronRight className={finalCls(`${prefixcls}-icon ${prefixcls}-icon-expand`)} />);
             case 'tick':
-                return (<IconTick className={finalStyle(`${prefixcls}-icon ${prefixcls}-icon-active`)} />);
+                return (<IconTick className={finalCls(`${prefixcls}-icon ${prefixcls}-icon-active`)} />);
             case 'loading':
-                return <Spin wrapperClassName={finalStyle(`${prefixcls}-spin-icon`)} />;
+                return <Spin wrapperClassName={finalCls(`${prefixcls}-spin-icon`)} />;
             case 'empty':
-                return (<span aria-hidden={true} className={finalStyle(`${prefixcls}-icon ${prefixcls}-icon-empty`)} />);
+                return (<span aria-hidden={true} className={finalCls(`${prefixcls}-icon ${prefixcls}-icon-empty`)} />);
             default:
                 return null;
         }


### PR DESCRIPTION
…the left margin

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style: Cascader 的菜单项中右侧图标增加左侧外边距

---

🇺🇸 English
- Style: Cascader 的菜单项中右侧图标增加左侧外边距


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

修改如下：
1. Cascader 的菜单项中右侧图标增加8px左侧外边距；
2. 调整加载图标 spin 的大小，和展开图标大小保持一致。