### PR TITLE
fix: change table bg color to fit dark mode

### DIFF
--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -238,6 +238,7 @@ $module: #{$prefix}-table;
                 box-sizing: border-box;
                 position: relative;
                 vertical-align: middle;
+                background-color: $color-table_body-bg-default;
 
                 &.resizing {
                     border-right: $width-table_resizer_border solid $color-table_resizer-bg-default;

--- a/packages/semi-foundation/table/variables.scss
+++ b/packages/semi-foundation/table/variables.scss
@@ -47,18 +47,18 @@ $height-table_pagination_outer_min: 60px; // 表格分页器高度
 // Color no need to change
 $color-table_panel-bg-default: var(--semi-color-primary); // 操作区域样式默认背景颜色
 $color-table_panel-text-default: var(--semi-color-primary-light-active); // 操作区域样式默认文字颜色
-$color-table-bg-default: var(--semi-color-bg-2); // 单元格默认背景颜色
+$color-table-bg-default: var(--semi-color-bg-1); // 单元格默认背景颜色
 $color-table-text-default: var(--semi-color-text-0); // 单元格默认文字颜色
 
 $color-table-border-default: var(--semi-color-border); // 表格描边颜色
 $color-table_shadow-bg-default: var(--semi-color-shadow); // 表格滚动后阴影颜色
 $color-table_shadow-border-default: var(--semi-color-border); // 表格拟阴影 描边颜色
-$color-table_th-bg-default: transparent; // 表头背景色
+$color-table_th-bg-default: var(--semi-color-bg-1); // 表头背景色
 $color-table_th-border-default: var(--semi-color-border); // 表头底部分割线颜色
 $color-table_th-text-default: var(--semi-color-text-2); // 表头文字颜色
 
 $color-table_pl-bg-default: transparent;
-$color-table_body-bg-default: var(--semi-color-bg-2); // 表格背景颜色 - 默认
+$color-table_body-bg-default: var(--semi-color-bg-1); // 表格背景颜色 - 默认
 $color-table_body-bg-hover: var(--semi-color-fill-0); // 表格背景颜色 - 悬浮
 $color-table_footer-bg-default: var(--semi-color-fill-0); // 表格 footer 背景颜色 - 默认
 $color-table_row_expanded-bg-default: var(--semi-color-fill-0); // 表格展开行背景颜色 - 默认


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
通过以下 token 色值的修改统一 Table 在亮暗色模式下的颜色表现
1. 将 token $color-table_body-bg-default 和 $color-table-bg-default 值从 var(--semi-color-bg-2) 改为 var(--semi-color-bg-1)
2. 将 token $color-table_th-bg-default 值从 transparent 改为 var(--semi-color-bg-1)

Unify the color performance of Table in light and dark mode by modifying the following token color values
1. Change token $color-table_body-bg-default and $color-table-bg-default value from var(--semi-color-bg-2) to var(--semi-color-bg-1)
2. Change token $color-table_th-bg-default value from transparent to var(--semi-color-bg-1)

修改前（before）
![20230208145839_rec_](https://user-images.githubusercontent.com/101160769/217457208-beaac0d9-dae6-49c3-9456-4c58a0fb4271.gif)

修改后（after）
![20230208145702_rec_](https://user-images.githubusercontent.com/101160769/217456915-43da3676-72ac-4dc9-a59d-f42a8433e753.gif)


### Changelog
🇨🇳 Chinese
- Design Token: Table Design Token 变更，修改以下 Token 默认值：$color-table_body-bg-default 、$color-table-bg-default ， 由 var(--semi-color-bg-2) 变更为 var(--semi-color-bg-1)，$color-table_th-bg-default 值从 transparent 改为 var(--semi-color-bg-1)

---

🇺🇸 English
- Design Token: Table Design Token changes before modification, modify the following Token default values: $color-table_body-bg-default, $color-table-bg-default, from var(--semi-color-bg-2) to var(-- semi-color-bg-1), $color-table_th-bg-default value changed from transparent to var(--semi-color-bg-1)


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
