### PR TITLE
fix: Remove repeated comparisons of the same variable

### DIFF
--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -213,8 +213,11 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
             return firstInProps || treeDataHasChange;
         };
 
+        const needUpdateTreeData = needUpdate('treeData');
+        const needUpdateSimpleJson = needUpdate('treeDataSimpleJson');
+
         // Update the data of tree in state
-        if (needUpdate('treeData') || (props.draggable && needUpdateData())) {
+        if (needUpdateTreeData || (props.draggable && needUpdateData())) {
             treeData = props.treeData;
             newState.treeData = treeData;
             const entitiesMap = convertDataToEntities(treeData);
@@ -224,7 +227,7 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
             keyEntities = newState.keyEntities;
             newState.cachedKeyValuePairs = { ...entitiesMap.valueEntities };
             valueEntities = newState.cachedKeyValuePairs;
-        } else if (needUpdate('treeDataSimpleJson')) {
+        } else if (needUpdateSimpleJson) {
             // Convert treeDataSimpleJson to treeData
             treeData = convertJsonToData(props.treeDataSimpleJson);
             newState.treeData = treeData;
@@ -244,7 +247,7 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
                 newState.motionType = null;
             }
         }
-        const dataUpdated = needUpdate('treeDataSimpleJson') || needUpdate('treeData');
+        const dataUpdated = needUpdateSimpleJson || needUpdateTreeData;
         const expandAllWhenDataChange = dataUpdated && props.expandAll;
         if (!isSeaching) {
             // Update expandedKeys

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -366,9 +366,11 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const newState: Partial<TreeSelectState> = {
             prevProps: props,
         };
+        const needUpdateTreeData = needUpdate('treeData');
+        const needUpdateExpandedKeys = needUpdate('expandedKeys');
 
         // TreeNode
-        if (needUpdate('treeData')) {
+        if (needUpdateTreeData) {
             treeData = props.treeData;
             newState.treeData = treeData;
             const entitiesMap = convertDataToEntities(treeData);
@@ -391,9 +393,9 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 newState.motionType = null;
             }
         }
-        const expandAllWhenDataChange = needUpdate('treeData') && props.expandAll;
+        const expandAllWhenDataChange = needUpdateTreeData && props.expandAll;
         // expandedKeys
-        if (needUpdate('expandedKeys') || (prevProps && needUpdate('autoExpandParent'))) {
+        if (needUpdateExpandedKeys || (prevProps && needUpdate('autoExpandParent'))) {
             newState.expandedKeys = calcExpandedKeys(
                 props.expandedKeys,
                 keyEntities,
@@ -429,7 +431,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             );
         }
         // flattenNodes
-        if (treeData || needUpdate('expandedKeys')) {
+        if (treeData || needUpdateExpandedKeys) {
             const flattenNodes = flattenTreeData(
                 treeData || prevState.treeData,
                 newState.expandedKeys || prevState.expandedKeys
@@ -511,7 +513,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         }
 
         // ================== rePosKey ==================
-        if (needUpdate('treeData') || needUpdate('value')) {
+        if (needUpdateTreeData || needUpdate('value')) {
             newState.rePosKey = rePosKey + 1;
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 去掉 TreeSelect/Tree 的 getDerivedState 中对 TreeData 是否变化的多余比较

---

🇺🇸 English
- Fix: Remove the redundant comparison of whether TreeData has changed in getDerivedState of TreeSelect/Tree


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
