### PR TITLE
fix: Grid span = 0 not work when responsive

### DIFF
--- a/packages/semi-foundation/grid/grid.scss
+++ b/packages/semi-foundation/grid/grid.scss
@@ -19,7 +19,7 @@ $module: #{$prefix};
     }
 }
 
-.#{$module}-col-0 {
+.#{$module}-col-0, .#{$module}-col-xs-0, .#{$module}-col-sm-0, .#{$module}-col-md-0, .#{$module}-col-lg-0, .#{$module}-col-xl-0, .#{$module}-col-xxl-0 {
     display: none;
 }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1314 

### Changelog
🇨🇳 Chinese
- Fix: 修复Grid组件span设置为0，在响应式模式下异常显示的问题

---

🇺🇸 English
- Fix: fix the problem that the Grid component span is set to 0 and displays abnormally in response mode


### Checklist
- [X] Test or no need
- [X] Document or no need
- [X] Changelog or no need

### Other
- [X] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
