### PR TITLE
fix: only compare key to determine whether to update the item #1456 #1502

### DIFF
--- a/cypress/integration/tabs.spec.js
+++ b/cypress/integration/tabs.spec.js
@@ -82,4 +82,22 @@ describe('tabs', () => {
         cy.get('[id=semiTab1]').type('{backspace}');
         cy.get('[id=semiTab1]').should('not.exist');
     });
+
+    it('collapsible', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=tabs--fix-1456&args=&viewMode=story');
+
+        // Ensure the correctness of the dropdown item after selection
+        cy.get('[id=semiTab2]').click();
+        cy.get('.semi-button').eq(1).trigger('mouseover');
+        cy.get('.semi-dropdown-content .semi-dropdown-item').contains('tab-7').should('exist');
+        cy.get('li span').contains('Tab-0').should('not.exist');
+        
+        cy.get('.semi-button').eq(1).trigger('mouseout');
+
+        // Make sure that the state of the button does not change after vertical scrolling makes the tabs obscured
+        cy.get('.semi-button').eq(2).click();
+        cy.get('[id=wrapper]').scrollTo(0, 40);
+        cy.get('.semi-button-disabled').eq(0).should('exist');
+        cy.get('.semi-tabs-bar-arrow .semi-button-primary').eq(0).should('exist');
+    });
 });

--- a/packages/semi-ui/overflowList/index.tsx
+++ b/packages/semi-ui/overflowList/index.tsx
@@ -170,8 +170,15 @@ class OverflowList extends BaseComponent<OverflowListProps, OverflowListState> {
 
     componentDidUpdate(prevProps: OverflowListProps, prevState: OverflowListState): void {
 
+        const prevItemsKeys = prevProps.items.map((item) =>
+            item.key
+        );
+        const nowItemsKeys = this.props.items.map((item) =>
+            item.key
+        );
 
-        if (!isEqual(prevProps.items, this.props.items)) {
+        // Determine whether to update by comparing key values
+        if (!isEqual(prevItemsKeys, nowItemsKeys)) {
             this.itemRefs = {};
             this.setState({ visibleState: new Map() });
         }

--- a/packages/semi-ui/tabs/_story/tabs.stories.jsx
+++ b/packages/semi-ui/tabs/_story/tabs.stories.jsx
@@ -963,3 +963,27 @@ export const TabItem = () => {
     ))}
   </div>)
 }
+
+
+export const Fix1456 = () =>{
+  const [key, setKey] = useState([0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+
+  return (
+        <div id='wrapper' style={{ height: 300, overflowY: 'scroll' }}>
+          <div style={{ height: 500 }}>
+          <Tabs style={{ width: '300px', margin: '20px' }} type="card" collapsible>
+            {key.map(i => (
+              <TabPane tab={`tab-${i}`} itemKey={`${i}`} key={i}>
+                  Content of card tab {i}
+              </TabPane>
+            ))}
+          </Tabs>
+          <Button onClick={()=>{setKey([8, 9, 10, 11, 12, 13, 14, 15])}}>change key</Button>
+        </div>
+        </div>
+  );
+}
+
+Fix1456.story = {
+  name: 'Fix-1456',
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -1680,7 +1680,7 @@
     memoize-one "^5.2.1"
     scroll-into-view-if-needed "^2.2.24"
 
-"@douyinfe/semi-icons@2.33.1", "@douyinfe/semi-icons@^2.0.0", "@douyinfe/semi-icons@latest":
+"@douyinfe/semi-icons@2.33.1", "@douyinfe/semi-icons@latest":
   version "2.33.1"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.33.1.tgz#8e2871d9bc0ab7e12df74e3c71802d53d69b7425"
   integrity sha512-OfPHihSmUPqFbHOSp9EGquX1c8HC8m9PVqjILYPYzz5WjM1uAfKeMLOQnrCc8CCWVIAx7UGpwExdufpPcNkj2Q==
@@ -1765,7 +1765,7 @@
   dependencies:
     glob "^7.1.6"
 
-"@douyinfe/semi-ui@^2.0.0", "@douyinfe/semi-ui@latest":
+"@douyinfe/semi-ui@latest":
   version "2.33.1"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-ui/-/semi-ui-2.33.1.tgz#3234ca96eb3560b8299bc9750fbe59446522d9bb"
   integrity sha512-zHyjhLm2Q2l8l4ric+xHy22sPDSP+y/QmUEmQxhmWfgQosA3PEYV5OWsa7BGm033bQxF7GNRxpO5O4MGsHxn8Q==
@@ -11153,11 +11153,6 @@ eslint-plugin-react@^7.20.6, eslint-plugin-react@^7.24.0:
     resolve "^2.0.0-next.3"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.6"
-
-eslint-plugin-semi-design@^2.33.0:
-  version "2.33.1"
-  resolved "https://registry.npmjs.org/eslint-plugin-semi-design/-/eslint-plugin-semi-design-2.33.1.tgz#fa68c62c27efbf71150bfcbf73bcc8544033c3eb"
-  integrity sha512-ZpOUV7btOuG1Y+cOftaTQUdfHjBalHtR4T9/6vdBccsKz2VH2RDlK6r7u91cHtpLAR0Sdwm3HyKcDPFEZ7xvKw==
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION


<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1456  #1502
之前通过直接比较 items 更新前后的值，来解决 tabs 的 tabpanel 值改变后的 visibleState 问题。具体见 #1363 
点击 tab 跳转后会导致 items 的 active 值变化，造成不预期的 setState  visibleState，所以为了达到 fix #1363 的效果，仅比较 key 值即可。

Previously, the visibleState problem after the tabpanel value of tabs changed was solved by directly comparing the values before and after the items were updated. See #1363 for details
Clicking the tab to jump will cause the active value of items to change, resulting in unexpected setState visibleState, so in order to achieve the effect of fix #1363, only compare the key value.

### Changelog
🇨🇳 Chinese
- Fix: 修复 collapsible Tabs 切换 tab 后，Dropdown item 异常问题

---

🇺🇸 English
- Fix: fix the problem that the Dropdown item is abnormal after switching tabs in collapsible Tabs


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
