### PR TITLE
fix: DatePicker disabledDate interaction is not easy to use when type…

### DIFF
--- a/cypress/integration/datePicker.spec.js
+++ b/cypress/integration/datePicker.spec.js
@@ -584,4 +584,24 @@ describe('DatePicker', () => {
         cy.get('.semi-datepicker-month-grid-left .semi-datepicker-day.semi-datepicker-day-disabled').eq(0).contains('17');
         cy.get('.semi-datepicker-month-grid-left .semi-datepicker-day.semi-datepicker-day-disabled').eq(6).contains('23');
     });
+
+    it('auto scroll to no disabled month', () => {
+        cy.visit('http://localhost:6006/iframe.html?id=datepicker--fix-disabled-month&viewMode=story');
+        cy.get('.semi-input').eq(0).click();
+        cy.wait(100);
+
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(2) li').contains('10').click({ force: true });
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(1) li').contains('2021').click({ force: true });
+        cy.wait(100);
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(1) .semi-scrolllist-item-sel').should('contain.text', '2021年');
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(2) .semi-scrolllist-item-sel').should('contain.text', '11月');
+        cy.get('.semi-input').eq(0).should('have.value', '2021-11');
+        
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(2) li').contains('12').click({ force: true });
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(1) li').contains('2022').click({ force: true });
+        cy.wait(100);
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(1) .semi-scrolllist-item-sel').should('contain.text', '2022年');
+        cy.get('.semi-scrolllist-body .semi-scrolllist-item:nth-child(2) .semi-scrolllist-item-sel').should('contain.text', '1月');
+        cy.get('.semi-input').eq(0).should('have.value', '2022-01');
+    });
 });

--- a/packages/semi-ui/datePicker/_story/v2/FixDisabledMonth.tsx
+++ b/packages/semi-ui/datePicker/_story/v2/FixDisabledMonth.tsx
@@ -1,0 +1,26 @@
+import DatePicker from '../../index';
+import React from 'react';
+import { set } from 'date-fns';
+
+/**
+ * test by cypress, don't modify this story
+ */
+export default function App() {
+    const disabledDate = (date: Date) => {
+        const isBefore = date < set(date, { year: 2021, month: 10 });
+        const isAfter = date > set(date, { year: new Date().getFullYear(), month: new Date().getMonth() });
+        return isBefore || isAfter;
+    };
+
+    return (
+        <DatePicker
+            motion={false}
+            yearAndMonthOpts={{ motion: false }}
+            disabledDate={disabledDate}
+            defaultValue={new Date('2022-11')}
+            type="month"
+            onChange={console.log}
+            style={{ width: 140 }}
+        />
+    );
+}

--- a/packages/semi-ui/datePicker/_story/v2/index.js
+++ b/packages/semi-ui/datePicker/_story/v2/index.js
@@ -10,3 +10,4 @@ export { default as AutoFillTime } from './AutoFillTime';
 export { default as InputFormatConfirm } from './InputFormatConfirm';
 export { default as FixedTriggerRender } from './FixTriggerRender';
 export { default as DisabledRange } from './DisabledRange';
+export { default as FixDisabledMonth } from './FixDisabledMonth';

--- a/packages/semi-ui/datePicker/yearAndMonth.tsx
+++ b/packages/semi-ui/datePicker/yearAndMonth.tsx
@@ -13,7 +13,7 @@ import { IconChevronLeft } from '@douyinfe/semi-icons';
 import { BASE_CLASS_PREFIX } from '@douyinfe/semi-foundation/base/constants';
 
 import { noop, stubFalse } from 'lodash';
-import { setYear, setMonth } from 'date-fns';
+import { setYear, setMonth, set } from 'date-fns';
 import { Locale } from '../locale/interface';
 import { strings } from '@douyinfe/semi-foundation/datePicker/constants';
 
@@ -87,7 +87,7 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
             ...super.adapter,
             // updateYears: years => this.setState({ years }),
             // updateMonths: months => this.setState({ months }),
-            setCurrentYear: currentYear => this.setState({ currentYear }),
+            setCurrentYear: (currentYear, cb) => this.setState({ currentYear }, cb),
             setCurrentMonth: currentMonth => this.setState({ currentMonth }),
             notifySelectYear: year =>
                 this.props.onSelect({
@@ -119,14 +119,19 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
     }
 
     renderColYear() {
-        const { years, currentYear, currentMonth } = this.state;
+        const { years, currentYear, currentMonth, months } = this.state;
         const { disabledDate, localeCode, yearCycled, yearAndMonthOpts } = this.props;
         const currentDate = setMonth(Date.now(), currentMonth - 1);
-        const list: any[] = years.map(({ value, year }) => ({
-            year,
-            value, // Actual rendered text
-            disabled: disabledDate(setYear(currentDate, year)),
-        }));
+        const list: any[] = years.map(({ value, year }) => {
+            const isAllMonthDisabled = months.every(({ month }) => {
+                return disabledDate(set(currentDate, { year, month: month - 1 }));
+            });
+            return ({
+                year,
+                value, // Actual rendered text
+                disabled: isAllMonthDisabled,
+            });
+        });
         let transform = (val: string) => val;
         if (localeCode === 'zh-CN' || localeCode === 'zh-TW') {
             // Only Chinese needs to add [year] after the selected year


### PR DESCRIPTION
… is month #520

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 DatePicker 月份选择 disabledDate 交互问题 #520

---

🇺🇸 English
- Fix: fixed DatePicker disabledDate interaction is not easy to use when type is month #520


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
