### PR TITLE
fix: [Select] Fix the problem that there is still a drop-down box whe…

### DIFF
--- a/cypress/integration/select.spec.js
+++ b/cypress/integration/select.spec.js
@@ -47,6 +47,13 @@ describe('Select', () => {
         cy.get('@consoleLog').should('be.calledWith', 'onBlur');
     });
 
+    it('emptyContent=null', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?path=/story/select--empty-content');
+        // when emptyContent = null， The dropdown list will not be displayed
+        // so element(which class has semi-popover-wrapper) show have 0px height;
+        cy.get('.semi-popover-wrapper').eq(0).should('have.css', 'height', '0px');
+    });
+
     // it('should trigger onSearch when click x icon', () => {
     //     cy.visit('http://127.0.0.1:6006/iframe.html?path=/story/select--select-filter-single');
     //     cy.get('.semi-select').eq(0).click();

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -2994,3 +2994,11 @@ export const RenderSelectedItemCallCount = () => {
 RenderSelectedItemCallCount.story = {
   name: 'RenderSelectedItemCallCount',
 };
+
+
+export const emptyContent = () => {
+  const list = null;
+  return (
+    <Select placeholder='请选择业务线' emptyContent={null} style={{ width: 180 }} optionList={list} defaultOpen={true}/>
+  )
+}

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -862,6 +862,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
             loading,
             virtualize,
             multiple,
+            emptyContent
         } = this.props;
 
         // Do a filter first, instead of directly judging in forEach, so that the focusIndex can correspond to
@@ -884,7 +885,11 @@ class Select extends BaseComponent<SelectProps, SelectState> {
             // eslint-disable-next-line jsx-a11y/no-static-element-interactions
             <div 
                 id={`${prefixcls}-${this.selectOptionListID}`} 
-                className={cls(`${prefixcls}-option-list-wrapper`, dropdownClassName)} 
+                className={cls({
+                    // When emptyContent is null and the option is empty, there is no need for the drop-down option for the user,
+                    // so there is no need to set padding through this className
+                    [`${prefixcls}-option-list-wrapper`]: !(isEmpty && emptyContent === null),
+                }, dropdownClassName)} 
                 style={style}
                 ref={this.setOptionContainerEl} 
                 onKeyDown={e => this.foundation.handleContainerKeyDown(e)}


### PR DESCRIPTION
…n the option in Select is empty and emptyContent=null

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复当 Select 中选项为空，并且 emptyContent=null 时候仍然有下拉框的问题

---

🇺🇸 English
- Fix: fix the problem that there is still a drop-down box when the option in Select is empty and emptyContent=null


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
此前关于select的一个样式修改中，将原来第一个选项上的padding-top，和最后一个选项上的padding-bottom添加到了选项的外层（semi-select-option-list-wrapper), 导致当内容为空，并且emptyContent=null时候，下拉框仍然有长度，因此导致改情况下对用户来说，视觉上仍然有下拉框，不符合用户预期
![image](https://user-images.githubusercontent.com/101110131/208020351-5c5be27d-03f1-49e2-88ac-733dc52da8a7.png)
修改后
![image](https://user-images.githubusercontent.com/101110131/208020447-c43a065d-bd52-42aa-83a5-cf64bd711049.png)
