### PR TITLE
Fix/typography vertical align

### DIFF
--- a/content/basic/typography/index.md
+++ b/content/basic/typography/index.md
@@ -351,6 +351,18 @@ function Demo() {
             <Paragraph ellipsis={{ rows: 3, expandable: true, collapsible: true, collapseText: '折叠我吧', onExpand: (bool, e) => console.log(bool, e) }} style={{ width: 300 }}>
                 支持展开和折叠：Semi Design 是由互娱社区前端团队与 UED 团队共同设计开发并维护的设计系统。设计系统包含设计语言以及一整套可复用的前端组件，帮助设计师与开发者更容易地打造高质量的、用户体验一致的、符合设计规范的 Web 应用。
             </Paragraph>
+            <br/>
+            <Text 
+                ellipsis={{ 
+                    showTooltip: {
+                        opts: { content: '全英文设置了word-break' }
+                    },
+                    pos: 'middle'
+                }}
+                style={{ width: 150, wordBreak: 'break-word' }}
+            >
+                sssssssssssssssssssssssss
+            </Text>
         </div>
     );
 }

--- a/packages/semi-foundation/typography/typography.scss
+++ b/packages/semi-foundation/typography/typography.scss
@@ -140,6 +140,7 @@ $module: #{$prefix}-typography;
             display: inline-block;
             // Ensure that Text component can be limited by the parent's width when no specific width is set
             max-width: 100%;
+            vertical-align: top;
         }
     }
 

--- a/packages/semi-ui/typography/_story/typography.stories.jsx
+++ b/packages/semi-ui/typography/_story/typography.stories.jsx
@@ -418,7 +418,7 @@ export const EllipsisChaos = () => (
       Web 应用。 区别于其他的设计系统而言，Semi Design
       以用户中心、内容优先、设计人性化为设计理念，具有四大优势。
     </Text>
-    <br />
+    <br /><br />
     <Title
       icon={<IconLink />}
       heading={5}
@@ -701,6 +701,12 @@ export const EdgeCases = () => (
     <p>Case 1: pos: 'middle', 无content，测试是否触发 TypeError</p>
     <Text 
       ellipsis={{  rows: 3,  pos: 'middle',  expandable: true, }} 
+      style={{ width: 300 }}
+    ></Text>
+    <br />
+    <p>Case 2: css 截断, 无 content，测试是否触发 TypeError</p>
+    <Text 
+      ellipsis={{ rows: 1 }} 
       style={{ width: 300 }}
     ></Text>
     <br />

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -287,6 +287,15 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             "[Semi Typography] 'Only children with pure text could be used with ellipsis at this moment."
         );
 
+        // If children is null, css/js truncated flag isTruncate is false
+        if (isNull(children)) {
+            this.setState({
+                isTruncated: false,
+                isOverflowed: false
+            });
+            return undefined;
+        }
+
         if (!rows || rows < 0 || expanded) {
             return undefined;
         }
@@ -304,16 +313,8 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
 
         const extraNode = { expand: this.expandRef.current, copy: this.copyRef && this.copyRef.current };
 
-        // If children is null, js truncated flag isTruncate is false
-        if (isNull(children)) {
-            this.setState({
-                isTruncated: false,
-            });
-            return undefined;
-        }
-
         const content = getRenderText(
-            ReactDOM.findDOMNode(this.wrapperRef.current) as HTMLElement,
+            this.wrapperRef.current,
             rows,
             // Perform type conversion on children to prevent component crash due to non-string type of children
             String(children),
@@ -518,7 +519,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
 
         warning(
             hasObject,
-            'content to be copied in Typography is a object, it will case a [object Object] mistake when copy to clipboard.'
+            'Content to be copied in Typography is a object, it will case a [object Object] mistake when copy to clipboard.'
         );
         const copyConfig = {
             content: copyContent,

--- a/packages/semi-ui/typography/typography.tsx
+++ b/packages/semi-ui/typography/typography.tsx
@@ -5,7 +5,7 @@ import { cssClasses } from '@douyinfe/semi-foundation/typography/constants';
 import '@douyinfe/semi-foundation/typography/typography.scss';
 import { BaseProps } from '../_base/baseComponent';
 const prefixCls = cssClasses.PREFIX;
-interface TypographyProps extends BaseProps{
+interface TypographyProps extends BaseProps {
     component?: React.ElementType;
     forwardRef?: React.RefObject<any>
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix:  修复 Typography 中 Text 设置 inline-block，对外部容器高度的影响

---

🇺🇸 English
- Fix: fix the effect of setting inline-block for Text in Typography to the height of the external container


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

对 #1514 的补充
 Typography 中的 Text 组件设置 inline-block，影响了 Anchor 组件中高度计算，原因是因为inline-block的元素默认放在baseline，所以父元素高度计算的时候会多出来一块。可以参考 https://www.cnblogs.com/cc156676/p/5676237.html
 通过给 Text 设置 inline-block 属性位置增加 vertical-align: top来解决
 
 本修复的本地chromatic 对比见 ​https://www.chromatic.com/build?appId=618c866f557c10003ac4cc42&number=421，
其中涉及Typography的修改都是可接受的



