### PR TITLE
fix: min-Width -> min-width, avoid compile warning of tooltip.scss

### DIFF
--- a/packages/semi-foundation/tooltip/tooltip.scss
+++ b/packages/semi-foundation/tooltip/tooltip.scss
@@ -79,7 +79,7 @@ $module-icon: #{$module}-icon-arrow;
     }
 
     &-content {
-        min-Width: 0
+        min-width: 0;
     }
 
     &-trigger {


### PR DESCRIPTION
…lose #1680

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

### Changelog
🇨🇳 Chinese
- Fix: 修复 min-Width 属性大小写拼写错误导致的 warning，影响范围 (2.37.0-beta.0 - 2.38.0-beta.0) #1680

---

🇺🇸 English
- Fix: Fix the warning caused by the misspelling of the min-Width attribute, the scope of influence (2.37.0-beta.0 - 2.38.0-beta.0) #1680


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
