### PR TITLE
fix: [Tree] Fix the problem of re-rendering every time the tree is re…

### DIFF
--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -664,6 +664,10 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
         return item.key;
     };
 
+    option = ({ index, style, data }: OptionProps) => (
+        this.renderTreeNode(data[index], index, style)
+    );
+
     renderNodeList() {
         const { flattenNodes, cachedFlattenNodes, motionKeys, motionType } = this.state;
         const { virtualize, motion } = this.props;
@@ -683,9 +687,6 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
                 />
             );
         }
-        const option = ({ index, style, data }: OptionProps) => (
-            this.renderTreeNode(data[index], index, style)
-        );
 
         return (
             <AutoSizer defaultHeight={virtualize.height} defaultWidth={virtualize.width}>
@@ -701,7 +702,7 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
                         className={`${prefixcls}-virtual-list`}
                         style={{ direction }}
                     >
-                        {option}
+                        {this.option}
                     </VirtualList>
                 )}
             </AutoSizer>


### PR DESCRIPTION
…ndered under virtualization

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1725

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tree 组件在虚拟话情况下每次render 会重新渲染问题 #1725 

---

🇺🇸 English
- Fix: Fix the problem that the Tree component will re-render every time it is rendered in the virtual environment #1725 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
虚拟化中的 children 是一个函数，在 render 中进行赋值，传入到虚拟化组件中每次都是新的，导致每次状态更新/props 更新触发 render，都会导致重新渲染，也就产生了 如 dropdown 在 label 中，第一次点击无法响应问题