### PR TITLE
fix: remove flex-wrap from Checkbox

### DIFF
--- a/packages/semi-foundation/checkbox/checkbox.scss
+++ b/packages/semi-foundation/checkbox/checkbox.scss
@@ -12,7 +12,6 @@ $module: #{$prefix}-checkbox;
     position: relative;
     display: flex;
     align-items: flex-start;
-    flex-wrap: wrap;
     @include font-size-regular;
     cursor: pointer;
     transition: background-color $transition_duration-checkbox-bg $transition_function-checkbox-bg $transition_delay-checkbox-bg,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->

Checkbox 图标与文本之间不能换行，不然会出现如下错误

<img width="312" alt="image" src="https://github.com/DouyinFE/semi-design/assets/26477537/ae661529-3dcd-4c9a-9130-3385b4b78dd4">


### Changelog
🇨🇳 Chinese
- Fix: 移除 Checkbox 最外层侧 flex-wrap

---

🇺🇸 English
- Fix: Remove the flex-wrap on the outermost side of the Checkbox


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
