### PR TITLE
fix: fix portal not popup when in react18 strict mode

### DIFF
--- a/packages/semi-ui/_portal/index.tsx
+++ b/packages/semi-ui/_portal/index.tsx
@@ -55,7 +55,7 @@ class Portal extends PureComponent<PortalProps, PortalState> {
     initContainer = (context: ContextValue, catchError = false) => {
         try {
             let container: HTMLElement | undefined = undefined;
-            if (!this.state?.container || !this.el || !Array.from(this.state.container.childNodes).includes(this.el)) {
+            if (!this.el || !this.state?.container || !Array.from(this.state.container.childNodes).includes(this.el)) {
                 this.el = document.createElement('div');
                 const getContainer = this.props.getPopupContainer || context.getPopupContainer || defaultGetContainer;
                 const portalContainer = getContainer();


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 React18 strict mode 下 portal 不弹出的问题 #1769 

---

🇺🇸 English
- Fix: fix portal not popup when in react18 strict mode. #1769 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
