### PR TITLE
fix: [Numeral] Modify the calculation rules when the rule in the Nume…

### DIFF
--- a/content/basic/typography/index-en-US.md
+++ b/content/basic/typography/index-en-US.md
@@ -152,7 +152,7 @@ function Demo() {
 Based on Text component, added properties: `rule`, `precision`, `truncate`, `parser`, to provide the ability to handle Numeral in text separately.
 <Notice title='Note'>
     The Numeral component recursively traverses Children to detect all numeric text within it for conversion and display, taking care to control the rendering structure hierarchy.<br />
-    For Numeral components with a rule of percentage, the data processing rules have changed. In v2.22.0-v2.29.0, for num whose absolute value is greater than or equal to 1, the result is num%; for num whose absolute value is less than or equal to 1, the result is (num*100)%. After the v2.30.0 version, it is unified to (num*100)%.
+    For Numeral components with a rule of percentage, the data processing rules have changed. In <strong>v2.22.0-v2.29.0</strong>, for num whose absolute value is greater than or equal to 1, the result is num%; for num whose absolute value is less than or equal to 1, the result is (num*100)%. After the <strong>v2.30.0</strong> version, it is unified to (num*100)%.
 </Notice>
 
 `precision` allows you to set the number of decimal places to be retained, used to set precision  

--- a/content/basic/typography/index-en-US.md
+++ b/content/basic/typography/index-en-US.md
@@ -151,7 +151,8 @@ function Demo() {
 
 Based on Text component, added properties: `rule`, `precision`, `truncate`, `parser`, to provide the ability to handle Numeral in text separately.
 <Notice title='Note'>
-    The Numeral component recursively traverses Children to detect all numeric text within it for conversion and display, taking care to control the rendering structure hierarchy.
+    The Numeral component recursively traverses Children to detect all numeric text within it for conversion and display, taking care to control the rendering structure hierarchy.<br />
+    For Numeral components with a rule of percentage, the data processing rules have changed. In v2.22.0-v2.29.0, for num whose absolute value is greater than or equal to 1, the result is num%; for num whose absolute value is less than or equal to 1, the result is (num*100)%. After the v2.30.0 version, it is unified to (num*100)%.
 </Notice>
 
 `precision` allows you to set the number of decimal places to be retained, used to set precision  

--- a/content/basic/typography/index-en-US.md
+++ b/content/basic/typography/index-en-US.md
@@ -189,7 +189,7 @@ function Demo() {
             </Numeral>
 
             <Numeral rule="percentages" style={{ marginBottom: 12 }}>
-                My odds of winning this game are 60 and my odds of losing are 40.
+                My odds of winning this game are 0.6 and my odds of losing are 0.4.
             </Numeral>
 
             <Numeral rule="bytes-decimal" precision={2} truncate="floor">

--- a/content/basic/typography/index.md
+++ b/content/basic/typography/index.md
@@ -143,7 +143,7 @@ Numeral 组件在Text组件的基础上，添加了属性: `rule`, `precision`, 
 <Notice title='注意'>
     Numeral 组件会递归遍历 Children 检测其中所有的数字文本进行转换展示，请注意控制渲染结构层级；
     <br />
-    对于 rule 为 percentage 的 Numeral 组件，数据处理规则有变化。在 v2.22.0-v2.29.0 中，对于绝对值大于等于 1 的 num，结果为 num%； 对于绝对值小于等于 1 的 num，结果为（num*100)%。在 v2.30.0版本及之后统一为 （num*100)%。
+    对于 rule 为 percentage 的 Numeral 组件，数据处理规则有变化。在 <strong>v2.22.0-v2.29.0</strong> 中，对于绝对值大于等于 1 的 num，结果为 num%； 对于绝对值小于等于 1 的 num，结果为 (num*100)%。在 <strong>v2.30.0</strong> 版本及之后统一为 (num*100)%。
 </Notice>
 
 `precision` 可以设置小数点后保留位数, 用于设置精度  

--- a/content/basic/typography/index.md
+++ b/content/basic/typography/index.md
@@ -179,7 +179,7 @@ function Demo() {
             </Numeral>
 
             <Numeral rule="percentages" style={{ marginBottom: 12 }}>
-                这场比赛我的胜率是60，输的概率是40
+                这场比赛我的胜率是0.6，输的概率是0.4
             </Numeral>
 
             <Numeral rule="bytes-decimal" precision={2} truncate="floor">

--- a/content/basic/typography/index.md
+++ b/content/basic/typography/index.md
@@ -141,7 +141,9 @@ function Demo() {
 
 Numeral 组件在Text组件的基础上，添加了属性: `rule`, `precision`, `truncate`, `parser`, 以提供需要单独处理文本中数值的能力。
 <Notice title='注意'>
-    Numeral 组件会递归遍历 Children 检测其中所有的数字文本进行转换展示，请注意控制渲染结构层级。
+    Numeral 组件会递归遍历 Children 检测其中所有的数字文本进行转换展示，请注意控制渲染结构层级；
+    <br />
+    对于 rule 为 percentage 的 Numeral 组件，数据处理规则有变化。在 v2.22.0-v2.29.0 中，对于绝对值大于等于 1 的 num，结果为 num%； 对于绝对值小于等于 1 的 num，结果为（num*100)%。在 v2.30.0版本及之后统一为 （num*100)%。
 </Notice>
 
 `precision` 可以设置小数点后保留位数, 用于设置精度  

--- a/packages/semi-foundation/typography/formatNumeral.ts
+++ b/packages/semi-foundation/typography/formatNumeral.ts
@@ -42,11 +42,8 @@ export default class FormatNumeral {
             return `${this.truncatePrecision(value)} ${units[i]}`;
         },
         percentages: (value: number) => {
-            const cArr = value.toString().split('.');
-            if (Number(cArr[0]) === 0) {
-                return `${this.truncatePrecision(value * 100)}%`;
-            }
-            return `${this.truncatePrecision(value)}%`;
+            // The rules here have been modified in version v2.30.0
+            return `${this.truncatePrecision(value * 100)}%`;
         },
         exponential: (value: number) => {
             const vExponential = value.toExponential(this.precision + 2);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [x] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Breaking change：修改 Numeral 组件中 rule 为 percentages 时候的计算规则


---

🇺🇸 English
- Breaking change：Modify the calculation rules when the rule in the Numeral component is percentages



### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
接到用户反馈，Numeral 组件中 rule 为 percentages 时候，数值大于1时的计算规则和小于等于1的计算规则不同。此处为统一计算规则，统一为数值*100