### PR TITLE
Fix 1892

### DIFF
--- a/packages/semi-ui/calendar/_story/calendar.stories.jsx
+++ b/packages/semi-ui/calendar/_story/calendar.stories.jsx
@@ -634,3 +634,89 @@ export const MonthEventRender = () => {
             ></Calendar>
         )
 }
+
+export const TestDemo = () => {
+    const [events, setEvents] = React.useState([]);
+        const allDayStyle = {
+            borderRadius: '3px',
+            boxSizing: 'border-box',
+            border: 'var(--semi-color-bg-1) 1px solid',
+            padding: '2px 4px',
+            backgroundColor: 'var(--semi-color-primary-light-active)',
+            height: '100%',
+            overflow: 'hidden',
+        };
+        const dailyStyle = allDayStyle;
+        const events1 = [
+            {
+                key: '0',
+                start: new Date(2019, 5, 25, 14, 45, 0),
+                end: new Date(2019, 6, 26, 6, 18, 0),
+                children: <div style={dailyStyle}>6月25日 14:45 ~ 7月26日 6:18</div>,
+            },
+            {
+                key: '1',
+                start: new Date(2019, 6, 18, 10, 0, 0),
+                end: new Date(2019, 6, 30, 8, 0, 0),
+                children: <div style={allDayStyle}>7月18日 10:00 ~ 7月30日 8:00</div>,
+            },
+            {
+                key: '2',
+                start: new Date(2019, 6, 19, 20, 0, 0),
+                end: new Date(2019, 6, 23, 14, 0, 0),
+                children: <div style={allDayStyle}>7月19日 20:00 ~ 7月23日 14:00</div>,
+            },
+            {
+                key: '3',
+                start: new Date(2019, 6, 21, 6, 0, 0),
+                end: new Date(2019, 6, 25, 6, 0, 0),
+                children: <div style={allDayStyle}>7月21日 6:00 ~ 7月25日 6:00</div>,
+            },
+            {
+                key: '4',
+                allDay: true,
+                start: new Date(2019, 6, 22, 8, 0, 0),
+                children: <div style={allDayStyle}>7月22日 全天</div>,
+            },
+            {
+                key: '5',
+                start: new Date(2019, 6, 22, 9, 0, 0),
+                end: new Date(2019, 6, 23, 23, 0, 0),
+                children: <div style={allDayStyle}>7月22日 9:00 ~ 7月23日 23:00</div>,
+            },
+            {
+                key: '6',
+                start: new Date(2019, 6, 23, 8, 32, 0),
+                children: <div style={dailyStyle}>7月23日 8:32</div>,
+            },
+            {
+                key: '7',
+                start: new Date(2019, 6, 23, 14, 30, 0),
+                end: new Date(2019, 6, 23, 20, 0, 0),
+                children: <div style={dailyStyle}>7月23日 14:30-20:00</div>,
+            },
+            {
+                key: '8',
+                start: new Date(2019, 6, 25, 8, 0, 0),
+                end: new Date(2019, 6, 27, 6, 0, 0),
+                children: <div style={allDayStyle}>7月25日 8:00 ~ 7月27日 6:00</div>,
+            },
+            {
+                key: '9',
+                start: new Date(2019, 6, 26, 10, 0, 0),
+                end: new Date(2019, 6, 27, 16, 0, 0),
+                children: <div style={allDayStyle}>7月26日 10:00 ~ 7月27日 16:00</div>,
+            },
+        ];
+        return (
+            <>
+                <Calendar
+                    height={305}
+                    mode={'month'}
+                    displayValue={new Date(2019, 6, 23, 8, 32, 0)}
+                    events={events}
+                ></Calendar>
+                <Button onClick={()=> setEvents(events1)}>change events</Button>
+            </>
+        );
+    }

--- a/packages/semi-ui/calendar/_story/calendar.stories.jsx
+++ b/packages/semi-ui/calendar/_story/calendar.stories.jsx
@@ -635,7 +635,7 @@ export const MonthEventRender = () => {
         )
 }
 
-export const TestDemo = () => {
+export const Fix1892 = () => {
     const [events, setEvents] = React.useState([]);
         const allDayStyle = {
             borderRadius: '3px',

--- a/packages/semi-ui/calendar/monthCalendar.tsx
+++ b/packages/semi-ui/calendar/monthCalendar.tsx
@@ -157,7 +157,7 @@ export default class monthCalendar extends BaseComponent<MonthCalendarProps, Mon
             }
         }
         if (!isEqual(prevEventKeys, nowEventKeys) || itemLimitUpdate || !isEqual(prevProps.displayValue, this.props.displayValue)) {
-            this.foundation.parseMonthlyEvents((itemLimit || this.props.events) as any);
+            this.foundation.parseMonthlyEvents(itemLimit);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1892
根本原因是在 componentDidUpdate 时，更新了一个非 number 值的 itemLimit。
导致 shouldRenderCollapsed 的判断始终为 false，不展示 「还有 x 项」。

### Changelog
🇨🇳 Chinese
- Fix: 修复高度不足以容纳一个事件时，更新事件后不展示 「还有 x 项」问题

---

🇺🇸 English
- Fix: Fixed the problem that "x more" is not displayed after updating the event when the height is not enough to accommodate an event.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
