### PR TITLE
Fix: typography multiple issues

### DIFF
--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -44,10 +44,9 @@ interface BaseTypographyState {
     editable: boolean;
     copied: boolean;
     isOverflowed: boolean;
-    ellipsisContent: string;
+    ellipsisContent: React.ReactNode;
     expanded: boolean;
     isTruncated: boolean;
-    first: boolean;
     prevChildren: React.ReactNode
 }
 const prefixCls = cssClasses.PREFIX;
@@ -158,12 +157,10 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             // ellipsis
             // if text is overflow in container
             isOverflowed: true,
-            ellipsisContent: null,
+            ellipsisContent: props.children,
             expanded: false,
             // if text is truncated with js
-            isTruncated: false,
-            // record if has click expanded
-            first: true,
+            isTruncated: true,
             prevChildren: null,
         };
         this.wrapperRef = React.createRef();
@@ -186,10 +183,9 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         if (props.ellipsis && prevChildren !== props.children) {
             // reset ellipsis state if children update
             newState.isOverflowed = true;
-            newState.ellipsisContent = null;
+            newState.ellipsisContent = props.children;
             newState.expanded = false;
-            newState.isTruncated = false;
-            newState.first = true;
+            newState.isTruncated = true;
         }
         return newState;
     }
@@ -315,9 +311,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             suffix,
             pos
         );
-        if (children === content) {
-            this.setState({ expanded: true });
-        } else if (ellipsisContent !== content || isOverflowed !== updateOverflow) {
+        if (ellipsisContent !== content || isOverflowed !== updateOverflow) {
             this.setState({
                 ellipsisContent: content,
                 isOverflowed: updateOverflow,
@@ -336,7 +330,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         const { expanded } = this.state;
         onExpand && onExpand(!expanded, e);
         if ((expandable && !expanded) || (collapsible && expanded)) {
-            this.setState({ expanded: !expanded, first: false });
+            this.setState({ expanded: !expanded });
         }
     };
 
@@ -360,16 +354,17 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
     };
 
     renderExpandable = () => {
+        const { expanded, isTruncated } = this.state;
+        if (!isTruncated) return null;
+
         const { expandText, expandable, collapseText, collapsible } = this.getEllipsisOpt();
-        const { expanded, first } = this.state;
         const noExpandText = !expandable && isUndefined(expandText);
         const noCollapseText = !collapsible && isUndefined(collapseText);
         let text;
 
         if (!expanded && !noExpandText) {
             text = expandText;
-        } else if (expanded && !first && !noCollapseText) {
-            // if expanded is true but the text is initally mounted, we dont show collapseText
+        } else if (expanded && !noCollapseText) {
             text = collapseText;
         }
         if (!noExpandText || !noCollapseText) {
@@ -458,22 +453,13 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
 
     renderEllipsisText = (opt: Ellipsis) => {
         const { suffix } = opt;
-        const { children } = this.props;
-        const { isTruncated, expanded, ellipsisContent } = this.state;
-        if (expanded || !isTruncated) {
-            return (
-                <>
-                    {children}
-                    {suffix && suffix.length ? suffix : null}
-                </>
-            );
-        }
+        const { ellipsisContent } = this.state;
+
         return (
-            <span>
+            <>
                 {ellipsisContent}
-                {/* {ELLIPSIS_STR} */}
-                {suffix}
-            </span>
+                {suffix && suffix.length ? suffix : null}
+            </>
         );
     };
 

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -297,7 +297,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             return undefined;
         }
 
-        const extraNode = [this.expandRef.current, this.copyRef && this.copyRef.current];
+        const extraNode = { expand: this.expandRef.current, copy: this.copyRef && this.copyRef.current };
         warning(
             'children' in this.props && typeof children !== 'string',
             "[Semi Typography] 'Only children with pure text could be used with ellipsis at this moment."

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -240,9 +240,9 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             return false;
         }
         const updateOverflow =
-            rows <= 1
-                ? this.wrapperRef.current.scrollWidth > this.wrapperRef.current.clientWidth
-                : this.wrapperRef.current.scrollHeight > this.wrapperRef.current.offsetHeight;
+            rows <= 1 ?
+                this.wrapperRef.current.scrollWidth > this.wrapperRef.current.offsetWidth :
+                this.wrapperRef.current.scrollHeight > this.wrapperRef.current.offsetHeight;
         return updateOverflow;
     };
 
@@ -284,19 +284,20 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             this.onResize();
             return false;
         }
-        const { ellipsisContent, isOverflowed, isTruncated, expanded } = this.state;
+        const { ellipsisContent, isOverflowed, expanded } = this.state;
         const updateOverflow = this.shouldTruncated(rows);
         const canUseCSSEllipsis = this.canUseCSSEllipsis();
-        const needUpdate = updateOverflow !== isOverflowed;
 
         if (!rows || rows < 0 || expanded) {
             return undefined;
         }
 
         if (canUseCSSEllipsis) {
-            if (needUpdate) {
-                this.setState({ expanded: !updateOverflow });
-            }
+            // isOverflowed needs to be updated to show tooltip when using css ellipsis
+            this.setState({
+                isOverflowed: updateOverflow
+            });
+
             return undefined;
         }
 
@@ -440,7 +441,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             };
         }
         const { rows } = this.getEllipsisOpt();
-        const { isOverflowed, expanded, isTruncated } = this.state;
+        const { expanded } = this.state;
         const useCSS = !expanded && this.canUseCSSEllipsis();
         const ellipsisCls = cls({
             [`${prefixCls}-ellipsis`]: true,
@@ -451,14 +452,14 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         const ellipsisStyle = useCSS && rows > 1 ? { WebkitLineClamp: rows } : {};
         return {
             ellipsisCls,
-            ellipsisStyle: isOverflowed ? ellipsisStyle : {},
+            ellipsisStyle,
         };
     };
 
     renderEllipsisText = (opt: Ellipsis) => {
         const { suffix } = opt;
         const { children } = this.props;
-        const { isTruncated, expanded, isOverflowed, ellipsisContent } = this.state;
+        const { isTruncated, expanded, ellipsisContent } = this.state;
         if (expanded || !isTruncated) {
             return (
                 <>
@@ -527,7 +528,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         const iconSize: Size = size === 'small' ? 'small' : 'default';
         return (
             <span className={`${prefixCls}-icon`} x-semi-prop="icon">
-                {isSemiIcon(icon) ? React.cloneElement(icon as React.ReactElement, { size: iconSize }) : icon}
+                {isSemiIcon(icon) ? React.cloneElement((icon as React.ReactElement), { size: iconSize }) : icon}
             </span>
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
bug的可复现链接（chrome打开，firefox因为不溢出时，scrollHeight > offsetHeight，bug可能不会复现）https://codesandbox.io/s/semi-design-simple-story-forked-5tdpeo?file=/src/App.jsx

Fixes 
1. 有省略的文本，resize到省略消失，再resize回原来的尺寸，没有省略状态
2. 可展开的文本，在折叠状态下，resize到展开消失，再resize回原来的尺寸，变成了展开状态
3. js计算溢出时，由于把展开按钮的宽度也计算在内（实际展开按钮不一定展示），会导致展开前后的行数其实是一样的（即没有溢出的情况下展示了展开按钮）

解决方法
1. cssEllipsis时，resize后通过scollHeight和clientHeight判断是否溢出不准确，因为css加省略的样式仅在isOverflow时生效，而在resize后溢出指定行数的情况下，isOverflow是false，css省略的样式没有生效
2. 因为在getEllipsisState时，若js计算的值和chidren不同，则会将expanded置为true（即使用户没有点击展开按钮）。这还引入了其他比较脏的逻辑，如first相关的逻辑
3. 在最开始js计算溢出时，先不计算展开的按钮，而是先计算一定会包含在最终内容的节点。当判断到文本会溢出的时候，再将展开按钮参与计算。

### Changelog
🇨🇳 Chinese
- Fix: Typography resize后可能会丢失省略
- Fix: Typography resize后展开状态可能会被变成折叠
- Fix: Typography 展开按钮可能会在不需要折叠时出现

---

🇺🇸 English
- Fix: Typography ellipsis disappear when resize to larger and back
- Fix: Typography expanded may change to true after resize
- Fix: Typography  expand may show when not overflow


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
