### PR TITLE
fix: single select will flush when filter is true, close #1207

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,9 +11,9 @@
             "runtimeArgs": [
                 "--inspect-brk",
                 "${workspaceRoot}/node_modules/.bin/jest",
-                "${workspaceRoot}/packages/semi-ui/form/", // 需要调试哪个组件，替换文件夹路径即可
+                "${workspaceRoot}/packages/semi-ui/select/", // 需要调试哪个组件，替换文件夹路径即可
                 "--runInBand",
-                "--coverage",
+                // "--coverage",
                 "--silent" // ignore warning such as componentWillReceiveProps will be abondon...
             ],
             "env": {
@@ -21,37 +21,12 @@
                 // "type": "story" // 调试snapshot快照的时候用这个
                 "type": "unit"     // 调试unitTest的时候用这个
             },
+            "runtimeExecutable": "/Users/bytedance/.nvm/versions/node/v16.17.1/bin/node",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229
         },
-        {
-            "type": "node",
-            "request": "launch",
-            "name": "compile css",
-            "env": {
-                "NODE_ENV": "dev"
-            },
-            "runtimeExecutable": "node",
-            "program": "${workspaceFolder}/scripts/build-css.js",
-            "restart": true,
-            "console": "integratedTerminal",
-            "internalConsoleOptions": "neverOpen"
-        },
-        {
-            "type": "node",
-            "request": "launch",
-            "runtimeArgs": [
-            ],
-            "name": "debug snapshot update",
-            "env": {
-                "NODE_ENV": "dev"
-            },
-            "runtimeExecutable": "node",
-            "program": "${workspaceFolder}/scripts/snapshotUpdate.js",
-            "restart": true,
-            "console": "integratedTerminal",
-        },
+
         {
             "name": "Debug StorySnapShot",
             "type": "node",

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -54,7 +54,7 @@ export interface SelectAdapter<P = Record<string, any>, S = Record<string, any>>
     on(eventName: string, eventCallback: () => void): void;
     off(eventName: string): void;
     emit(eventName: string): void;
-    once(eventName, eventCallback: () => void): void
+    once(eventName: string, eventCallback: () => void): void
 }
 
 type LabelValue = string | number;

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -416,7 +416,6 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
         const selections = new Map().set(label, { value, label, ...rest });
         // First trigger onSelect, then trigger onChange
         this._notifySelect(value, { value, label, ...rest });
-
         // If it is a controlled component, directly notify
         // Make sure that the operations of updating updateOptions are done after the animation ends
         // otherwise the content will be updated when the popup layer is not collapsed, and it looks like it will flash once when it is closed
@@ -426,12 +425,12 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
             });
         } else {
             this.close(event, () => {
-                // Update the selected item in the drop-down box
-                this._adapter.updateSelection(selections);
-                // notify user
                 this.updateOptionsActiveStatus(selections);
+                // notify user
                 this._notifyChange(selections);
             });
+            // Update the selected item in the drop-down box
+            this._adapter.updateSelection(selections);
         }
     }
 

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -426,11 +426,11 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
         } else {
             this.close(event, () => {
                 this.updateOptionsActiveStatus(selections);
-                // notify user
-                this._notifyChange(selections);
             });
             // Update the selected item in the drop-down box
             this._adapter.updateSelection(selections);
+            // notify user
+            this._notifyChange(selections);
         }
     }
 

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -424,13 +424,13 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
                 this._notifyChange(selections);
             });
         } else {
-            this.close(event, () => {
-                this.updateOptionsActiveStatus(selections);
-            });
             // Update the selected item in the drop-down box
             this._adapter.updateSelection(selections);
             // notify user
             this._notifyChange(selections);
+            this.close(event, () => {
+                this.updateOptionsActiveStatus(selections);
+            });
         }
     }
 

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -379,11 +379,14 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
         this._adapter.unregisterClickOutsideHandler();
         // this._adapter.updateFocusState(false);
 
+        const isFilterable = this._isFilterable();
+        if (isFilterable) {
+            this.toggle2SearchInput(false);
+        }
+
         this._adapter.once('popoverClose', () => {
-            const isFilterable = this._isFilterable();
             if (isFilterable) {
                 this.clearInput();
-                this.toggle2SearchInput(false);
             }
             if (closeCb) {
                 closeCb();
@@ -427,6 +430,7 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
             this._adapter.updateSelection(selections);
             // notify user
             this._notifyChange(selections);
+
             this.close(event, () => {
                 // Update the selected item in the drop-down box
                 this.updateOptionsActiveStatus(selections);

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -424,11 +424,11 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
                 this._notifyChange(selections);
             });
         } else {
-            // Update the selected item in the drop-down box
             this._adapter.updateSelection(selections);
             // notify user
             this._notifyChange(selections);
             this.close(event, () => {
+                // Update the selected item in the drop-down box
                 this.updateOptionsActiveStatus(selections);
             });
         }

--- a/packages/semi-foundation/utils/Event.ts
+++ b/packages/semi-foundation/utils/Event.ts
@@ -23,7 +23,7 @@ export default class Event {
         }
     }
 
-    off(event: string, callback: null | (() => void)) {
+    off(event: string, callback?: null | (() => void)) {
         if (event) {
             if (typeof callback === 'function') {
                 const callbacks = this._eventMap.get(event);

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -397,6 +397,8 @@ export const WithPrefixSuffixInsetLabelShowClearShowArrow = () => (
       style={{
         width: '250px',
       }}
+      motion={false}
+      filter
       optionList={options}
       prefix={<IconSearch />}
       suffix={<IconGift></IconGift>}

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -14,6 +14,7 @@ import TagGroup from '../tag/group';
 import LocaleConsumer from '../locale/localeConsumer';
 import Popover, { PopoverProps } from '../popover/index';
 import { numbers as popoverNumbers } from '@douyinfe/semi-foundation/popover/constants';
+import Event from '@douyinfe/semi-foundation/utils/Event';
 import { FixedSizeList as List } from 'react-window';
 import { getOptionsFromGroup } from './utils';
 import VirtualRow from './virtualRow';
@@ -333,6 +334,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
     clickOutsideHandler: (e: MouseEvent) => void;
     foundation: SelectFoundation;
     context: ContextValue;
+    eventManager: Event;
 
     constructor(props: SelectProps) {
         super(props);
@@ -367,6 +369,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
         this.onMouseLeave = this.onMouseLeave.bind(this);
         this.renderOption = this.renderOption.bind(this);
         this.onKeyPress = this.onKeyPress.bind(this);
+        this.eventManager = new Event();
 
         this.foundation = new SelectFoundation(this.adapter);
 
@@ -457,6 +460,10 @@ class Select extends BaseComponent<SelectProps, SelectState> {
             ...keyboardAdapter,
             ...filterAdapter,
             ...multipleAdapter,
+            on: (eventName, eventCallback) => this.eventManager.on(eventName, eventCallback),
+            off: (eventName) => this.eventManager.off(eventName),
+            once: (eventName, eventCallback) => this.eventManager.once(eventName, eventCallback),
+            emit: (eventName) => this.eventManager.emit(eventName),
             // Collect all subitems, each item is visible by default when collected, and is not selected
             getOptionsFromChildren: (children = this.props.children) => {
                 let optionGroups = [];
@@ -1285,6 +1292,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
                 stopPropagation={stopPropagation}
                 disableArrowKeyDown={true}
                 onVisibleChange={status => this.handlePopoverVisibleChange(status)}
+                afterClose={() => this.foundation.handlePopoverClose()}
             >
                 {selection}
             </Popover>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
修复 Select 单选模式下，filter 为true，当前如果进行了搜索筛选，点击选择后，收起Options列表的同时，由于Options列表重置内容更新，导致看起来会闪烁一次的问题

#### 原因分析
单选点击后存在以下调用链
- foundation.handleSingleSelection  -> this.close -> clearInput ->  updateOptions (因为input变化了，所以需要重置下拉列表中的筛选结果) 
由于存在收起动画，close 与 updateOptions 并不是严格的先后顺序，所以 close的动画未执行完， updateOptions已经更新了，导致的闪烁。


#### 改进措施
- 将 close中 的 clearInput 操作延迟，在动画结束回调后再执行
- 受控模式下，原有逻辑：close调用后立即执行  notifyChange -> close调用后，动画结束再执行 notifyChange
- 非受控模式，将 uptionOptions 放在close动画结束回调中执行，而 notifyChange、updateSelection 等逻辑不变


### Changelog
🇨🇳 Chinese
- Fix: 修复 Select 单选模式下，filter 开启情况下，点击选择收起列表时，会闪烁一次的问题 #1207

---

🇺🇸 English
- Fix: Fix the issue that in the Select radio mode, when the filter is enabled, when you click to select to close the list, it will flash once #1207


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
