### PR TITLE
fix: select option never use key in jsx declare usage

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -939,6 +939,8 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
         delete newOption._show;
         delete newOption._selected;
         delete newOption._scrollIndex;
+        delete newOption._keyInJsx;
+        
         if ('_keyInOptionList' in newOption) {
             newOption.key = newOption._keyInOptionList;
             delete newOption._keyInOptionList;

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -3367,3 +3367,21 @@ class VirtualizeAllowCreate extends React.Component {
 
 // virtualize allowCreate + renderCreateItem, optionList render not as expected
 export const Fix1856 = () => (<VirtualizeAllowCreate />); 
+
+
+export const TestOptionKey = () => {
+  return <><Select style={{ width: 300 }}>
+      <Select.Option label='3' value='2' key='abc'></Select.Option>
+      <Select.Option label='2' value='3' key='efg'></Select.Option>
+      <Select.Option label='4' value='5'></Select.Option>
+      <Select.Option label='5' value='4'></Select.Option>
+    </Select>
+    <br/><br/>
+    <Select style={{ width: 300 }} optionList={[
+      { label: '1', value: '2', key: 'kkk' },
+      { label: '2', value: '3', key: 'jjj' },
+      { label: '3', value: '2' },
+    ]}>
+    </Select>
+  </>
+}

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -181,14 +181,14 @@ export type SelectProps = {
     showRestTagsPopover?: boolean;
     restTagsPopoverProps?: PopoverProps
 } & Pick<
-    TooltipProps,
-    | 'spacing'
-    | 'getPopupContainer'
-    | 'motion'
-    | 'autoAdjustOverflow'
-    | 'mouseLeaveDelay'
-    | 'mouseEnterDelay'
-    | 'stopPropagation'
+TooltipProps,
+| 'spacing'
+| 'getPopupContainer'
+| 'motion'
+| 'autoAdjustOverflow'
+| 'mouseLeaveDelay'
+| 'mouseEnterDelay'
+| 'stopPropagation'
 > & React.RefAttributes<any>;
 
 export interface SelectState {
@@ -775,7 +775,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
                     focused={isFocused}
                     onMouseEnter={() => this.onOptionHover(optionIndex)}
                     style={optionStyle}
-                    key={option.key || option.label as string + option.value as string + optionIndex}
+                    key={option._keyInOptionList || option._keyInJsx || option.label as string + option.value as string + optionIndex}
                     renderOptionItem={renderOptionItem}
                     inputValue={inputValue}
                     semiOptionId={`${this.selectID}-option-${optionIndex}`}

--- a/packages/semi-ui/select/utils.tsx
+++ b/packages/semi-ui/select/utils.tsx
@@ -22,7 +22,7 @@ const generateOption = (child: React.ReactElement, parent: any, index: number): 
     // Props are collected from ReactNode, after React.Children.toArray
     // no need to determine whether the key exists in child
     // Even if the user does not explicitly declare it, React will always generate a key.
-    option.key = child.key;
+    option._keyInJsx = child.key;
     
     return option;
 };

--- a/packages/semi-ui/select/utils.tsx
+++ b/packages/semi-ui/select/utils.tsx
@@ -10,7 +10,7 @@ const generateOption = (child: React.ReactElement, parent: any, index: number): 
     }
     const option = {
         value: childProps.value,
-        // Drop-down menu rendering priority label value, children, value in turn downgrade
+        // Dropdown menu rendering priority label value, children, value in turn downgrade
         label: childProps.label || childProps.children || childProps.value,
         _show: true,
         _selected: false,
@@ -18,6 +18,12 @@ const generateOption = (child: React.ReactElement, parent: any, index: number): 
         ...childProps,
         _parentGroup: parent,
     };
+
+    // Props are collected from ReactNode, after React.Children.toArray
+    // no need to determine whether the key exists in child
+    // Even if the user does not explicitly declare it, React will always generate a key.
+    option.key = child.key;
+    
     return option;
 };
 


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
1. Select 使用 JSX 传入 Option时，Option的 key 未被收集，从而导致在 renderOption 列表时，总是走到兜底逻辑中去，在少数场景下，会导致react 抛出列表项 key 重复 的 warning
![image](https://github.com/DouyinFE/semi-design/assets/88709023/afa51d45-b735-4f28-afad-b83b0689dbc7)

2. 仅影响 JSX 传入 option 写法，若使用 props.optionList 传入后选项无该问题

3. 需要区分 props.optionList 中带key，与  JSX 传入 option时带key两种情况。前者的key 在 onSelect、onChange回调入参里需要保留，后者不需要


### Changelog
🇨🇳 Chinese
- Fix: 修复 Select 使用 JSX 传入 Option时，Option传入的 key 未在渲染时生效的问题

---

🇺🇸 English
- Fix: Fix the problem that when Select uses JSX to pass in Option, the key passed in Option does not take effect during rendering.


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
