### PR TITLE
fix: [Tooltip] Modify delay visible logic in componentDidUpdate

### DIFF
--- a/packages/semi-ui/datePicker/__test__/datePicker.test.js
+++ b/packages/semi-ui/datePicker/__test__/datePicker.test.js
@@ -58,6 +58,7 @@ describe(`DatePicker`, () => {
 
         const elem = mount(<DatePicker motion={motion} defaultOpen={open} defaultValue={defaultValue} />);
 
+        await sleep();
         expect(document.querySelectorAll(popupSelector).length).toBe(1);
 
         // document.body.click();

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -496,7 +496,11 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             "[Semi Tooltip] 'mouseLeaveDelay' cannot be less than 'mouseEnterDelay', which may cause the dropdown layer to not be hidden."
         );
         if (prevProps.visible !== this.props.visible) {
-            this.props.visible ? this.foundation.delayShow() : this.foundation.delayHide();
+            if (["hover", "focus"].includes(this.props.trigger)) {
+                this.props.visible ? this.foundation.delayShow() : this.foundation.delayHide();
+            } else {
+                this.props.visible ? this.foundation.show() : this.foundation.hide();
+            }
         }
         if (!isEqual(prevProps.rePosKey, this.props.rePosKey)) {
             this.rePosition();


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
mouseEnterDelay和mouseLeaveDelay应仅对trigger为hover和focus的trigger生效。在visible变化时，老代码没有检测trigger，直接调用了delayShow/delayHide（使用到了mouseEnterDelay和mouseLeaveDelay）

### Changelog
🇨🇳 Chinese
- Fix: 修复 visible 属性变化时，trigger 不为 hover 和 focus 的 tooltip 也延迟了展示/隐藏

---

🇺🇸 English
- Fix: fix when the visible prop changes, tooltips whose trigger is not hover/focus also delay showing/hiding


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
