### PR TITLE
Docs: Corrected english documentation

### DIFF
--- a/content/input/button/index-en-US.md
+++ b/content/input/button/index-en-US.md
@@ -502,7 +502,7 @@ function SplitButtonDemo(){
 | size                | Button size, optional value: `"large"`,`"default"`,`"small"`                                                                                      | string                           | "default" |
 | style               | Custom style                                                                                                                                      | CSSProperties                           |           |
 | theme               | Button theme, optional value: `"solid"` (with background color), `"borderless"` (no background color), `"light"` (light background color)         | string                           | "light"   |
-| type                | Type, optional values: `"primary"`,`"secondary"`, `"late"`, `"warning"`, `"danger"`                                                               | string                           | "primary" |
+| type                | Type, optional values: `"primary"`,`"secondary"`, `"tertiary"`, `"warning"`, `"danger"`                                                               | string                           | "primary" |
 | onClick             | Click event                                                                                                                                       | Function(MouseEvent)                         |           |
 | onMouseDown             | Mouse down                                                                                                   | Function(MouseEvent)                        |           |
 | onMouseEnter             | Mouse Enter                                                                                                   | Function(MouseEvent)                        |           |

--- a/content/show/popover/index-en-US.md
+++ b/content/show/popover/index-en-US.md
@@ -547,7 +547,7 @@ Please refer to [Use with Tooltip/Popconfirm](/en-US/show/tooltip#%E6%90%AD%E9%8
 | rePosKey | You can update the value of this item to manually trigger the repositioning of the pop-up layer | string\|number |  |  |
 | returnFocusOnClose | After pressing the Esc key, whether the focus returns to the trigger, it only takes effect when the trigger is set to hover, focus, click, etc | boolean | true | **2.8.0** |
 | visible | Display popup or not | boolean |  |
-| position | Directions, optional values: `top`, `topLeft`, `topRight`, `leftTop`, `leftBottom`, `rightTop`, `rightTop`, `rightBottom`, `bottomLeft`, `bottomRight`, `bottomRight` | string | "bottom" |
+| position | Directions, optional values: `top`, `topLeft`, `topRight`, `left`, `leftTop`, `leftBottom`, `right`, `rightTop`, `rightBottom`, `bottom`, `bottomLeft`, `bottomRight` | string | "bottom" |
 | spacing | The distance between the out layer and the children element, in px | number | 4(while showArrow=false) 10(while showArrow=true) |  |
 | showArrow | Display little arrow or not | boolean |  |
 | trigger | Trigger mode, optional value: `hover`, `focus`, `click`, `custom` | string | 'hover' |


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- Fix English documentation of semi-design

### Changelog
🇨🇳 Chinese
- Fix: [Popover] position 的 optional value 是错的
- Fix: [Button] type 的 value 里有一个无效的 optional value
---

🇺🇸 English
- Fix: [Popover] position properties optional value is incorrect
- Fix: [Button] type properties has an invalid value (changed from `late` to `tertiary`)

### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog