### PR TITLE
style: [Cascader] fix cursor position incorrent in cascader, single-s…

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -324,6 +324,14 @@ $module: #{$prefix}-cascader;
             align-items: center;
             position: relative;
 
+            &-small {
+                height: $height-cascader_selection_wrapper_small;
+            }
+
+            &-large {
+                height: $height-cascader_selection_wrapper_large;
+            }
+
             .#{$prefix}-input-wrapper {
                 position: absolute;
                 top: 0;

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -96,7 +96,9 @@ $height-cascader_option_list: 180px; // 级联选择菜单高度
 $height-cascader_selection_tagInput_wrapper_small: 22px;  //级联选择多选搜索时搜索框最小高度 - 小尺寸
 $height-cascader_selection_tagInput_wrapper_default: 30px;  //级联选择多选搜索时搜索框最小高度 - 默认尺寸
 $height-cascader_selection_tagInput_wrapper_large: 38px;  //级联选择多选搜索时搜索框最小高度 - 大尺寸
-$height-cascader_selection_wrapper: 30px;
+$height-cascader_selection_wrapper_small: 22px;  //级联选择单选搜索时搜索框高度 - 小尺寸
+$height-cascader_selection_wrapper: 30px; // 级联选择单选搜索时搜索框高度 - 默认尺寸
+$height-cascader_selection_wrapper_large: 38px;  //级联选择单选搜索时搜索框高度 - 大尺寸
 
 $spacing-cascader_text-marginX: $spacing-base-tight; // 级联选择 prefix/suffix 文字水平内间距
 $spacing-cascader_icon-marginX: $spacing-tight; // 级联选择 prefix/suffix 图标水平内间距

--- a/packages/semi-ui/cascader/_story/cascader.stories.jsx
+++ b/packages/semi-ui/cascader/_story/cascader.stories.jsx
@@ -1880,3 +1880,32 @@ export const RefMethods = () => {
       </div>
   );
 };
+
+
+export const FixCursorPositionError = () => {
+  // https://github.com/DouyinFE/semi-design/issues/1468
+  const props = {
+    style: { width: 300 },
+    treeData: treeData5,
+    filterTreeNode: true,
+    leafOnly: true,
+  };
+
+  const multipleProps =  { ...props, multiple: true };
+
+  return (<>
+    <p>多选</p>
+    <Cascader {...multipleProps} size={'small'} />
+    <br/><br/>
+    <Cascader {...multipleProps} size={'default'} />
+    <br/><br/>
+    <Cascader {...multipleProps} size={'large'}/>
+
+    <p>单选</p>
+    <Cascader {...props} size={'small'} />
+    <br/><br/>
+    <Cascader {...props} size={'default'} />
+    <br/><br/>
+    <Cascader {...props} size={'large'}/>
+  </>);
+}

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -580,6 +580,7 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
         };
         const wrappercls = cls({
             [`${prefixcls}-search-wrapper`]: true,
+            [`${prefixcls}-search-wrapper-${size}`]: size !== 'default',
         });
 
         const displayText = this.renderDisplayText();


### PR DESCRIPTION
…elect, size small & large

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1468 

### Changelog
🇨🇳 Chinese
- Style: 修复单选， 可搜索的 Cascader ，size 为 small 或 large 时，其输入框光标位置不正确问题 #1468 

---

🇺🇸 English
- Style: fix the problem that the cursor position of the input box is incorrect when the size is small or large in the single-choice, searchable Cascader #1468 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
