### PR TITLE
fix: OverflowList change items props and scroll vertically to be cover bring the wrong overflow item

### DIFF
--- a/packages/semi-ui/overflowList/_story/overflowList.stories.jsx
+++ b/packages/semi-ui/overflowList/_story/overflowList.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Icon, Tag, Table, Slider } from '../../index';
+import { Icon, Tag, Table, Slider, Button } from '../../index';
 import OverflowList from '..';
 import {
   IconAlarm,
@@ -439,5 +439,60 @@ OverflowListWithSlide.story = {
   name: 'overflowList with slide',
 };
 
-// TODO large data will cause memory heap
-// stories.add('large amount of data', () => <LargeData />);
+
+
+export const Fix1362 = () =>{
+  const items1 = [
+        { icon: <IconAlarm style={{ marginRight: 4 }} />, key: 'alarm' },
+        { icon: <IconBookmark style={{ marginRight: 4 }} />, key: 'bookmark' },
+        { icon: <IconCamera style={{ marginRight: 4 }} />, key: 'camera' },
+        { icon: <IconDuration style={{ marginRight: 4 }} />, key: 'duration' },
+        { icon: <IconEdit style={{ marginRight: 4 }} />, key: 'edit' },
+        { icon: <IconFolder style={{ marginRight: 4 }} />, key: 'folder' },
+    ];
+
+  const items2 = [
+      { icon: <IconAlarm style={{ marginRight: 4 }} />, key: 'newAlarm' },
+      { icon: <IconBookmark style={{ marginRight: 4 }} />, key: 'newBookmark' },
+      { icon: <IconCamera style={{ marginRight: 4 }} />, key: 'newCamera' },
+      { icon: <IconDuration style={{ marginRight: 4 }} />, key: 'newDuration' },
+  ];
+
+  const [items, setItem] = useState(items1);
+  const [flag, setFlag] = useState(false);
+
+  const renderOverflow = items => {
+    return items.map(item => <Tag>{item.length}</Tag>);
+  };
+  const renderItem = (item, ind) => {
+    return (
+      <div key={item.key} style={{ marginRight: 8 }}>
+        {item.key}
+      </div>
+    );
+  };
+
+  const change = () =>{
+    setItem(flag ? items1: items2)
+    setFlag(!flag)
+  }
+
+  return (
+      <div style={{ marginTop: 100, height: 1000 }}>
+          <Button onClick={change}>change</Button>
+          <br />
+          <br />
+          <div style={{ width: 500 }}>
+              <OverflowList
+                  renderMode='scroll'
+                  items={items}
+                  overflowRenderer={renderOverflow}
+                  visibleItemRenderer={renderItem}
+              />
+          </div>
+      </div>
+  );
+}
+Fix1362.story = {
+  name: 'fix #1362',
+};

--- a/packages/semi-ui/overflowList/index.tsx
+++ b/packages/semi-ui/overflowList/index.tsx
@@ -163,6 +163,7 @@ class OverflowList extends BaseComponent<OverflowListProps, OverflowListState> {
 
         if (!isEqual(prevProps.items, this.props.items)) {
             this.itemRefs = {};
+            this.setState({ visibleState: new Map() });
         }
 
         const { overflow, containerWidth, visible, overflowStatus } = this.state;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1362 
visibleState 用来标识每个item当前的可见状态。修改前仅在 foundation 中的 `handleIntersect` 有调用函数 `updateVisibleState` 更新 visibleState 的值。
如若一开始 props.items 传入两个 item ，key 为 'item1' 与  'item2'，visibleState 则为 { 'item1' => true, 'item2' => true }，而后修改items为 'newItem1'与 'newItem2'，**当纵向滚动使得 OverflowList 内的item上半部分被一半以上时，会调用 `handleIntersect` 函数**，此时 visibleState 变为{ 'item1' => true, 'item2' => true, 'newItem1' => false, 'newItem2' => false  }。造成 OverflowList 靠近顶部后，溢出部分 items 数量不符合预期问题


### Changelog
🇨🇳 Chinese
- Fix: 修复  OverflowList items 改变后靠近顶部溢出部分 items 数量不符合预期问题 #1362 

---

🇺🇸 English
- Fix: fix the problem that the number of items in the overflow part near the top after the OverflowList items are changed is not as expected #1362 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
