### PR TITLE
fix: add stopPropagation to focus and blur event in tooltip portal

### DIFF
--- a/packages/semi-ui/_utils/index.tsx
+++ b/packages/semi-ui/_utils/index.tsx
@@ -11,7 +11,7 @@ import { isHTMLElement } from '@douyinfe/semi-foundation/utils/dom';
  * @param {React.MouseEvent<HTMLElement>} e React mouse event object
  * @param {boolean} noImmediate Skip stopping immediate propagation
  */
-export function stopPropagation(e: React.MouseEvent, noImmediate?: boolean) {
+export function stopPropagation(e: React.MouseEvent | React.FocusEvent<HTMLElement>, noImmediate?: boolean) {
     if (e && typeof e.stopPropagation === 'function') {
         e.stopPropagation();
     }

--- a/packages/semi-ui/tooltip/_story/tooltip.stories.jsx
+++ b/packages/semi-ui/tooltip/_story/tooltip.stories.jsx
@@ -15,7 +15,9 @@ import {
   Popover,
   Input,
   RadioGroup,
-  SideSheet
+  SideSheet,
+  Dropdown,
+  Popconfirm
 } from '@douyinfe/semi-ui';
 
 import InTableDemo from './InTable';
@@ -1503,3 +1505,28 @@ Bottom2BottomLeftDemo.storyName = `✅ auto : bottom -> bottomLeft`;
 
 export const Bottom2BottomRightDemo = () => <Bottom2BottomRight />;
 Bottom2BottomRightDemo.storyName = `✅ auto : bottom -> bottomRight`;
+
+
+export const Fix1557 = () =>{
+   return (
+      <Dropdown
+          trigger='hover'
+          disableFocusListener
+          render={
+              <Dropdown.Menu>
+                  <Popconfirm
+                    content={
+                        <>
+                        <Select filter/>
+                        </>
+                    }
+                  >
+                      <Button>点我后再点击select, Dropdown 面板不收起</Button>
+                  </Popconfirm>
+              </Dropdown.Menu>
+          }
+      >
+          <Tag>Hover Me</Tag>
+      </Dropdown>
+  );
+}

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -571,6 +571,18 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         }
     }
 
+    handlePortalFocus = (e: React.FocusEvent<HTMLElement>) => {
+        if (this.props.stopPropagation) {
+            stopPropagation(e);
+        }
+    }
+
+    handlePortalBlur = (e: React.FocusEvent<HTMLElement>) => {
+        if (this.props.stopPropagation) {
+            stopPropagation(e);
+        }
+    }
+
     handlePortalInnerKeyDown = (e: React.KeyboardEvent) => {
         this.foundation.handleContainerKeydown(e);
     }
@@ -655,6 +667,8 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                     style={portalInnerStyle}
                     ref={this.setContainerEl}
                     onClick={this.handlePortalInnerClick}
+                    onFocus={this.handlePortalFocus}
+                    onBlur={this.handlePortalBlur}
                     onMouseDown={this.handlePortalMouseDown}
                     onKeyDown={this.handlePortalInnerKeyDown}
                 >


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1557

semi 弹层类组件都依赖于 Tooltip，trigger 为 hover 的弹层类组件在**弹层上**会有 onFocus 打开面板 和 onBlur 关闭面板 的事件。

在 **2.29.0** 版本中，点击 PopConfirm 内部任意处都会导致面板关闭。响应路径如下
1. 点击 button，打开 PopConfirm 面板，Dropdown 弹层触发 onFocus。
2. 点击 PopConfirm 面板，button 失焦，Dropdown 弹层触发 onBlur，Dropdown 弹层关闭。
此时应给 Dropdown 设置 disabledFocusListener，屏蔽弹层 onFocus 和 onBlur 事件即可。
![image](https://user-images.githubusercontent.com/101160769/232992280-eb15755b-4f46-4bdc-9e8e-8375af41a5ec.png)

在 **2.30.0 - 2.33.0** 版本中，增加了 Popconfirm 的 A11y 支持，给 Tooltip portal 内层 div 增加了 tabindex=-1 设置，此时内层 
 div 可以响应聚焦事件。因为未对弹层内 onFocus 和 onBlur 事件进行拦截，所以响应路径如下
1. 点击 button，打开 PopConfirm 面板，Dropdown 弹层触发 onFocus。
2. 点击 PopConfirm 面板，button 失焦，Dropdown 弹层触发 onBlur。同时内层 div 响应聚焦事件，冒泡到 Dropdown，Dropdown 弹层触发 onFocus。所以此时 Dropdown 不设置 disabledFocusListener，也不收起。
![image](https://user-images.githubusercontent.com/101160769/232992808-53a04d34-5a84-4824-902e-a5d876e76f6c.png)

Popconfirm 的 stopPropagation 默认为 true，需要对 focus 和 blur的事件进行拦截。增加拦截后，表现会和 2.29.0 版本相似，用户给 Dropdown 设置 disabledFocusListener，屏蔽弹层 onFocus 和 onBlur 事件即可。


### Changelog
🇨🇳 Chinese
- Fix: 修复 stopPropagation 为 true 未拦截 focus 和 blur 事件问题

---

🇺🇸 English
- Fix: Fix the problem that stopPropagation is true and focus and blur events are not intercepted


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
