### PR TITLE
fix: Fix the problem that AutoComplete cannot select the value after …

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -155,7 +155,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         this._adapter.notifySearch(inputValue);
         this._adapter.notifyChange(inputValue);
         this._modifyFocusIndex(inputValue);
-        if (!this.isPanelOpen){
+        if (!this.isPanelOpen) {
             this.openDropdown();
         }
     }
@@ -335,6 +335,9 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
             case KeyCode.ESC:
                 this.closeDropdown();
                 break;
+            case KeyCode.TAB:
+                this.closeDropdown();
+                break;
             default:
                 break;
         }
@@ -383,7 +386,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
 
     _handleArrowKeyDown(offset: number): void {
         const { visible } = this.getStates();
-        if (!visible){
+        if (!visible) {
             this.openDropdown();
         } else {
             this._getEnableFocusIndex(offset);  
@@ -392,7 +395,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
 
     _handleEnterKeyDown() {
         const { visible, options, focusIndex } = this.getStates();
-        if (!visible){
+        if (!visible) {
             this.openDropdown();
         } else {
             if (focusIndex !== undefined && focusIndex !== -1 && options.length !== 0) {
@@ -424,7 +427,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         // internal-issues:1231
         setTimeout(() => {
             this._adapter.notifyBlur(e);
-            this.closeDropdown();
+            // this.closeDropdown();
         }, 100);
     }
 }


### PR DESCRIPTION
…long press and trigger onSelect

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1665 

### Changelog
🇨🇳 Chinese
- Fix: 修复 AutoComplete 长按无法选中，onSelect 未触发问题 #1665 

---

🇺🇸 English
- Fix: Fix the problem that AutoComplete cannot be selected by long pressing, and onSelect is not triggered #1665 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
<strong>问题原因</strong>：
AutoComplete 长按无法选中，onSelect 未触发原因在于 foundation 的 设置了 this.closeDropdown, 虽然 this.closeDropdown 放在了 setTimeout 中，但是，长按时， setTimeout 设置的时间到，面板被关闭，则面板上的 option 的 Dom 消失，无法触发相应的点击事件，导致无法选中

<strong>修复方法</strong>：
去掉 handleBlur 中的 this.closeDropdown ，点击选中后的面板关闭由 Option 的 click 事件处理， 
在 foundation 关于按键处理的地方加上 对 Tab 键的处理，保证在 Tab 时，面板能够收起

