### PR TITLE
fix: [Taginput] Fixed an issue in FireFox where Chinese input could n…

### DIFF
--- a/packages/semi-foundation/tagInput/foundation.ts
+++ b/packages/semi-foundation/tagInput/foundation.ts
@@ -66,36 +66,45 @@ class TagInputFoundation extends BaseFoundation<TagInputAdapter> {
     };
 
     handleInputCompositionStart = (e: any) => {
+        const { maxLength } = this.getProps();
+        if (!isNumber(maxLength)) {
+            return;
+        }
         this._adapter.setEntering(true);
     }
 
     handleInputCompositionEnd = (e: any) => {
-        this._adapter.setEntering(false);
         const { value } = e.target;
         const {
             maxLength, 
             onInputExceed,
             separator
         } = this.getProps();
+        if (!isNumber(maxLength)) {
+            return;
+        }
+        this._adapter.setEntering(false);
         let allowChange = true;
-        const { inputValue } = this.getStates();
-        if (isNumber(maxLength)) {
-            const inputArr = getSplitedArray(inputValue, separator);
-            let index = 0;
-            for (; index < inputArr.length; index++) {
-                if (inputArr[index].length > maxLength) {
-                    allowChange = false;
-                    isFunction(onInputExceed) && onInputExceed(value);
-                    break;
-                }
+        const inputArr = getSplitedArray(value, separator);
+        let index = 0;
+        for (; index < inputArr.length; index++) {
+            if (inputArr[index].length > maxLength) {
+                allowChange = false;
+                isFunction(onInputExceed) && onInputExceed(value);
+                break;
             }
-            if (!allowChange) {
-                const newInputArr = inputArr.slice(0, index);
-                if (index < inputArr.length) {
-                    newInputArr.push(inputArr[index].slice(0, maxLength));
-                }
-                this._adapter.setInputValue(newInputArr.join(separator));
+        }
+        if (!allowChange) {
+            const newInputArr = inputArr.slice(0, index);
+            if (index < inputArr.length) {
+                newInputArr.push(inputArr[index].slice(0, maxLength));
             }
+            this._adapter.setInputValue(newInputArr.join(separator));
+        } else {
+            // Why does it need to be updated here instead of in onChange when the value meets the maxLength limit?
+            // Because in firefox, the state change in InputCompositionEnd causes onChange to not be triggered after 
+            // the composition input completes input.
+            this._adapter.setInputValue(value);
         }
     }
 


### PR DESCRIPTION
…ot complete character-to-Chinese conversion

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1810 

### Changelog
🇨🇳 Chinese
- Fix: 修复在 Firefox 浏览器中， 中文输入无法正常显示问题（影响版本 2.26.0～2.42.4） #1810 

---

🇺🇸 English
- Fix: Fixed the problem that Chinese input cannot be displayed properly in Firefox browser(effect version 2.26.0～2.42.4) #1810 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

问题原因：
v2.26.0 中 [1347](https://github.com/DouyinFE/semi-design/issues/1347)修复 TagInput 在中文输入(mac 自带输入法）时，会将拼音的长度用于判断是否超出 maxLength 的问题。 在 TagInput 的 Input 增加组合输入开始和结束的回调 onCompositionEnd 和 onCompositionStart， 并通过增加 entering 的状态变量标识是否处于输入中。

通过对于普通的 [input](https://codesandbox.io/s/nameless-dawn-9cmnm2?file=/src/App.jsx) 中： onCompositionEnd， onInput， onChange 的触发顺序是 
Chrome/Safari：onInput -> onChange->onCompositionEnd;
FireFox:  onCompositionEnd -> onInput -> onChange;

在 FireFox 中，对于 Taginput ，onCompositionEnd 的状态变更导致 onChange 没有被触发，影响了中文的回显。该情况在 Chrome /Safari 中未出现。


本次提交的修改：
1. entering，onCompositionEnd，onCompositionStart的引入是为了解决 maxLength 情况下中文输入问题。将 entering 的状态变更限制在设置了合理的 maxLength 的情况下，防止entering，onCompositionEnd，onCompositionStart 对未设置 maxLength 的 Taginput 造成影响。
2. 在设置 maxLength 情况下，为保障中文正常回显，将 InputValue 的状态变更放在 onCompositionEnd 中，防止 onChange 未触发导致影响
