### PR TITLE
feat: upload add picHeight, picWidth, close #1757

### DIFF
--- a/content/input/upload/index-en-US.md
+++ b/content/input/upload/index-en-US.md
@@ -97,7 +97,7 @@ import { IconPlus } from '@douyinfe/semi-icons';
         };
         let style = { ...basicStyle, ...marginStyle[pos] };
 
-        return <div style={style}>Please upload pet certification materials</div>;
+        return <div style={style}>Please upload certification materials</div>;
     };
     const defaultFileList = [
         {
@@ -739,7 +739,7 @@ Set `hotSpotLocation` to customize the order of click hotspots, the default is a
 
 ```jsx live=true width=48%
 import React from 'react';
-import { Upload, Select } from '@douyinfe/semi-ui';
+import { Upload, Select, RadioGroup, Radio } from '@douyinfe/semi-ui';
 import { IconPlus, IconEyeOpened } from '@douyinfe/semi-icons';
 
 () => {
@@ -759,13 +759,16 @@ import { IconPlus, IconEyeOpened } from '@douyinfe/semi-icons';
         const feature = "width=300,height=300";
         window.open(file.url, 'imagePreview', feature);
     };
-    const [hotSpotLocation, $hotSpotLocation] = useState('end');
+    const [hotSpotLocation, setLocation] = useState('end');
     return (
         <>
-            <Select value={hotSpotLocation} onChange={$hotSpotLocation} style={{ width: 120 }}>
-                <Select.Option value='start'>Start</Select.Option>
-                <Select.Option value='end'>End</Select.Option>
-            </Select>
+            <RadioGroup
+                value={hotSpotLocation}
+                type='button'
+                onChange={e => setLocation(e.target.value)}>
+                <Radio value='start'>start</Radio>
+                <Radio value='end'>end</Radio>
+            </RadioGroup>
             <hr />
             <Upload
                 action={action}
@@ -778,6 +781,84 @@ import { IconPlus, IconEyeOpened } from '@douyinfe/semi-icons';
                 onPreviewClick={handlePreview}
             >
                 <IconPlus size="extra-large" />
+            </Upload>
+        </>
+    );
+};
+```
+
+### Photo Wall With Preview
+With the Image component, through the renderThumbnail API, you can click on the image to enlarge the preview
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Image } from '@douyinfe/semi-ui';
+import { IconPlus } from '@douyinfe/semi-icons';
+
+() => {
+    let action = 'https://api.semi.design/upload';
+    const defaultFileList = [
+        {
+            uid: '1',
+            name: 'music.png',
+            status: 'success',
+            size: '130KB',
+            preview: true,
+            url:
+                'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/Resso.png',
+        }
+    ];
+    return (
+        <>
+            <Upload
+                action={action}
+                listType="picture"
+                accept="image/*"
+                multiple
+                defaultFileList={defaultFileList}
+                renderThumbnail={(file) => (<Image src={file.url} />)}
+            >
+                <IconPlus size="extra-large" />
+            </Upload>
+        </>
+    );
+};
+```
+
+### Photo Wall Width/Height
+By setting picHeight, picWidth (provided after v2.42), the width and height of picture wall elements can be uniformly set
+
+```jsx live=true dir="column"
+import React from 'react';
+import { Upload } from '@douyinfe/semi-ui';
+import { IconPlus } from '@douyinfe/semi-icons';
+
+() => {
+    let action = 'https://api.semi.design/upload';
+    const defaultFileList = [
+        {
+            uid: '1',
+            name: 'image-1.jpg',
+            status: 'success',
+            size: '130KB',
+            preview: true,
+            url:
+                'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract.jpg',
+        }
+    ];
+    return (
+        <>
+            <Upload
+                action={action}
+                listType="picture"
+                accept="image/*"
+                multiple
+                defaultFileList={defaultFileList}
+                picHeight={110}
+                picWidth={200}
+            >
+                <IconPlus size="extra-large" style={{ margin: 4 }} />
+                Click to add picture
             </Upload>
         </>
     );
@@ -1251,6 +1332,8 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |onRetry | Upload retry callback | (file: <FileItem\>) => void | | 1.18.0 |
 |onSizeError | File size invalid callback| (file:[File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList:Array<FileItem\>) => void | | |
 |onSuccess | Callback after successful upload| (responseBody: object, file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList:Array<FileItem\> ) => void | |
+|picHeight | Set picture display height when listType='picture' | string\|number |  | 2.42.0 |
+|picWidth | Set picture display width when listType='picture' | string\|number |  | 2.42.0 |
 |previewFile | Customize the preview logic, the content returned by this function will replace the original thumbnail | (fileItem: FileItem) => ReactNode | | |
 |prompt | Custom slot, which can be used to insert prompt text. Different from writing directly in `children`, the content of `prompt` will not trigger upload when clicked.<br/>(In the picture wall mode, the incoming prompt is only supported after v1.3.0) | ReactNode | | |
 |promptPosition | The position of the prompt text. When the listType is list, the reference object is the children element; when the listType is picture, the reference object is the picture list. Optional values ​​`left`, `right`, `bottom`<br/> (In picture wall mode, promptPosition is only supported after v1.3.0) | string |'right' | |

--- a/content/input/upload/index.md
+++ b/content/input/upload/index.md
@@ -494,7 +494,7 @@ import { IconUpload, IconFile } from '@douyinfe/semi-icons';
 ```jsx live=true width=48%
 import React from 'react';
 import { Upload, Button } from '@douyinfe/semi-ui';
-import { IconUpload, IconDownload, IconEyeOpened } from '@douyinfe/semi-icons';
+import { IconUpload, IconDownload, IconEyeOpened, IconDelete } from '@douyinfe/semi-icons';
 
 () => {
     let action = 'https://api.semi.design/upload';
@@ -628,7 +628,7 @@ import { IconUpload } from '@douyinfe/semi-icons';
 };
 ```
 
-### 照片墙
+### 图片墙
 
 设置 `listType = 'picture'`，用户可以上传图片并在列表中显示缩略图
 
@@ -699,10 +699,47 @@ import { IconPlus } from '@douyinfe/semi-icons';
 };
 ```
 
+### 图片墙放大预览
+配合 Image 组件，通过 renderThumbnail API ，可以实现点击图片放大预览
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Image } from '@douyinfe/semi-ui';
+import { IconPlus } from '@douyinfe/semi-icons';
+
+() => {
+    let action = 'https://api.semi.design/upload';
+    const defaultFileList = [
+        {
+            uid: '1',
+            name: 'music.png',
+            status: 'success',
+            size: '130KB',
+            preview: true,
+            url:
+                'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/Resso.png',
+        }
+    ];
+    return (
+        <>
+            <Upload
+                action={action}
+                listType="picture"
+                accept="image/*"
+                multiple
+                defaultFileList={defaultFileList}
+                renderThumbnail={(file) => (<Image src={file.url} />)}
+            >
+                <IconPlus size="extra-large" />
+            </Upload>
+        </>
+    );
+};
+```
+
 可以通过 `renderPicPreviewIcon`，`onPreviewClick` 来自定义预览图标，当显示替换图标 `showReplace` 时，不会再显示预览图标<br />
 当需要自定义预览/替换功能时，需要关闭替换功能，使用 `renderPicPreviewIcon` 监听图标点击事件即可。<br />
 `onPreviewClick` 监听的是单张图片容器的点击事件
-
 
 ```jsx live=true width=48%
 import React from 'react';
@@ -745,11 +782,53 @@ import { IconPlus, IconEyeOpened } from '@douyinfe/semi-icons';
 };
 ```
 
+### 图片墙设置宽高
+通过设置 picHeight, picWidth （ v2.42 后提供），可以统一设置图片墙元素的宽高
+
+```jsx live=true dir="column"
+import React from 'react';
+import { Upload } from '@douyinfe/semi-ui';
+import { IconPlus } from '@douyinfe/semi-icons';
+
+() => {
+    let action = 'https://api.semi.design/upload';
+    const defaultFileList = [
+        {
+            uid: '1',
+            name: 'image-1.jpg',
+            status: 'success',
+            size: '130KB',
+            preview: true,
+            url:
+                'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract.jpg',
+        }
+    ];
+    return (
+        <>
+            <Upload
+                action={action}
+                listType="picture"
+                accept="image/*"
+                multiple
+                defaultFileList={defaultFileList}
+                picHeight={110}
+                picWidth={200}
+            >
+                <IconPlus size="extra-large" style={{ margin: 4 }} />
+                点击添加图片
+            </Upload>
+        </>
+    );
+};
+```
+
+
+
 设置 `hotSpotLocation` 自定义点击热区的顺序，默认在照片墙列表结尾
 
 ```jsx live=true width=48%
 import React from 'react';
-import { Upload, Select } from '@douyinfe/semi-ui';
+import { Upload, Select, RadioGroup, Radio } from '@douyinfe/semi-ui';
 import { IconPlus, IconEyeOpened } from '@douyinfe/semi-icons';
 
 () => {
@@ -769,13 +848,16 @@ import { IconPlus, IconEyeOpened } from '@douyinfe/semi-icons';
         const feature = "width=300,height=300";
         window.open(file.url, 'imagePreview', feature);
     };
-    const [hotSpotLocation, $hotSpotLocation] = useState('end');
+    const [hotSpotLocation, setLocation] = useState('end');
     return (
         <>
-            <Select value={hotSpotLocation} insetLabel='hotSpotLocation' onChange={$hotSpotLocation} style={{ width: 250 }}>
-                <Select.Option value='start'>开始</Select.Option>
-                <Select.Option value='end'>结尾</Select.Option>
-            </Select>
+            <RadioGroup
+                value={hotSpotLocation}
+                type='button'
+                onChange={e => setLocation(e.target.value)}>
+                <Radio value='start'>start</Radio>
+                <Radio value='end'>end</Radio>
+            </RadioGroup>
             <hr />
             <Upload
                 action={action}
@@ -1221,20 +1303,20 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |accept | `html` 原生属性，接受上传的[文件类型](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#attr-accept)。<br/>`accept` 的值为你允许选择文件的[MIME types 字符串](https://developer.mozilla.org/en-US/docs/Web/HTTP/Basics_of_HTTP/MIME_types/Complete_list_of_MIME_types)或文件后缀（.jpg等） | string | |  |
 |action | 文件上传地址，必填 | string |  |  |
 |afterUpload | 文件上传后的钩子，根据 return 的 object 更新文件状态 | function(auProps) => afterUploadResult |  | 1.0.0 |
-|beforeClear|清空文件前回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(fileList: Array<FileItem \>) => boolean \| Promise||1.31.0|
-|beforeRemove|移除文件前的回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(file: <FileItem\>, fileList: Array<FileItem \>) => boolean \| Promise||1.31.0|
+|beforeClear|清空文件前回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(fileList: Array<FileItem \>) => boolean\|Promise||1.31.0|
+|beforeRemove|移除文件前的回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(file: <FileItem\>, fileList: Array<FileItem \>) => boolean\|Promise||1.31.0|
 |beforeUpload | 上传文件前的钩子，根据 return 的 object 更新文件状态，控制是否上传 | function(buProps) => beforeUploadResult \| Promise \| boolean |  | 1.0.0 |
-|capture | 文件上传控件中媒体拍摄的方式 | boolean \| string \| undefined | | |
+|capture | 文件上传控件中媒体拍摄的方式 | boolean\|string\|undefined | | |
 |className | 类名 | string |  |  |
 |customRequest | 自定义上传使用的异步请求方法 | (object: customRequestArgs) => void |  | 1.5.0 |
 |data | 上传时附带的额外参数或返回上传额外参数的方法 | object\|(file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File)) => object | {} |  |
 |defaultFileList | 已上传的文件列表 | Array<FileItem\> | [] |  |
 |directory | 文件夹类型上传 | boolean | false | 1.20.0 |
 |disabled | 是否禁用 | boolean | false |  |
-|dragIcon | 拖拽区左侧 Icon | ReactNode | `<IconUpload />` | 0.22.0 |
-|dragMainText | 拖拽区主文本 | ReactNode | '点击上传文件或拖拽文件到这里' | 0.22.0 |
-|dragSubText | 拖拽区帮助文本 | ReactNode | '' | 0.22.0 |
-|draggable | 是否支持拖拽上传 | boolean | false | 0.22.0 |
+|dragIcon | 拖拽区左侧 Icon | ReactNode | `<IconUpload />` |  |
+|dragMainText | 拖拽区主文本 | ReactNode | '点击上传文件或拖拽文件到这里' | |
+|dragSubText | 拖拽区帮助文本 | ReactNode | '' |  |
+|draggable | 是否支持拖拽上传 | boolean | false |  |
 |fileList | 已上传的文件列表，传入该值时，upload 即为受控组件 | Array<FileItem\> |  | 1.0.0 |
 |fileName | 作用与 name 相同，主要在 Form.Upload 中使用，为了避免与 Field 的 props.name 冲突，此处另外提供一个重命名的 props | string |  | 1.0.0 |
 |headers | 上传时附带的 headers 或返回上传额外 headers 的方法 | object\|(file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File)) => object | {} |  |
@@ -1260,6 +1342,8 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |onRetry | 上传重试的回调 | (file: <FileItem\>) => void |  | 1.18.0 |
 |onSizeError | 文件尺寸非法的回调 | (file:[File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList:Array<FileItem\>) => void |  |  |
 |onSuccess | 上传成功后的回调 | (responseBody: object, file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList:Array<FileItem\>) => void |  |
+|picHeight | 图片墙模式下，可通过该 API 定制图片展示高度 | string\|number |  | 2.42.0 |
+|picWidth | 图片墙模式下，可通过该 API 定制图片展示宽度 | string\|number |  | 2.42.0 |
 |previewFile | 自定义预览逻辑，该函数返回内容将会替换原缩略图 | (fileItem: FileItem) => ReactNode |  |  |
 |prompt | 自定义插槽，可用于插入提示文本。与直接在 `children` 中写的区别时，`prompt` 的内容在点击时不会触发上传<br/>（图片墙模式下，v1.3.0 后才支持传入 prompt） | ReactNode |  |  |
 |promptPosition | 提示文本的位置，当 listType 为 list 时，参照物为 children 元素；当 listType 为 picture 时，参照物为图片列表。可选值 `left`、`right`、`bottom`<br/>（图片墙模式下，v1.3.0 后才支持使用 promptPosition） | string | 'right' |  |

--- a/packages/semi-ui/upload/_story/upload.stories.jsx
+++ b/packages/semi-ui/upload/_story/upload.stories.jsx
@@ -265,6 +265,10 @@ const defaultFileList = [
     name: 'jiafang2.jpeg',
     status: 'uploadFail',
     size: '222kb',
+    style: {
+      width: 300,
+      height: 300,
+    },
     url:
       'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg',
   },
@@ -277,15 +281,15 @@ const defaultFileList = [
     url:
       'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg',
   },
-  {
-    uid: '4',
-    name: 'jiafang3.jpeg',
-    status: 'validateFail',
-    validateMessage: '文件过大',
-    size: '222kb',
-    url:
-      'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg',
-  },
+  // {
+  //   uid: '4',
+  //   name: 'jiafang3.jpeg',
+  //   status: 'validateFail',
+  //   validateMessage: '文件过大',
+  //   size: '222kb',
+  //   url:
+  //     'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/bag.jpeg',
+  // },
   {
     uid: '5',
     name: 'jiafang4.jpeg',
@@ -413,6 +417,42 @@ export const PictureListTypeWithDefaultFileList = () => (
 
 PictureListTypeWithDefaultFileList.story = {
   name: 'picture listType with default file list',
+};
+
+export const PictureListTypeWithCustomHeightWidth = () => {
+  const urls = [
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/abstract.jpg",
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/sky.jpg",
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/greenleaf.jpg",
+        "https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/colorful.jpg",
+  ];
+  const list = defaultFileList.map((item, i) => {
+    let newItem = {...item};
+    newItem.url = urls[i];
+    return newItem;
+  });
+  return (
+    <>
+      <Upload
+        {...commonProps}
+        showReplace={false}
+        action={action}
+        listType="picture"
+        accept="image/*"
+        picHeight={110}
+        picWidth={200}
+        defaultFileList={list}
+      >
+        <React.Fragment>
+          <IconPlus size="extra-large" />
+        </React.Fragment>
+      </Upload>
+    </>
+  )
+};
+
+PictureListTypeWithCustomHeightWidth.story = {
+  name: 'picture listType with custom height width',
 };
 
 class ManulUploadDemo extends React.Component {
@@ -1148,3 +1188,4 @@ export const ClickToOpenUploadDemo = () => <ClickToOpenUpload></ClickToOpenUploa
 ClickToOpenUploadDemo.story = {
   name: 'click to open upload demo',
 };
+

--- a/packages/semi-ui/upload/fileCard.tsx
+++ b/packages/semi-ui/upload/fileCard.tsx
@@ -44,7 +44,9 @@ const DirectorySvg: FC<SVGProps<SVGSVGElement>> = (props = {}) => (
 
 export interface FileCardProps extends RenderFileItemProps {
     className?: string;
-    style?: CSSProperties
+    style?: CSSProperties;
+    picWidth?: string | number;
+    picHeight?: string | number
 }
 
 
@@ -61,6 +63,8 @@ class FileCard extends PureComponent<FileCardProps> {
         percent: PropTypes.number,
         preview: PropTypes.bool,
         previewFile: PropTypes.func,
+        picWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        picHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         showReplace: PropTypes.bool,
         showRetry: PropTypes.bool,
         size: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
@@ -123,7 +127,7 @@ class FileCard extends PureComponent<FileCardProps> {
     }
 
     renderPic(locale: Locale['Upload']): ReactNode {
-        const { url, percent, status, disabled, style, onPreviewClick, showPicInfo, renderPicInfo, renderPicPreviewIcon, renderThumbnail, name, index } = this.props;
+        const { url, percent, status, disabled, style, onPreviewClick, showPicInfo, renderPicInfo, renderPicPreviewIcon, renderThumbnail, name, index, picHeight, picWidth } = this.props;
         const showProgress = status === strings.FILE_STATUS_UPLOADING && percent !== 100;
         const showRetry = status === strings.FILE_STATUS_UPLOAD_FAIL && this.props.showRetry;
         const showReplace = status === strings.FILE_STATUS_SUCCESS && this.props.showReplace;
@@ -162,10 +166,23 @@ class FileCard extends PureComponent<FileCardProps> {
             <div className={`${prefixCls }-picture-file-card-pic-info`}>{index + 1}</div>
         );
 
-        const thumbnail = typeof renderThumbnail === 'function' ? renderThumbnail(this.props) : <img src={url} alt={name} />;
+        let imgStyle: { height?: number | string; width?: number | string } = {};
+        let itemStyle = style ? { ...style } : {};
+
+        if (picHeight) {
+            itemStyle.height = picHeight;
+            imgStyle.height = picHeight;
+        }
+
+        if (picWidth) {
+            itemStyle.width = picWidth;
+            imgStyle.width = picWidth;
+        }
+
+        const thumbnail = typeof renderThumbnail === 'function' ? renderThumbnail(this.props) : <img src={url} alt={name} style={imgStyle}/>;
 
         return (
-            <div role="listitem" className={filePicCardCls} style={style} onClick={onPreviewClick}>
+            <div role="listitem" className={filePicCardCls} style={itemStyle} onClick={onPreviewClick}>
                 {thumbnail}
                 {showProgress ? <Progress percent={percent} type="circle" size="small" orbitStroke={'#FFF'} aria-label="uploading file progress" /> : null}
                 {showRetry ? retry : null}

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -95,6 +95,8 @@ export interface UploadProps {
     previewFile?: (renderFileItemProps: RenderFileItemProps) => ReactNode;
     prompt?: ReactNode;
     promptPosition?: PromptPositionType;
+    picHeight?: string | number;
+    picWidth?: string | number;
     renderFileItem?: (renderFileItemProps: RenderFileItemProps) => ReactNode;
     renderPicInfo?: (renderFileItemProps: RenderFileItemProps) => ReactNode;
     renderThumbnail?: (renderFileItemProps: RenderFileItemProps) => ReactNode;
@@ -170,6 +172,8 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
         previewFile: PropTypes.func, // Custom preview
         prompt: PropTypes.node,
         promptPosition: PropTypes.oneOf<UploadProps['promptPosition']>(strings.PROMPT_POSITION),
+        picWidth: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
+        picHeight: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         renderFileItem: PropTypes.func,
         renderPicPreviewIcon: PropTypes.func,
         renderFileOperation: PropTypes.func,
@@ -389,6 +393,8 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
             renderThumbnail,
             disabled,
             onPreviewClick,
+            picWidth,
+            picHeight,
         } = this.props;
         const onRemove = (): void => this.remove(file);
         const onRetry = (): void => {
@@ -418,6 +424,8 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
                 typeof onPreviewClick !== 'undefined'
                     ? (): void => this.foundation.handlePreviewClick(file)
                     : undefined,
+            picWidth,
+            picHeight
         };
 
         if (status === strings.FILE_STATUS_UPLOAD_FAIL && !validateMessage) {
@@ -449,7 +457,7 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     };
 
     renderFileListPic = () => {
-        const { showUploadList, limit, disabled, children, draggable, hotSpotLocation } = this.props;
+        const { showUploadList, limit, disabled, children, draggable, hotSpotLocation, picHeight, picWidth } = this.props;
         const { fileList: stateFileList, dragAreaStatus } = this.state;
         const fileList = this.props.fileList || stateFileList;
         const showAddTriggerInList = limit ? limit > fileList.length : true;
@@ -470,6 +478,10 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
             role: 'button',
             className: uploadAddCls,
             onClick: this.onClick,
+            style: {
+                height: picHeight,
+                width: picWidth
+            }
         };
         const containerProps = {
             className: fileListCls,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description


### Changelog
🇨🇳 Chinese
- Feat:  Upload 新增 picWidth、picHeight 快速设置图片墙模式下图片展示宽高 #1757 

---

🇺🇸 English
- Feat: Upload adds picWidth and picHeight to quickly set the width and height of pictures in picture wall mode #1757


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
