### PR TITLE
fix: [Tree/TreeSelect] Fixed where checkRelation is unRelated, asynch…

### DIFF
--- a/cypress/e2e/tree.spec.js
+++ b/cypress/e2e/tree.spec.js
@@ -32,5 +32,13 @@ describe('tree', () => {
         cy.get('.semi-tree-option-expand-icon');
     });
 
+    it("unRelated + async load", () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=tree--un-related-and-async-load&args=&viewMode=story');
+        cy.get('.semi-checkbox').eq(0).get('.semi-checkbox-inner-checked').should("exist");
+        cy.get('.semi-icon-tree_triangle_down').eq(0).trigger('click');
+        // sync load, 1000ms
+        cy.wait(1000);
+        cy.get('.semi-checkbox').eq(0).get('.semi-checkbox-inner-checked').should("exist");
+    });
 
 });

--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -108,5 +108,14 @@ describe('treeSelect', () => {
         cy.get('.semi-tree-select').eq(1).click();
         cy.get('.semi-tree-select-popover').should('exist');
     });
+
+    it("unRelated + async load", () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--un-related-and-async-load');
+        cy.get('.semi-checkbox').eq(0).get('.semi-checkbox-inner-checked').should("exist");
+        cy.get('.semi-icon-tree_triangle_down').eq(0).trigger('click');
+        // sync load, 1000ms
+        cy.wait(1000);
+        cy.get('.semi-checkbox').eq(0).get('.semi-checkbox-inner-checked').should("exist");
+    });
 });
 

--- a/packages/semi-ui/tree/_story/tree.stories.jsx
+++ b/packages/semi-ui/tree/_story/tree.stories.jsx
@@ -2694,3 +2694,73 @@ export const SearchableAndExpandedKeys = () => {
       </>
   )
 }
+
+export const UnRelatedAndAsyncLoad = () => {
+  const initialData = [
+      {
+          label: 'Expand to load0',
+          value: '0',
+          key: '0',
+      },
+      {
+          label: 'Expand to load1',
+          value: '1',
+          key: '1',
+      },
+      {
+          label: 'Leaf Node',
+          value: '2',
+          key: '2',
+          isLeaf: true,
+      },
+  ];
+  const [treeData, setTreeData] = useState(initialData);
+
+  function updateTreeData(list, key, children) {
+      return list.map(node => {
+          if (node.key === key) {
+              return { ...node, children };
+          }
+          if (node.children) {
+              return { ...node, children: updateTreeData(node.children, key, children) };
+          }
+          return node;
+      });
+  }
+
+  function onLoadData({ key, children }) {
+      return new Promise(resolve => {
+          if (children) {
+              resolve();
+              return;
+          }
+          setTimeout(() => {
+              setTreeData(origin =>
+                  updateTreeData(origin, key, [
+                      {
+                          label: `Child Node${key}-0`,
+                          key: `${key}-0`,
+                      },
+                      {
+                          label: `Child Node${key}-1`,
+                          key: `${key}-1`,
+                      },
+                  ]),
+              );
+              resolve();
+          }, 1000);
+      });
+  }
+  return (
+    <>
+      <span>issue 1852: checkRelation='unRelated', 异步加载数据</span>
+      <Tree
+        checkRelation='unRelated'
+        defaultValue={['0']}
+        multiple
+        loadData={onLoadData}
+        treeData={[...treeData]}
+      />
+    </>
+  );
+};

--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -431,7 +431,7 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
                         isMultiple
                     );
                 } else {
-                    checkedKeyValues = updateKeys(prevState.checkedKeys, keyEntities);
+                    checkedKeyValues = updateKeys(props.checkRelation === 'related' ? prevState.checkedKeys : prevState.realCheckedKeys, keyEntities);
                 }
             }
 

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2346,3 +2346,74 @@ export const LongLabel = () => {
     </>
   );
 }
+
+export const UnRelatedAndAsyncLoad = () => {
+  const initialData = [
+      {
+          label: 'Expand to load0',
+          value: '0',
+          key: '0',
+      },
+      {
+          label: 'Expand to load1',
+          value: '1',
+          key: '1',
+      },
+      {
+          label: 'Leaf Node',
+          value: '2',
+          key: '2',
+          isLeaf: true,
+      },
+  ];
+  const [treeData, setTreeData] = useState(initialData);
+
+  function updateTreeData(list, key, children) {
+      return list.map(node => {
+          if (node.key === key) {
+              return { ...node, children };
+          }
+          if (node.children) {
+              return { ...node, children: updateTreeData(node.children, key, children) };
+          }
+          return node;
+      });
+  }
+
+  function onLoadData({ key, children }) {
+      return new Promise(resolve => {
+          if (children) {
+              resolve();
+              return;
+          }
+          setTimeout(() => {
+              setTreeData(origin =>
+                  updateTreeData(origin, key, [
+                      {
+                          label: `Child Node${key}-0`,
+                          key: `${key}-0`,
+                      },
+                      {
+                          label: `Child Node${key}-1`,
+                          key: `${key}-1`,
+                      },
+                  ]),
+              );
+              resolve();
+          }, 1000);
+      });
+  }
+  return (
+    <>
+      <span>issue 1852: checkRelation='unRelated', 异步加载数据</span>
+      <TreeSelect
+        checkRelation='unRelated'
+        defaultValue={['0']}
+        multiple
+        defaultOpen
+        loadData={onLoadData}
+        treeData={[...treeData]}
+      />
+    </>
+  );
+};

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -491,7 +491,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                         isMultiple
                     );
                 } else {
-                    checkedKeyValues = updateKeys(prevState.checkedKeys, keyEntities);
+                    checkedKeyValues = updateKeys(props.checkRelation === 'related' ? prevState.checkedKeys : prevState.realCheckedKeys, keyEntities);
                 }
             }
 


### PR DESCRIPTION
…ronous loading of data will cause the selected status to be lost

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1852 

### Changelog
🇨🇳 Chinese
- Fix: 修复 checkRelation 为 unRelated 的 Tree/TreeSelect 中，异步加载数据导致已选状态丢失问题
---

🇺🇸 English
- Fix: Fixed the problem of asynchronous loading of data in Tree/TreeSelect where checkRelation is unRelated, causing the selected status to be lost.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
