### PR TITLE
fix: disabled  switch can't trigger mouseLeave, tooltip can't hide

### DIFF
--- a/packages/semi-foundation/switch/switch.scss
+++ b/packages/semi-foundation/switch/switch.scss
@@ -76,6 +76,11 @@ $module: #{$prefix}-switch;
             @include shadow-0;
             border: $width-switch_knob_disabled-border $color-switch_knob-border-default solid;
         }
+        
+        .#{$module}-native-control {
+            pointer-events: none;
+            cursor: not-allowed;
+        }
 
         &.#{$module}-checked {
             border-color: $color-switch_checked_disabled-border-default;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

####  现状
- React本身对于 disabled input/ button 只会触发 onMouseEnter、不会触发 onMouseLeave [4251](https://github.com/facebook/react/issues/4251)，在 disabled switch 被 Tooltip包裹的情况下，虽然tooltip已经自动 wrap了一个span元素 在外层，并且 onMouseEnter、onMouseLeave等事件监听器也是加在 span上的。但由于 disabled input 的宽高 与 span 完全相等。此时 span 依然无法触发 onMouseLeave事件
  - 仅在chrome和 safari下无法触发，在火狐下一切正常（即火狐下不存在该bug）
  - 如果我们将span的padding从0 -> 任意正数，此时onMouseLeave 是可以触发的
 
#### 修改方案
- 对 disabled input增加 point-event: none 与 cursor: not-allowed。让span的事件监听能正常工作


### Changelog
🇨🇳 Chinese
- Fix: 修复 disabled switch 被 Tooltip或 Popover等组件包裹，且trigger为hover时，在chrome浏览器下，鼠标移开后未能正确隐藏的问题

---

🇺🇸 English
- Fix: Fix the problem that when the disabled switch is wrapped by components such as Tooltip or Popover, and the trigger is hover, it cannot be hidden correctly after the mouse is moved under the chrome browser


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
