### PR TITLE
style: [TreeSelect] Fix the content exceeds the trigger box when disp…

### DIFF
--- a/packages/semi-foundation/treeSelect/treeSelect.scss
+++ b/packages/semi-foundation/treeSelect/treeSelect.scss
@@ -133,11 +133,15 @@ $module: #{$prefix}-tree-select;
         padding-right: 0;
         cursor: pointer;
         color: $color-treeSelect_selection-text-default;
+        position: relative;
 
-        &-placeholder {
+        &-content {
             overflow: hidden;
             white-space: nowrap;
             text-overflow: ellipsis;
+        }
+        
+        &-placeholder {
             color: $color-treeSelect_input_placeholder-text-default;
         }
 
@@ -154,6 +158,10 @@ $module: #{$prefix}-tree-select;
 
         &-TriggerSearchItem {
             position: absolute;
+            max-width: calc(100% - $spacing-treeSelect_selection-paddingLeft);
+            text-overflow: ellipsis;
+            overflow: hidden;
+            white-space: nowrap;
             
             &-placeholder {
                 opacity: .6;

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2272,3 +2272,77 @@ export const AutoSearchFocusPlusPreventScroll = () => {
       </div>
   );
 };
+
+export const LongLabel = () => {
+  const treeData = [
+    {
+        label: '这是一个超长的中文测试用标题这是一个超长的中文测试用标题这是一个超长的中文测试用标题这是一个超长的中文测试用标题',
+        value: 'v1',
+        key: '0',
+    },
+    {
+        label: 'ThisISAVeryLongTestSentenceThisISAVeryLongTestSentenceThisISAVeryLongTestSentence',
+        value: 'v2',
+        key: '1',
+    }
+  ];
+
+  return (
+    <>
+      <p>单选</p>
+      <TreeSelect
+        defaultValue='v1'
+        style={{ width: 300 }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        treeData={treeData}
+        placeholder="请选择"
+      />
+      <p>单选，可搜索, searchPosition='trigger'</p>
+      <TreeSelect
+        filterTreeNode
+        searchPosition='trigger'
+        defaultValue='v1'
+        style={{ width: 300 }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        treeData={treeData}
+        placeholder="请选择"
+      />
+       <p>单选，可搜索, searchPosition='dropDown'</p>
+      <TreeSelect
+        filterTreeNode
+        defaultValue='v1'
+        style={{ width: 300 }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        treeData={treeData}
+        placeholder="请选择"
+      />
+       <p>单选</p>
+      <TreeSelect
+        defaultValue='v2'
+        style={{ width: 300 }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        treeData={treeData}
+        placeholder="请选择"
+      />
+      <p>单选，可搜索, searchPosition='trigger'</p>
+      <TreeSelect
+        filterTreeNode
+        searchPosition='trigger'
+        defaultValue='v2'
+        style={{ width: 300 }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        treeData={treeData}
+        placeholder="请选择"
+      />
+       <p>单选，可搜索, searchPosition='dropDown'</p>
+      <TreeSelect
+        filterTreeNode
+        defaultValue='v2'
+        style={{ width: 300 }}
+        dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+        treeData={treeData}
+        placeholder="请选择"
+      />
+    </>
+  );
+}

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -869,7 +869,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         // searchPosition = dropdown and single seleciton
         if (!multiple || !this.hasValue()) {
             const renderText = this.foundation.getRenderTextInSingle();
-            const spanCls = cls({
+            const spanCls = cls(`${prefixcls}-selection-content`, {
                 [`${prefixcls}-selection-placeholder`]: !renderText,
             });
             return <span className={spanCls}>{renderText ? renderText : placeholder}</span>;


### PR DESCRIPTION
…laying a long label in TreeSelect

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #623 

### Changelog
🇨🇳 Chinese
- Style: 修复 TreeSelect 中在展示长 label 时内容超出 trigger 框问题 #623 

---

🇺🇸 English
- Style: Fix the problem that the content exceeds the trigger box when displaying a long label in TreeSelect #623 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
