### PR TITLE
Fix search input icon

### DIFF
--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -462,8 +462,7 @@ $module: #{$prefix}-input;
     &[type="password"]::-ms-clear {
         display: none;
     }
-    &[type="search"]::-webkit-search-cancel-button,
-    &[type="search"]::-moz-search-cancel {
+    &[type="search"]::-webkit-search-cancel-button {
         display: none;
     }
 

--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -462,6 +462,10 @@ $module: #{$prefix}-input;
     &[type="password"]::-ms-clear {
         display: none;
     }
+    &[type="search"]::-webkit-search-cancel-button,
+    &[type="search"]::-moz-search-cancel {
+        display: none;
+    }
 
     &::placeholder {
         color: $color-input_placeholder-text-default;

--- a/packages/semi-ui/input/_story/input.stories.jsx
+++ b/packages/semi-ui/input/_story/input.stories.jsx
@@ -104,11 +104,12 @@ InputDisabled.story = {
 export const InputClearable = () => (
   <div className="input">
     <Input showClear defaultValue="ies" />
+    <Input showClear defaultValue="search input" type='search' />
   </div>
 );
 
 InputClearable.story = {
-  name: 'Input clearable',
+  name: 'Input showClear',
 };
 
 export const InputPrefixSuffixDemo = () => (


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description


### Changelog
🇨🇳 Chinese
- Fix: 修复 Input type=search 且 showClear 为true时，原生清除按钮与 Semi 清除按钮同时显示的问题
![img_v2_de350c3e-4af1-4270-84e5-8fa0b85f7e9g](https://user-images.githubusercontent.com/88709023/236984491-1340cb5d-e363-4b89-bfcb-697bfef8d610.jpg)

---

🇺🇸 English
- Fix: When Input type=search and showClear is true, the original clear button and the Semi clear button are displayed at the same time


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
