### PR TITLE
fix: timepicker rangeType error when select endTime first, close #1563

### DIFF
--- a/packages/semi-foundation/timePicker/foundation.ts
+++ b/packages/semi-foundation/timePicker/foundation.ts
@@ -10,7 +10,7 @@ import {
     transformToArray,
     isTimeFormatLike
 } from './utils';
-import { split } from 'lodash';
+import { split, isUndefined } from 'lodash';
 import { isValid, format, getHours } from 'date-fns';
 import { utcToZonedTime, zonedTimeToUtc } from '../utils/date-fns-extra';
 import isNullOrUndefined from '../utils/isNullOrUndefined';
@@ -182,7 +182,7 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
             isAM[index] = panelIsAM;
             const inputValue = this.formatValue(value);
 
-            if (this.getState('isAM')[index] !== result.isAM){
+            if (this.getState('isAM')[index] !== result.isAM) {
                 this.setState({ isAM } as any);
             }
             if (!this._isControlledComponent('value')) {
@@ -369,7 +369,16 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
         }
 
         if (_dates && Array.isArray(_dates)) {
-            return _dates.map(date => formatToString(date, validFormat, dateFnsLocale)).join(rangeSeparator);
+            const result = _dates.map(date => {
+                let str;
+                if (isUndefined(date)) {
+                    str = '';
+                } else {
+                    str = formatToString(date, validFormat, dateFnsLocale);
+                }
+                return str;
+            });
+            return result.join(rangeSeparator);
         }
         return undefined;
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1465,15 +1465,6 @@
     "@douyinfe/semi-animation-styled" "2.23.2"
     classnames "^2.2.6"
 
-"@douyinfe/semi-animation-react@2.32.2":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-react/-/semi-animation-react-2.32.2.tgz#c388ed32d1713c13d0400d7c209d8816bc6579cf"
-  integrity sha512-ALi+M7fF5IPQaf2fjLmykMjV/NFiRl9IvaoQsDv4uNFlVLANrZXeuHjqxQb3en6RM2NCcrtq4KwWnvZ8y7V1jw==
-  dependencies:
-    "@douyinfe/semi-animation" "2.12.0"
-    "@douyinfe/semi-animation-styled" "2.23.2"
-    classnames "^2.2.6"
-
 "@douyinfe/semi-animation-styled@2.23.2":
   version "2.23.2"
   resolved "https://registry.npmjs.org/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.23.2.tgz"
@@ -1494,13 +1485,6 @@
   dependencies:
     bezier-easing "^2.1.0"
 
-"@douyinfe/semi-animation@2.32.2":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation/-/semi-animation-2.32.2.tgz#f0b1164941671fa335d4e54027a5a52e6c09ba2c"
-  integrity sha512-dW/1SpcgBWeEnPDshNysFeAu6L6FDcxiOeYHd7u0C6+Oet+4rtDXe/9HqxhFkVuLbjyy0MCLFI+izTgycUvH3w==
-  dependencies:
-    bezier-easing "^2.1.0"
-
 "@douyinfe/semi-foundation@2.30.2":
   version "2.30.2"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-foundation/-/semi-foundation-2.30.2.tgz#f7a3f983da02a2843c8e95604f10c08d5c8e922c"
@@ -1515,31 +1499,10 @@
     memoize-one "^5.2.1"
     scroll-into-view-if-needed "^2.2.24"
 
-"@douyinfe/semi-foundation@2.32.2":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-foundation/-/semi-foundation-2.32.2.tgz#c61a621e900fdc9a5605532012808a3722f97ac2"
-  integrity sha512-F+b3u1XvqlufKZilyM0eepk/COfBsnLED/XtEimt2uGWWk+Ftv9Th+CNcxs1mAW3fhM8hqw4EkVA5RYEogHq3g==
-  dependencies:
-    "@douyinfe/semi-animation" "2.12.0"
-    async-validator "^3.5.0"
-    classnames "^2.2.6"
-    date-fns "^2.29.3"
-    date-fns-tz "^1.3.8"
-    lodash "^4.17.21"
-    memoize-one "^5.2.1"
-    scroll-into-view-if-needed "^2.2.24"
-
 "@douyinfe/semi-icons@2.30.2":
   version "2.30.2"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.30.2.tgz#03bf9a5ef99bf3b77557379d631908889767b8aa"
   integrity sha512-Km8SEwDHIF/sZlvFEPW5vItlnSlWSme/N8Kd3pgsHXPIaslyhHcTaOq7LnHFahf4weTWcq6i6RTdDJKhzn6YGg==
-  dependencies:
-    classnames "^2.2.6"
-
-"@douyinfe/semi-icons@2.32.2", "@douyinfe/semi-icons@^2.0.0":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.32.2.tgz#ba713d95ae4365bf7d05c1dbb78976ba29c7cf04"
-  integrity sha512-Bo085OU8xhqenTiFepKrEXjY63GI1u8310ZAynHQsg2vRNdSVmQH5RRV2Tgqj27Uq6Q3rtEtN0f/lGxE+MNYQw==
   dependencies:
     classnames "^2.2.6"
 
@@ -1555,11 +1518,6 @@
   version "2.30.2"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.30.2.tgz#e31007086d75c98c6b87789945bffcdb72cf195e"
   integrity sha512-cjJ02F4Fg6wfWgVCpGSEUU/MDg/fc6zy2eAxMJ2yMqbERYI99y3Qk4RlckPcUnXx5LzfFAeFtM6E/ri+xMtIKQ==
-
-"@douyinfe/semi-illustrations@2.32.2":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.32.2.tgz#a580339eea5e526bfc33196f6b5b1a5f07d005b6"
-  integrity sha512-DmDo1/DdjJiFgq0vs2se5zrtM8mFdne5F8dL0g96sHcPFAG2tzVYzlcpgQ11gVRiiCpBJKOcem1UwKe32jWv7w==
 
 "@douyinfe/semi-scss-compile@2.23.2":
   version "2.23.2"
@@ -1633,38 +1591,6 @@
   integrity sha512-8ZqCWxzh6pG4nGMjHZvxNLMys27gYtNmBbleKfgDYUWeQac4lh5AU9f1TVfpe8cz2FI3JJsJt2BHfjg7t64/uA==
   dependencies:
     glob "^7.1.6"
-
-"@douyinfe/semi-theme-default@2.32.2":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.32.2.tgz#5ad25f274b66508f9167e05f154db4fada921162"
-  integrity sha512-qjepAmNQ+1JY8dQVfaXAng0jD+n4dWsz33xWnbIRQ93lgmqBsvP7JRKKcNkOsWe5nbhxP3R0HZMQ5KeJoNm0Bg==
-  dependencies:
-    glob "^7.1.6"
-
-"@douyinfe/semi-ui@^2.0.0":
-  version "2.32.2"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-ui/-/semi-ui-2.32.2.tgz#fb21c2ba6a6a6f650d460dcb35d274d608796dec"
-  integrity sha512-AVOLhJ16FIHZuL6izmlM5AYVyLiPcsUtFxbMdm47d6dgCMA2OevvwrkUZX/uMBvprnM62IP12SB3pfpOUoI0Fw==
-  dependencies:
-    "@douyinfe/semi-animation" "2.32.2"
-    "@douyinfe/semi-animation-react" "2.32.2"
-    "@douyinfe/semi-foundation" "2.32.2"
-    "@douyinfe/semi-icons" "2.32.2"
-    "@douyinfe/semi-illustrations" "2.32.2"
-    "@douyinfe/semi-theme-default" "2.32.2"
-    async-validator "^3.5.0"
-    classnames "^2.2.6"
-    copy-text-to-clipboard "^2.1.1"
-    date-fns "^2.29.3"
-    date-fns-tz "^1.3.8"
-    lodash "^4.17.21"
-    prop-types "^15.7.2"
-    react-resizable "^1.8.0"
-    react-sortable-hoc "^2.0.0"
-    react-window "^1.8.2"
-    resize-observer-polyfill "^1.5.1"
-    scroll-into-view-if-needed "^2.2.24"
-    utility-types "^3.10.0"
 
 "@douyinfe/semi-ui@latest":
   version "2.30.2"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
当先选择endTime，  handlePanelChange 中的值为 [empty,   xxx]; 

- 修改 timepicker foudation 的 formatValue 逻辑，原逻辑未对 undefined 做处理，会导致 formatToString 抛出 error

![20230420204544_rec_](https://user-images.githubusercontent.com/88709023/233370102-53429929-3009-44ef-b748-4df88451bc34.gif)


TODO：
需确认的问题，当前 validateDates 的逻辑亦未对 array[0]为空，array[1] 有值的情况做判断，所以首次选择时，invalid 并不正确。第二次时才正确（即 input的 validateStatus更新，背景色为error 色）。
validateDates应该也需要做对应的变更。


### Changelog
🇨🇳 Chinese
- Fix: 修复TimePicker range 模式先选择结束时间，会导致报错的问题 #1563 

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
