### PR TITLE
fix: some project can't resolve animation.scss with pnpm, lost animat…

### DIFF
--- a/packages/semi-webpack/src/semi-theme-loader.ts
+++ b/packages/semi-webpack/src/semi-theme-loader.ts
@@ -11,7 +11,7 @@ export default function SemiThemeLoader(source: string) {
     let animationStr = `@import "~${theme}/scss/animation.scss";\n`;
 
     try {
-        require.resolve(`${theme}/scss/animation.scss`);
+        resolve.sync(this.context, `${theme}/scss/animation.scss`);
     } catch (e) {
         animationStr = ""; // fallback to empty string
     }


### PR DESCRIPTION

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description 
原 animation.scss 与 local.scss 的判断方式不同，animation.scss 用的是 require.resolve，local.scss 用的是 webpack 提供的 enhanced-resolve 的resolve.sync (this.context, xxx)

经测试，在用户配置了主题时，在某些极特殊情况下（但并非所有pnpm项目），前者无法正确检测到包中是否存在 animation.scss 文件（oncall - 4686194），从而导致animation相关的 css variable 丢失，动画无法正常执行。 Tooltip、Popover等图层可能无法被正确隐藏卸载。

### Changelog
🇨🇳 Chinese
- Fix: Semi Webpack Plugin 修改 theme loader 引用 animation.scss 相关的逻辑，对 pnpm 场景下某些特殊目录组织兼容

---

🇺🇸 English
- Fix: Semi Webpack Plugin modifies the logic related to animation.scss referenced by theme loader, which is compatible with some special directory organizations in pnpm scenarios


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
