### PR TITLE
fix: [TreeSelect] Fix when searchAutoFocus is true and searchPosition…

### DIFF
--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -631,7 +631,23 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             toggleHovering: bool => {
                 this.setState({ isHovering: bool });
             },
-            updateInputFocus: bool => { } // eslint-disable-line
+            updateInputFocus: bool => { 
+                if (bool) {
+                    if (this.inputRef && this.inputRef.current) {
+                        (this.inputRef.current as any).focus();
+                    }
+                    if (this.tagInputRef && this.tagInputRef.current) {
+                        this.tagInputRef.current.focus();
+                    }
+                } else {
+                    if (this.inputRef && this.inputRef.current) {
+                        (this.inputRef.current as any).blur();
+                    }
+                    if (this.tagInputRef && this.tagInputRef.current) {
+                        this.tagInputRef.current.blur();
+                    }
+                }
+            } // eslint-disable-line
         };
     }
 
@@ -1094,7 +1110,9 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             maxTagCount,
             checkRelation,
             showRestTagsPopover, 
-            restTagsPopoverProps
+            restTagsPopoverProps,
+            searchPosition,
+            filterTreeNode
         } = this.props;
         const {
             keyEntities,
@@ -1108,6 +1126,14 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         } else if (checkRelation === 'unRelated') {
             keyList = [...realCheckedKeys];
         }
+        // auto focus search input divide into two parts
+        // 1. filterTreeNode && searchPosition === strings.SEARCH_POSITION_TRIGGER
+        //    Implemented by passing autofocus to the underlying input's autofocus
+        // 2. filterTreeNode && searchPosition === strings.SEARCH_POSITION_DROPDOWN
+        //    Due to the off-screen rendering in the tooltip implementation mechanism, if it is implemented through the 
+        //    autofocus of the input, when the option panel is opened, the page will scroll to top, so it is necessary 
+        //    to call the focus method through ref in the onVisibleChange callback of the Popover to achieve focus
+        const autoFocus = (filterTreeNode && searchPosition === strings.SEARCH_POSITION_TRIGGER) ? searchAutoFocus : undefined;
         return (
             <TagInput
                 maxTagCount={maxTagCount}
@@ -1121,7 +1147,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 showRestTagsPopover={showRestTagsPopover}
                 restTagsPopoverProps={restTagsPopoverProps}
                 // eslint-disable-next-line jsx-a11y/no-autofocus
-                autoFocus={searchAutoFocus}
+                autoFocus={autoFocus}
                 renderTagItem={(itemKey, index) => this.renderTagItem(itemKey, index)}
                 onRemove={itemKey => this.removeTag(itemKey)}
                 expandRestTagsOnClick={false}
@@ -1156,6 +1182,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             prefix: <IconSearch />,
         };
         const inputTriggerProps = {
+            autofocus: searchAutoFocus,
             onFocus: (e: React.FocusEvent) => this.foundation.handleInputTriggerFocus(),
             onBlur: (e: React.FocusEvent) => this.foundation.handleInputTriggerBlur(),
             disabled,
@@ -1183,7 +1210,6 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                             <Input
                                 aria-label='Filter TreeSelect item'
                                 ref={this.inputRef as any}
-                                autofocus={searchAutoFocus}
                                 placeholder={placeholder}
                                 {...baseInputProps}
                                 {...realInputProps}
@@ -1243,10 +1269,13 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
 
     /* Event handler function after popover is closed */
     handlePopoverClose = isVisible => {
-        const { filterTreeNode } = this.props;
+        const { filterTreeNode, searchAutoFocus, searchPosition } = this.props;
         if (isVisible === false && Boolean(filterTreeNode)) {
             this.foundation.clearInput();
         }
+        if (filterTreeNode && searchPosition === strings.SEARCH_POSITION_DROPDOWN && isVisible && searchAutoFocus) {
+            this.foundation.focusInput(true);
+        } 
     }
 
     renderTreeNode = (treeNode: FlattenNode, ind: number, style: React.CSSProperties) => {


### PR DESCRIPTION
… is in dropdown, opening the options panel causes the page scrolling problem

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1306 

### Changelog
🇨🇳 Chinese
- Fix: 修复 TreeSelect 中当 searchAutoFocus 为 true ，并且 searchPosition 在 dropdown 中，打开选项面板导致页面滚动问题 #1306 

---

🇺🇸 English
- Fix: Fix the page scrolling problem caused by opening the option panel when searchAutoFocus is true and searchPosition is in dropdown in TreeSelect #1306 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

原来的 autofocus 时通过将 searchAutoFocus 传至底层的 input 的 autofocus 参数实现，当 searchPosition="dropdown", 由于弹出层的依赖 Tooltip 组件，Tooltip 组件有离屏渲染逻辑，弹出层中的组件 focus，页面移动到被 focus 的位置，从而出现屏幕滚动的问题
解决方法：
将 searchAutoFocus 的功能点进行拆分，
1. 如果 searchPosition="Trigger"， 因为不在弹出层中, 所以依然可以使用原来的方式（将 searchAutoFocus 传至底层的 input 的 autofocus 参数；
2. 如果searchPosition="Dropdown"，则在 Popover 的 onVisibleChange 回调中去通过 ref 调用 focus 方法 实现聚焦。

