### PR TITLE
fix: refresh thumb pic when beforeUpload update fileInstance

### DIFF
--- a/content/input/upload/index.md
+++ b/content/input/upload/index.md
@@ -1351,7 +1351,7 @@ Upload组件是一个可交互的控件，在点击或拖拽时触发文件选�
 -   Semi Upload把图片存到哪里了？
     -   Semi Upload不负责图片的保存，当你使用 Upload 组件时需要自定义 action。你可以选择把 action 设置为自己的服务器地址或者图片服务地址。
 -   Form.Upload props.name无效？
-    - Form.Field 中有props.name，Upload也有props.name，同名props会冲突。使用Form.Upload时，可以转为使用 props.fileName，避免冲突
+    - Form.Field 中有 props.name，Upload也有 props.name，同名 props 会冲突。使用 Form.Upload 时，可以转为使用 props.fileName，避免冲突
 -   上传图片后没有调用 XXX 方法？
     - 如果你设置了 `accept`，可以尝试把 accept 属性去掉，然后再看是否调用了改方法。去掉后调用了该方法说明，accept 在当前环境下获取的 file type 与设置的 accept 不符，上传行为提前终止。可以打个断点到 upload/foundation.js checkFileFormat 函数，看下获取的 file.type 真实值是否符合预期。
 

--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -487,6 +487,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
                 newFileList[index].fileInstance = fileInstance;
                 newFileList[index].size = getFileSize(fileInstance.size);
                 newFileList[index].name = fileInstance.name;
+                newFileList[index].url = this._createURL(fileInstance);
             }
             newFileList[index].shouldUpload = shouldUpload;
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
用户以类似的方式使用，借助 beforeUpload 对图片做裁剪
![img_v2_80fa5b82-e906-46e3-b8dc-63c275c93acg](https://github.com/DouyinFE/semi-design/assets/88709023/75236848-2604-4a94-9493-075aea4f65fd)




### Changelog
🇨🇳 Chinese
- Fix: 修复 Upload 在 beforeUpload中更新 fileInstance后，未更新缩略图渲染的问题

---

🇺🇸 English
- Fix: Fix the problem that the thumbnail rendering is not updated after Upload updates the fileInstance in beforeUpload


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
