### PR TITLE
fix: fixed Cascader disabled tag bg color

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -137,6 +137,7 @@ $module: #{$prefix}-cascader;
 
             &-disabled.#{$prefix}-tag {
                 color: $color-cascader_input_disabled-text-default;
+                background-color: $color-cascader_tag_disabled-bg-default;
                 cursor: not-allowed;
 
                 .#{$prefix}-tag-close {

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -14,6 +14,7 @@ $color-cascader_option-bg-selected: var(--semi-color-primary-light-default); // 
 $color-cascader_option_disabled-text-default: var(--semi-color-disabled-text); // 级联选择菜单项文字颜色 - 禁用
 $color-cascader_option_disabled-bg-hover: transparent; // 级联选择菜禁用单项背景颜色 - 悬浮
 $color-cascader_option_disabled-bg-active: transparent; // 级联选择菜禁用单项背景颜色 - 按下
+$color-cascader_tag_disabled-bg-default: transparent; // 级联选择菜禁用Tag背景颜色
 
 // warning，same as Input
 $color-cascader_warning-bg-default: var(--semi-color-warning-light-default); // 级联选择触发器警告背景颜色


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix




### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

修复 Cascader 禁用态 Tag 背景色与其他输入类组件不一致问题


![image](https://github.com/DouyinFE/semi-design/assets/26477537/b1996443-2b32-4a2a-8b16-b9a61001da20)

![image](https://github.com/DouyinFE/semi-design/assets/26477537/84d41c4a-f981-417d-84df-4e899f177fbc)



### Changelog
🇨🇳 Chinese
- Fix: 修复 Cascader 禁用态 Tag 背景色与其他输入类组件不一致问题

---

🇺🇸 English
- Fix: fixed Cascader disabled tag bg color


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
