### PR TITLE
fix: radioGroup add vertical-align, close #1573

### DIFF
--- a/packages/semi-foundation/radio/radio.scss
+++ b/packages/semi-foundation/radio/radio.scss
@@ -83,7 +83,6 @@ $inner-width: $width-icon-medium;
     &-buttonRadioGroup {
         // Button needs to be positioned relative to parent
         position: relative;
-        vertical-align: bottom; // Fix 1573
         padding: $spacing-radio_buttonRadioGroup_middle-padding;
         border-radius: $radius-radio_buttonRadio;
         line-height: $font-radio_buttonRadioGroup_middle-lineHeight;
@@ -417,6 +416,7 @@ $inner-width: $width-icon-medium;
     &-horizontal {
         display: inline-flex;
         flex-wrap: wrap;
+        vertical-align: bottom; // Fix 1573
         gap: $spacing-radio_group_horizontal-marginRight;
     }
 

--- a/packages/semi-foundation/radio/radio.scss
+++ b/packages/semi-foundation/radio/radio.scss
@@ -83,6 +83,7 @@ $inner-width: $width-icon-medium;
     &-buttonRadioGroup {
         // Button needs to be positioned relative to parent
         position: relative;
+        vertical-align: bottom; // Fix 1573
         padding: $spacing-radio_buttonRadioGroup_middle-padding;
         border-radius: $radius-radio_buttonRadio;
         line-height: $font-radio_buttonRadioGroup_middle-lineHeight;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- RadioGroup 为 inline-flex 布局
   - 方案A：inline-flex 改 flex
   - 方案B：vertical-align 设为 bottom或top，非baseline 值

选择方案B，维持RadioGroup的 inline 属性。修改前后 height 均为20px。选择 bottom而非top，因为radio目前已有类似属性设置，在Parent Group级别维持一致 (且top、bottom实测表现一致)
![image](https://user-images.githubusercontent.com/88709023/234220515-99446f82-c212-4875-8c73-e1530d79fbdf.png)


### Changelog
🇨🇳 Chinese
- Fix: 修复 RadioGroup 父级容器高度会跟随 RadioGroup 选项不同而变化的问题 #1573 

---

🇺🇸 English
- Fix: Fix the problem that the height of the RadioGroup parent container will change with the RadioGroup option #1573


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
