### PR TITLE
fix: [Typo] Fix Typography under the js truncation strategy. When it …

### DIFF
--- a/cypress/e2e/typography.spec.js
+++ b/cypress/e2e/typography.spec.js
@@ -81,4 +81,12 @@ describe('typography', () => {
         cy.get('.semi-typography-ellipsis').eq(1).children('.semi-typography-ellipsis-expand').should('not.exist');
     });
 
+    it('js ellipsis, no truncate, no tooltip', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=typography--js-ellipsis-no-tooltip&args=&viewMode=story');
+        cy.viewport(800, 1000);
+        cy.get('.semi-typography').trigger('mouseover');
+        cy.wait(1000);
+        cy.get('.semi-tooltip-content').should('not.exist');;
+    });
+
 });

--- a/packages/semi-ui/typography/_story/typography.stories.jsx
+++ b/packages/semi-ui/typography/_story/typography.stories.jsx
@@ -809,3 +809,14 @@ export const TextNoWarning = () => {
     </div>
   )
 }
+
+export const JsEllipsisNoTooltip = () => (
+  <Title 
+    heading={5} 
+    ellipsis={{ showTooltip: true, suffix: ' ' }} 
+    // wordBreak 设置在 Title 的style里
+    style={{ width: 250, wordBreak: 'break-all' }}
+  >
+      data_tns
+  </Title>
+)

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -327,6 +327,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             pos
         );
         this.setState({
+            isOverflowed: false,
             ellipsisContent: content,
             isTruncated: children !== content,
         });


### PR DESCRIPTION
…is judged not to truncate, an unexpected tooltip will appear when the mouse moves into the content

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 js 截断策略下的 Typography ，当判断为不截断，鼠标移入内容出现意外 tooltip 问题

---

🇺🇸 English
- Fix: Fix Typography under the Js truncation strategy. When it is judged not to truncate, an unexpected tooltip will still appear when the mouse moves into the content


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
