### PR TITLE
fix: add vertical-align top to fix wrong height

### DIFF
--- a/packages/semi-foundation/autoComplete/autoComplete.scss
+++ b/packages/semi-foundation/autoComplete/autoComplete.scss
@@ -27,6 +27,8 @@ $module: #{$prefix}-autocomplete;
         padding-top: $spacing-autoComplete_loading_wrapper-paddingTop;
         padding-bottom: $spacing-autoComplete_loading_wrapper-paddingBottom;
         cursor: not-allowed;
+        // make sure that spin align vertical, no need to make 20px as a spacing token here
+        height: 20px;
         // height: $spacing-extra-loose;
         // @include all-center;
         .#{$prefix}-spin {

--- a/packages/semi-foundation/spin/spin.scss
+++ b/packages/semi-foundation/spin/spin.scss
@@ -29,6 +29,7 @@ $module: #{$prefix}-spin;
         & > svg {
             animation: $animation_duration-spin_wrapper-spin linear infinite #{$prefix}-animation-rotate;
             animation-fill-mode: forwards;
+            vertical-align: top;
             @include size($width-spin_middle);
         }
     }

--- a/packages/semi-foundation/tree/tree.scss
+++ b/packages/semi-foundation/tree/tree.scss
@@ -302,6 +302,7 @@ $module: #{$prefix}-tree;
 
         &-spin-icon {
             display: flex;
+            line-height: 0; // make the spin icon in the center
             & svg {
                 width: $width-tree_spinIcon;
                 height: $width-tree_spinIcon;

--- a/packages/semi-foundation/upload/upload.scss
+++ b/packages/semi-foundation/upload/upload.scss
@@ -258,6 +258,7 @@ $module: #{$prefix}-upload;
             }
 
             &-loading {
+                line-height: 0; // make the spin icon in the center
                 .#{$prefix}-spin-wrapper svg {
                     height: $width-upload_file_card-icon;
                     width: $width-upload_file_card-icon;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1507 
div 包裹着 svg， svg 的 display 属性虽然为 inline，但是却具有 inline-block 的特性，导致 .semi-spin-wrapper 层级 div 高度比内容高。通过 vertical-align 将对齐方式从 baseline 改为 top 解决问题

回归用到<Spin / >的其他组件，主要可以分为三类，一类是修改前后没有影响的，一类是修改后纠正了原来不符合预期位置偏移的，还有一类是修改后没有解决问题，甚至还让表现变得更加离谱的。
  - 无影响
    - Switch 
    - Cascader(之前通过给外层div加line-height 0 的方案修过 [PR #1244](https://github.com/DouyinFE/semi-design/pull/1244))
  - 纠正后符合预期
    - Transfer
    - Image
    - List
    - Table
    - Select
  - 未解决问题，甚至表现地更加糟糕
    - [AutoComplete](https://bytedance.feishu.cn/docx/UpP8dVotkoqkcExX2IVcxxCLnOg#FwMUdM0QEoYUEQx2joJchYI9nlc)（参考 Select 改法已修正）
    - Upload（参考 Cascaader 改法已修正）
    - Tree （参考 Cascaader 改法已修正）

详细修改说明参考飞书文档 [Spin 位置偏移问题修复](https://bytedance.feishu.cn/docx/UpP8dVotkoqkcExX2IVcxxCLnOg) 

### Changelog
🇨🇳 Chinese
- Fix: 修复 Spin 因为 .semi-spin-wrapper div 高度不正确导致位置上移问题

---

🇺🇸 English
- Fix: fix Spin because the height of the .semi-spin-wrapper div is incorrect, causing the position to move up


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
