### PR TITLE
fix: fixed Popconfirm promise callback content footer buttons not re-…

### DIFF
--- a/cypress/integration/popconfirm.spec.js
+++ b/cypress/integration/popconfirm.spec.js
@@ -55,4 +55,21 @@ describe('popConfirm', () => {
         cy.get('.test-text').type('{esc}');
         cy.get('.test-ok').should('not.exist');
     });
+
+    it('onConfirm promise', () => {
+        cy.visit('http://localhost:6006/iframe.html?id=popconfirm--promise-callback&viewMode=story');
+        cy.get('.semi-button').click();
+        cy.get('.semi-button').contains('确定').click();
+        cy.get('.semi-button-loading').contains('确定');
+        cy.wait(2000);
+        cy.get('.semi-button-loading').should('not.exist');
+    });
+
+    it('onCancel promise', () => {
+        cy.visit('http://localhost:6006/iframe.html?id=popconfirm--promise-callback&viewMode=story');
+        cy.get('.semi-button').click();
+        cy.get('.semi-button').contains('取消').click();
+        cy.wait(2000);
+        cy.get('.semi-button-loading').should('not.exist');;
+    });
 });

--- a/packages/semi-ui/popconfirm/index.tsx
+++ b/packages/semi-ui/popconfirm/index.tsx
@@ -272,7 +272,9 @@ export default class Popconfirm extends BaseComponent<PopconfirmProps, Popconfir
             <Popover
                 ref={this.popoverRef}
                 {...attrs}
-                content={this.renderConfirmPopCard}
+                // A arrow function needs to be passed here, otherwise the content will not be updated after the Popconfirm state is updated
+                // Popover is a PureComponent, same props will not trigger update
+                content={({ initialFocusRef }) => this.renderConfirmPopCard({ initialFocusRef })}
                 visible={visible}
                 position={position}
                 {...popProps}


### PR DESCRIPTION
…render bug #1489

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1489

### Changelog
🇨🇳 Chinese
- Fix: 修复 Popconfirm 确认按钮与取消按钮在返回 promise 时没有展示 loading 问题（影响 2.30 ~ 2.31 版本） #1489

---

🇺🇸 English
- Fix: Fixed confirmation button and cancel button not displaying the loading icon when returning promise (2.30 ~ 2.31 versions are affected) #1489


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
