### PR TITLE
style: Set the font-family of datePicker to $font-family-regular, con…

### DIFF
--- a/packages/semi-foundation/datePicker/datePicker.scss
+++ b/packages/semi-foundation/datePicker/datePicker.scss
@@ -1072,6 +1072,7 @@ $module-list: #{$prefix}-scrolllist;
                 font-weight: $font-datepicker_range_input_prefix_suffix_clearbtn-fontWeight;
                 font-size: $font-datepicker_range_input_prefix_suffix_clearbtn-fontSize;
                 line-height: $font-datepicker_range_input_prefix_suffix_clearbtn-lineHeight;
+                font-family: $font-family-regular;
                 white-space: nowrap;
                 color: $color-datepicker_range_input-text-default;
             }


### PR DESCRIPTION
…sistent with the insert-label of other components

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style: 设置 datePicker 的内嵌标签的 font-family 为 $font-family-regular，和其他组件的内嵌标签保持一致

---

🇺🇸 English
- Style: Set the font-family of the inset label of datePicker to $font-family-regular, consistent with the  inset label  of other components


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
用户反馈 Datepicker 的 inset label 在使用时候和其他组件（select, input, cascader,.....）的样式不同, 对比了下是 datePicker 的 inset label 的样式设置中没有指定 font-family，加上 font-family 设置，和其他组件保持一致，font-family 设置为 $font-family-regular