### PR TITLE
fix: The non-last child select under the input group has an unexpected scroll bar

### DIFF
--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -623,6 +623,10 @@ $module: #{$prefix}-input;
             }
         }
 
+        .#{$prefix}-select{
+            overflow-y: visible;
+        }
+        
         .#{$prefix}-input-number,
         .#{$prefix}-datepicker,
         .#{$prefix}-timepicker,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1395 
Input Group 包裹的 not last child select 右侧会有一个分割线，在 overflow-y auto 的属性的影响下导致 select 中出现滚动条。一般情况下，Input Group 的用法不会出现使用多行 select 的情况，所以做了一个内部的样式覆盖解决问题。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Input grou下 Select出现 不符合预期的滚动条

---

🇺🇸 English
- Fix: fix the scroll bar that does not meet expectations when Select appears under the Input group


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
