### PR TITLE
fix: [TagInput] Fix max Length judgment is wrong in composition input

### DIFF
--- a/packages/semi-ui/tagInput/_story/tagInput.stories.jsx
+++ b/packages/semi-ui/tagInput/_story/tagInput.stories.jsx
@@ -527,3 +527,31 @@ export const TagInputInPopover = () => {
   );
 }
 
+export const testMaxLength = () => (
+  <>
+    <p>maxLength=5</p>
+    <TagInput 
+      maxLength={5} 
+      placeholder='单个标签长度不超过5...'  
+      style={{ marginTop: 12, width: 400 }}
+      onChange={v => console.log(v)}
+      onInputExceed={v => {
+          Toast.warning('超过 maxLength');
+          console.log(v);
+      }} 
+    />
+    <p>maxLength=5, separator='/'</p>
+    <TagInput 
+      maxLength={5} 
+      separator={'/'}
+      placeholder='单个标签长度不超过5...'  
+      style={{ marginTop: 12, width: 400 }}
+      onChange={v => console.log(v)}
+      onInputExceed={v => {
+          Toast.warning('超过 maxLength');
+          console.log(v);
+      }} 
+    />
+  </>
+);
+

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -89,7 +89,9 @@ export interface TagInputState {
     inputValue?: string;
     focusing?: boolean;
     hovering?: boolean;
-    active?: boolean
+    active?: boolean;
+    // entering: Used to identify whether the user is in a new composition session（eg，Input Chinese）
+    entering?: boolean
 }
 
 class TagInput extends BaseComponent<TagInputProps, TagInputState> {
@@ -171,6 +173,7 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             focusing: false,
             hovering: false,
             active: false,
+            entering: false,
         };
         this.inputRef = React.createRef();
         this.tagInputRef = React.createRef();
@@ -221,6 +224,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             },
             setActive: (active: boolean) => {
                 this.setState({ active });
+            },
+            setEntering: (entering: boolean) => {
+                this.setState({ entering });
             },
             getClickOutsideHandler: () => {
                 return this.clickOutsideHandler;
@@ -534,6 +540,14 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         }
     }
 
+    handleInputCompositionStart = (e) => {
+        this.foundation.handleInputCompositionStart(e);
+    }
+
+    handleInputCompositionEnd = (e) => {
+        this.foundation.handleInputCompositionEnd(e);
+    }
+
     render() {
         const {
             size,
@@ -608,6 +622,8 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
                         onFocus={(e: React.FocusEvent<HTMLInputElement>) => {
                             this.handleInputFocus(e as any);
                         }}
+                        onCompositionStart={this.handleInputCompositionStart}
+                        onCompositionEnd={this.handleInputCompositionEnd}
                     />
                 </div>
                 {this.renderClearBtn()}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1347 

### Changelog
🇨🇳 Chinese
- Fix: 修复 TagInput 在中文输入时，会将拼音的长度用于判断是否超出 maxLength 的问题 #1347 

---

🇺🇸 English
- Fix: fix the problem that when TagInput is input in Chinese, the length of pinyin will be used to judge whether it exceeds maxLength #1347 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
