### PR TITLE
fix: Table rowSelection header checkbox status bug #325

### DIFF
--- a/cypress/integration/table.spec.js
+++ b/cypress/integration/table.spec.js
@@ -128,4 +128,19 @@ describe('table', () => {
         cy.get('.semi-table-body .semi-table-row').eq(2).contains('Semi Pro');
         cy.contains('显示第 1 条-第 10 条，共 23 条');
     });
+
+    it('fixed row selection header state', () => {
+        cy.visit('http://localhost:6006/iframe.html?id=table--fix-select-all-325&args=&viewMode=story');
+        cy.get('.semi-table-row-head .semi-checkbox-inner-display').click();
+        cy.get('.semi-checkbox-checked').should('have.length', 3);
+        cy.get('.semi-page-item').contains('2').click();
+        cy.get('.semi-table-row-head .semi-checkbox-checked');
+        cy.get('.semi-table-row-head .semi-checkbox-indeterminate').should('not.exist');
+        cy.get('.semi-checkbox-checked').should('have.length', 4);
+        cy.get('.semi-table-tbody .semi-checkbox-inner-display').eq(0).click();
+        cy.get('.semi-table-row-head .semi-checkbox-indeterminate');
+        cy.get('.semi-table-row-head .semi-checkbox-inner-display').click();
+        cy.get('.semi-table-row-head .semi-checkbox-checked');
+        cy.get('.semi-checkbox-checked').should('have.length', 4);
+    });
 });

--- a/packages/semi-ui/table/ColumnSelection.tsx
+++ b/packages/semi-ui/table/ColumnSelection.tsx
@@ -14,7 +14,7 @@ export interface TableSelectionCellProps {
     columnTitle?: string; // TODO: future api
     getCheckboxProps?: () => CheckboxProps;
     type?: string; // TODO: future api
-    onChange?: (value: any, e: TableSelectionCellEvent) => void;
+    onChange?: (checked: boolean, e: TableSelectionCellEvent) => void;
     selected?: boolean;
     disabled?: boolean;
     indeterminate?: boolean; // Intermediate state, shown as a solid horizontal line
@@ -53,6 +53,7 @@ export default class TableSelectionCell extends BaseComponent<TableSelectionCell
         };
     }
 
+    foundation: TableSelectionCellFoundation;
     constructor(props: TableSelectionCellProps) {
         super(props);
         this.foundation = new TableSelectionCellFoundation(this.adapter);

--- a/packages/semi-ui/table/_story/Demos/rowSelection.jsx
+++ b/packages/semi-ui/table/_story/Demos/rowSelection.jsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { Table, Avatar } from '@douyinfe/semi-ui';
 import { IconMore } from '@douyinfe/semi-icons';
 
+/**
+ * test in cypress
+ */
 function App() {
     const columns = [
         {
@@ -127,4 +130,6 @@ function App() {
     return <Table columns={columns} dataSource={data} rowSelection={rowSelection} pagination={pagination} />;
 }
 
-render(App);
+App.storyName = 'fixed rowSelection #325';
+
+export default App;

--- a/packages/semi-ui/table/_story/table.stories.jsx
+++ b/packages/semi-ui/table/_story/table.stories.jsx
@@ -77,6 +77,7 @@ export { default as TableSpan } from './TableSpan';
 export { default as FixRenderReturnProps } from './FixRenderReturnProps';
 export { default as WarnColumnWithoutDataIndex } from './WarnColumnWithoutDataIndex';
 export * from './v2';
+export { default as FixSelectAll325 } from './Demos/rowSelection';
 
 // empty table
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #325

问题原因：翻页后 disabledRowKeysSet 是翻页后的数据，由于第二页没有禁用的行，导致已选行与所有行对比时认为有一行未选择，不是全选。

解决问题的方式：缓存所有禁用的行，在 dataSource、columns（里面可能有筛选受控）、rowSelection（里面可能有） 变化后更新它的值

### Changelog
🇨🇳 Chinese
- Fix: 修复 Table 全选后翻页表头选择框状态错误问题 #325

---

🇺🇸 English
- Fix: Fix the wrong state of the selection box in the header of the second page after selecting all the Table #325


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
