### PR TITLE
Fix/month calendar

### DIFF
--- a/packages/semi-foundation/calendar/eventUtil.ts
+++ b/packages/semi-foundation/calendar/eventUtil.ts
@@ -121,15 +121,16 @@ export const calcRangeData = (value: Date, start: Date, rangeLen: number, mode: 
 
 /**
  *
- * @param {value} date
+ * @param {value} date current date, using for month mode
  * @param {string} mode
  * @param {string} locale
  * @returns {object[]} { date: Date, dayString: string, ind: number, isToday: boolean, isWeekend: boolean, weekday: string }
  * create weekly object array
  */
-export const calcWeekData = (value: Date, mode = 'week', locale: Locale, weekStartsOn: weekStartsOnEnum) => {
+export const calcWeekData = (value: Date, monthStart: Date | null, mode = 'week', locale: Locale, weekStartsOn: weekStartsOnEnum) => {
     const start = startOfWeek(value, { weekStartsOn });
-    return calcRangeData(value, start, 7, mode, locale, weekStartsOn);
+    const realValue = monthStart || value;
+    return calcRangeData(realValue, start, 7, mode, locale, weekStartsOn);
 };
 
 /**

--- a/packages/semi-foundation/calendar/eventUtil.ts
+++ b/packages/semi-foundation/calendar/eventUtil.ts
@@ -121,7 +121,8 @@ export const calcRangeData = (value: Date, start: Date, rangeLen: number, mode: 
 
 /**
  *
- * @param {value} date current date, using for month mode
+ * @param {Date} date
+ * @param {Date} monthStart current month start date, using for month mode
  * @param {string} mode
  * @param {string} locale
  * @returns {object[]} { date: Date, dayString: string, ind: number, isToday: boolean, isWeekend: boolean, weekday: string }

--- a/packages/semi-foundation/calendar/eventUtil.ts
+++ b/packages/semi-foundation/calendar/eventUtil.ts
@@ -96,9 +96,9 @@ export interface DateObj {
     month: string
 }
 
-export type weeekStartsOnEnum = 0 | 1 | 2 | 3 | 4 | 5 | 6;
+export type weekStartsOnEnum = 0 | 1 | 2 | 3 | 4 | 5 | 6;
 
-export const calcRangeData = (value: Date, start: Date, rangeLen: number, mode: string, locale: Locale, weekStartsOn: weeekStartsOnEnum) => {
+export const calcRangeData = (value: Date, start: Date, rangeLen: number, mode: string, locale: Locale, weekStartsOn: weekStartsOnEnum) => {
     const today = getCurrDate();
     const arr: Array<DateObj> = [];
     [...Array(rangeLen).keys()].map(ind => {
@@ -127,7 +127,7 @@ export const calcRangeData = (value: Date, start: Date, rangeLen: number, mode: 
  * @returns {object[]} { date: Date, dayString: string, ind: number, isToday: boolean, isWeekend: boolean, weekday: string }
  * create weekly object array
  */
-export const calcWeekData = (value: Date, mode = 'week', locale: Locale, weekStartsOn: weeekStartsOnEnum) => {
+export const calcWeekData = (value: Date, mode = 'week', locale: Locale, weekStartsOn: weekStartsOnEnum) => {
     const start = startOfWeek(value, { weekStartsOn });
     return calcRangeData(value, start, 7, mode, locale, weekStartsOn);
 };
@@ -250,7 +250,7 @@ export const filterEvents = (events: Map<string, EventObject[]>, start: Date, en
  * filter out event that is not in the week range
  */
 // eslint-disable-next-line max-len
-export const filterWeeklyEvents = (events: Map<string, EventObject[]>, weekStart: Date, weekStartsOn: weeekStartsOnEnum ) => filterEvents(events, weekStart, addDays(endOfWeek(weekStart, { weekStartsOn }), 1));
+export const filterWeeklyEvents = (events: Map<string, EventObject[]>, weekStart: Date, weekStartsOn: weekStartsOnEnum ) => filterEvents(events, weekStart, addDays(endOfWeek(weekStart, { weekStartsOn }), 1));
 
 /**
  * @returns {arr}
@@ -309,7 +309,7 @@ export const parseWeeklyAllDayEvent = (
     startDate: Date,
     weekStart: Date,
     parsed: Array<Array<ParsedRangeEvent>>,
-    weekStartsOn: weeekStartsOnEnum
+    weekStartsOn: weekStartsOnEnum
 ) => parseRangeAllDayEvent(event, startDate, weekStart, addDays(endOfWeek(startDate, { weekStartsOn }), 1), parsed);
 
 

--- a/packages/semi-foundation/calendar/foundation.ts
+++ b/packages/semi-foundation/calendar/foundation.ts
@@ -191,7 +191,7 @@ export default class CalendarFoundation<P = Record<string, any>, S = Record<stri
         const data = {} as WeeklyData;
         const { weekStartsOn } = this.getProps();
         data.month = format(value, 'LLL', { locale: dateFnsLocale, weekStartsOn });
-        data.week = calcWeekData(value, 'week', dateFnsLocale, weekStartsOn);
+        data.week = calcWeekData(value, null, 'week', dateFnsLocale, weekStartsOn);
         this._adapter.setWeeklyData(data);
         return data;
     }
@@ -212,7 +212,7 @@ export default class CalendarFoundation<P = Record<string, any>, S = Record<stri
         const { weekStartsOn } = this.getProps();
         const numberOfWeek = getWeeksInMonth(value, { weekStartsOn });
         [...Array(numberOfWeek).keys()].map(ind => {
-            data[ind] = calcWeekData(addDays(monthStart, ind * 7), 'month', dateFnsLocale, weekStartsOn);
+            data[ind] = calcWeekData(addDays(monthStart, ind * 7), monthStart, 'month', dateFnsLocale, weekStartsOn);
         });
         this._adapter.setMonthlyData(data);
         return data;

--- a/packages/semi-foundation/calendar/foundation.ts
+++ b/packages/semi-foundation/calendar/foundation.ts
@@ -33,9 +33,9 @@ import {
     DateObj,
     checkWeekend,
 } from './eventUtil';
-import type { weeekStartsOnEnum } from './eventUtil';
+import type { weekStartsOnEnum } from './eventUtil';
 
-export { weeekStartsOnEnum };
+export { weekStartsOnEnum };
 export interface EventObject {
     [x: string]: any;
     key: string;

--- a/packages/semi-ui/calendar/__test__/calendar.test.js
+++ b/packages/semi-ui/calendar/__test__/calendar.test.js
@@ -180,7 +180,7 @@ describe('Calendar', () => {
         expect(defaultFirstHead).toEqual('周日');
     });
 
-    it('test getMonthlyData fixture', () => {
+    it('test getMonthlyData same month fixture', () => {
         const displayValue = new Date(2023, 3, 10, 8, 32, 0);
 
         let calendar = mount(<Calendar
@@ -190,14 +190,14 @@ describe('Calendar', () => {
 
         let firstRow = calendar.find('.semi-calendar-month-weekrow').at(0);
         let lastRow = calendar.find('.semi-calendar-month-weekrow').last();
-        let sameMonthClass = 'calendar-month-same';
+        let sameMonthClass = `${BASE_CLASS_PREFIX}-calendar-month-same`;
         // 2023-03-26
-        expect(firstRow.find('.gridcell').at(0).className).toEqual(expect.not.stringContaining(sameMonthClass));
+        expect(firstRow.find('li').at(0).hasClass(sameMonthClass)).toEqual(false);
         // 2023-04-01
-        expect(firstRow.find('.gridcell').last().className).toEqual(expect.stringContaining(sameMonthClass));
+        expect(firstRow.find('li').last().hasClass(sameMonthClass)).toEqual(true);
         // 2023-04-30
-        expect(lastRow.find('.gridcell').at(0).className).toEqual(expect.stringContaining(sameMonthClass));
+        expect(lastRow.find('li').at(0).hasClass(sameMonthClass)).toEqual(true);
         // 2023-05-06
-        expect(lastRow.find('.gridcell').last().className).toEqual(expect.not.stringContaining(sameMonthClass));
+        expect(lastRow.find('li').last().hasClass(sameMonthClass)).toEqual(false);
     });
 })

--- a/packages/semi-ui/calendar/__test__/calendar.test.js
+++ b/packages/semi-ui/calendar/__test__/calendar.test.js
@@ -179,4 +179,25 @@ describe('Calendar', () => {
         let defaultFirstHead = defaultCalendar.find('.semi-calendar-month-header li').at(0).text();
         expect(defaultFirstHead).toEqual('周日');
     });
+
+    it('test getMonthlyData fixture', () => {
+        const displayValue = new Date(2023, 3, 10, 8, 32, 0);
+
+        let calendar = mount(<Calendar
+            mode={'month'}
+            displayValue={displayValue}
+        ></Calendar>);
+
+        let firstRow = calendar.find('.semi-calendar-month-weekrow').at(0);
+        let lastRow = calendar.find('.semi-calendar-month-weekrow').last();
+        let sameMonthClass = 'calendar-month-same';
+        // 2023-03-26
+        expect(firstRow.find('.gridcell').at(0).className).toEqual(expect.not.stringContaining(sameMonthClass));
+        // 2023-04-01
+        expect(firstRow.find('.gridcell').last().className).toEqual(expect.stringContaining(sameMonthClass));
+        // 2023-04-30
+        expect(lastRow.find('.gridcell').at(0).className).toEqual(expect.stringContaining(sameMonthClass));
+        // 2023-05-06
+        expect(lastRow.find('.gridcell').last().className).toEqual(expect.not.stringContaining(sameMonthClass));
+    });
 })

--- a/packages/semi-ui/calendar/interface.ts
+++ b/packages/semi-ui/calendar/interface.ts
@@ -1,7 +1,7 @@
 import { strings } from '@douyinfe/semi-foundation/calendar/constants';
 import type { ArrayElement } from '../_base/base';
 import type { BaseProps } from '../_base/baseComponent';
-import type { EventObject, weeekStartsOnEnum } from '@douyinfe/semi-foundation/calendar/foundation';
+import type { EventObject, weekStartsOnEnum } from '@douyinfe/semi-foundation/calendar/foundation';
 
 export interface CalendarProps extends BaseProps {
     displayValue?: Date;
@@ -10,7 +10,7 @@ export interface CalendarProps extends BaseProps {
     events?: EventObject[];
     mode?: ArrayElement<typeof strings.MODE>;
     showCurrTime?: boolean;
-    weekStartsOn?: weeekStartsOnEnum;
+    weekStartsOn?: weekStartsOnEnum;
     scrollTop?: number;
     onClick?: (e: React.MouseEvent, value: Date) => void;
     onClose?: (e: React.MouseEvent) => void;


### PR DESCRIPTION
- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

> 因release分支并没有与main分支完全同步，若目标分支选择release会有额外不相关diff出现；因此提交PR时选择了main分支；

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [x] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
In calendar component, semi will add className `semi-calendar-month-same` for the date when its month is same as `displayValue`, but the last week is wrong.
For example, `displayValue` is 2023-04-01, dates between 2023-04-01 and 2023-04-30 should have `semi-calendar-month-same` className, other dates not. But 2023-04-30 does not currently have it, and 2023-05-01 to 2023-05-06 have.
Reproduction at [semi official site](https://semi.bytedance.net/zh-CN/show/calendar#%E6%9C%88%E8%A7%86%E5%9B%BE)

在calendar组件中，当某日期月份与displayValue相同时，semi会为其添加`semi-calendar-month-same`的className，但最后一周是有问题的。
例如，`displayValue` 是 2023-04-01，2023-04-01 和 2023-04-30 之间的日期应该有 `semi-calendar-month-same` className，其他日期没有。 但目前版本中，2023-04-30没有，2023-05-01到2023-05-06有。
复现于[Semi官网](https://semi.bytedance.net/zh-CN/show/calendar#%E6%9C%88%E8%A7%86%E5%9B%BE)
（顺便修复了一个拼写错误）

### Changelog
🇨🇳 Chinese
- Fix: 修复Calendar组件月视图中，最后一周日期样式错误

---

🇺🇸 English
- Fix: fix last week got wrong style in Calendar component with `month` mode


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

Semi offical site
![image](https://user-images.githubusercontent.com/5326684/233903985-011adc46-b721-4781-9329-7f36f85a8e89.png)

![image](https://user-images.githubusercontent.com/5326684/233904066-6ea6d8ba-293a-45ae-bb1b-e58fe72528fb.png)

Fixed:
![image](https://user-images.githubusercontent.com/5326684/233904108-9199e085-283d-4991-bc04-93cc8426d691.png)
![image](https://user-images.githubusercontent.com/5326684/233904152-6d6405ac-093a-47f2-87d7-412ca0b90698.png)

