### PR TITLE
fix: [Typography] remove unnecessary ellipsis waring when ellipsis no…

### DIFF
--- a/packages/semi-ui/typography/_story/typography.stories.jsx
+++ b/packages/semi-ui/typography/_story/typography.stories.jsx
@@ -719,7 +719,7 @@ export const EdgeCases = () => (
         collapseText: '折叠我吧' 
       }} 
       style={{ width: 300 }}>
-        case 2：长度刚好符合预期，不应该省略，不应该显示展开按钮。长度刚好符合预期，不应该省略，不应该显示展开按钮。不应该显示展开的。
+        case 3：长度刚好符合预期，不应该省略，不应该显示展开按钮。长度刚好符合预期，不应该省略，不应该显示展开按钮。不应该显示展开的。
     </Paragraph>
   </>
 );
@@ -794,3 +794,18 @@ export const whiteSpaceNoWrap = () => (
     </Typography.Text>
   </div>
 )
+
+export const TextNoWarning = () => {
+  const { Text } = Typography;
+  return (
+    <div>
+      <div style={{ width: 500 }}>
+        <Text 
+          style={{ width: 300 }}
+        >
+          <div>这是一个非 string 类型的 Text 的 children, 无省略功能，控制台不应该出现和省略相关的 warning</div>
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -643,7 +643,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         );
         if (this.props.ellipsis) {
             return (
-                <ResizeObserver onResize={this.onResize}>
+                <ResizeObserver onResize={this.onResize} observeParent>
                     {content}
                 </ResizeObserver>
             );

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -632,16 +632,22 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
     }
 
     render() {
-        return (
-            <ResizeObserver onResize={this.props.ellipsis ? this.onResize : undefined}>
-                <LocaleConsumer componentName="Typography">     
-                    {(locale: Locale['Typography']) => {
-                        this.expandStr = locale.expand;
-                        this.collapseStr = locale.collapse;
-                        return this.renderTipWrapper();
-                    }}
-                </LocaleConsumer>
-            </ResizeObserver>
+        const content = (
+            <LocaleConsumer componentName="Typography">
+                {(locale: Locale['Typography']) => {
+                    this.expandStr = locale.expand;
+                    this.collapseStr = locale.collapse;
+                    return this.renderTipWrapper();
+                }}
+            </LocaleConsumer>
         );
+        if (this.props.ellipsis) {
+            return (
+                <ResizeObserver onResize={this.onResize}>
+                    {content}
+                </ResizeObserver>
+            );
+        }
+        return content;
     }
 }

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -279,13 +279,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         }
         const { expanded } = this.state;
         const canUseCSSEllipsis = this.canUseCSSEllipsis();
-
-        // Currently only text truncation is supported, if there is non-text, 
-        // both css truncation and js truncation should throw a warning
-        warning(
-            'children' in this.props && typeof children !== 'string',
-            "[Semi Typography] 'Only children with pure text could be used with ellipsis at this moment."
-        );
+        
 
         // If children is null, css/js truncated flag isTruncate is false
         if (isNull(children)) {
@@ -295,6 +289,13 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             });
             return undefined;
         }
+
+        // Currently only text truncation is supported, if there is non-text, 
+        // both css truncation and js truncation should throw a warning
+        warning(
+            'children' in this.props && typeof children !== 'string',
+            "[Semi Typography] Only children with pure text could be used with ellipsis at this moment."
+        );
 
         if (!rows || rows < 0 || expanded) {
             return undefined;
@@ -632,7 +633,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
 
     render() {
         return (
-            <ResizeObserver onResize={this.onResize}>
+            <ResizeObserver onResize={this.props.ellipsis ? this.onResize : undefined}>
                 <LocaleConsumer componentName="Typography">     
                     {(locale: Locale['Typography']) => {
                         this.expandStr = locale.expand;


### PR DESCRIPTION
…t turn on

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 去除 Typography 中省略未开启时的 ellipsis warning 

---

🇺🇸 English
- Fix: remove the ellipsis warning when omitting is not enabled in Typography


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
