### PR TITLE
feat: [Anchor] The showTooltip API of Anchor supports object type

### DIFF
--- a/content/navigation/anchor/index-en-US.md
+++ b/content/navigation/anchor/index-en-US.md
@@ -342,7 +342,7 @@ import { Anchor } from '@douyinfe/semi-ui';
 | position     | Tooltip position，same as `position` property of Tooltip component                                                  | string                              | -         | |
 | railTheme    | Style of scroll rail，one of `primary`，`tertiary`，`muted`                                                         | string                              | `primary` | |
 | scrollMotion | Animation of scroll behavior                                                                                        | boolean                             | false     | |
-| showTooltip  | Show Tooltip                                                                                                        | boolean                             | false     | |
+| showTooltip  | Toggle whether to show tooltip, if passed in as object: type，type of component to show tooltip, support Tooltip and Popover, the default is Tooltip; opts, properties that will be passed directly to the component. The object form setting is provided since version 2.36.0   | boolean \| {type: 'tooltip'\|'popover', opts: object}                             | false     | |
 | size         | Size of Anchor，one of `small`，`default`                                                                           | string                              | `default` | |
 | style        | Style object                                                                                                        | object                              | -         | |
 | targetOffset | Anchor offset from top of target                                                                     | number                              | 0         | 1.9.0 |

--- a/content/navigation/anchor/index.md
+++ b/content/navigation/anchor/index.md
@@ -264,7 +264,7 @@ import { Anchor } from '@douyinfe/semi-ui';
 
 ### 显示工具提示
 
-Anchor 设置 `showTooltip` 可以在 Link 超出最大宽度时显示 Link 的文字内容。默认值为 `false`。
+Anchor 设置 `showTooltip` 可以在 Link 超出最大宽度时显示 Link 的文字内容。默认值为 `false`, 更多使用参考 API 说明。
 
 ```jsx live=true
 import React from 'react';
@@ -343,7 +343,7 @@ import { Anchor } from '@douyinfe/semi-ui';
 | position      | Tooltip 显示位置，可选值同 Tooltip 组件 position | string                              | -         |        |
 | railTheme     | 滑轨主题，可选值：`primary`，`tertiary`，`muted` | string                              | `primary` |        |
 | scrollMotion  | 是否开启滚动动画                                 | boolean                             | false     |        |
-| showTooltip   | 文字缩略时是否显示 Tooltip                       | boolean                             | false     |        |
+| showTooltip   | 文字缩略时是否显示 Tooltip 及相关配置, type，浮层内容承载的组件，支持 Tooltip（默认） \| Popover；opts，其他需要透传给浮层组件的属性, object 形式设置自 2.36.0 版本提供   | boolean \| {type: 'tooltip'\|'popover', opts: object}  | false     |        |
 | size          | 锚点尺寸，可选值： `small`，`default`            | string                              | `default` |        |
 | style         | 样式对象                                         | object                              | -         |        |
 | targetOffset  | 锚点滚动时距离顶部偏移量                         | number                              | 0         | 1.9.0  |

--- a/packages/semi-ui/anchor/_story/anchor.stories.jsx
+++ b/packages/semi-ui/anchor/_story/anchor.stories.jsx
@@ -286,3 +286,31 @@ export const AutoCollapse = () => {
       </div>
   )
 };
+
+export const SetTooltip = () => {
+  const getContainer = () => {
+      return document.querySelector('window');
+  };
+  return (
+      <div>
+          <Anchor
+              showTooltip={{
+                type: 'popover',
+                opts: {
+                  style: { wordBreak: 'break-all' }
+                }
+              }}
+              position={'right'}
+              getContainer={getContainer}
+              targetOffset={60}
+              offsetTop={100}
+          >
+              <Anchor.Link href="#工具提示位置" title="基本示例111111111111111111111111111111111111111111111112" />
+              <Anchor.Link href="#组件" title="组件" />
+              <Anchor.Link href="#设计语言" title="设计语言" />
+              <Anchor.Link href="#物料平台" title="物料平台" />
+              <Anchor.Link href="#主题商店" title="主题商店" />
+          </Anchor>
+      </div>
+  );
+};

--- a/packages/semi-ui/anchor/index.tsx
+++ b/packages/semi-ui/anchor/index.tsx
@@ -11,6 +11,7 @@ import { noop, debounce, throttle } from 'lodash';
 import getUuid from '@douyinfe/semi-foundation/utils/uuid';
 import { ArrayElement } from '../_base/base';
 import ConfigContext, { ContextValue } from '../configProvider/context';
+import { ShowTooltip } from '../typography/interface';
 
 const prefixCls = cssClasses.PREFIX;
 
@@ -28,7 +29,7 @@ export interface AnchorProps {
     position?: ArrayElement<typeof strings.POSITION_SET>;
     railTheme?: ArrayElement<typeof strings.SLIDE_COLOR>;
     scrollMotion?: boolean;
-    showTooltip?: boolean;
+    showTooltip?: boolean | ShowTooltip;
     size?: ArrayElement<typeof strings.SIZE>;
     style?: React.CSSProperties;
     targetOffset?: number;

--- a/packages/semi-ui/anchor/link.tsx
+++ b/packages/semi-ui/anchor/link.tsx
@@ -100,12 +100,17 @@ export default class Link extends BaseComponent<LinkProps, {}> {
             [`${prefixCls}-link-tooltip-active`]: active,
             [`${prefixCls}-link-tooltip-disabled`]: disabled,
         });
-        const toolTipOpt = position ? { position } : {};
         if (showTooltip) {
+            const showTooltipObj = Object.prototype.toString.call(showTooltip) === '[object Object]' ? 
+                Object.assign({ opts: {} }, showTooltip) : { opts: {} };
+            // The position can be set through showTooltip, here it is compatible with the position API
+            if (position) {
+                showTooltipObj.opts['position'] = position;
+            }
             return (
                 <Typography.Text
                     size={size === 'default' ? 'normal' : 'small'}
-                    ellipsis={{ showTooltip: { opts: { ...toolTipOpt } } }}
+                    ellipsis={{ showTooltip: showTooltipObj }}
                     type={'tertiary'}
                     className={linkTitleCls}
                 >


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Feat: Anchor 的 showTooltip API 支持 object 类型设置

---

🇺🇸 English
- Fix: The showTooltip API of Anchor supports object type


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
Link 底层使用 Typography 进行省略，为支持设置 弹出层更多属性，因此 showTooltip API 支持 object 类型配置，object 具体设置和 Typography 中相同