### PR TITLE
fix: use props.id apply to form x-form-id first

### DIFF
--- a/packages/semi-ui/form/baseForm.tsx
+++ b/packages/semi-ui/form/baseForm.tsx
@@ -196,8 +196,10 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
             },
             getAllErrorDOM: () => {
                 const { formId } = this.state;
+                const { id } = this.props;
+                const xId = id ? id : formId;
                 return document.querySelectorAll(
-                    `form[x-form-id="${formId}"] .${cssClasses.PREFIX}-field-error-message`
+                    `form[x-form-id="${xId}"] .${cssClasses.PREFIX}-field-error-message`
                 );
             },
             getFieldDOM: (field: string) =>
@@ -263,6 +265,7 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
             autoScrollToError,
             showValidateIcon,
             extraTextPosition,
+            id,
             ...rest
         } = this.props;
 
@@ -279,7 +282,7 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
                 onReset={this.reset}
                 onSubmit={this.submit}
                 className={formCls}
-                x-form-id={formId}
+                x-form-id={id ? id : formId}
             >
                 {this.content}
             </form>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix:  Form 有 id 传入时，x-form-id 优先使用传入的 id

---

🇺🇸 English
- Fix: When a Form has an id passed in, x-form-id will use the passed id first


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
