### PR TITLE
fix: fix ComponentPropsWithRef type function failed with Button

### DIFF
--- a/packages/semi-ui/button/index.tsx
+++ b/packages/semi-ui/button/index.tsx
@@ -19,7 +19,7 @@ class Button extends React.PureComponent<ButtonProps> {
         ...IconButton.propTypes,
     };
     static elementType: string;
-    constructor(props = {}) {
+    constructor(props: ButtonProps = {}) {
         super(props);
     }
     render() {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Button 使用 ComponentPropsWithRef 获取不到Props 类型的问题

---

🇺🇸 English
- Fix: Fix the problem that Button cannot get the Props type using ComponentPropsWithRef


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
