### PR TITLE
fix: some font weight use scss token in themepackage

### DIFF
--- a/packages/semi-foundation/avatar/avatar.scss
+++ b/packages/semi-foundation/avatar/avatar.scss
@@ -33,7 +33,7 @@ $colors: 'amber', 'blue', 'cyan', 'green', 'grey', 'indigo', 'light-blue', 'ligh
         display: flex;
         align-items: center;
         @include font-size-regular;
-        font-weight: 600;
+        font-weight: $font-weight-bold;
     }
 
     &-content {

--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -257,7 +257,7 @@ $module: #{$prefix}-cascader;
     &-inset-label {
         display: inline;
         margin-right: $spacing-cascader_label-marginRight;
-        font-weight: 600;
+        font-weight: $font-weight-bold;
         @include font-size-regular;
         color: $color-cascader_label-text-default;
         flex-shrink: 0;

--- a/packages/semi-foundation/form/form.scss
+++ b/packages/semi-foundation/form/form.scss
@@ -286,7 +286,7 @@ $rating: #{$prefix}-rating;
         margin-block-start: 0;
         margin-block-end: 0;
         @include font-size-header-5;
-        font-weight: 600;
+        font-weight: $font-weight-bold;
         width: 100%;
         padding-bottom: $spacing-form_section_text-paddingBottom;
         padding-top: $spacing-form_section_text-paddingTop;

--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -515,7 +515,7 @@ $module: #{$prefix}-input;
         &-text {
             margin: 0 $spacing-base-tight;
             color: $color-input_prefix-text-default;
-            font-weight: 600;
+            font-weight: $font-weight-bold;
             white-space: nowrap;
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Replace some raw value of font weight with scss token in theme package.

### Changelog
🇨🇳 Chinese
- Fix: Avatar Cascader form input 的字重定义使用默认 `$font-weight-bold`

---

🇺🇸 English
- Fix: Avatar Cascader form input font weight use `$font-weight-bold`


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
