### PR TITLE
fix: [Image] Put the declaration of the IntersectionObserver object in ImagePreview in componentdidMount to prevent errors in SSR scenarios

### DIFF
--- a/packages/semi-ui/image/image.tsx
+++ b/packages/semi-ui/image/image.tsx
@@ -82,22 +82,6 @@ export default class Image extends BaseComponent<ImageProps, ImageStates> {
         return willUpdateStates;
     }
 
-    componentDidMount() {
-        this.observeImage();
-    }
-
-    componentDidUpdate(prevProps: ImageProps, prevState: ImageStates) {
-        prevProps.src !== this.props.src && this.observeImage();
-    }
-
-    observeImage() {
-        if (!this.isLazyLoad()) {
-            return;
-        }
-        const { previewObserver } = this.context;
-        previewObserver.observe(this.imgRef.current);
-    }
-
     isInGroup() {
         return Boolean(this.context && this.context.isGroup);
     }

--- a/packages/semi-ui/image/preview.tsx
+++ b/packages/semi-ui/image/preview.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from "react";
+import React, { ReactNode, isValidElement } from "react";
 import { PreviewContext } from "./previewContext";
 import BaseComponent from "../_base/baseComponent";
 import PropTypes, { array } from "prop-types";
@@ -84,15 +84,21 @@ export default class Preview extends BaseComponent<PreviewProps, PreviewState> {
     }
 
     componentDidMount() {
-        this.observerImages();
+        this.props.lazyLoad && this.observerImages();
     }
 
     componentDidUpdate(prevProps) {
-        const prevChildren = React.Children.toArray(prevProps.children);
-        const currChildren = React.Children.toArray(this.props.children);
-    
-        if (!isEqual(prevChildren, currChildren)) {
-            this.observerImages();
+        if (this.props.lazyLoad) {
+            const prevChildrenKeys = React.Children.toArray(prevProps.children).map((child) =>
+                isValidElement(child) ? child.key : null
+            );
+            const currChildrenKeys = React.Children.toArray(this.props.children).map((child) =>
+                isValidElement(child) ? child.key : null
+            );
+        
+            if (!isEqual(prevChildrenKeys, currChildrenKeys)) {
+                this.observerImages();
+            }
         }
     }
 

--- a/packages/semi-ui/image/preview.tsx
+++ b/packages/semi-ui/image/preview.tsx
@@ -109,6 +109,13 @@ export default class Preview extends BaseComponent<PreviewProps, PreviewState> {
         return willUpdateStates;
     }
 
+    componentWillUnmount(): void {
+        if (this.previewObserver) {
+            this.previewObserver.disconnect();
+            this.previewObserver = null;
+        }
+    }
+
     handleVisibleChange = (newVisible: boolean) => {
         this.foundation.handleVisibleChange(newVisible);
     };


### PR DESCRIPTION
…iew unmount phase

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1595 

### Changelog
🇨🇳 Chinese
- Fix:  将 ImagePreview 中的 IntersectionObserver 对象的声明放在 componentDidMount 而不是 constructor 中，防止 SSR 场景下出错 #1595 
---

🇺🇸 English
- Fix: Put the declaration of the IntersectionObserver object in ImagePreview in componentDidMount instead of constructor to prevent errors in SSR scenarios #1595 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

IntersectionObserver 的对象放在 constructor 中，是为了让 ImagePreview 下的 children 的 Image 能够拿到该 observer，在 Image 的 componentDidMount/ componentDidUpdata 中 props的src 变化时候能够被 observer 观察到。

由于IntersectionObserver 是浏览器 API， 放在 constructor 中会导致 SSR 场景下报错， 因此修改到 ImagePreview 的 componentDidMount 中，同时将在 componentDidUpdate 中对 children 进行监视，如果children 发生修改修改，则重新监听 img 元素