### PR TITLE
refactor: split Toast padding token

### DIFF
--- a/packages/semi-foundation/toast/toast.scss
+++ b/packages/semi-foundation/toast/toast.scss
@@ -22,7 +22,7 @@ $icon: #{$prefix}-toast-icon;
         @include font-size-regular;
         background-color: $color-toast-bg-default;
         border-radius: $radius-toast_content;
-        padding: $spacing-toast_content-paddingY $spacing-toast_content-paddingX;
+        padding: $spacing-toast_content-paddingTop $spacing-toast_content-paddingRight $spacing-toast_content-paddingBottom $spacing-toast_content-paddingLeft;
         display: inline-flex;
         align-items: flex-start;
         justify-content: center;

--- a/packages/semi-foundation/toast/variables.scss
+++ b/packages/semi-foundation/toast/variables.scss
@@ -26,6 +26,10 @@ $color-toast_danger_light-border: var(--semi-color-danger); // 多色样式 错�
 $spacing-toast_wrapper-top: 0; // 通知容器顶部位置
 $spacing-toast_content-paddingY: $spacing-base-tight; // 通知内容垂直内边距
 $spacing-toast_content-paddingX: $spacing-tight; // 通知内容水平内边距
+$spacing-toast_content-paddingTop: $spacing-toast_content-paddingY; // 通知内容 top 内边距
+$spacing-toast_content-paddingBottom: $spacing-toast_content-paddingY; // 通知内容 bottom 内边距
+$spacing-toast_content-paddingLeft: $spacing-toast_content-paddingX; // 通知内容 left 内边距
+$spacing-toast_content-paddingRight: $spacing-toast_content-paddingX; // 通知内容 right 内边距
 $spacing-toast_content-margin: $spacing-base-tight; // 通知内容外边距
 $spacing-toast_content_close_btn-marginTop: -2px; // 通知关闭按钮顶部外边距
 $spacing-toast_content_text-marginLeft: $spacing-base-tight; // 通知文本左侧外边距


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [x] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- design token: Toast padding token 拆分细化，$spacing-toast_content-paddingY 拆分为 $spacing-toast_content-paddingTop、$spacing-toast_content-paddingBottom，$spacing-toast_content-paddingX 拆分为 $spacing-toast_content-paddingLeft、$spacing-toast_content-paddingRight

---

🇺🇸 English
- design token: Toast padding token is split into 4. $spacing-toast_content-paddingY is split into $spacing-toast_content-paddingTop, $spacing-toast_content-paddingBottom, and $spacing-toast_content-paddingX is split into $spacing-toast_content-paddingLeft, $spacing-toast_content-paddingRight

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
