### PR TITLE
fix: typography multiple issues

### DIFF
--- a/cypress/integration/typography.spec.js
+++ b/cypress/integration/typography.spec.js
@@ -11,7 +11,7 @@ describe('typography', () => {
 
     });
 
-    it.only('showTooltip', () => {
+    it('showTooltip', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--show-tooltip&args=&viewMode=story');
         cy.get('.semi-typography-ellipsis').eq(0).trigger('mouseover');
         cy.wait(1000);
@@ -56,12 +56,10 @@ describe('typography', () => {
         // 第二个 test, js 截断，有展开按钮
         cy.get('.semi-typography-ellipsis-expand').eq(0).contains('展开');
 
-        cy.viewport(1900, 1000);
+        cy.viewport(1860, 1000);
         // 屏幕尺寸变化， 内容长度符合尺寸要求，不发生截断
         // 第一个 test 需要完整显示， 以下测试仅明确尺寸变化
         // Todo： 更直接确定尺寸变化
-        cy.get('.semi-typography-ellipsis').eq(0).should('have.css', 'width').and('eq', '1900px');
-        cy.get('.semi-typography-ellipsis').eq(0).should('have.css', 'height').and('eq', '40px');
         // 第二个 test 无展开按钮
         cy.get('.semi-typography-ellipsis-expand').should('not.exist');
 

--- a/cypress/integration/typography.spec.js
+++ b/cypress/integration/typography.spec.js
@@ -11,16 +11,74 @@ describe('typography', () => {
 
     });
 
+    it.only('showTooltip', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--show-tooltip&args=&viewMode=story');
+        cy.get('.semi-typography-ellipsis').eq(0).trigger('mouseover');
+        cy.wait(1000);
+        cy.get('.semi-tooltip-wrapper').contains('css 截断，本内容超出长度限制');
+        cy.get('.semi-typography-ellipsis').eq(0).trigger('mouseout');
+        cy.wait(1000);
+        cy.get('.semi-typography-ellipsis').eq(1).trigger('mouseover');
+        cy.wait(1000);
+        cy.get('.semi-tooltip-wrapper').contains('pos 为 middle，无 expanded');
+    });
+
     // todo:  The test currently work only in Electron
     // because the clipboard permission is granted when Cypress starts it.
     it('copyable', () => {
-        cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--copyable&args=&viewMode=story');
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--copyable&args=&viewMode=story', {
+            onBeforeLoad(win) {
+                cy.stub(win.console, 'log').as('consoleLog'); // 测试时用到控制台的前置步骤
+            },
+        });
+
         cy.viewport(800, 1000);
         cy.get('.semi-typography-action-copy').eq(1).click();
+        // 测试 copyable 中 onCopy 回调，控制台应该打印“点击右边的图标复制文本。”
+        cy.get('@consoleLog').should('be.calledWith', '点击右边的图标复制文本。'); 
         cy.get('span').contains('复制成功');
+        
         // cy.window()
         //     .its('navigator.clipboard')
         //     .invoke('点击右边的图标复制文本。');
+
+        // 测试自定义复制图标是否正确
+        cy.get('.semi-icon-setting').eq(0).click();
+        cy.get('.semi-typography-action-copied').eq(1).children('span').contains('复制成功');
+    });
+
+    it('resize', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--container-resize&args=&viewMode=story');
+        cy.viewport(800, 1000);
+        // 第一个，第二个容器宽度与页面一致，此时页面宽为 800，
+        // 第一个 test，内容长度超出 2 行， css 截断为 2 行
+        cy.get('.semi-typography-ellipsis').eq(0).should('have.css', 'height').and('eq', '40px');
+        // 第二个 test, js 截断，有展开按钮
+        cy.get('.semi-typography-ellipsis-expand').eq(0).contains('展开');
+
+        cy.viewport(1900, 1000);
+        // 屏幕尺寸变化， 内容长度符合尺寸要求，不发生截断
+        // 第一个 test 需要完整显示， 以下测试仅明确尺寸变化
+        // Todo： 更直接确定尺寸变化
+        cy.get('.semi-typography-ellipsis').eq(0).should('have.css', 'width').and('eq', '1900px');
+        cy.get('.semi-typography-ellipsis').eq(0).should('have.css', 'height').and('eq', '40px');
+        // 第二个 test 无展开按钮
+        cy.get('.semi-typography-ellipsis-expand').should('not.exist');
+
+        // 重新调整为宽度 800 原尺寸
+        cy.viewport(800, 1000);
+        cy.get('.semi-typography-ellipsis-expand').should('not.exist');
+        cy.get('.semi-typography-ellipsis').eq(0).should('have.css', 'height').and('eq', '40px');
+        cy.get('.semi-typography-ellipsis-expand').eq(0).contains('展开');
+
+    });
+
+    it('edge case', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--edge-cases&args=&viewMode=story');
+        cy.viewport(800, 1000);
+
+        // 第二个 test 为固定尺寸，容器宽度符合预期，不应该显示展开按钮
+        cy.get('.semi-typography-ellipsis').eq(1).children('.semi-typography-ellipsis-expand').should('not.exist');
     });
 
 });

--- a/packages/semi-foundation/typography/typography.scss
+++ b/packages/semi-foundation/typography/typography.scss
@@ -123,12 +123,24 @@ $module: #{$prefix}-typography;
         display: -webkit-box;
         -webkit-box-orient: vertical;
         overflow: hidden;
+
+        &.#{$module}-ellipsis-multiple-line-text {
+            // inline-block only works in the Text component, keeping the original external inline performance
+            display: -webkit-inline-box;
+        }
     }
 
     &-ellipsis-overflow-ellipsis {
         display: block;
         white-space: nowrap;
         text-overflow: ellipsis;
+
+        &.#{$module}-ellipsis-overflow-ellipsis-text {
+            // inline-block only works in the Text component, keeping the original external inline performance
+            display: inline-block;
+            // Ensure that Text component can be limited by the parent's width when no specific width is set
+            max-width: 100%;
+        }
     }
 
     &-ellipsis-expand {

--- a/packages/semi-ui/breadcrumb/item.tsx
+++ b/packages/semi-ui/breadcrumb/item.tsx
@@ -149,7 +149,7 @@ export default class BreadcrumbItem extends BaseComponent<BreadcrumbItemProps, B
                                 pos: ellipsisPos,
                             }}
                             // icon={this.renderIcon(icon)}
-                            style={{ width }}
+                            style={{ maxWidth: width }}
                             size={compact ? 'small' : 'normal'}
                         >
                             {children}
@@ -197,7 +197,7 @@ export default class BreadcrumbItem extends BaseComponent<BreadcrumbItemProps, B
             shouldRenderSeparator
             // children,
         } = this.props;
-        const pageLabel = active ? { 'aria-current': 'page' as const } : {} ;
+        const pageLabel = active ? { 'aria-current': 'page' as const } : {};
         const item = this.renderItem();
         const separator = !active ?
             this.props.separator || <span className={`${clsPrefix}-separator`}>{this.context.separator}</span> :

--- a/packages/semi-ui/typography/_story/typography.stories.jsx
+++ b/packages/semi-ui/typography/_story/typography.stories.jsx
@@ -55,6 +55,11 @@ export const _Text = () => (
       <IconLink />
       网页链接
     </Text>
+    <br />
+    <Text size='small'>小尺寸文本</Text>
+    <br />
+    <Text size='normal'>普通尺寸文本</Text>
+    <br />
   </div>
 );
 
@@ -606,7 +611,11 @@ export const Copyable = () => (
       以用户中心、内容优先、设计人性化为设计理念，具有四大优势。
     </Paragraph>
     <br />
-    <Paragraph copyable>点击右边的图标复制文本。</Paragraph>
+    <Paragraph copyable={{
+      onCopy: (e, content) => {
+        console.log(content);
+      }
+    }} >点击右边的图标复制文本。</Paragraph>
     <br />
     <Paragraph spacing="extended" copyable>
       Semi Design 是由互娱社区前端团队与 UED
@@ -647,3 +656,121 @@ export const Copyable = () => (
     >测试 renderCopyNode 属性</Paragraph>
   </div>
 );
+
+export const CopyableWarning = () => (
+  <>
+    <Paragraph 
+        spacing="extended" 
+        copyable
+      >这里有一个非text节点，控制台<strong>应该</strong>报 warning</Paragraph> 
+      <Paragraph 
+        spacing="extended" 
+        copyable={{
+          content: '复制结果是我'
+        }}
+      >这里有一个非text节点但是设置了copyable的 content（类型为 string），所以控制台对这条<strong>不应该</strong>报 warning</Paragraph>
+  </>
+)
+
+export const ContainerResize = () => (
+  // from https://github.com/DouyinFE/semi-design/pull/1514
+  // 用于 E2E 测试中容器尺寸 resize， 动态省略
+  <>
+    {/* css 截断 */}
+    <Typography.Text ellipsis={{ showTooltip: true, rows: 2 }}>
+      这是第一个test：有省略的文本，resize到省略消失，再resize回原来的尺寸，没有省略状态
+      这是第一个test：有省略的文本，resize到省略消失，再resize回原来的尺寸，没有省略状态
+      这是第一个test：有省略的文本，resize到省略消失，再resize回原来的尺寸，没有省略状态
+      这是第一个test：有省略的文本，resize到省略消失，再resize回原来的尺寸，没有省略状态
+    </Typography.Text>
+    <br />
+    {/* js 截断 */}
+    <Typography.Text
+      ellipsis={{ showTooltip: true, rows: 2, expandable: true }}
+    >
+      这是第二个test：可展开的文本，在折叠状态下，resize到展开消失，再resize回原来的尺寸，变成了展开状态;
+      这是第二个test：可展开的文本，在折叠状态下，resize到展开消失，再resize回原来的尺寸，变成了展开状态;
+      这是第二个test：可展开的文本，在折叠状态下，resize到展开消失，再resize回原来的尺寸，变成了展开状态;
+    </Typography.Text>
+    <br />
+  </>
+);
+
+export const EdgeCases = () => (
+  <>
+    <p>Case 1: pos: 'middle', 无content，测试是否触发 TypeError</p>
+    <Text 
+      ellipsis={{  rows: 3,  pos: 'middle',  expandable: true, }} 
+      style={{ width: 300 }}
+    ></Text>
+    <br />
+    <Paragraph 
+      ellipsis={{ 
+        pos: 'middle', 
+        rows: 3, 
+        expandable: true, 
+        collapsible: true, 
+        collapseText: '折叠我吧' 
+      }} 
+      style={{ width: 300 }}>
+        case 2：长度刚好符合预期，不应该省略，不应该显示展开按钮。长度刚好符合预期，不应该省略，不应该显示展开按钮。不应该显示展开的。
+    </Paragraph>
+  </>
+);
+
+export const showTooltip = () => (
+  <>
+    <Text 
+      ellipsis={{  showTooltip: true, rows: 3 }} 
+      style={{ width: 300 }}
+    > css 截断，本内容超出长度限制，需要截断，因为设置了ellipsis中 showTooltip 为 true，所以通过 hover 可以展示全部内容，鼠标移入触发hover效果下试试
+    </Text>
+    <br />
+    <Text 
+      ellipsis={{  showTooltip: true, rows: 3, pos: 'middle' }} 
+      style={{ width: 300 }}
+    > pos 为 middle，无 expanded /suffix 相关设置，js 截断，本内容超出长度限制，需要截断，因为设置了ellipsis中 showTooltip 为 true，所以通过 hover 可以展示全部内容，鼠标移入触发hover效果下试试
+    </Text> 
+  </>
+);
+
+export const childrenTypeNumber = () => {
+  // 如果 Text 的 children 为 number 类型，组件不应该出错
+  const { Text } = Typography;
+  const name = 123123;
+  return (
+      <div>
+          <Text 
+            ellipsis={{ showTooltip: true, pos: 'middle'}}
+            style={{ maxWidth: 120, width: '100%'}}>{name}
+          </Text>
+      </div>
+  );
+}
+
+export const TextInline = () => {
+  const { Text } = Typography;
+  return (
+    <div>
+      <div style={{ width: 500 }}>
+        <Text 
+          ellipsis={{ showTooltip: true }}
+          style={{ width: 300 }}
+        >
+          这是一个 Text，使用 css 截断，保持 Text 的 inline 属性，所以这行应该可以其他元素出现在一行
+        </Text>
+        <span style={{ fontSize: 12, lineHeight: '16px', backgroundColor: 'green' }}>这行</span>
+      </div>
+      <br />
+      <div style={{ width: 500 }}>
+        <Text 
+          ellipsis={{ showTooltip: true, rows: 2, pos: 'middle' }}
+          style={{ width: 300 }}
+        >
+          这是一个 Text，使用 js 截断，保持 Text 的 inline 属性，所以这行应该可以其他元素出现在一行
+        </Text>
+        <span style={{ fontSize: 12, lineHeight: '16px', backgroundColor: 'green' }}>这行</span>
+      </div>
+    </div>
+  )
+}

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -240,9 +240,9 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             return false;
         }
         const updateOverflow =
-            rows <= 1
-                ? this.wrapperRef.current.scrollWidth > this.wrapperRef.current.clientWidth
-                : this.wrapperRef.current.scrollHeight > this.wrapperRef.current.offsetHeight;
+            rows <= 1 ?
+                this.wrapperRef.current.scrollWidth > this.wrapperRef.current.offsetWidth :
+                this.wrapperRef.current.scrollHeight > this.wrapperRef.current.offsetHeight;
         return updateOverflow;
     };
 
@@ -284,19 +284,20 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             this.onResize();
             return false;
         }
-        const { ellipsisContent, isOverflowed, isTruncated, expanded } = this.state;
+        const { ellipsisContent, isOverflowed, expanded } = this.state;
         const updateOverflow = this.shouldTruncated(rows);
         const canUseCSSEllipsis = this.canUseCSSEllipsis();
-        const needUpdate = updateOverflow !== isOverflowed;
 
         if (!rows || rows < 0 || expanded) {
             return undefined;
         }
 
         if (canUseCSSEllipsis) {
-            if (needUpdate) {
-                this.setState({ expanded: !updateOverflow });
-            }
+            // isOverflowed needs to be updated to show tooltip when using css ellipsis
+            this.setState({
+                isOverflowed: updateOverflow
+            });
+
             return undefined;
         }
 
@@ -440,7 +441,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             };
         }
         const { rows } = this.getEllipsisOpt();
-        const { isOverflowed, expanded, isTruncated } = this.state;
+        const { expanded } = this.state;
         const useCSS = !expanded && this.canUseCSSEllipsis();
         const ellipsisCls = cls({
             [`${prefixCls}-ellipsis`]: true,
@@ -451,14 +452,14 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         const ellipsisStyle = useCSS && rows > 1 ? { WebkitLineClamp: rows } : {};
         return {
             ellipsisCls,
-            ellipsisStyle: isOverflowed ? ellipsisStyle : {},
+            ellipsisStyle,
         };
     };
 
     renderEllipsisText = (opt: Ellipsis) => {
         const { suffix } = opt;
         const { children } = this.props;
-        const { isTruncated, expanded, isOverflowed, ellipsisContent } = this.state;
+        const { isTruncated, expanded, ellipsisContent } = this.state;
         if (expanded || !isTruncated) {
             return (
                 <>
@@ -527,7 +528,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         const iconSize: Size = size === 'small' ? 'small' : 'default';
         return (
             <span className={`${prefixCls}-icon`} x-semi-prop="icon">
-                {isSemiIcon(icon) ? React.cloneElement(icon as React.ReactElement, { size: iconSize }) : icon}
+                {isSemiIcon(icon) ? React.cloneElement((icon as React.ReactElement), { size: iconSize }) : icon}
             </span>
         );
     }

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -298,7 +298,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             return undefined;
         }
 
-        const extraNode = [this.expandRef.current, this.copyRef && this.copyRef.current];
+        const extraNode = { expand: this.expandRef.current, copy: this.copyRef && this.copyRef.current };
         warning(
             'children' in this.props && typeof children !== 'string',
             "[Semi Typography] 'Only children with pure text could be used with ellipsis at this moment."


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
bug的可复现链接（chrome打开，firefox因为有时不溢出时，scrollHeight > offsetHeight，bug可能不会复现）https://codesandbox.io/s/semi-design-simple-story-forked-5tdpeo?file=/src/App.jsx

Fixes 
1. 有省略的文本，resize到省略消失，再resize回原来的尺寸，没有省略状态
2. 可展开的文本，在折叠状态下，resize到展开消失，再resize回原来的尺寸，变成了展开状态
3. js计算溢出时，由于把展开按钮的宽度也计算在内（实际展开按钮不一定展示），会导致展开前后的行数其实是一样的（即没有溢出的情况下展示了展开按钮）

解决方法
1. cssEllipsis时，resize后通过scollHeight和clientHeight判断是否溢出不准确，因为css加省略的样式仅在isOverflow时生效，而在resize后溢出指定行数的情况下，isOverflow是false，css省略的样式没有生效
2. 因为在getEllipsisState时，若js计算的值和chidren不同，则会将expanded置为true（即使用户没有点击展开按钮）。这还引入了其他比较脏的逻辑，如first相关的逻辑
3. 在最开始js计算溢出时，先不计算展开的按钮，而是先计算一定会包含在最终内容的节点。当判断到文本会溢出的时候，再将展开按钮参与计算。

### Changelog
🇨🇳 Chinese
- Fix: Typography resize后可能会丢失省略
- Fix: Typography resize后展开状态可能会被变成折叠
- Fix: Typography 展开按钮可能会在不需要折叠时出现

---

🇺🇸 English
- Fix: Typography ellipsis disappear when resize to larger and back
- Fix: Typography expanded may change to true after resize
- Fix: Typography  expand may show when not overflow


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
