### PR TITLE
fix: [Typography] ellipsis is hidden for empty strings

### DIFF
--- a/packages/semi-ui/typography/_story/typography.stories.jsx
+++ b/packages/semi-ui/typography/_story/typography.stories.jsx
@@ -432,9 +432,19 @@ export const EllipsisChaos = () => (
 EllipsisChaos.story = {
   name: 'Ellipsis chaos',
 };
-
 export const EllipsisCollapsible = () => (
   <div>
+    <Paragraph
+      ellipsis={{
+        rows: 1,
+        expandable: true,
+        collapsible: true,
+      }}
+      style={{ width: 300 }}
+    >
+      {''}
+    </Paragraph>
+    <br />
     <Paragraph
       ellipsis={{
         rows: 3,

--- a/packages/semi-ui/typography/util.tsx
+++ b/packages/semi-ui/typography/util.tsx
@@ -35,8 +35,11 @@ const getRenderText = (
     ellipsisStr: string,
     suffix: string,
     ellipsisPos: string
-// eslint-disable-next-line max-params
+    // eslint-disable-next-line max-params
 ) => {
+    if (content.length === 0) {
+        return '';
+    }
     if (!ellipsisContainer) {
         ellipsisContainer = document.createElement('div');
         ellipsisContainer.setAttribute('aria-hidden', 'true');


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #621

### Changelog
🇨🇳 Chinese
- Fix: 空字符串但没有达到最大宽度时，却展示了"展开/折叠"按钮及省略号

---

🇺🇸 English
- Fix: An empty string that has not reached its maximum width shows an "expand/collapse" button and an ellipsis


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
