### PR TITLE
fix: pagination popoverZIndex don't take effect on sizeChanger

### DIFF
--- a/content/start/changelog/index-en-US.md
+++ b/content/start/changelog/index-en-US.md
@@ -16,6 +16,9 @@ Version：Major.Minor.Patch (follow the **Semver** specification)
 
 ---
 
+#### 🎉 2.46.1 (2023-11-07)
+- 【Fix】
+    - Fixed the problem that Pagination popoverZIndex does not take effect on SizeChanger
 
 #### 🎉 2.46.0 (2023-11-03)
 - 【Fix】

--- a/content/start/changelog/index.md
+++ b/content/start/changelog/index.md
@@ -14,6 +14,9 @@ Semi 版本号遵循 **Semver** 规范（主版本号-次版本号-修订版本�
 -   不同版本间的详细关系，可查阅 [FAQ](/zh-CN/start/faq)
 
 
+#### 🎉 2.46.1 (2023-11-07)
+- 【Fix】
+    - 修复 Pagination popoverZIndex 在 SizeChanger 上不生效的问题
 
 #### 🎉 2.46.0 (2023-11-03)
 - 【Fix】

--- a/packages/semi-ui/pagination/index.tsx
+++ b/packages/semi-ui/pagination/index.tsx
@@ -275,7 +275,7 @@ export default class Pagination extends BaseComponent<PaginationProps, Paginatio
         // rtl modify the default position
         const { direction } = this.context;
         const defaultPopoverPosition = direction === 'rtl' ? 'bottomRight' : 'bottomLeft';
-        const { showSizeChanger, popoverPosition = defaultPopoverPosition, disabled } = this.props;
+        const { showSizeChanger, popoverPosition = defaultPopoverPosition, disabled, popoverZIndex } = this.props;
         const { pageSize } = this.state;
         const switchCls = classNames(`${prefixCls}-switch`);
         if (!showSizeChanger) {
@@ -303,6 +303,7 @@ export default class Pagination extends BaseComponent<PaginationProps, Paginatio
                     key={pageSize}
                     position={popoverPosition || 'bottomRight'}
                     clickToHide
+                    zIndex={popoverZIndex}
                     dropdownClassName={`${prefixCls}-select-dropdown`}
                 >
                     {options}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Pagination popoverZIndex 在 SizeChanger 上不生效的问题

---

🇺🇸 English
- Fix: Fixed the problem that Pagination popoverZIndex does not take effect on SizeChanger


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
