### PR TITLE
fix: modal danger type button color

### DIFF
--- a/packages/semi-ui/modal/confirm.tsx
+++ b/packages/semi-ui/modal/confirm.tsx
@@ -5,6 +5,7 @@ import ConfirmModal from './ConfirmModal';
 
 import '@douyinfe/semi-foundation/modal/modal.scss';
 import { IconAlertCircle, IconAlertTriangle, IconHelpCircle, IconInfoCircle, IconTickCircle } from '@douyinfe/semi-icons';
+import { omit } from "lodash";
 
 export interface ConfirmProps extends ModalReactProps {
     type: 'success' | 'info' | 'warning' | 'error' | 'confirm'
@@ -38,7 +39,7 @@ export default function confirm<T>(props: ConfirmProps) {
     function render(renderProps: ConfirmProps) {
         const { afterClose } = renderProps;
         //@ts-ignore
-        ReactDOM.render(<ConfirmModal {...renderProps} afterClose={(...args:any)=>{
+        ReactDOM.render(<ConfirmModal {...renderProps} afterClose={(...args: any) => {
             //@ts-ignore
             afterClose?.(...args);
             destroy();
@@ -98,7 +99,8 @@ export function withError(props: ModalReactProps) {
     return {
         type: 'error' as const,
         icon: <IconAlertCircle/>,
-        ...props
+        okButtonProps: { type: 'danger', ...props.okButtonProps },
+        ...(omit(props, ['okButtonProps']))
     };
 }
 

--- a/packages/semi-ui/modal/confirm.tsx
+++ b/packages/semi-ui/modal/confirm.tsx
@@ -6,6 +6,7 @@ import ConfirmModal from './ConfirmModal';
 import '@douyinfe/semi-foundation/modal/modal.scss';
 import { IconAlertCircle, IconAlertTriangle, IconHelpCircle, IconInfoCircle, IconTickCircle } from '@douyinfe/semi-icons';
 import { omit } from "lodash";
+import { type ButtonProps } from "../button";
 
 export interface ConfirmProps extends ModalReactProps {
     type: 'success' | 'info' | 'warning' | 'error' | 'confirm'
@@ -99,10 +100,10 @@ export function withError(props: ModalReactProps) {
     return {
         type: 'error' as const,
         icon: <IconAlertCircle/>,
-        okButtonProps: { type: 'danger', ...props.okButtonProps },
+        okButtonProps: { type: 'danger' as ButtonProps['type'], ...props.okButtonProps },
         ...(omit(props, ['okButtonProps']))
     };
-}
+} 
 
 export function withConfirm(props: ModalReactProps) {
     return {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Modal 在命令式调用时，danger type 底部按钮颜色不正确的问题，影响范围 v2.0.0 - v2.30.1

---

🇺🇸 English
- Fix: Fix the problem that the color of the button at the bottom of the danger type is incorrect when Modal is called imperatively


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
