### PR TITLE
style: [tagInput] Modify the height of Input in TagInput

### DIFF
--- a/packages/semi-foundation/tagInput/tagInput.scss
+++ b/packages/semi-foundation/tagInput/tagInput.scss
@@ -102,6 +102,18 @@ $module: #{$prefix}-tagInput;
         padding-right: $spacing-extra-tight;
         overflow: hidden;
 
+        &-small {
+            min-height: $height-tagInput-small;
+        }
+
+        &-default {
+            min-height: $height-tagInput-default;
+        }
+
+        &-large {
+            min-height: $height-tagInput-large;
+        }
+
         &-tag {
             margin-right: $spacing-extra-tight;
             white-space: pre;
@@ -165,6 +177,42 @@ $module: #{$prefix}-tagInput;
 
             &:not(:first-child) > input {
                 padding-left: 0;
+            }
+
+            &-small {
+                height: $height-tagInput_input_small;
+                margin-top: $spacing-tagInput_small-Y;
+                margin-bottom: $spacing-tagInput_small-Y;
+                line-height: $height-tagInput_input_small;
+
+                & .#{$prefix}-input-small {
+                    height: $height-tagInput_input_small;
+                    line-height: $height-tagInput_input_small;
+                }
+            }
+
+            &-default {
+                height: $height-tagInput_input_default;
+                margin-top: $spacing-tagInput_default-Y;
+                margin-bottom: $spacing-tagInput_default-Y;
+                line-height: $height-tagInput_input_default;
+
+                & .#{$prefix}-input-default {
+                    height: $height-tagInput_input_default;
+                    line-height: $height-tagInput_input_default;
+                }
+            }
+
+            &-large {
+                height: $height-tagInput_input_large;
+                margin-top: $spacing-tagInput_large-Y;
+                margin-bottom: $spacing-tagInput_large-Y;
+                line-height: $height-tagInput_input_large;
+
+                & .#{$prefix}-input-large {
+                    height: $height-tagInput_input_large;
+                    line-height: $height-tagInput_input_large;
+                }
             }
         }
     }

--- a/packages/semi-foundation/tagInput/variables.scss
+++ b/packages/semi-foundation/tagInput/variables.scss
@@ -40,6 +40,9 @@ $spacing-tagInput_tag_icon_paddingLeft: 4px; // tag中有handler icon时tag的�
 $height-tagInput-large: $height-control-large; // 大尺寸标签输入框高度
 $height-tagInput-default: $height-control-default; // 默认尺寸标签输入框高度
 $height-tagInput-small: $height-control-small; // 小尺寸标签输入框高度
+$height-tagInput_input_small: 20px; // 小尺寸标签输入框Input框高度
+$height-tagInput_input_default: 24px; // 默认尺寸标签输入框Input框高度
+$height-tagInput_input_large: 24px; // 大尺寸标签输入框Input框高度
 
 $width-tagInput-clear-medium: $width-icon-medium * 2; // 标签输入框清空按钮宽度
 $width-tagInput-border-default: $border-thickness-control; // 标签输入框描边描边宽度 - 默认

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -553,9 +553,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             [`${prefixCls}-warning`]: validateStatus === 'warning'
         });
 
-        const inputCls = cls(`${prefixCls}-wrapper-input`);
+        const inputCls = cls(`${prefixCls}-wrapper-input`, `${prefixCls}-wrapper-input-${size}`);
 
-        const wrapperCls = cls(`${prefixCls}-wrapper`);
+        const wrapperCls = cls(`${prefixCls}-wrapper`, `${prefixCls}-wrapper-${size}`);
 
         return (
             // eslint-disable-next-line 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style: 修改 TagInput 中 Input 的高度

---

🇺🇸 English
- Style: modify the height of Input in TagInput


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

TagInput中 多行 Tag，最后一行的 Tag 和上一行的间隙比其他行大
![image](https://user-images.githubusercontent.com/101110131/201572371-73952084-1ee7-4819-a2d2-972343632cbf.png)
原因是最后一行中有输入框，输入框的整体高度（height + margin + padding + border）比tag的高，导致将间隙撑开
修改后， 间隙一致
![2c353d01-15e5-4559-b172-8cad58b4a721](https://user-images.githubusercontent.com/101110131/201572478-fc3d7ce3-b18e-45a5-9472-5c77b9ea1195.jpeg)
修改点：
1. Input 高度和 tag 一致
2. 设置TagInput的最小高度，以保证当无tag时候，高度和设计图要求一致（原来是通过input高度一致撑开，这个设置导致了间隙不一致的问题）
