### PR TITLE
fix: timepicker under timezone and controll get the wrong time after select in panel in 1.3.8 date-fns-tz

### DIFF
--- a/packages/semi-foundation/timePicker/foundation.ts
+++ b/packages/semi-foundation/timePicker/foundation.ts
@@ -84,10 +84,8 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
         return hDis || mDis || sDis;
     }
 
-    isValidTimeZone(timeZone?: string | number) {
-        const _timeZone = timeZone === undefined ? this.getProp('timeZone') : timeZone;
-
-        return ['string', 'number'].includes(typeof _timeZone) && _timeZone !== '';
+    isValidTimeZone(timeZone: string | number) {
+        return ['string', 'number'].includes(typeof timeZone) && timeZone !== '';
     }
 
     getDefaultFormatIfNeed(): string {
@@ -121,7 +119,7 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
         (value as any[]).forEach(v => {
             const pv = parseToDate(v, formatToken, dateFnsLocale);
             if (!isNaN(pv.getTime())) {
-                parsedValues.push(this.isValidTimeZone() ? utcToZonedTime(pv, timeZone) : pv);
+                parsedValues.push(this.isValidTimeZone(timeZone) ? utcToZonedTime(pv, timeZone) : pv);
             }
         });
 
@@ -422,7 +420,7 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
             _value = Array.isArray(_value) ? _value[0] : _value;
         }
 
-        if (this.isValidTimeZone() && _value) {
+        if (this.isValidTimeZone(timeZone) && _value) {
             const formatToken = this.getValidFormat();
             if (Array.isArray(_value)) {
                 _value = _value.map(v => zonedTimeToUtc(v, timeZone));

--- a/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
+++ b/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
@@ -299,3 +299,16 @@ export const TimePickerWithOnChangeWithDateFirst = () => {
 TimePickerWithOnChangeWithDateFirst.story = {
   name: 'OnChangeWithDateFirst',
 };
+
+export const Fix1604 = () => {
+  const [value, setValue] = useState();
+  return (
+    <div>
+      <TimePicker value={value} onChange={(value) => {console.log('onChange', value); setValue(value);}} timeZone={0}/>
+    </div>
+  );
+};
+
+Fix1604.story = {
+  name: 'Fix Time Zone',
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1604

造成 bug 的主要原因是 date-fns-tz 1.3.7 ➡️ 1.3.8 的[变更](https://github.com/marnusw/date-fns-tz/commit/3bd32eef5dcdcbfd82709529ccc88ffa10fe50ff#diff-4c06f3ee39f66c80220e59b7d2c1f7d21d5406d5870dd737bd692538467deb69)。
![image](https://github.com/DouyinFE/semi-design/assets/101160769/6aa6a7f9-c57e-4253-ab01-e720452f6954)

该变更直接影响了 zonedTimeToUtc 函数 timezone 传 undefined 后的结果
before ：返回原时间
after：返回+8后的时间，相当于timezone 0
![image](https://github.com/DouyinFE/semi-design/assets/101160769/f9b0646a-b6a3-45ae-a7ff-c1ea1501acae)
![image](https://github.com/DouyinFE/semi-design/assets/101160769/039e2e02-e1e7-469b-a2e2-eeae9c653ac0)


semi 侧主要影响的相关代码是 `refreshProps` 中的  `isValidTimeZone` 。
原来 this.isValidTimeZone(__prevTimeZone) 为 true，__prevTimeZone 为 undefined，zonedTimeToUtc 后仍为原时间，是我们想要的结果。
date-fns-tz 1.3.8后，zonedTimeToUtc 的结果为 + 8后的时间，是非预期的结果。

所以正确的修改策略应该是避免给 zonedTimeToUtc 的timezone传 undefined ，使其始终有合法的 timezone。

### Changelog
🇨🇳 Chinese
- Fix: 修复 TimePicker 在 date-fns-tz 版本 >= 1.3.8 时 timeZone 转换问题

---

🇺🇸 English
- Fix: fix TimePicker timeZone conversion problem when date-fns-tz version >= 1.3.8


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
