### PR TITLE
style: remove unnessary margin for Button

### DIFF
--- a/packages/semi-foundation/button/button.scss
+++ b/packages/semi-foundation/button/button.scss
@@ -11,7 +11,6 @@ $module: #{$prefix}-button;
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    margin: 0;
     cursor: pointer;
     user-select: none;
     border: $width-button-border $color-button_primary-border-default solid;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1723 

### Changelog
🇨🇳 Chinese
- Style: 删除 Button 组件中的不必要的 margin

---

🇺🇸 English
- Fix: Remove unnecessary margin in button component


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

semi-button 类中的 margin 设置为 0， 没有产生任何实际效果，但是可能会影响用户的使用体验（#1723 ）。
删除影响面： 无。1. 没有以token的方式支持用户设置，因此删除无影响
 2. chrome，safari，firfox浏览器下并没有设置margin 为非 0 值，不存在为覆盖默认 margin 情况
![img_v2_1906be7a-2078-4c01-8f6f-d556c7abc46g](https://github.com/DouyinFE/semi-design/assets/101110131/035982ee-d8e2-41c9-8856-964a6b78565b)
![25e4c32a-11bc-4b34-a825-a508e889fd43](https://github.com/DouyinFE/semi-design/assets/101110131/65d17790-0f11-495a-be09-a645cc0e0d96)
![img_v2_d5c5da1e-3320-4f6b-8ec7-b556768e816g](https://github.com/DouyinFE/semi-design/assets/101110131/2a291e9d-59f2-4437-96ad-453cacbfb14f)



