### PR TITLE
fix: avoid ele.type.name changed after compiler, use static property …

### DIFF
--- a/packages/semi-ui/iconButton/index.tsx
+++ b/packages/semi-ui/iconButton/index.tsx
@@ -40,6 +40,8 @@ class IconButton extends PureComponent<IconButtonProps> {
         onMouseLeave: noop,
     };
 
+    static elementType = "IconButton";
+
     static propTypes = {
         iconStyle: PropTypes.object,
         style: PropTypes.object,

--- a/packages/semi-ui/navigation/Footer.tsx
+++ b/packages/semi-ui/navigation/Footer.tsx
@@ -31,6 +31,8 @@ export default class NavFooter extends PureComponent<NavFooterProps> {
 
     context: NavContextType;
 
+    static elementType = "NavFooter";
+
     renderCollapseButton = () => {
         const { collapseButton, collapseText } = this.props;
 

--- a/packages/semi-ui/navigation/Header.tsx
+++ b/packages/semi-ui/navigation/Header.tsx
@@ -37,6 +37,8 @@ export default class NavHeader extends PureComponent<NavHeaderProps> {
         prefixCls: cssClasses.PREFIX,
     };
 
+    static elementType = "NavHeader";
+
     context: NavContextType;
 
     renderLogo(logo: React.ReactNode) {

--- a/packages/semi-ui/navigation/index.tsx
+++ b/packages/semi-ui/navigation/index.tsx
@@ -69,7 +69,7 @@ export interface NavProps extends BaseProps {
     onDeselect?: (data?: any) => void;
     onOpenChange?: (data: { itemKey?: (string | number); openKeys?: (string | number)[]; domEvent?: MouseEvent; isOpen?: boolean }) => void;
     onSelect?: (data: OnSelectedData) => void;
-    renderWrapper?: ({ itemElement, isSubNav, isInSubNav, props }: { itemElement: ReactElement;isInSubNav:boolean; isSubNav: boolean; props: NavItemProps | SubNavProps }) => ReactNode
+    renderWrapper?: ({ itemElement, isSubNav, isInSubNav, props }: { itemElement: ReactElement;isInSubNav: boolean; isSubNav: boolean; props: NavItemProps | SubNavProps }) => ReactNode
 }
 
 export interface NavState {
@@ -343,12 +343,12 @@ class Nav extends BaseComponent<NavProps, NavState> {
             for (let i = 0; i < childrenLength; i++) {
                 const child = children[i];
 
-                if ((child as any).type === Footer || get(child, 'type.name') === 'NavFooter') {
+                if ((child as any).type === Footer || get(child, 'type.elementType') === 'NavFooter') {
                     footers.push(child);
                     children.splice(i, 1);
                     i--;
                     childrenLength--;
-                } else if ((child as any).type === Header || get(child, 'type.name') === 'NavHeader') {
+                } else if ((child as any).type === Header || get(child, 'type.elementType') === 'NavHeader') {
                     headers.push(child);
                     children.splice(i, 1);
                     i--;

--- a/packages/semi-ui/table/Column.tsx
+++ b/packages/semi-ui/table/Column.tsx
@@ -7,6 +7,8 @@ export default class Column extends React.PureComponent<ColumnProps> {
         ...ColumnShape,
     };
 
+    static elementType = 'Column';
+
     constructor(props: ColumnProps = {}) {
         super(props);
     }

--- a/packages/semi-ui/table/getColumns.tsx
+++ b/packages/semi-ui/table/getColumns.tsx
@@ -13,7 +13,7 @@ export default function getColumns(children: React.ReactNode) {
         const columns: ColumnProps[] = [];
 
         React.Children.forEach(children, child => {
-            if (React.isValidElement(child) && (child.type === Column || get(child, 'type.name') === Column.name)) {
+            if (React.isValidElement(child) && (child.type === Column || get(child, 'type.elementType') === 'Column')) {
                 const col = omit(child.props, ['children']);
 
                 if (Array.isArray(child.props.children) && child.props.children.length) {

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -486,8 +486,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             /* Only judge the loading state of the Button, and no longer judge other components */
             const isButton = !isEmpty(elem)
                 && !isEmpty(elem.type)
-                && (elem.type as any).name === 'Button'
-                || (elem.type as any).name === 'IconButton';
+                && (get(elem, 'type.elementType') === 'Button' || get(elem, 'type.elementType') === 'IconButton');
             if (loading && isButton) {
                 return strings.STATUS_LOADING;
             }


### PR DESCRIPTION
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
ele.type.name 并不稳定，在编译后可能会变。A组件并不应该依靠这个属性去判断某个 ReactNode是否为 B 组件。应当使用 static 属性代替，对齐 icon的判断方式。



### Changelog
🇨🇳 Chinese
- Fix：修复 Tooltip 配合 loading button 使用在生产环境可能会报错的问题 
- Fix：修复 Navigation使用 JSX 写法配置  Footer、Header ，在生产环境下可能未能正确识别的问题
- Fix：修复 Table 使用 JSX Children写法配置 Columns 时，在生产环境下可能未能正确识别 Column的问题
---

🇺🇸 English
- Fix: Fix the problem that an error may be reported when Tooltip is used in conjunction with the loading button in the production environment
- Fix: Fix the problem that Navigation uses JSX to configure Footer and Header, which may not be correctly recognized in the production environment
- Fix: Fix the problem that the Column may not be recognized correctly in the production environment when the Table uses the JSX Children notation to configure Columns


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
