### PR TITLE
fix: [Switch] Change the initial setting of the state in the construc…

### DIFF
--- a/packages/semi-foundation/switch/foundation.ts
+++ b/packages/semi-foundation/switch/foundation.ts
@@ -15,8 +15,7 @@ export default class SwitchFoundation<P = Record<string, any>, S = Record<string
     }
 
     init(): void {
-        const { defaultChecked, checked, disabled } = this.getProps();
-        this.setChecked(defaultChecked || checked);
+        const { disabled } = this.getProps();
         this.setDisabled(disabled);
     }
 
@@ -45,7 +44,7 @@ export default class SwitchFoundation<P = Record<string, any>, S = Record<string
             if (target.matches(':focus-visible')) {
                 this._adapter.setFocusVisible(true);
             }
-        } catch (error){
+        } catch (error) {
             warning(true, 'Warning: [Semi Switch] The current browser does not support the focus-visible');
         }
     }

--- a/packages/semi-ui/switch/index.tsx
+++ b/packages/semi-ui/switch/index.tsx
@@ -73,7 +73,7 @@ class Switch extends BaseComponent<SwitchProps, SwitchState> {
     constructor(props: SwitchProps) {
         super(props);
         this.state = {
-            nativeControlChecked: false,
+            nativeControlChecked: props.defaultChecked || props.checked,
             nativeControlDisabled: false,
             focusVisible: false
         };


### PR DESCRIPTION
…tor in the switch to prevent animations that do not meet expectations

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 更改 Switch 中 state 在 constructor 中的初始设置，避免在其他组件中使用时候出现不符合预期的动画

---

🇺🇸 English
- Fix: Change the initial setting of the state in the constructor in Switch to avoid unexpected animations when used in other components


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

复现代码：
v2.31.0 版本
```
function Demo(){
  const treeData = [
      {
          label: '亚洲',
          value: 'Asia',
          key: '0',
          children: [
              {
                  label: '中国',
                  value: 'China',
                  key: '0-0',
                  children: [
                      {
                          label:  <Switch defaultChecked={true}/>,
                          value: 'Beijing',
                          key: '0-0-0',
                      },
                      {
                          label: '上海',
                          value: 'Shanghai',
                          key: '0-0-1',
                      },
                  ],
              },
          ],
      },
      {
          label: '北美洲',
          value: 'North America',
          key: '1',
      }
  ];

  const style = {
      width: 260,
      height: 420,
      border: '1px solid var(--semi-color-border)'
  };

  return (
      <Tree
          treeData={treeData}
          defaultExpandAll
          style={style}
          // motion={false}
      />
  );
};
```

https://user-images.githubusercontent.com/101110131/226296658-f613acd1-678c-4b18-8202-e8727e46b8f0.mp4
可以看到，在点击中国收起展开选项时候，Switch 有个一个从false，到 true的动画

原因： 
Tree中使用Collapsible作为完成展开和关闭动画的组件，在动画状态下和非动画动态下的switch 节点非同一节点，因此在动画开始时候，Switch 的defaultChecked 虽然为 true，但是在Switch 的 constructor 时候为false，componentDidMount中才为true，导致Switch 渲染时候有一个从 false 到true的动画。单独使用Switch 组件不会出现上述问题。


