### PR TITLE
fix: calendar range mode

### DIFF
--- a/packages/semi-foundation/calendar/foundation.ts
+++ b/packages/semi-foundation/calendar/foundation.ts
@@ -201,7 +201,8 @@ export default class CalendarFoundation<P = Record<string, any>, S = Record<stri
         const { range, weekStartsOn } = this.getProps();
         const len = differenceInCalendarDays(range[1], range[0]);
         data.month = format(value, 'LLL', { locale: dateFnsLocale, weekStartsOn });
-        data.week = calcRangeData(value, range[0], len, 'week', dateFnsLocale, weekStartsOn);
+        const startDate = startOfDay(range[0]);
+        data.week = calcRangeData(value, startDate, len, 'week', dateFnsLocale, weekStartsOn);
         this._adapter.setRangeData(data);
         return data;
     }

--- a/packages/semi-ui/calendar/__test__/calendar.test.js
+++ b/packages/semi-ui/calendar/__test__/calendar.test.js
@@ -244,9 +244,10 @@ describe('Calendar', () => {
         const events = [
             {
                 key: '0',
+                allDay: false,
                 start: new Date(2023, 3, 1, 8, 32, 0),
                 end: new Date(2023, 3, 1, 9, 32, 0),
-                children: <div className="eventDay" />,
+                children: <div className="eventDay">eventDay</div>,
             },
         ];
         const range = [
@@ -256,12 +257,14 @@ describe('Calendar', () => {
 
         let calendar = mount(<Calendar
             mode="range"
+            height={400}
             displayValue={displayValue}
             range={range}
             events={events}
         ></Calendar>);
+        // force set scrollHeight to avoid skipped events render
+        calendar.childAt(0).setState({ scrollHeight: 400 });
 
-        // 2023-04-01
-        expect(calendar.find(".eventDay").length).toEqual(1);
+        expect(calendar.find(".eventDay").length).toBe(1);
     });
 })

--- a/packages/semi-ui/calendar/__test__/calendar.test.js
+++ b/packages/semi-ui/calendar/__test__/calendar.test.js
@@ -238,4 +238,30 @@ describe('Calendar', () => {
         expect(calendar.find(`.${customClassName}`).length).toEqual(1);
         expect(calendar.find(defaultElementSelector).length).toEqual(0);
     });
+
+    it('test range mode RangeData fixture', () => {
+        const displayValue = new Date(2023, 3, 1, 8, 32, 0);
+        const events = [
+            {
+                key: '0',
+                start: new Date(2023, 3, 1, 8, 32, 0),
+                end: new Date(2023, 3, 1, 9, 32, 0),
+                children: <div className="eventDay" />,
+            },
+        ];
+        const range = [
+            new Date(2023, 3, 1, 8, 32, 0),
+            new Date(2023, 3, 5, 8, 32, 0),
+        ];
+
+        let calendar = mount(<Calendar
+            mode="range"
+            displayValue={displayValue}
+            range={range}
+            events={events}
+        ></Calendar>);
+
+        // 2023-04-01
+        expect(calendar.find(".eventDay").length).toEqual(1);
+    });
 })


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [x] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
当mode=range时，semi用于计算rangeData的时候，会使用`range[0]`作为开始值；当range包含时间的时候，生成的rangeData如图：
![screenshot-20230523-154435](https://github.com/DouyinFE/semi-design/assets/5326684/2786c579-ab73-47ac-b03f-a53700173a1b)
但解析event时，semi默认会使用当日0时的日期作为key：
![screenshot-20230523-154540](https://github.com/DouyinFE/semi-design/assets/5326684/908046fa-dd86-4c6e-9f4d-2d02e2a0eb02)
因此导致range模式且`range[0]`包含时间时，非全天日程会无法显示：
![screenshot-20230523-154703](https://github.com/DouyinFE/semi-design/assets/5326684/cf874295-16b1-4831-9cd3-a275b26a6c2d)
![screenshot-20230523-154635](https://github.com/DouyinFE/semi-design/assets/5326684/85f270bb-34a1-4d27-8d5d-8b3d800cb3d0)
修复后，生成rangeData正常：
![screenshot-20230523-154336](https://github.com/DouyinFE/semi-design/assets/5326684/eb257e05-9557-4678-8a18-604238ec8fae)

Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复日历多日模式中，range包括时间时不显示非全天日程

---

🇺🇸 English
- Fix: in Calendar's range mode, the non-full-day events is not displayed when the `range` includes time

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
