### PR TITLE
fix: fix right click trigger the onClick func

### DIFF
--- a/packages/semi-ui/dropdown/dropdownItem.tsx
+++ b/packages/semi-ui/dropdown/dropdownItem.tsx
@@ -94,7 +94,11 @@ class DropdownItem extends BaseComponent<DropdownItemProps> {
         if (!disabled) {
             ['onClick', 'onMouseEnter', 'onMouseLeave', 'onContextMenu'].forEach(eventName => {
                 if (eventName === "onClick") {
-                    events["onMouseDown"] = this.props[eventName];
+                    events["onMouseDown"] = (e: React.MouseEvent<HTMLLIElement, MouseEvent>)=>{
+                        if (e.button===0) { 
+                            this.props[eventName](e); 
+                        }
+                    };
                 } else {
                     events[eventName] = this.props[eventName];
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Dropdown Item 右键和中键也会触发 onClick 的问题

---

🇺🇸 English
- Fix: Fix the problem that the right and middle click of Dropdown Item will also trigger onClick


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
