### PR TITLE
fix(select): 修复Select 通过 showClear 清空后，用户配置的 blur 失焦触发校验的Props 不生效的bug

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -506,6 +506,13 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
         const { isOpen } = this.getStates();
         if (isOpen) {
             this._adapter.rePositionDropdown();
+        } else {
+            // fix: #1453
+            this._adapter.registerClickOutsideHandler((e: MouseEvent) => {
+                this.close(e);
+                this._notifyBlur(e);
+                this._adapter.updateFocusState(false);
+            });
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1453

### Changelog
🇨🇳 Chinese
- Fix: 修复Select 通过 showClear 清空后，用户配置的 blur 失焦触发校验的Props 不生效的bug
修复原因：
因为Select在Open的时候，会注册registerClickOutsideHandler事件，来触发blur的规则校验，但是配置showClear之后，点击clear按钮，并没有open select，所以没有注册registerClickOutsideHandler，所以在clearSelected的时候注册registerClickOutsideHandler事件，这里不怕多次点击clear按钮会重复注册，因为注册事件的时候里面判断会解绑多余的注册事件，如下源码：

`tooltip/index.ts`
```ts
...
registerClickOutsideHandler: (cb: () => void) => {
   if (this.clickOutsideHandler) {
      this.adapter.unregisterClickOutsideHandler();
  }
...
```

---

🇺🇸 English
- Fix: Fix the bug that the Props configured by the user to trigger the verification of blur out of focus do not take effect after the Select is cleared through showClear.
Reason for repair:
Because when Select is Open, it will register the registerClickOutsideHandler event to trigger blur rule verification. However, after configuring showClear, clicking the clear button does not open select, so the registerClickOutsideHandler is not registered, so the registerClickOutsideHandler event is registered when clearSelected. Don't be afraid here. Clicking the clear button multiple times will result in repeated registration, because when registering events, it will be judged to unbind redundant registration events, as shown in the following source code:

`tooltip/index.ts`
```ts
...
registerClickOutsideHandler: (cb: () => void) => {
   if (this.clickOutsideHandler) {
      this.adapter.unregisterClickOutsideHandler();
  }
...
```
### Checklist
- [x] Test
- [x] Document no need
- [x] Changelog need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
