### PR TITLE
[layout] Fix layout mount sider class delay

### DIFF
--- a/packages/semi-foundation/base/foundation.ts
+++ b/packages/semi-foundation/base/foundation.ts
@@ -16,7 +16,7 @@ export interface DefaultAdapter<P = Record<string, any>, S = Record<string, any>
     getProps(): P;
     getState(key: string): any;
     getStates(): S;
-    setState(s: Partial<S>, callback?: any): void;
+    setState<K extends keyof S>(s: Pick<S, K>, callback?: any): void;
     getCache(c: string): any;
     getCaches(): any;
     setCache(key: any, value: any): void;
@@ -88,7 +88,7 @@ class BaseFoundation<T extends Partial<DefaultAdapter<P, S>>, P = Record<string,
         return this._adapter.getStates();
     }
 
-    setState(states: Partial<S>, cb?: (...args: any) => void) {
+    setState<K extends keyof S>(states: Pick<S, K>, cb?: (...args: any) => void) {
         return this._adapter.setState({ ...states }, cb);
     }
 

--- a/packages/semi-ui/layout/Sider.tsx
+++ b/packages/semi-ui/layout/Sider.tsx
@@ -61,6 +61,7 @@ class Sider extends React.PureComponent<SiderProps> {
     };
 
     static contextType = LayoutContext;
+    static type = "Sider"
 
     unRegisters: Array<() => void> = [];
     context: ContextType;

--- a/packages/semi-ui/layout/Sider.tsx
+++ b/packages/semi-ui/layout/Sider.tsx
@@ -61,7 +61,7 @@ class Sider extends React.PureComponent<SiderProps> {
     };
 
     static contextType = LayoutContext;
-    static type = "Sider"
+    static elementType = "Layout.Sider"
 
     unRegisters: Array<() => void> = [];
     context: ContextType;

--- a/packages/semi-ui/layout/index.tsx
+++ b/packages/semi-ui/layout/index.tsx
@@ -111,7 +111,9 @@ class Layout extends React.Component<BasicLayoutProps, BasicLayoutState> {
         const { prefixCls, className, children, hasSider, tagName, ...others } = this.props;
         const { siders } = this.state;
         const classString = cls(className, prefixCls, {
-            [`${prefixCls}-has-sider`]: typeof hasSider === 'boolean' ? hasSider : siders.length > 0,
+            [`${prefixCls}-has-sider`]: typeof hasSider === 'boolean' && hasSider || siders.length > 0 || React.Children.toArray(children).some((child: React.ReactNode) => {
+                return React.isValidElement(child) && child.type && (child.type as any).type==="Sider";
+            }),
         });
         const Tag: any = tagName;
         return (

--- a/packages/semi-ui/layout/index.tsx
+++ b/packages/semi-ui/layout/index.tsx
@@ -112,7 +112,7 @@ class Layout extends React.Component<BasicLayoutProps, BasicLayoutState> {
         const { siders } = this.state;
         const classString = cls(className, prefixCls, {
             [`${prefixCls}-has-sider`]: typeof hasSider === 'boolean' && hasSider || siders.length > 0 || React.Children.toArray(children).some((child: React.ReactNode) => {
-                return React.isValidElement(child) && child.type && (child.type as any).type === "Sider";
+                return React.isValidElement(child) && child.type && (child.type as any).elementType === "Layout.Sider";
             }),
         });
         const Tag: any = tagName;

--- a/packages/semi-ui/layout/index.tsx
+++ b/packages/semi-ui/layout/index.tsx
@@ -112,7 +112,7 @@ class Layout extends React.Component<BasicLayoutProps, BasicLayoutState> {
         const { siders } = this.state;
         const classString = cls(className, prefixCls, {
             [`${prefixCls}-has-sider`]: typeof hasSider === 'boolean' && hasSider || siders.length > 0 || React.Children.toArray(children).some((child: React.ReactNode) => {
-                return React.isValidElement(child) && child.type && (child.type as any).type==="Sider";
+                return React.isValidElement(child) && child.type && (child.type as any).type === "Sider";
             }),
         });
         const Tag: any = tagName;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Layout 挂载 has-sider className 慢一个任务周期的问题, #1361 

---

🇺🇸 English
- Fix: Fix the problem that Layout mount has-sider className is slow by one task cycle


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
