### PR TITLE
fix: Fix the inconsistent order of onBlur callback and onSelect callb…

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -426,10 +426,7 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         this._persistEvent(e);
         // In order to handle the problem of losing onClick binding when clicking on the padding area, the onBlur event is triggered first to cause the react view to be updated
         // internal-issues:1231
-        setTimeout(() => {
-            this._adapter.notifyBlur(e);
-            // this.closeDropdown();
-        }, 100);
+        this._adapter.notifyBlur(e);
     }
 }
 


### PR DESCRIPTION
…ack in AutoComplete

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1880 

### Changelog
🇨🇳 Chinese
- Fix: 修复 AutoComplete 中 onBlur 和 onSelect 的调用顺序不一致问题 #1880 

---

🇺🇸 English
- Fix: Fix the inconsistent order of onBlur callback and onSelect callback in AutoComplete #1880 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->

问题分析：
实际响应顺序应当是  onBlur, onSelect, 历史修改有由于某些原因将 onBlur 的回调放在了 setTimeout 中，导致调用顺序不一致问题，当前代码结构中，不需要将 onBlur 放在 setTimeout 中，去掉 setTimeout，从而保持两者调用顺序的一致性
