### PR TITLE
Fix/breadcrumb max item count

### DIFF
--- a/cypress/integration/breadcrumb.spec.js
+++ b/cypress/integration/breadcrumb.spec.js
@@ -1,0 +1,7 @@
+describe('breadcrumb', () => {
+    it('moreType + maxItemCount', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=breadcrumb--max-item-count-and-more-type&args=&viewMode=story');
+        cy.get('.semi-breadcrumb-item-more').trigger('mouseover');
+        cy.get('.semi-popover-content').children('.semi-breadcrumb-item-wrap').should('have.length', 2);
+    });
+});

--- a/packages/semi-ui/breadcrumb/_story/breadcrumb.stories.jsx
+++ b/packages/semi-ui/breadcrumb/_story/breadcrumb.stories.jsx
@@ -329,3 +329,14 @@ export const RenderMore = () => (
     </div>
   </div>
 );
+
+export const MaxItemCountAndMoreType = () => (
+  // 用于测试 moreType 为 popover, maxItemCount 自定义情况下，
+  // item 个数超出时候是否可弹出, 弹出层中内容是否正确
+  <Breadcrumb maxItemCount={2} moreType={'popover'}>
+    <Breadcrumb.Item>第一层</Breadcrumb.Item>
+    <Breadcrumb.Item>第二层</Breadcrumb.Item>
+    <Breadcrumb.Item>第二层</Breadcrumb.Item>
+    <Breadcrumb.Item>第四层</Breadcrumb.Item>
+  </Breadcrumb>
+);

--- a/packages/semi-ui/breadcrumb/index.tsx
+++ b/packages/semi-ui/breadcrumb/index.tsx
@@ -162,7 +162,7 @@ class Breadcrumb extends BaseComponent<BreadcrumbProps, BreadcrumbState> {
     handleCollapse = (template: Array<React.ReactNode>, itemsLen: number) => {
         const { maxItemCount, renderMore, moreType } = this.props;
         const hasRenderMore = isFunction(renderMore);
-        const restItem = template.slice(1, itemsLen - 3);
+        const restItem = template.slice(1, itemsLen - maxItemCount + 1);
         const spread = (
             <span className={`${clsPrefix}-collapse`} key={`more-${itemsLen}`}>
                 <span className={`${clsPrefix}-item-wrap`}>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 BreadCrumb 在设置 moreType 为 popover， MaxItem 为非默认值时候，弹出层中内容个数不正确问题

---

🇺🇸 English
- Fix: fix the problem that when BreadCrumb sets moreType to popover and MaxItem to a non-default value, the number of contents in the popup layer is incorrect

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
