### PR TITLE
fix: [Tranfer] Fix items with the same label cannot be dragged when t…

### DIFF
--- a/packages/semi-ui/transfer/index.tsx
+++ b/packages/semi-ui/transfer/index.tsx
@@ -178,7 +178,7 @@ const SortableList = SortableContainer(({ items }: { items: Array<ResolvedDataIt
     <div className={`${prefixCls}-right-list`} role="list" aria-label="Selected list">
         {items.map((item, index: number) => (
             // @ts-ignore skip SortableItem type check
-            <SortableItem key={item.label} index={index} item={item} />
+            <SortableItem key={item.key} index={index} item={item} />
         ))}
     </div>
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment


### PR DESCRIPTION
…he draggable item in Transfer uses the label as the key of the SortableIte

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Transfer 中可拖拽 item 使用 label 作 SortableItem 的 key 导致相同 label 的 item 无法拖动问题

---

🇺🇸 English
- Fix: fix the problem that items with the same label cannot be dragged when the draggable item in Transfer uses the label as the key of the SortableItem


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
