### PR TITLE
fix: select onSearch add event param to detech operation origin

### DIFF
--- a/content/input/select/index-en-US.md
+++ b/content/input/select/index-en-US.md
@@ -1379,7 +1379,7 @@ import { Select, Checkbox } from '@douyinfe/semi-ui';
 | onDropdownVisibleChange | A callback when the drop-down menu expands / collapsed | function(visible: boolean) |  |
 | onExceed | Callback invoked when the number of attempts to select exceeds the max limit, effective only at multi-selection | function |  |
 | onFocus | Callback when focus select | function(event) |  |
-| onSearch | The callback function when the content of the input box changes. The second parameter is available after v2.32 | function(sugInput: string, e: ReactEvent) |  |
+| onSearch | The callback function when the content of the input box changes. The second parameter is available after v2.31 | function(sugInput: string, e: ReactEvent) |  |
 | onSelect | Callback when selected | function (value, option) |  |
 
 ### Option Props

--- a/content/input/select/index-en-US.md
+++ b/content/input/select/index-en-US.md
@@ -1379,7 +1379,7 @@ import { Select, Checkbox } from '@douyinfe/semi-ui';
 | onDropdownVisibleChange | A callback when the drop-down menu expands / collapsed | function(visible: boolean) |  |
 | onExceed | Callback invoked when the number of attempts to select exceeds the max limit, effective only at multi-selection | function |  |
 | onFocus | Callback when focus select | function(event) |  |
-| onSearch | The callback function when the content of the input box changes. | function(sugInput: string) |  |
+| onSearch | The callback function when the content of the input box changes. The second parameter is available after v2.32 | function(sugInput: string, e: ReactEvent) |  |
 | onSelect | Callback when selected | function (value, option) |  |
 
 ### Option Props

--- a/content/input/select/index.md
+++ b/content/input/select/index.md
@@ -1411,18 +1411,6 @@ import { Select, Checkbox } from '@douyinfe/semi-ui';
 | multiple | 是否多选 | boolean | false |
 | outerTopSlot | 渲染在弹出层顶部，与 optionList 平级的自定义 slot | ReactNode |  |
 | outerBottomSlot | 渲染在弹出层底部，与 optionList 平级的自定义 slot | ReactNode |  |
-| onBlur | 失去焦点时的回调 | function(event) |  |
-| onChange | 变化时回调函数 | function(value:string\|number\|array) |  |
-| onCreate | allowCreate 为 true，创建备选项时的回调 | function(option) |  |
-| onClear | 清除按钮的回调 | function |  |
-| onChangeWithObject | 是否将选中项 option 的其他属性作为回调。设为 true 时，onChange 的入参类型会从 string 变为 object: { value, label, ...rest } | boolean | false |
-| onDropdownVisibleChange | 下拉菜单展开/收起时的回调 | function(visible:boolean) |  |
-| onListScroll | 候选项列表滚动时的回调 | function(e) |  |
-| onSearch | input 输入框内容发生改变时回调函数 | function(sugInput:string) |  |
-| onSelect | 被选中时的回调 | function(value, option) |  |
-| onDeselect | 取消选中时的回调，仅在多选时有效 | function(value, option) |  |
-| onExceed | 当试图选择数超出 max 限制时的回调，仅在多选时生效 <br/> 入参在 v1.16.0 后提供 | function(option) |  |
-| onFocus | 获得焦点时的回调 | function(event) |  |
 | optionList | 可以通过该属性传入 Option,请确保数组内每个元素都具备 label、value 属性 | array(\[{value, label}\]) |  |
 | placeholder | 选择框默认文字 | ReactNode |  |
 | position | 菜单展开的位置，可选项同 Tooltip position | string | 'bottomLeft' |
@@ -1446,6 +1434,18 @@ import { Select, Checkbox } from '@douyinfe/semi-ui';
 | validateStatus | 校验结果，可选`warning`、`error`、 `default`（只影响样式背景色） | string | 'default' |
 | virtualize | 列表虚拟化，用于大量节点的情况优化性能表现，由 height, width, itemSize 组成 | object |  |
 | zIndex | 弹层的 zIndex | number | 1030 |
+| onBlur | 失去焦点时的回调 | function(event) |  |
+| onChange | 变化时回调函数 | function(value:string\|number\|array) |  |
+| onCreate | allowCreate 为 true，创建备选项时的回调 | function(option) |  |
+| onClear | 清除按钮的回调 | function |  |
+| onChangeWithObject | 是否将选中项 option 的其他属性作为回调。设为 true 时，onChange 的入参类型会从 string 变为 object: { value, label, ...rest } | boolean | false |
+| onDropdownVisibleChange | 下拉菜单展开/收起时的回调 | function(visible:boolean) |  |
+| onListScroll | 候选项列表滚动时的回调 | function(e) |  |
+| onSearch | input 输入框内容发生改变时回调函数，第二个参数于 v2.32 后提供 | function(sugInput:string, e: ReactEvent) |  |
+| onSelect | 被选中时的回调 | function(value, option) |  |
+| onDeselect | 取消选中时的回调，仅在多选时有效 | function(value, option) |  |
+| onExceed | 当试图选择数超出 max 限制时的回调，仅在多选时生效 <br/> 入参在 v1.16.0 后提供 | function(option) |  |
+| onFocus | 获得焦点时的回调 | function(event) |  |
 
 ### Option Props
 

--- a/content/input/select/index.md
+++ b/content/input/select/index.md
@@ -1441,7 +1441,7 @@ import { Select, Checkbox } from '@douyinfe/semi-ui';
 | onChangeWithObject | 是否将选中项 option 的其他属性作为回调。设为 true 时，onChange 的入参类型会从 string 变为 object: { value, label, ...rest } | boolean | false |
 | onDropdownVisibleChange | 下拉菜单展开/收起时的回调 | function(visible:boolean) |  |
 | onListScroll | 候选项列表滚动时的回调 | function(e) |  |
-| onSearch | input 输入框内容发生改变时回调函数，第二个参数于 v2.32 后提供 | function(sugInput:string, e: ReactEvent) |  |
+| onSearch | input 输入框内容发生改变时回调函数，第二个参数于 v2.31 后提供 | function(sugInput:string, e: ReactEvent) |  |
 | onSelect | 被选中时的回调 | function(value, option) |  |
 | onDeselect | 取消选中时的回调，仅在多选时有效 | function(value, option) |  |
 | onExceed | 当试图选择数超出 max 限制时的回调，仅在多选时生效 <br/> 入参在 v1.16.0 后提供 | function(option) |  |

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -118,7 +118,7 @@ export type SelectProps = {
     onDropdownVisibleChange?: (visible: boolean) => void;
     zIndex?: number;
     position?: Position;
-    onSearch?: (value: string) => void;
+    onSearch?: (value: string, event: React.KeyboardEvent | React.MouseEvent) => void;
     dropdownClassName?: string;
     dropdownStyle?: React.CSSProperties;
     dropdownMargin?: PopoverProps['margin'];
@@ -388,16 +388,6 @@ class Select extends BaseComponent<SelectProps, SelectState> {
         this.eventManager = new Event();
 
         this.foundation = new SelectFoundation(this.adapter);
-
-        warning(
-            'optionLabelProp' in this.props,
-            '[Semi Select] \'optionLabelProp\' has already been deprecated, please use \'renderSelectedItem\' instead.'
-        );
-
-        warning(
-            'labelInValue' in this.props,
-            '[Semi Select] \'labelInValue\' has already been deprecated, please use \'onChangeWithObject\' instead.'
-        );
     }
 
     setOptionContainerEl = (node: HTMLDivElement) => (this.optionContainerEl = { current: node });
@@ -533,8 +523,8 @@ class Select extends BaseComponent<SelectProps, SelectState> {
             notifyDropdownVisibleChange: (visible: boolean) => {
                 this.props.onDropdownVisibleChange(visible);
             },
-            notifySearch: (input: string) => {
-                this.props.onSearch(input);
+            notifySearch: (input: string, event: React.MouseEvent | React.KeyboardEvent) => {
+                this.props.onSearch(input, event);
             },
             notifyCreate: (input: OptionProps) => {
                 this.props.onCreate(input);
@@ -647,7 +637,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
         }
     }
 
-    handleInputChange = (value: string) => this.foundation.handleInputChange(value);
+    handleInputChange = (value: string, event: React.KeyboardEvent) => this.foundation.handleInputChange(value, event);
 
     renderInput() {
         const { size, multiple, disabled, inputProps, filter } = this.props;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Select onSearch 提供第二个入参，用于区分 onSearch 触发类型
![image](https://user-images.githubusercontent.com/88709023/224996034-9760199f-c77a-4960-aaf6-59721d3ae190.png)

can be use like this:

```
    <Select
         onSearch={(v, e) => {
             console.log(e.nativeEvent)
         }}
         filter 
         multiple 
         style={{ width: 300 }}
   >
            <Select.Option value="semi-0">Semi-0</Select.Option>
            <Select.Option value="semi-1">Semi-1</Select.Option>
            <Select.Option value="semi-2">Semi-2</Select.Option>
            <Select.Option value="semi-3">Semi-3</Select.Option>
            <Select.Option value="semi-4">Semi-4</Select.Option>
        </Select>
```

沿着 notifySearch 开始加入参，往上的调用链路
- A) 回车、esc、tab、shift tab
   -> close -> clearInput
        -> notifySearch
- B) 多选 
   -> clearInput
        -> notifySearch
- C) clear 图标  click
    -> clearInput
        -> notifySearch
- D)  Input 的 onChange
     -> notifySearch


### Changelog
🇨🇳 Chinese
- Fix:  Select onSearch 提供第二个入参，解决无法区分 1选择后自动清空input 触发onSearch 、2 主动使用 backspace清空input触发 onSearch 3 点击 clear icon触发onSearch 等不同场景的问题  #867

---

🇺🇸 English
- Fix: Select onSearch provides a second input parameter to solve the problem of indistinguishable 1. Automatically clear the input after selection to trigger onSearch, 2. Actively use backspace to clear the input to trigger onSearch 3. Click the clear icon to trigger onSearch and other different scenarios #867


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
