### PR TITLE
fix(auto-complete): Long press the candidate dropdown box to disappear and not select it, and sometimes `onSelect` is not triggered when short press

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -155,7 +155,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         this._adapter.notifySearch(inputValue);
         this._adapter.notifyChange(inputValue);
         this._modifyFocusIndex(inputValue);
-        if (!this.isPanelOpen){
+        if (!this.isPanelOpen) {
             this.openDropdown();
         }
     }
@@ -383,16 +383,16 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
 
     _handleArrowKeyDown(offset: number): void {
         const { visible } = this.getStates();
-        if (!visible){
+        if (!visible) {
             this.openDropdown();
         } else {
-            this._getEnableFocusIndex(offset);  
+            this._getEnableFocusIndex(offset);
         }
     }
 
     _handleEnterKeyDown() {
         const { visible, options, focusIndex } = this.getStates();
-        if (!visible){
+        if (!visible) {
             this.openDropdown();
         } else {
             if (focusIndex !== undefined && focusIndex !== -1 && options.length !== 0) {
@@ -404,9 +404,13 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
             }
         }
     }
-
+    
     handleOptionMouseEnter(optionIndex: number): void {
         this._adapter.updateFocusIndex(optionIndex);
+    }
+    
+    handleOptionMouseLeave(): void {
+        this._adapter.updateFocusIndex(-1);
     }
 
     handleFocus(e: FocusEvent) {

--- a/packages/semi-ui/autoComplete/index.tsx
+++ b/packages/semi-ui/autoComplete/index.tsx
@@ -242,7 +242,6 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
                 this.setState({ keyboardEventSet: {} });
             },
             updateFocusIndex: (focusIndex: number): void => {
-                console.log("---->", focusIndex);
                 this.setState({ focusIndex });
             },
         };

--- a/packages/semi-ui/autoComplete/index.tsx
+++ b/packages/semi-ui/autoComplete/index.tsx
@@ -242,6 +242,7 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
                 this.setState({ keyboardEventSet: {} });
             },
             updateFocusIndex: (focusIndex: number): void => {
+                console.log("---->", focusIndex);
                 this.setState({ focusIndex });
             },
         };
@@ -324,7 +325,12 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
         this.foundation.handleSearch(value);
     };
 
-    onBlur = (e: React.FocusEvent): void => this.foundation.handleBlur(e);
+    onBlur = (e: React.FocusEvent): void => {
+        // Fix out of focus when and only when the dropdown selection item is suspended beyond the viewport, otherwise prohibit hiding the dropdown selection area
+        if (this.state.focusIndex < 0) {
+            return this.foundation.handleBlur(e);
+        }
+    };
 
     onFocus = (e: React.FocusEvent): void => this.foundation.handleFocus(e);
 
@@ -416,7 +422,7 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
             </div>
         );
     }
-
+    
     renderLoading() {
         const loadingWrapperCls = `${prefixCls}-loading-wrapper`;
         return (
@@ -437,6 +443,7 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
                 // selected={selection.has(option.label)}
                 focused={isFocused}
                 onMouseEnter={() => this.foundation.handleOptionMouseEnter(optionIndex)}
+                onMouseLeave={() => this.foundation.handleOptionMouseLeave(optionIndex)}
                 key={option.key || option.label + option.value + optionIndex}
                 {...option}
             >

--- a/packages/semi-ui/autoComplete/option.tsx
+++ b/packages/semi-ui/autoComplete/option.tsx
@@ -85,6 +85,7 @@ class Option extends PureComponent<OptionProps> {
             className,
             style,
             onMouseEnter,
+            onMouseLeave,
             prefixCls,
             renderOptionItem,
             inputValue,
@@ -125,6 +126,7 @@ class Option extends PureComponent<OptionProps> {
                 value,
                 inputValue,
                 onMouseEnter: (e: React.MouseEvent) => onMouseEnter(e),
+                onMouseLeave: (e: React.MouseEvent) => onMouseLeave(e),
                 onClick: (e: React.MouseEvent) => this.onClick({ value, label, children, ...rest }, e),
                 ...rest
             });
@@ -145,6 +147,7 @@ class Option extends PureComponent<OptionProps> {
                     this.onClick({ value, label, children, ...rest }, e);
                 }}
                 onMouseEnter={e => onMouseEnter && onMouseEnter(e)}
+                onMouseLeave={e => onMouseLeave && onMouseLeave(e)}
                 role="option"
                 aria-selected={selected ? "true" : "false"}
                 aria-disabled={disabled ? "true" : "false"}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1665 

### Changelog
🇨🇳 Chinese
- Fix: `<AutoComplete />` 长按候选项 下拉框消失且没有选中，短按 有时 `onSelect` 未触发。

---

🇺🇸 English
- Fix: `<AutoComplete/>` Long press the candidate dropdown box to disappear and not select it, and sometimes `onSelect` is not triggered when short press


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
![image](https://github.com/DouyinFE/semi-design/assets/23185852/89485a4f-05b4-441d-aef0-784f5f06b583)