### PR TITLE
fix: [TreeSelect] Fix single selection, filterTreeNode and virtualize…

### DIFF
--- a/cypress/integration/treeSelect.spec.js
+++ b/cypress/integration/treeSelect.spec.js
@@ -84,4 +84,13 @@ describe('treeSelect', () => {
         cy.get('.semi-tree-select').eq(2).click();
         cy.get('@consoleLog').should('be.calledWith', 'blur');
     });
+
+    it('filterTreeNode & virtualize', () => {
+        // 该例子为测试当 filterTreeNode 和 virtualize 功能同时使用时, 点击选中是否符合预期
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--search-position-in-trigger-and-virtualize');
+        cy.get('.semi-tree-select').eq(0).click();
+        cy.get('.semi-tree-option').eq(0).click();
+        cy.get('.semi-tree-select-selection-TriggerSearchItem').eq(0).should('contain.text', '亚洲');
+    });
 });
+

--- a/packages/semi-ui/select/virtualRow.tsx
+++ b/packages/semi-ui/select/virtualRow.tsx
@@ -4,10 +4,11 @@ export interface VirtualRowProps{
     data: Record<string, any>;
     style?: React.CSSProperties
 }
+
 const VirtualRow = ({ index, data, style }: VirtualRowProps) => {
-    const { visibleOptions } = data;
+    const { visibleOptions, renderOption } = data;
     const option = visibleOptions[index];
-    return data.renderOption(option, index, style);
+    return renderOption(option, index, style);
 };
 
 export default VirtualRow;

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -1,5 +1,5 @@
-import React, { useState, useMemo } from 'react';
-import { Icon, Button, Form, Popover, Tag, Typography, CheckboxGroup } from '../../index';
+import React, { useState, useMemo, useRef } from 'react';
+import { Icon, Input, Button, Form, Popover, Tag, Typography, CheckboxGroup } from '../../index';
 import TreeSelect from '../index';
 import { flattenDeep } from 'lodash';
 import CustomTrigger from './CustomTrigger';
@@ -2086,3 +2086,24 @@ class ValueTypeIsNumber extends React.Component {
 }
 
 export const valueIsNumber = () => <ValueTypeIsNumber />
+
+export const searchPositionInTriggerAndVirtualize = () => {
+  return (
+      <>
+          <TreeSelect  
+              searchPosition="trigger"
+              style={{ width: 300 }}
+              dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+              treeData={treeData2}
+              filterTreeNode
+              placeholder="单选"
+              virtualize={{
+                  itemSize: 28,
+                  // dropDown height 300 minus search box height minus padding 8 * 2
+                  // or if you set dropdown height, it will fill 100% of rest space
+                  height: 236                
+              }}
+          />
+      </>
+  );
+};

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -50,6 +50,7 @@ import { OptionProps, TreeProps, TreeState, FlattenNode, TreeNodeData, TreeNodeP
 import { IconChevronDown, IconClear, IconSearch } from '@douyinfe/semi-icons';
 import CheckboxGroup from '../checkbox/checkboxGroup';
 import Popover, { PopoverProps } from '../popover/index';
+import VirtualRow from '../select/virtualRow';
 
 export type ExpandAction = false | 'click' | 'doubleClick';
 
@@ -1308,9 +1309,10 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         return <TreeNode {...treeNodeProps} {...data} key={key} data={data} style={style} />;
     };
 
-    itemKey = (index: number, data: TreeNodeData) => {
+    itemKey = (index: number, data: Record<string, any>) => {
+        const { visibleOptions } = data;
         // Find the item at the specified index.
-        const item = data[index];
+        const item = visibleOptions[index];
         // Return a value that uniquely identifies this item.
         return item.key;
     };
@@ -1340,7 +1342,10 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             );
         }
 
-        const option = ({ index, style, data }: OptionProps) => this.renderTreeNode(data[index], index, style);
+        const data = {
+            visibleOptions: flattenNodes,
+            renderOption: this.renderTreeNode
+        };
 
         return (
             <AutoSizer defaultHeight={virtualize.height} defaultWidth={virtualize.width}>
@@ -1351,12 +1356,12 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                         height={height}
                         width={width}
                         // @ts-ignore avoid strict check of itemKey
-                        itemKey={this.itemKey as ListItemKeySelector<TreeNodeData>}
-                        itemData={flattenNodes as any}
+                        itemKey={this.itemKey}
+                        itemData={data}
                         className={`${prefixTree}-virtual-list`}
                         style={{ direction }}
                     >
-                        {option}
+                        {VirtualRow}
                     </VirtualList>
                 )}
             </AutoSizer>


### PR DESCRIPTION
…d TreeSelect, the user needs to click twice to select the option

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1487 

### Changelog
🇨🇳 Chinese
- Fix: 修复对于单选，可搜索且搜索框在 Trigger中，虚拟化的 TreeSelect ，用户需要点击两次选项才能选中问题 #1487 

---

🇺🇸 English
- Fix: Fix the problem that the user needs to click the option twice to select it for single selection, searchable and search box in Trigger, virtualized TreeSelect #1487 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

问题表现：
在单选，可搜索且搜索框在 Trigger中，虚拟化的 TreeSelect 中，需要点击选项2次才能选中，或者先让input框blur，然后才能选中。

问题原因：
从表现上来说
在单选，可搜索且搜索框在 Trigger中，虚拟化的 TreeSelect 中，点击选项的第一次，搜索框 blur，触发 state 中的inputTriggerFocus 更新，选项卸载，导致选项上的 click 事件还没来得及响应，因此无法选中。
第二次点击过程中，由于此时点击不会触发 state 更新，因此 click 事件能够正确响应。

VirtualList 中传入的 children 是在 render 方法中定义的箭头函数，因此每次 state 更新时候，触发 TreeSelect 的 render ，每次render， 传入 VirtualList 用于生成选项的函数都是一个新的函数，从而导致选项被卸载。

修改方式：
不要将在 render 方法中定义的箭头函数作为VirtualList 的 children，类似的方法定义在 Select 组件中有