### PR TITLE
fix: only when dropdown panel visible trigger handlePrevent function

### DIFF
--- a/packages/semi-foundation/dropdown/foundation.ts
+++ b/packages/semi-foundation/dropdown/foundation.ts
@@ -13,7 +13,7 @@ export default class DropdownFoundation extends BaseFoundation<DropdownAdapter> 
         this._adapter.notifyVisibleChange(visible);
 
         const { trigger } = this.getProps();
-        if (visible && trigger === "click"){
+        if (visible && trigger === "click") {
             const popupId = this._adapter.getPopupId();
             this.setFocusToFirstMenuItem(popupId);
         }
@@ -37,6 +37,7 @@ export default class DropdownFoundation extends BaseFoundation<DropdownAdapter> 
 
     handleKeyDown(event: any): void {
         const id = event.target?.attributes['data-popupid']?.value;
+        const { visible } = this._adapter.getStates();
         switch (event.key) {
             case ' ':
             case 'Enter':
@@ -46,11 +47,11 @@ export default class DropdownFoundation extends BaseFoundation<DropdownAdapter> 
                 break;
             case 'ArrowDown':
                 this.setFocusToFirstMenuItem(id);
-                handlePrevent(event);
+                visible && handlePrevent(event);
                 break;
             case 'ArrowUp':
                 this.setFocusToLastMenuItem(id);
-                handlePrevent(event);
+                visible && handlePrevent(event);
                 break;
             default:
                 break;

--- a/packages/semi-ui/dropdown/_story/dropdown.stories.jsx
+++ b/packages/semi-ui/dropdown/_story/dropdown.stories.jsx
@@ -8,6 +8,7 @@ import MultiDropdown from './MultiDropdown';
 import DisabledItem from './DisabledItem';
 import InHoverElements from './InHoverElements';
 import WrapAvatar from './WrapAvatar';
+import TextArea from '../../input/textarea'
 import { IconBox, IconChevronDown, IconSimilarity, IconSetting, IconForward, IconColorPalette, IconRefresh, IconSearch, IconBranch } from '@douyinfe/semi-icons';
 
 export { DropdownItem } from '../_story/C2D';
@@ -375,5 +376,23 @@ export function ShowTick() {
               <Button style={{ marginLeft: 90 }}>ShowTick+始终展示</Button>
           </Dropdown>
       </div>
+  );
+}
+
+export function Fix1606() {
+  return (
+      <Dropdown
+        trigger="customer"
+        visible={false}
+        render={
+              <Dropdown.Menu>
+                  <Dropdown.Item>Menu Item 1</Dropdown.Item>
+                  <Dropdown.Item>Menu Item 2</Dropdown.Item>
+                  <Dropdown.Item>Menu Item 3</Dropdown.Item>
+              </Dropdown.Menu>
+        }
+        >
+          <TextArea style={{ width: 200 }} defaultValue='请尝试在此处使用上下箭头切换当前行'/>
+      </Dropdown>
   );
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1606 

### Changelog
🇨🇳 Chinese
- Fix: 仅当 Dropdown panel 可见时，才触发上下箭头按下事件的 stopPropagation 和 preventDefault

---

🇺🇸 English
- Fix: the stopPropagation and preventDefault of the up and down arrow press events are triggered only when the Dropdown panel is visible


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
