### PR TITLE
style: [Tag] children is string type child can be omitted, otherwise …

### DIFF
--- a/packages/semi-foundation/tag/tag.scss
+++ b/packages/semi-foundation/tag/tag.scss
@@ -53,15 +53,19 @@ $types: "ghost", "solid", "light";
 
     &-content {
         flex: 1;
-        overflow: hidden;
-        white-space: nowrap;
-        text-overflow: ellipsis;
-    }
 
-    &-content-center {
-        display: flex;
-        @include all-center;
-        height: 100%;
+        &-ellipsis {
+            overflow: hidden;
+            white-space: nowrap;
+            text-overflow: ellipsis;
+        }
+
+        &-center {
+            display: flex;
+            @include all-center;
+            height: 100%;
+            min-width: 0;
+        }
     }
 
     &-close {

--- a/packages/semi-foundation/tag/tag.scss
+++ b/packages/semi-foundation/tag/tag.scss
@@ -58,6 +58,12 @@ $types: "ghost", "solid", "light";
         text-overflow: ellipsis;
     }
 
+    &-content-center {
+        display: flex;
+        @include all-center;
+        height: 100%;
+    }
+
     &-close {
         @include all-center;
         color: $color-tag_close-icon-default;

--- a/packages/semi-ui/tag/index.tsx
+++ b/packages/semi-ui/tag/index.tsx
@@ -9,6 +9,7 @@ import { TagProps, TagSize, TagColor, TagType } from './interface';
 import { handlePrevent } from '@douyinfe/semi-foundation/utils/a11y';
 import '@douyinfe/semi-foundation/tag/tag.scss';
 import { isString } from 'lodash';
+import cls from 'classnames';
 
 export * from './interface';
 
@@ -156,11 +157,12 @@ export default class Tag extends Component<TagProps, TagState> {
             </div>
         ) : null;
         const stringChild = isString(children);
+        const contentCls = cls(`${prefixCls}-content`, `${prefixCls}-content-${stringChild ? 'ellipsis' : 'center' }`);
 
         return (
             <div aria-label={this.props['aria-label'] || stringChild ? `${closable ? 'Closable ' : ''}Tag: ${children}` : '' } {...wrapProps}>
                 {avatarSrc ? this.renderAvatar() : null}
-                <div className={`${prefixCls}-content${stringChild ? '' : '-center'}`}>
+                <div className={contentCls}>
                     {children}
                 </div>
                 {closeIcon}

--- a/packages/semi-ui/tag/index.tsx
+++ b/packages/semi-ui/tag/index.tsx
@@ -155,10 +155,12 @@ export default class Tag extends Component<TagProps, TagState> {
                 <IconClose size="small" />
             </div>
         ) : null;
+        const stringChild = isString(children);
+
         return (
-            <div aria-label={this.props['aria-label'] || isString(children) ? `${closable ? 'Closable ' : ''}Tag: ${children}` : '' } {...wrapProps}>
+            <div aria-label={this.props['aria-label'] || stringChild ? `${closable ? 'Closable ' : ''}Tag: ${children}` : '' } {...wrapProps}>
                 {avatarSrc ? this.renderAvatar() : null}
-                <div className={`${prefixCls}-content`}>
+                <div className={`${prefixCls}-content${stringChild ? '' : '-center'}`}>
                     {children}
                 </div>
                 {closeIcon}

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -452,16 +452,13 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
                         visible
                         aria-label={`${!disabled ? 'Closable ' : ''}Tag: ${value}`}
                     >
-                        {/* Wrap a layer of div outside IconHandler and Value to ensure that the two are aligned */}
-                        <div className={`${prefixCls}-tag-content-wrapper`}>
-                            {showIconHandler && <DragHandle />}
-                            <Paragraph
-                                className={typoCls}
-                                ellipsis={{ showTooltip: showContentTooltip, rows: 1 }}
-                            >
-                                {value}
-                            </Paragraph>
-                        </div>
+                        {showIconHandler && <DragHandle />}
+                        <Paragraph
+                            className={typoCls}
+                            ellipsis={{ showTooltip: showContentTooltip, rows: 1 }}
+                        >
+                            {value}
+                        </Paragraph>
                     </Tag>
                 );
             }


### PR DESCRIPTION
…align

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style: 根据 children类型处理 Tag 组件中内容样式，children 是 String 则能够自定文本省略，否则样式对齐

---

🇺🇸 English
-Style: process the content style in the Tag component according to the type of children, if the children are String, they can be omitted automatically, otherwise the styles will be aligned


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
关联PR #1339  #1302 
