### PR TITLE
fix: typography popover ellipsis remove default 240px width, close #1766

### DIFF
--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -259,7 +259,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
                 return merge(
                     {
                         opts: {
-                            style: { width: '240px' },
+                            // style: { width: '240px' },
                             showArrow: true,
                         },
                     },


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description


### Changelog
🇨🇳 Chinese
- Style:  Typography ellipsis showTooltip设为 popover时，移除默认自带的 240px width，与popover单独使用时保持一致 #1766 

---

🇺🇸 English
- Style: Typography when ellipsis showTooltip is set to popover, remove the default 240px width, which is consistent with popover alone #1766


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
