### PR TITLE
feat: update Radio content row-gap from 0 to 4px

### DIFF
--- a/packages/semi-foundation/radio/radio.scss
+++ b/packages/semi-foundation/radio/radio.scss
@@ -241,6 +241,7 @@ $inner-width: $width-icon-medium;
     &-content {
         display: flex;
         flex-direction: column;
+        row-gap: $spacing-radio_content-rowGap;
     }
 
     &:hover {

--- a/packages/semi-foundation/radio/variables.scss
+++ b/packages/semi-foundation/radio/variables.scss
@@ -77,6 +77,7 @@ $spacing-radio_addon_buttonRadio_middle-paddingX: $spacing-base; // 中尺寸按
 $spacing-radio_addon_buttonRadio_middle-paddingY: $spacing-extra-tight; // 中尺寸按钮式单选按钮垂直内边距
 $spacing-radio_addon_buttonRadio_marginLeft: $spacing-none; // 按钮式单选按钮左侧外边距
 $spacing-radio_extra-paddingLeft: $width-radio_inner + $spacing-tight; // 单选副标题左侧内边距
+$spacing-radio_content-rowGap: 4px; // 内容行间距
 
 $spacing-radio_group_vertical-marginBottom: $spacing-base-tight; // 垂直布局单选框组底部外边距
 $spacing-radio_card_group_vertical-marginBottom: $spacing-base; // 垂直布局卡片式单选框组底部外边距


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Style


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

Radio addon 与 extra 的间距由 0 调整为 4px，与 Checkbox 保持一致。

<img width="395" alt="image" src="https://github.com/DouyinFE/semi-design/assets/26477537/4ec59f48-9e15-4bde-9b67-aa2ff07f30ed">


### Changelog
🇨🇳 Chinese
- Style: Radio addon 与 extra 的间距由 0 调整为 4px，新增Token： $spacing-radio_content-rowGap 

---

🇺🇸 English
- Style: Adjust the spacing between Radio addon and extra from 0 to 4px，add design token：$spacing-radio_content-rowGap


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
