### PR TITLE
fix: select is single select and renderSelectedItem, the placeholder is not displayed when the value is null #1584

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -247,7 +247,7 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
         const selectedValue = onChangeWithObject && typeof propValue !== 'undefined' ? (propValue as BasicOptionProps).value : propValue;
         const selectedOptions = originalOptions.filter(option => option.value === selectedValue);
 
-        const noMatchOptionInList = !selectedOptions.length && typeof selectedValue !== 'undefined';
+        const noMatchOptionInList = !selectedOptions.length && typeof selectedValue !== 'undefined' && selectedValue !== null;
 
         // If the current value, there is a matching option in the optionList
         if (selectedOptions.length) {

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -3251,4 +3251,41 @@ export const emptyContent = () => {
   )
 }
 
+export const Fix1584 = () => {
+  return (
+    <>
+      defaultValue is null
+      <br />
+      <Select 
+        style={{ width: 180 }} 
+        defaultValue={null}
+        placeholder="带搜索功能的单选"
+        renderSelectedItem={(item) => {
+          console.log('items', item);  
+          return <div>{item.label}</div>}}
+      >
+        <Select.Option value="abc">抖音</Select.Option>
+        <Select.Option value="ulikecam">轻颜相机</Select.Option>
+        <Select.Option value="jianying">剪映</Select.Option>
+        <Select.Option value="xigua">西瓜视频</Select.Option>
+      </Select>
+      <br />
+      <br />
+      defaultValue is undefined
+      <br />
+      <Select 
+        style={{ width: 180 }} 
+        defaultValue={undefined}
+        placeholder="带搜索功能的单选"
+        renderSelectedItem={(item) => <div>{item.label}</div>}
+      >
+        <Select.Option value="abc">抖音</Select.Option>
+        <Select.Option value="ulikecam">轻颜相机</Select.Option>
+        <Select.Option value="jianying">剪映</Select.Option>
+        <Select.Option value="xigua">西瓜视频</Select.Option>
+      </Select>
+    </>
+  );
+}
+
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # 1584

### Changelog
🇨🇳 Chinese
- Fix: 修复 select 单选和 renderSelectedItem 情况下，defaultValue 为 null 时不显示 placeholder 问题

---

🇺🇸 English
- Fix: fix select is single select and renderSelectedItem, the placeholder is not displayed when the value is null


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
