### PR TITLE
fix: TreeSelect searchAutoFocous preventScroll bug

### DIFF
--- a/packages/semi-ui/input/index.tsx
+++ b/packages/semi-ui/input/index.tsx
@@ -219,6 +219,15 @@ class Input extends BaseComponent<InputProps, InputState> {
         }
     }
 
+    componentDidMount(): void {
+        // autofocus is changed from the original support of input to the support of manually calling the focus method,
+        // so that preventScroll can still take effect under the setting of autofocus
+        const { disabled, autofocus, preventScroll } = this.props;
+        if (!disabled && autofocus) {
+            this.inputRef.current.focus({ preventScroll });
+        }
+    }
+
     handleClear = (e: React.MouseEvent<HTMLInputElement>) => {
         this.foundation.handleClear(e);
     };
@@ -483,7 +492,6 @@ class Input extends BaseComponent<InputProps, InputState> {
         const inputProps: React.InputHTMLAttributes<HTMLInputElement> = {
             ...rest,
             style: inputStyle,
-            autoFocus: autofocus,
             className: inputCls,
             disabled,
             readOnly: readonly,

--- a/packages/semi-ui/input/index.tsx
+++ b/packages/semi-ui/input/index.tsx
@@ -222,6 +222,7 @@ class Input extends BaseComponent<InputProps, InputState> {
     componentDidMount(): void {
         // autofocus is changed from the original support of input to the support of manually calling the focus method,
         // so that preventScroll can still take effect under the setting of autofocus
+        this.foundation.init();
         const { disabled, autofocus, preventScroll } = this.props;
         if (!disabled && autofocus) {
             this.inputRef.current.focus({ preventScroll });

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2251,3 +2251,24 @@ export const triggerRenderAddMethod = () => {
     </>
   );
 }
+
+export const AutoSearchFocusPlusPreventScroll = () => {
+  return (
+      <div>
+        <div style={{height: '100vh' }}>我是一个高度和视窗高度一致的div。
+          <br />由于 TreeSelect 设置了 searchAutoFocus 以及 preventScroll，
+          <br /> 符合预期的情况是在没有滚动屏幕情况下，你不会看到 TreeSelect 的 trigger
+        </div>
+        <TreeSelect
+          searchAutoFocus
+          searchPosition="trigger"
+          preventScroll={true}
+          style={{ width: 300 }}
+          dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+          treeData={treeData2}
+          filterTreeNode
+          placeholder="单选"
+        />
+      </div>
+  );
+};

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -644,7 +644,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             toggleHovering: bool => {
                 this.setState({ isHovering: bool });
             },
-            updateInputFocus: bool => { 
+            updateInputFocus: bool => {
                 if (bool) {
                     if (this.inputRef && this.inputRef.current) {
                         const { preventScroll } = this.props;
@@ -664,7 +664,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             },
             updateIsFocus: bool => {
                 this.setState({ isFocus: bool });
-            } 
+            }
         };
     }
 
@@ -858,8 +858,8 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             maxTagCount,
             searchPosition,
             filterTreeNode,
-            showRestTagsPopover, 
-            restTagsPopoverProps 
+            showRestTagsPopover,
+            restTagsPopoverProps
         } = this.props;
         const isTriggerPositionSearch = filterTreeNode && searchPosition === strings.SEARCH_POSITION_TRIGGER;
         // searchPosition = trigger
@@ -947,7 +947,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                     onClick={this.handleClear}
                     onKeyPress={this.handleClearEnterPress}
                 >
-                    { clearIcon ? clearIcon : <IconClear />}
+                    {clearIcon ? clearIcon : <IconClear />}
                 </div>
             );
         }
@@ -1135,7 +1135,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             placeholder,
             maxTagCount,
             checkRelation,
-            showRestTagsPopover, 
+            showRestTagsPopover,
             restTagsPopoverProps,
             searchPosition,
             filterTreeNode,
@@ -1193,6 +1193,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             searchAutoFocus,
             multiple,
             disabled,
+            preventScroll,
         } = this.props;
         const isDropdownPositionSearch = searchPosition === strings.SEARCH_POSITION_DROPDOWN;
         const inputcls = cls({
@@ -1203,6 +1204,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const baseInputProps = {
             value: inputValue,
             className: inputcls,
+            preventScroll,
             onChange: (value: string) => this.search(value),
         };
         const inputDropdownProps = {
@@ -1303,7 +1305,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         }
         if (filterTreeNode && searchPosition === strings.SEARCH_POSITION_DROPDOWN && isVisible && searchAutoFocus) {
             this.foundation.focusInput(true);
-        } 
+        }
     }
 
     renderTreeNode = (treeNode: FlattenNode, ind: number, style: React.CSSProperties) => {
@@ -1439,10 +1441,10 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                         this.renderInput()
                     }
                     <div className={listCls} role="tree" aria-multiselectable={multiple ? true : false} style={optionListStyle}>
-                        { noData ? this.renderEmpty() : (multiple ? 
+                        {noData ? this.renderEmpty() : (multiple ?
                             (<CheckboxGroup value={Array.from(checkRelation === 'related' ? checkedKeys : realCheckedKeys)}>
                                 {this.renderNodeList()}
-                            </CheckboxGroup>) : 
+                            </CheckboxGroup>) :
                             this.renderNodeList()
                         )}
                     </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes preventScroll 未透传给 Input 问题，导致 Input autofocus 时 preventScroll 未生效
修改 Input 的 autoFocus 生效方式，从借助原生的 autofocus 到通过调用元素的 focus 方法实现，区别在于调用 focus 方法 preventScroll 设置可以生效，而前者 preventScroll 无法生效

### Changelog
🇨🇳 Chinese
- Fix: 修复 TreeSelect searchAutoFocus 的 preventScroll 未生效问题
- Fix: 修复 Input 在 autofocus 为 true 时 preventScroll 未生效问题

---

🇺🇸 English
- Fix: Fix the problem that preventScroll of TreeSelect searchAutoFocus does not take effect
- Fix: Fix the problem that preventScroll does not take effect when autofocus is true in Input


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
