### PR TITLE
fix: issues 1560 Wrong number of tags after selection under ellipsisTrigger

### DIFF
--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -1094,7 +1094,9 @@ class Select extends BaseComponent<SelectProps, SelectState> {
         const { maxTagCount } = this.props;
         const maxVisibleCount = selections.size - maxTagCount;
         const newOverFlowItemCount = maxVisibleCount > 0 ? maxVisibleCount + items.length - 1 : items.length - 1;
-        if (items.length > 1 && overflowItemCount !== newOverFlowItemCount) {
+
+        // fix: issues 1560
+        if (items.length >= 1 && overflowItemCount !== newOverFlowItemCount) {
             this.foundation.updateOverflowItemCount(selections.size, newOverFlowItemCount);
         }
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->


- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1560

### Changelog
🇨🇳 Chinese
- Fix:  issues #1560  
下拉框折叠更多数量显示错误的问题

修复原因：是因为需要正确的数量更新的那一次update，没有调用update，没有调用update的原因是因为if判断的问题

bug截图
![image](https://user-images.githubusercontent.com/101160769/233000874-64efb21d-e8c3-4b24-860a-fc906f3905f1.gif)

---

🇺🇸 English
- Fix:  issues #1560  Wrong number of tags after selection under ellipsisTrigger

The drop-down box collapses with more numbers and displays the wrong problem

Reason for repair: The update was not called when the correct number of updates was needed. The reason why update was not called was because of the if judgment problem.

bug screenshot
![image](https://user-images.githubusercontent.com/101160769/233000874-64efb21d-e8c3-4b24-860a-fc906f3905f1.gif)

---

### Checklist
- [x] Test
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
