### PR TITLE
fix: [Image] Fix the image is not loaded normally when the src in Ima…

### DIFF
--- a/cypress/integration/image.spec.js
+++ b/cypress/integration/image.spec.js
@@ -501,7 +501,7 @@ describe('image', () => {
 
     // 测试在预览状态下，图片改变 ratio 状态后，切换图片，ratio 状态是否正确
     //（在未受控 ratio ，无默认 ratio 情况下，切换后的图片ratio 应该为适应页面）
-    it.only('ratio status after change pic', () => {
+    it('ratio status after change pic', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?id=image--basic-preview&args=&viewMode=story');
         cy.wait(2000);
         // 进入预览状态
@@ -514,5 +514,14 @@ describe('image', () => {
         cy.wait(1000);
         // 当前 ratio 状态应该为适应页面
         cy.get('.semi-icon-real_size_stroked').should('exist');
+    });
+
+    // 测试懒加载状态下 src 变化时候图片是否正常加载
+    it('src change', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=image--issue-1526&args=&viewMode=story');
+        // 等待 5000 ms， 确保当前src 已经完全改变上
+        cy.wait(5000);
+        // 进入预览状态
+        cy.get('.semi-image-img').eq(0).should('have.attr', 'src', 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/lion.jpeg');
     });
 });

--- a/packages/semi-ui/image/_story/image.stories.jsx
+++ b/packages/semi-ui/image/_story/image.stories.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useMemo } from "react";
+import React, { useState, useCallback, useMemo, useEffect } from "react";
 import {
     Image,
     Button,
@@ -549,3 +549,37 @@ export const CustomRenderTitle = () => (
         </ImagePreview>
     </>
 );
+
+export const issue1526 = () => {
+    // 测试懒加载状态下，image src 改变时候加载是否符合预期
+    const [src, setSrc] = useState([]);
+    const srcList1 = [
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/lion.jpeg",
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/seaside.jpeg",
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/beach.jpeg",
+    ];
+
+    // 模拟远程加载
+    useEffect(() => {
+       setTimeout(() => {
+        setSrc(srcList1);
+       }, 1000);
+    }, []);
+
+    return (
+        <ImagePreview zIndex={1000} >
+            {src.map((file, index) => (
+                <div
+                    style={{
+                        position: 'relative',
+                        cursor: 'pointer',
+                        display: 'inline-block',
+                    }}
+                    key={file}
+                >
+                    <Image key={file} src={file} width={96} height={96} />
+                </div>
+            ))}
+        </ImagePreview>
+    )
+}

--- a/packages/semi-ui/image/image.tsx
+++ b/packages/semi-ui/image/image.tsx
@@ -50,6 +50,7 @@ export default class Image extends BaseComponent<ImageProps, ImageStates> {
 
     context: PreviewContextProps;
     foundation: ImageFoundation;
+    imgRef: React.RefObject<HTMLImageElement>;
 
     constructor(props: ImageProps) {
         super(props);
@@ -60,6 +61,7 @@ export default class Image extends BaseComponent<ImageProps, ImageStates> {
         };
 
         this.foundation = new ImageFoundation(this.adapter);
+        this.imgRef = React.createRef<HTMLImageElement>();
     }
 
     static getDerivedStateFromProps(props: ImageProps, state: ImageStates) {
@@ -78,6 +80,22 @@ export default class Image extends BaseComponent<ImageProps, ImageStates> {
         }
 
         return willUpdateStates;
+    }
+
+    componentDidMount() {
+        this.observeImage();
+    }
+
+    componentDidUpdate(prevProps: ImageProps, prevState: ImageStates) {
+        prevProps.src !== this.props.src && this.observeImage();
+    }
+
+    observeImage() {
+        if (!this.isLazyLoad()) {
+            return;
+        }
+        const { previewObserver } = this.context;
+        previewObserver.observe(this.imgRef.current);
     }
 
     isInGroup() {
@@ -169,7 +187,7 @@ export default class Image extends BaseComponent<ImageProps, ImageStates> {
             <IconEyeOpened size="extra-large"/>
             <span className={`${prefixCls}-mask-info-text`}>{this.getLocalTextByKey("preview")}</span>
         </div>
-    </div>)
+    </div>);
 
     render() {
         const { src, loadStatus, previewVisible } = this.state;
@@ -189,6 +207,7 @@ export default class Image extends BaseComponent<ImageProps, ImageStates> {
                 onClick={this.handleClick}
             >
                 <img
+                    ref={this.imgRef}
                     {...restProps}
                     src={this.isInGroup() && this.isLazyLoad() ? undefined : src}
                     data-src={src}

--- a/packages/semi-ui/image/previewContext.tsx
+++ b/packages/semi-ui/image/previewContext.tsx
@@ -7,6 +7,7 @@ export interface PreviewContextProps {
     titles: ReactNode[];
     currentIndex: number;
     visible: boolean;
+    previewObserver: IntersectionObserver;
     setCurrentIndex: (current: number) => void;
     handleVisibleChange: (visible: boolean, preVisible?: boolean) => void
 }


### PR DESCRIPTION
…ge changes in lazy loading mode

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1526 

### Changelog
🇨🇳 Chinese
- Fix: 修复懒加载模式下 Image 的 src 变化，图片无法正常加载问题 #1526 

---

🇺🇸 English
- Fix: Fix the problem that the src of Image changes in lazy loading mode, and the image cannot be loaded normally.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

懒加载使用的是 IntersectionObserver， 原来的方式是在 preivew 层的 componentDidmout 去找到所有的 img元素，加入observe，此方式对 src 变化不友好（比如远程加载，修改src）

修改：
1. new 出来的 IntersectionObserver在 Preview的constructor中，通过 context 传给子组件
2. 在 Image 中 componentdidMout / componentdidUpdate 中查看 src 是否更新，将子组件注册给 observer
