### PR TITLE
fix: fixed DatePicker timeZone map logic and use Etc/GMT* id #1585

### DIFF
--- a/packages/semi-foundation/utils/date-fns-extra.ts
+++ b/packages/semi-foundation/utils/date-fns-extra.ts
@@ -52,6 +52,40 @@ export const IANAOffsetMap = [
     [14, ['Pacific/Kiritimati']],
 ];
 
+/**
+ * Etc/GMT* no DST
+ * @see https://data.iana.org/time-zones/tzdb/etcetera
+ */
+const IANAEtcGMTOffsetMap = {
+    '0': 'Etc/GMT',
+    '1': 'Etc/GMT-1',
+    '2': 'Etc/GMT-2',
+    '3': 'Etc/GMT-3',
+    '4': 'Etc/GMT-4',
+    '5': 'Etc/GMT-5',
+    '6': 'Etc/GMT-6',
+    '7': 'Etc/GMT-7',
+    '8': 'Etc/GMT-8',
+    '9': 'Etc/GMT-9',
+    '10': 'Etc/GMT-10',
+    '11': 'Etc/GMT-11',
+    '12': 'Etc/GMT-12',
+    '13': 'Etc/GMT-13',
+    '14': 'Etc/GMT-14',
+    '-1': 'Etc/GMT+1',
+    '-2': 'Etc/GMT+2',
+    '-3': 'Etc/GMT+3',
+    '-4': 'Etc/GMT+4',
+    '-5': 'Etc/GMT+5',
+    '-6': 'Etc/GMT+6',
+    '-7': 'Etc/GMT+7',
+    '-8': 'Etc/GMT+8',
+    '-9': 'Etc/GMT+9',
+    '-10': 'Etc/GMT+10',
+    '-11': 'Etc/GMT+11',
+    '-12': 'Etc/GMT+12',
+};
+
 const GMTStringReg = /([\-\+]{1})(\d{2})\:(\d{2})/;
 
 /**
@@ -74,10 +108,32 @@ export const toIANA = (tz: string | number) => {
     }
 
     if (typeof tz === 'number') {
+        // if tz can be transformed to a Etc/GMT* and browser supports it
+        if (tz in IANAEtcGMTOffsetMap) {
+            const etcGMTtimeZone = IANAEtcGMTOffsetMap[tz];
+            if (isValidTimezoneIANAString(etcGMTtimeZone)) {
+                return etcGMTtimeZone;
+            }
+        }
         const found = IANAOffsetMap.find(item => item[0] === tz);
         return found && found[1][0];
     }
 };
+
+const validIANATimezoneCache = {};
+/**
+ * @see https://github.com/marnusw/date-fns-tz/blob/a92e0ad017d101a0c50e39a63ef5d322b4d849f6/src/_lib/tzParseTimezone/index.js#L137
+ */
+export function isValidTimezoneIANAString(timeZoneString: string) {
+    if (validIANATimezoneCache[timeZoneString]) return true;
+    try {
+        new Intl.DateTimeFormat(undefined, { timeZone: timeZoneString });
+        validIANATimezoneCache[timeZoneString] = true;
+        return true;
+    } catch (error) {
+        return false;
+    }
+}
 
 /**
  *

--- a/packages/semi-ui/datePicker/_story/v2/FeatEtcGMT.tsx
+++ b/packages/semi-ui/datePicker/_story/v2/FeatEtcGMT.tsx
@@ -1,0 +1,27 @@
+import React, { useMemo } from 'react';
+import { DatePicker, Space } from '@douyinfe/semi-ui';
+
+App.storyName = 'timeZone Etc/GMT*';
+
+/**
+ * test with chromatic
+ * @see https://github.com/DouyinFE/semi-design/issues/1585
+ */
+export default function App(props = {}) {
+    const gmtList = useMemo(() => {
+        const list = [];
+        for (let hourOffset = -11; hourOffset <= 14; hourOffset++) {
+            const prefix = hourOffset >= 0 ? '+' : '-';
+            const hOffset = Math.abs(parseInt(hourOffset, 10));
+            list.push(`GMT${prefix}${String(hOffset).padStart(2, '0')}:00`);
+        }
+        return list;
+    }, []);
+    return (
+        <Space vertical>
+            {gmtList.map(gmt => (
+                <DatePicker key={gmt} prefix={gmt} timeZone={gmt} type={'dateTime'} defaultValue={1683084540000} />
+            ))}
+        </Space>
+    );
+}

--- a/packages/semi-ui/datePicker/_story/v2/index.js
+++ b/packages/semi-ui/datePicker/_story/v2/index.js
@@ -22,3 +22,4 @@ export { default as FeatOnClickOutside } from './FeatOnClickOutside';
 export { default as FeatRefClass } from './FeatRefClass';
 export { default as FixNeedConfirmInTabs } from './FixNeedConfirmInTabs';
 export { default as DynamicDisabledDate } from './dynamicDisabledDate';
+export { default as FeatEtcGMT } from './FeatEtcGMT';


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1585

Etc/GMT 在做时区转换时，不考虑夏令时，使用它会比具体某个地区的时区好，因为某个地区的时区可能随着时间变化而调整是否应用夏令时。（例如 +2 时区，埃及/开罗，在2023.4.28，时隔七年后又重新决定启用夏令时）

### Changelog
🇨🇳 Chinese
- Fix: 修复 DatePicker timeZone 为整数值时的判断逻辑，使用 IANA Etc/GMT 替换 IANA 地区标识 #1585

---

🇺🇸 English
- Fix: Fix the judgment logic when DatePicker timeZone is an integer value, and replace the IANA region identifier with IANA Etc/GMT #1585


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
