### PR TITLE
feat: DatePicker insetInput support clear icon #1638

### DIFF
--- a/packages/semi-foundation/datePicker/datePicker.scss
+++ b/packages/semi-foundation/datePicker/datePicker.scss
@@ -993,12 +993,15 @@ $module-list: #{$prefix}-scrolllist;
             &:hover {
                 .#{$module}-range-input-clearbtn {
                     display: flex;
-                    color: $color-datepicker_range_input_clearbtn-icon-hover;
                     cursor: pointer;
                 }
 
                 .#{$module}-range-input-clearbtn ~ .#{$module}-range-input-suffix {
                     display: none;
+                }
+
+                .#{$module}-range-input-clearbtn:hover {
+                    color: $color-datepicker_range_input_clearbtn-icon-hover;
                 }
             }
 

--- a/packages/semi-foundation/datePicker/foundation.ts
+++ b/packages/semi-foundation/datePicker/foundation.ts
@@ -617,9 +617,11 @@ export default class DatePickerFoundation extends BaseFoundation<DatePickerAdapt
         const inputValue = '';
         if (!this._isControlledComponent('value')) {
             this._updateValueAndInput(value, true, inputValue);
+            this._adapter.updateInsetInputValue(null);
             this.resetCachedSelectedValue(value);
         }
         this._notifyChange(value);
+        this._adapter.setRangeInputFocus(false);
         this._adapter.notifyClear(e);
     }
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/packages/semi-foundation/datePicker/inputFoundation.ts
+++ b/packages/semi-foundation/datePicker/inputFoundation.ts
@@ -261,6 +261,7 @@ export default class InputFoundation extends BaseFoundation<DateInputAdapter> {
             case 'dateTime':
             case 'dateTimeRange':
                 [datePlaceholder, timePlaceholder] = insetInputFormat.split(' ');
+                break;
             case 'monthRange':
                 datePlaceholder = insetInputFormat + rangeSeparator + insetInputFormat;
                 break;

--- a/packages/semi-foundation/input/foundation.ts
+++ b/packages/semi-foundation/input/foundation.ts
@@ -270,8 +270,8 @@ class InputFoundation extends BaseFoundation<InputAdapter> {
 
     isAllowClear() {
         const { value, isFocus, isHovering } = this._adapter.getStates();
-        const { showClear, disabled } = this._adapter.getProps();
-        const allowClear = value && showClear && !disabled && (isFocus || isHovering);
+        const { showClear, disabled, showClearIgnoreDisabled } = this._adapter.getProps();
+        const allowClear = value && showClear && (!disabled || showClearIgnoreDisabled) && (isFocus || isHovering);
         return allowClear;
     }
 

--- a/packages/semi-ui/datePicker/_story/datePicker.stories.jsx
+++ b/packages/semi-ui/datePicker/_story/datePicker.stories.jsx
@@ -67,7 +67,8 @@ export {
     FixNeedConfirmInTabs,
     DynamicDisabledDate,
     FeatEtcGMT,
-    FixDisabledDate
+    FixDisabledDate,
+    FeatInsetInputShowClear
 } from './v2';
 
 

--- a/packages/semi-ui/datePicker/_story/v2/FeatInsetInputShowClear.tsx
+++ b/packages/semi-ui/datePicker/_story/v2/FeatInsetInputShowClear.tsx
@@ -1,0 +1,17 @@
+import React from "react";
+import { DatePicker, Space, Input } from "@douyinfe/semi-ui";
+
+export default function App() {
+    const props = {
+        insetInput: true,
+        showClear: true,
+        position: "topLeft"
+    } as const;
+    return (
+        <Space vertical align="start">
+            <DatePicker {...props} />
+            <DatePicker {...props} type="dateRange" />
+            <DatePicker {...props} type="dateTimeRange" />
+        </Space>
+    );
+}

--- a/packages/semi-ui/datePicker/_story/v2/index.js
+++ b/packages/semi-ui/datePicker/_story/v2/index.js
@@ -25,3 +25,4 @@ export { default as DynamicDisabledDate } from './dynamicDisabledDate';
 export { default as FeatEtcGMT } from './FeatEtcGMT';
 export { default as FixDisabledDate } from './FixDisabledDate';
 export { default as FeatYearScrollRange } from './FeatYearScrollRange';
+export { default as FeatInsetInputShowClear } from './FeatInsetInputShowClear';

--- a/packages/semi-ui/datePicker/dateInput.tsx
+++ b/packages/semi-ui/datePicker/dateInput.tsx
@@ -38,7 +38,8 @@ export interface DateInputProps extends DateInputFoundationProps, BaseProps {
     value?: Date[];
     inputRef?: React.RefObject<HTMLInputElement>;
     rangeInputStartRef?: React.RefObject<HTMLInputElement>;
-    rangeInputEndRef?: React.RefObject<HTMLInputElement>
+    rangeInputEndRef?: React.RefObject<HTMLInputElement>;
+    showClearIgnoreDisabled?: boolean
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -200,15 +201,16 @@ export default class DateInput extends BaseComponent<DateInputProps, {}> {
     }
 
     renderRangeClearBtn(rangeStart: string, rangeEnd: string) {
-        const { showClear, prefixCls, disabled, clearIcon } = this.props;
-        const allowClear = (rangeStart || rangeEnd) && showClear;
-        return allowClear && !disabled ? (
+        const { showClear, prefixCls, disabled, clearIcon, showClearIgnoreDisabled } = this.props;
+        const isRealDisabled = disabled && !showClearIgnoreDisabled;
+        const allowClear = (rangeStart || rangeEnd) && showClear && !isRealDisabled;
+        return allowClear ? (
             <div
                 role="button"
                 tabIndex={0}
                 aria-label="Clear range input value"
                 className={`${prefixCls}-range-input-clearbtn`}
-                onMouseDown={e => !disabled && this.handleRangeInputClear(e)}>
+                onMouseDown={e => this.handleRangeInputClear(e)}>
                 {clearIcon ? clearIcon : <IconClear aria-hidden />}
             </div>
         ) : null;
@@ -360,7 +362,7 @@ export default class DateInput extends BaseComponent<DateInputProps, {}> {
                     onChange={this.handleInsetInputChange}
                     onFocus={handleInsetTimeFocus}
                 />
-                { this.isRenderMultipleInputs() && (
+                {this.isRenderMultipleInputs() && (
                     <>
                         <div className={separatorCls}>{density === 'compact' ? null : '-'}</div>
                         <InsetDateInput
@@ -420,6 +422,7 @@ export default class DateInput extends BaseComponent<DateInputProps, {}> {
             insetInput,
             insetInputValue,
             defaultPickerValue,
+            showClearIgnoreDisabled,
             ...rest
         } = this.props;
         const dateIcon = <IconCalendar aria-hidden />;
@@ -448,6 +451,7 @@ export default class DateInput extends BaseComponent<DateInputProps, {}> {
                 ref={inputRef}
                 insetLabel={insetLabel}
                 disabled={disabled}
+                showClearIgnoreDisabled={showClearIgnoreDisabled}
                 readonly={inputReadOnly}
                 className={inputCls}
                 style={inputStyle}

--- a/packages/semi-ui/datePicker/datePicker.tsx
+++ b/packages/semi-ui/datePicker/datePicker.tsx
@@ -584,7 +584,7 @@ export default class DatePicker extends BaseComponent<DatePickerProps, DatePicke
             defaultPickerValue
         };
 
-        return insetInput ? <DateInput {...props} insetInput={insetInput}/> : null;
+        return insetInput ? <DateInput {...props} insetInput={insetInput} /> : null;
     }
 
     handleOpenPanel = () => this.foundation.openPanel();
@@ -666,6 +666,7 @@ export default class DatePicker extends BaseComponent<DatePickerProps, DatePicke
         // These values should be passed to triggerRender, do not delete any key if it is not necessary
         const props = {
             ...extraProps,
+            showClearIgnoreDisabled: Boolean(insetInput),
             placeholder: phText,
             clearIcon,
             disabled: inputDisabled,

--- a/packages/semi-ui/input/index.tsx
+++ b/packages/semi-ui/input/index.tsx
@@ -66,7 +66,9 @@ export interface InputProps extends
     inputStyle?: React.CSSProperties;
     getValueLength?: (value: string) => number;
     forwardRef?: ((instance: any) => void) | React.MutableRefObject<any> | null;
-    preventScroll?: boolean
+    preventScroll?: boolean;
+    /** internal prop, DatePicker use it */
+    showClearIgnoreDisabled?: boolean
 }
 
 export interface InputState {
@@ -309,7 +311,7 @@ class Input extends BaseComponent<InputProps, InputState> {
                     className={clearCls}
                     onMouseDown={this.handleClear}
                 >
-                    { clearIcon ? clearIcon : <IconClear />}
+                    {clearIcon ? clearIcon : <IconClear />}
                 </div>
             );
         }
@@ -370,12 +372,6 @@ class Input extends BaseComponent<InputProps, InputState> {
         );
     }
 
-    showClearBtn() {
-        const { value, isFocus, isHovering } = this.state;
-        const { disabled, showClear } = this.props;
-        return Boolean(value) && showClear && !disabled && (isFocus || isHovering);
-    }
-
     renderSuffix(suffixAllowClear: boolean) {
         const { suffix, hideSuffix } = this.props;
         if (!suffix) {
@@ -406,7 +402,7 @@ class Input extends BaseComponent<InputProps, InputState> {
             if (typeof forwardRef === 'function') {
                 return (node: HTMLInputElement) => {
                     forwardRef(node);
-                    this.inputRef = { current: node } ;
+                    this.inputRef = { current: node };
                 };
             } else if (Object.prototype.toString.call(forwardRef) === '[object Object]') {
                 this.inputRef = forwardRef;
@@ -446,10 +442,11 @@ class Input extends BaseComponent<InputProps, InputState> {
             getValueLength,
             preventScroll,
             borderless,
+            showClearIgnoreDisabled,
             ...rest
         } = this.props;
         const { value, isFocus, minLength: stateMinLength } = this.state;
-        const suffixAllowClear = this.showClearBtn();
+        const suffixAllowClear = this.foundation.isAllowClear();
         const suffixIsIcon = isSemiIcon(suffix);
         const ref = this.getInputRef();
         const wrapperPrefix = `${prefixCls}-wrapper`;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [x] Feature


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

- Feat

内嵌输入框在 trigger 上增加 clear 按钮

<img width="456" alt="image" src="https://github.com/DouyinFE/semi-design/assets/26477537/65d98b92-9995-42ab-917a-e1a62e34e0cf">

- Fix

placeholder 多了字符，原因是 switch break 漏了（v2.32.0-beta.0 DatePicker 新增 type monthRange API 引入）

<img width="637" alt="image" src="https://github.com/DouyinFE/semi-design/assets/26477537/cfc627e1-db16-406e-bb6b-ac606a355555">

未 hover icon 时不应该是蓝色

<img width="470" alt="image" src="https://github.com/DouyinFE/semi-design/assets/26477537/8e0d72bc-fe89-4799-b04c-88486b64fa41">



### Changelog
🇨🇳 Chinese
- Feat：DatePicker 内嵌输入框在 trigger 上增加 clear 按钮  #1638
- Fix: 修复 DatePicker insetInput 内嵌输入框 placeholder 占位文本错误问题
- Fix: 修复 DatePicker 范围输入框 clear 按钮默认颜色不对问题

---

🇺🇸 English
- Feat: DatePicker insetInput input box supports clearing input box content through trigger #1638
- Fix: Fix DatePicker insetInput input box placeholder placeholder text error
- Fix：Fix DatePicker range input clear icon color bug


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
