### PR TITLE
style: Fix the style error when icon and text exist at the same time …

### DIFF
--- a/packages/semi-foundation/breadcrumb/breadcrumb.scss
+++ b/packages/semi-foundation/breadcrumb/breadcrumb.scss
@@ -82,14 +82,14 @@ $module: #{$prefix}-breadcrumb;
         }
     }
 
-    &-item-icon+&-item-title {
-        margin-left: $spacing-breadcrumb_item_text-marginLeft;
-    }
+    // &-item-icon+&-item-title {
+    //     margin-left: $spacing-breadcrumb_item_text-marginLeft;
+    // }
 
     &-item-link {
         display: inline-flex;
         align-items: center;
-        column-gap: 4px;
+        column-gap: $spacing-breadcrumb_item_text-marginLeft;
         text-decoration: inherit;
         transition: color $transition_duration-breadcrumb_link-text $transition-function_breadcrumb_link-text $transition_delay-breadcrumb_link-text;
         transform: scale($transform_scale-breadcrumb_link-text);


### PR DESCRIPTION
…in BreadCrumb

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style:  BreadCrumb 中 icon 和文本间距从 8px 修改为 4px（影响面 v2.0.0～v2.33.1）

---

🇺🇸 English
- Style: Changed the spacing between icon and text in BreadCrumb from 8px to 4px（Affects v2.0.0～v2.33.1）


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
由用户提过来， BreadCrumb中 BreadCrumb.Item 中 1.x 和2.x间隔不同
1.x
![image](https://user-images.githubusercontent.com/101110131/233896322-c25a981e-32f5-488a-b085-da6f9c99c5ba.png)
2.x
![image](https://user-images.githubusercontent.com/101110131/233896589-741ba6bd-e1d1-4e64-8735-821a115dfd4e.png)
![image](https://user-images.githubusercontent.com/101110131/233896728-9cca3393-4fe3-4271-9001-971803526da0.png)

修改：去掉icon+title的css 设置， column-gap处使用 cssToken， 使用原来的 margin-left 的 token
影响面：v2.0.0-v2.33.1
本地 chromatic 对比见 https://www.chromatic.com/build?appId=618c866f557c10003ac4cc42&number=422
