### PR TITLE
fix: [Cascader] Fix cascader cannot display +N Popover in disabled an…

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -25,7 +25,7 @@ $module: #{$prefix}-cascader;
         border: $width-cascader_hover-border $color-cascader_default-border-hover solid;
     }
 
-    &:focus {
+    &:focus:not(&-disabled) {
         border: $width-cascader_focus-border solid $color-cascader_default-border-focus;
         background-color: $color-cascader_default-bg-default;
         outline: 0;

--- a/packages/semi-ui/cascader/_story/cascader.stories.jsx
+++ b/packages/semi-ui/cascader/_story/cascader.stories.jsx
@@ -2099,3 +2099,28 @@ export const TriggerAddMethods = () => {
       </>
   );
 }
+
+export const DisabledAndPlusN = () => {
+  const commonProps = {
+    multiple: true,
+    maxTagCount: 1,
+    showRestTagsPopover: true,
+    disabled: true,
+    style: { width: 300 },
+    treeData: treeData4,
+    placeholder: "请选择所在地区",
+    defaultValue: [
+        ['zhejiang', 'ningbo', 'haishu'],
+        ['zhejiang', 'hangzhou', 'xihu']
+    ]
+  }
+  return (
+    <>
+      <span>disabled + maxTagCount + showRestTagsPopover</span><br /><br />
+      <Cascader {...commonProps} />
+      <br /><br />
+      <span>disabled + filterTreeNode + maxTagCount + showRestTagsPopover</span><br /><br />
+      <Cascader {...commonProps} filterTreeNode/>
+    </> 
+  )
+}

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -705,7 +705,7 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
             [`${prefixcls}-selection-n-disabled`]: disabled,
         });
         const renderPlusNChildren = <span className={plusNCls}>+{hiddenTag.length}</span>;
-        return showRestTagsPopover && !disabled ? (
+        return showRestTagsPopover ? (
             <Popover
                 content={hiddenTag}
                 showArrow


### PR DESCRIPTION
…d non-search situations

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 disabled 的 Cascader 无法通过 hover +N 部分显示多余 Tag 问题
- style：在 disabled 情况下，点击 Cascader 不触发 focus 样式

---

🇺🇸 English
- Fix: Fix the problem that the disabled Cascader cannot display redundant Tags by hovering the +N part
- Style: In the disabled case, clicking the Cascader does not trigger the focus style


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
1. 版本v2.37.0:
filterTreeNode，disabled 的 Casdcader 可以通过 hover +N 部分显示多余 tag；
filterTreeNode=false，disabled 的 Casdcader 可以通过 hover +N 部分显示多余 tag；
修改后：
disabled 的 Cascader 都能够通过 hover +N 部分显示多余 tag；

2. 版本v2.37.0: disabled 的 Casdcader被点击后，会出现蓝色的 border
修改后：disabled 的 Casdcader被点击后，border 保持无透明色

