### PR TITLE
Fix upload preview fallback

### DIFF
--- a/packages/semi-foundation/upload/fileCardFoundation.ts
+++ b/packages/semi-foundation/upload/fileCardFoundation.ts
@@ -1,0 +1,17 @@
+import BaseFoundation, { DefaultAdapter } from '../base/foundation';
+
+export interface FileCardAdapter<P = Record<string, any>, S = Record<string, any>> extends DefaultAdapter<P, S> {
+    updateFallbackPreview: (fallback: boolean) => void
+}
+
+class FileCardFoundation<P = Record<string, any>, S = Record<string, any>> extends BaseFoundation<FileCardAdapter<P, S>, P, S> {
+    constructor(adapter: FileCardAdapter<P, S>) {
+        super({ ...adapter });
+    }
+
+    handleImageError(error: any) {
+        this._adapter.updateFallbackPreview(true);
+    }
+}
+
+export default FileCardFoundation;

--- a/packages/semi-foundation/upload/upload.scss
+++ b/packages/semi-foundation/upload/upload.scss
@@ -425,6 +425,13 @@ $module: #{$prefix}-upload;
                 transform: translate3D(-50%, -50%, 0);
             }
 
+            &-preview-fallback {
+                background-color: $color-upload_pic_add-bg;
+                border: $width-upload_picture_add-border $color-upload-border;
+                color: $color-upload-icon;
+                border-radius: $radius-upload_picture_add;
+            }
+
             &-pic-info {
                 display: inline-flex;
                 box-sizing: border-box;

--- a/packages/semi-ui/upload/_story/upload.stories.jsx
+++ b/packages/semi-ui/upload/_story/upload.stories.jsx
@@ -1148,3 +1148,66 @@ export const ClickToOpenUploadDemo = () => <ClickToOpenUpload></ClickToOpenUploa
 ClickToOpenUploadDemo.story = {
   name: 'click to open upload demo',
 };
+
+
+const PreviewFallbackDemo = () => {
+    let action = 'https://api.semi.design/upload';
+    const defaultFileList = [
+        {
+            uid: '1',
+            name: 'test.pdf',
+            status: 'success',
+            size: '130KB',
+            preview: true,
+            url: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/githubdemo/collapse.pdf',
+        },
+        {
+            uid: '2',
+            name: 'normal.png',
+            status: 'success',
+            size: '120KB',
+            preview:true,
+            url: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/dy.png'
+        }
+    ];
+
+    const SmartPreview = (props) => {
+        const [src, setSrc] = useState(props.src);
+        const fallback = () => {
+            setSrc('https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/edit-bag.jpeg')
+        };
+        return <img src={src} onError={fallback} />
+    };
+
+    const  previewFile = (file) => {
+        return <SmartPreview src={file.url} />
+    };
+
+    return (
+      <>
+          <Upload
+              defaultFileList={defaultFileList}
+              action={action}
+              // previewFile={previewFile}
+          >
+              <Button icon={<IconUpload />} theme="light">
+                  点击上传
+              </Button>
+          </Upload>
+          <Upload
+              listType='picture'
+              defaultFileList={defaultFileList}
+              action={action}
+              // renderThumbnail={previewFile}
+          >
+             <IconPlus size="extra-large" />
+          </Upload>
+        </>
+    );
+};
+
+export const PreviewFallback = () => <PreviewFallbackDemo></PreviewFallbackDemo>;
+
+PreviewFallback.story = {
+  name: 'preview other type',
+};

--- a/packages/semi-ui/upload/fileCard.tsx
+++ b/packages/semi-ui/upload/fileCard.tsx
@@ -1,11 +1,13 @@
-import React, { PureComponent, ReactNode, MouseEventHandler, MouseEvent, CSSProperties, SVGProps, FC } from 'react';
+import React, { Component, ReactNode, MouseEventHandler, MouseEvent, CSSProperties, SVGProps, FC } from 'react';
 import cls from 'classnames';
 import PropTypes from 'prop-types';
 import { cssClasses, strings } from '@douyinfe/semi-foundation/upload/constants';
+import FileCardFoundation, { FileCardAdapter } from '@douyinfe/semi-foundation/upload/fileCardFoundation';
 import { getFileSize } from '@douyinfe/semi-foundation/upload/utils';
 import { IconAlertCircle, IconClose, IconClear, IconFile, IconRefresh, IconEyeOpened } from '@douyinfe/semi-icons';
 import LocaleConsumer from '../locale/localeConsumer';
 import { Locale } from '../locale/interface';
+import BaseComponent from '../_base/baseComponent';
 
 import Button from '../button/index';
 import Progress from '../progress/index';
@@ -47,8 +49,11 @@ export interface FileCardProps extends RenderFileItemProps {
     style?: CSSProperties
 }
 
+export interface FileCardState {
+    fallbackPreview?: boolean
+}
 
-class FileCard extends PureComponent<FileCardProps> {
+class FileCard extends BaseComponent<FileCardProps, FileCardState> {
     static propTypes = {
         className: PropTypes.string,
         disabled: PropTypes.bool,
@@ -79,6 +84,21 @@ class FileCard extends PureComponent<FileCardProps> {
         preview: false,
         size: '',
     };
+
+    constructor(props: FileCardProps) {
+        super(props);
+        this.state = {
+            fallbackPreview: false,
+        };
+        this.foundation = new FileCardFoundation(this.adapter);
+    }
+
+    get adapter(): FileCardAdapter<FileCardProps, FileCardState> {
+        return {
+            ...super.adapter,
+            updateFallbackPreview: (fallbackPreview: boolean): void => this.setState({ fallbackPreview }),
+        };
+    }
 
     transSize(size: string | number): string {
         if (typeof size === 'number') {
@@ -124,12 +144,14 @@ class FileCard extends PureComponent<FileCardProps> {
 
     renderPic(locale: Locale['Upload']): ReactNode {
         const { url, percent, status, disabled, style, onPreviewClick, showPicInfo, renderPicInfo, renderPicPreviewIcon, renderThumbnail, name, index } = this.props;
+        const { fallbackPreview } = this.state;
         const showProgress = status === strings.FILE_STATUS_UPLOADING && percent !== 100;
         const showRetry = status === strings.FILE_STATUS_UPLOAD_FAIL && this.props.showRetry;
         const showReplace = status === strings.FILE_STATUS_SUCCESS && this.props.showReplace;
         const showPreview = status === strings.FILE_STATUS_SUCCESS && !this.props.showReplace;
         const filePicCardCls = cls({
             [`${prefixCls}-picture-file-card`]: true,
+            [`${prefixCls}-picture-file-card-preview-fallback`]: fallbackPreview,
             [`${prefixCls}-picture-file-card-disabled`]: disabled,
             [`${prefixCls}-picture-file-card-show-pointer`]: typeof onPreviewClick !== 'undefined',
             [`${prefixCls}-picture-file-card-error`]: status === strings.FILE_STATUS_UPLOAD_FAIL,
@@ -162,7 +184,9 @@ class FileCard extends PureComponent<FileCardProps> {
             <div className={`${prefixCls }-picture-file-card-pic-info`}>{index + 1}</div>
         );
 
-        const thumbnail = typeof renderThumbnail === 'function' ? renderThumbnail(this.props) : <img src={url} alt={name} />;
+        const defaultThumbTail = !fallbackPreview ? <img src={url} alt={name} onError={error => this.foundation.handleImageError(error)} /> : <IconFile size="large" />;
+
+        const thumbnail = typeof renderThumbnail === 'function' ? renderThumbnail(this.props) : defaultThumbTail;
 
         return (
             <div role="listitem" className={filePicCardCls} style={style} onClick={onPreviewClick}>
@@ -180,6 +204,7 @@ class FileCard extends PureComponent<FileCardProps> {
 
     renderFile(locale: Locale["Upload"]) {
         const { name, size, percent, url, showRetry: propsShowRetry, showReplace: propsShowReplace, preview, previewFile, status, style, onPreviewClick, renderFileOperation } = this.props;
+        const { fallbackPreview } = this.state;
         const fileCardCls = cls({
             [`${prefixCls}-file-card`]: true,
             [`${prefixCls}-file-card-fail`]: status === strings.FILE_STATUS_VALID_FAIL || status === strings.FILE_STATUS_UPLOAD_FAIL,
@@ -187,7 +212,7 @@ class FileCard extends PureComponent<FileCardProps> {
         });
         const previewCls = cls({
             [`${prefixCls}-file-card-preview`]: true,
-            [`${prefixCls}-file-card-preview-placeholder`]: !preview || previewFile
+            [`${prefixCls}-file-card-preview-placeholder`]: !preview || previewFile || fallbackPreview
         });
         const infoCls = `${prefixCls}-file-card-info`;
         const closeCls = `${prefixCls}-file-card-close`;
@@ -197,7 +222,7 @@ class FileCard extends PureComponent<FileCardProps> {
         const showRetry = status === strings.FILE_STATUS_UPLOAD_FAIL && propsShowRetry;
         const showReplace = status === strings.FILE_STATUS_SUCCESS && propsShowReplace;
         const fileSize = this.transSize(size);
-        let previewContent: ReactNode = preview ? (<img src={url} alt={name} />) : (<IconFile size="large" />);
+        let previewContent: ReactNode = (preview && !fallbackPreview) ? (<img src={url} alt={name} onError={(error) => this.foundation.handleImageError(error)} />) : (<IconFile size="large" />);
         if (previewFile) {
             previewContent = previewFile(this.props);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- 问题
Upload preivew 设为true时，默认会以 img 元素消费 url，如果用户文件类型不明确，且无法从 name 或 url 后缀判断时。若默认情况不做处理，预览 pdf文件时会显示 x。需要用户自行通过 previewFile  API 创建 img 元素并监听 onError 决定返回 reactNode 类型，较为繁琐。

![image](https://github.com/DouyinFE/semi-design/assets/88709023/4856b01d-7cb2-4d38-ae55-09bdc47414e6)


- 处理方案
增加默认兜底逻辑，如果 img 加载 error，则自动切换成fallback 图标
![image](https://github.com/DouyinFE/semi-design/assets/88709023/580b64b9-284a-46d0-b8ba-fd4c95b04d2c)



### Changelog
🇨🇳 Chinese
- Fix: Upload preview 为true时，增加对其他类型文件的预览兜底，防止 pdf 等其他类型文件加载失败时显示 x 裂图

---

🇺🇸 English
- Fix: When Upload preview is true, add previews for other types of files to prevent pdf and other types of files from displaying x-cracked images when loading fails


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
