### PR TITLE
fix: remove useless setPaddingLeft call in input, close #1262, 1181

### DIFF
--- a/packages/semi-foundation/input/foundation.ts
+++ b/packages/semi-foundation/input/foundation.ts
@@ -21,7 +21,6 @@ export interface InputAdapter extends Partial<DefaultAdapter>, Partial<InputDefa
     notifyKeyUp(e: any): void;
     notifyKeyPress(e: any): void;
     notifyEnterPress(e: any): void;
-    setPaddingLeft(paddingLeft: string): void;
     isEventTarget(e: any): boolean
 }
 
@@ -264,10 +263,6 @@ class InputFoundation extends BaseFoundation<InputAdapter> {
         if (e.key === ENTER_KEY) {
             this._adapter.notifyEnterPress(e);
         }
-    }
-
-    setPaddingLeft(paddingLeft: string) {
-        this._adapter.setPaddingLeft(paddingLeft);
     }
 
     isAllowClear() {

--- a/packages/semi-ui/input/index.tsx
+++ b/packages/semi-ui/input/index.tsx
@@ -72,7 +72,6 @@ export interface InputState {
     cachedValue: React.ReactText;
     disabled: boolean;
     props: Record<string, any>;
-    paddingLeft: string;
     isFocus: boolean;
     isHovering: boolean;
     eyeClosed: boolean;
@@ -157,7 +156,6 @@ class Input extends BaseComponent<InputProps, InputState> {
             cachedValue: null, // Cache current props.value value
             disabled: false,
             props: {},
-            paddingLeft: '',
             isFocus: false,
             isHovering: false,
             eyeClosed: props.mode === 'password',
@@ -195,7 +193,6 @@ class Input extends BaseComponent<InputProps, InputState> {
             notifyKeyUp: (e: React.KeyboardEvent<HTMLInputElement>) => this.props.onKeyUp(e),
             notifyEnterPress: (e: React.KeyboardEvent<HTMLInputElement>) => this.props.onEnterPress(e),
             notifyClear: (e: React.MouseEvent<HTMLDivElement>) => this.props.onClear(e),
-            setPaddingLeft: (paddingLeft: string) => this.setState({ paddingLeft }),
             setMinLength: (minLength: number) => this.setState({ minLength }),
             isEventTarget: (e: React.MouseEvent) => e && e.target === e.currentTarget,
         };
@@ -429,7 +426,7 @@ class Input extends BaseComponent<InputProps, InputState> {
             preventScroll,
             ...rest
         } = this.props;
-        const { value, paddingLeft, isFocus, minLength: stateMinLength } = this.state;
+        const { value, isFocus, minLength: stateMinLength } = this.state;
         const suffixAllowClear = this.showClearBtn();
         const suffixIsIcon = isSemiIcon(suffix);
         const ref = forwardRef || this.inputRef;
@@ -462,7 +459,7 @@ class Input extends BaseComponent<InputProps, InputState> {
         const inputValue = value === null || value === undefined ? '' : value;
         const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
             ...rest,
-            style: { paddingLeft, ...inputStyle },
+            style: inputStyle,
             autoFocus: autofocus,
             className: inputCls,
             disabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- React 17/18 在 nextjs ssr场景下使用 input会有不同表现；报错中的 padingLefft属于 input state，但经过查阅调用链，现在已经没有代码调用该 adapter，应该是可以移除的代码。移除后预期即可解决报错问题。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Next Js项目 在 React 18 下使用 Input 组件关于 style props 报错的问题, #1262 
---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
