### PR TITLE
style: change typography copy icon from vertical-align text-bottom to middle

### DIFF
--- a/packages/semi-foundation/typography/typography.scss
+++ b/packages/semi-foundation/typography/typography.scss
@@ -140,7 +140,7 @@ $module: #{$prefix}-typography;
 
     &-action-copy {
         display: inline-flex;
-        vertical-align: text-bottom;
+        vertical-align: middle;
         padding: $spacing-typography_copyIcon-padding;
         margin-left: $spacing-typography_copyIcon-marginLeft;
     }
@@ -156,7 +156,7 @@ $module: #{$prefix}-typography;
         color: $color-typography_copied-text-success;
 
         .#{$prefix}-icon {
-            vertical-align: text-bottom;
+            vertical-align: middle;
             color: $color-typography_copied-icon-success;
         }
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
根据设计师要求，将 Typography 中的 copy/copied icon 垂直对齐方式从 text-bottom 改为 middle（行内居中对齐）

### Changelog
🇨🇳 Chinese
- Fix: 将 Typography 中的 copy/copied icon 垂直对齐方式从 text-bottom 改为 middle

---

🇺🇸 English
- Fix: change the vertical-align of copy/copied icon in Typography from text-bottom to middle


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
