### PR TITLE
fix: form validate resolve value not satisfy scope isolation

### DIFF
--- a/packages/semi-foundation/form/foundation.ts
+++ b/packages/semi-foundation/form/foundation.ts
@@ -175,14 +175,16 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
                 maybePromisedErrors = errors;
             }
             if (!maybePromisedErrors) {
-                resolve(values);
+                const _values = this._adapter.cloneDeep(values);
+                resolve(_values);
                 this.injectErrorToField({});
             } else if (isPromise(maybePromisedErrors)) {
                 maybePromisedErrors.then(
                     (result: any) => {
                         // validate success，clear error
                         if (!result) {
-                            resolve(values);
+                            const _values = this._adapter.cloneDeep(values);
+                            resolve(_values);
                             this.injectErrorToField({});
                         } else {
                             this.data.errors = result;
@@ -237,7 +239,8 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
                 this._adapter.forceUpdate();
                 const errors = this.getError();
                 if (this._isValid(targetFields)) {
-                    resolve(values);
+                    const _values = this._adapter.cloneDeep(values);
+                    resolve(_values);
                 } else {
                     this._autoScroll();
                     reject(errors);


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
```
formApi.validate.then( (values) => {
   
})
```
入参中的 values 未做作用域隔离，用户若直接读取了 values，Field 对应的 DOM 若卸载了，这里的values的值也会被卸载。应该为一个不变的快照才对。

所以增加输出前的 deepClone环节


### Changelog
🇨🇳 Chinese
- Fix: 修复 Form validate.then() 中的 values 入参未做作用域隔离，会受到 Field DOM 挂载、卸载影响的问题

---

🇺🇸 English
- Fix: Fix the problem that the values input parameter in Form validate.then() is not scope isolated and will be affected by Field DOM mount and unmount


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
