### PR TITLE
fix: select group option without key, filter error after v2.46

### DIFF
--- a/cypress/e2e/select.spec.js
+++ b/cypress/e2e/select.spec.js
@@ -63,6 +63,23 @@ describe('Select', () => {
         cy.get('.semi-select-option').should('have.text', 'Design');
     });
 
+    it('optionGroup without key setting, filter',  () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?path=/story/select--select-option-group');
+        cy.get('#without-key').eq(0).click();
+        cy.get('#without-key .semi-input').eq(0).type('dou');
+        cy.wait(500);
+        cy.get('.semi-select-option-keyword').should('have.text', 'Dou');
+        cy.get('.semi-select-group').should('have.text', 'Group1');
+        cy.get('#without-key .semi-input').eq(0).type('{backspace}{backspace}{backspace}');
+        cy.wait(500);
+        cy.get('.semi-select-group').eq(0).should('have.text', 'Group1');
+        cy.get('.semi-select-group').eq(1).should('have.text', 'Group2');
+        cy.get('.semi-select-option').eq(0).should('have.text', 'Douyin');
+        cy.get('.semi-select-option').eq(1).should('have.text', 'Ulikecam');
+        cy.get('.semi-select-option').eq(2).should('have.text', 'Capcut');
+        cy.get('.semi-select-option').eq(3).should('have.text', 'Xigua');
+    });
+
     // it('ellipsisTrigger', () => {
     //     cy.visit('http://127.0.0.1:6006/iframe.html?path=/story/select--fix-1560');
 

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -2101,7 +2101,6 @@ _CustomCreate.story = {
 class OptionGroupDemo extends React.Component {
   constructor(props) {
     super(props);
-    this.handleSearch = this.handleSearch.bind(this);
     this.state = {
       groups: [
         {
@@ -2143,24 +2142,6 @@ class OptionGroupDemo extends React.Component {
     };
   }
 
-  handleSearch(input) {
-    let groups = [1, 2, 3].map(i => {
-      return {
-        label: i,
-        // label: Math.random(),
-        children: [10, 20].map(j => {
-          return {
-            label: Math.random(),
-            value: Math.random(),
-          };
-        }),
-      };
-    });
-    this.setState({
-      groups,
-    });
-  }
-
   renderGroup(group, index) {
     const options = group.children.map(option => (
       <Select.Option value={option.value} label={option.label} key={option.label} />
@@ -2173,16 +2154,44 @@ class OptionGroupDemo extends React.Component {
     return (
       <>
         <Select
-          placeholder=""
+          placeholder="with key"
+          id='with-key'
           style={{
             width: 180,
           }}
           filter
-          onSearch={this.handleSearch}
-          remote
         >
           {groups.map((group, index) => this.renderGroup(group, index))}
         </Select>
+
+        <Select
+          filter={(sugInput, option) => {
+              let label = option.label.toUpperCase();
+              let sug = sugInput.toUpperCase();
+              return label.includes(sug);
+          }}
+          id='without-key'
+          style={{ width: "180px" }}
+          placeholder="without key"
+        >
+          <Select.OptGroup label="Group1">
+            <Select.Option value="douyin">
+              Douyin
+            </Select.Option>
+            <Select.Option value="ulikecam">
+              Ulikecam
+            </Select.Option>
+          </Select.OptGroup>
+          <Select.OptGroup label="Group2">
+            <Select.Option value="jianying">
+              Capcut
+            </Select.Option>
+            <Select.Option value="xigua">
+              Xigua
+            </Select.Option>
+          </Select.OptGroup>
+        </Select>
+
       </>
     );
   }
@@ -3371,10 +3380,10 @@ export const Fix1856 = () => (<VirtualizeAllowCreate />);
 
 export const TestOptionKey = () => {
   return <><Select style={{ width: 300 }}>
-      <Select.Option label='3' value='2' key='abc'></Select.Option>
-      <Select.Option label='2' value='3' key='efg'></Select.Option>
-      <Select.Option label='4' value='5'></Select.Option>
-      <Select.Option label='5' value='4'></Select.Option>
+      <Select.Option label='abc' value='2' key='abc'></Select.Option>
+      <Select.Option label='efg' value='3' key='efg'></Select.Option>
+      <Select.Option label='kkk' value='5'></Select.Option>
+      <Select.Option label='fff' value='4'></Select.Option>
     </Select>
     <br/><br/>
     <Select style={{ width: 300 }} optionList={[

--- a/packages/semi-ui/select/utils.tsx
+++ b/packages/semi-ui/select/utils.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import warning from '@douyinfe/semi-foundation/utils/warning';
 import { OptionProps } from './option';
 import { OptionGroupProps } from './optionGroup';
-import Item from 'cascader/item';
 
 const generateOption = (child: React.ReactElement, parent: any, index: number, newKey?: string | number): OptionProps => {
     const childProps = child.props;

--- a/packages/semi-ui/select/utils.tsx
+++ b/packages/semi-ui/select/utils.tsx
@@ -55,7 +55,13 @@ const getOptionsFromGroup = (selectChildren: React.ReactNode) => {
             type = 'group';
             // Avoid saving children (reactNode) by... removing other props from the group except children, causing performance problems
             let { children, ...restGroupProps } = child.props;
-            const originKeys = children.map(item => item.key);
+            let originKeys = [];
+            if (Array.isArray(children)) {
+                // if group has children > 1
+                originKeys = children.map(item => item.key);
+            } else {
+                originKeys.push(children.key);
+            }
             children = React.Children.toArray(children);
             const childrenOption = children.map((option: React.ReactElement, index: number) => {
                 let newKey = option.key;

--- a/packages/semi-ui/select/utils.tsx
+++ b/packages/semi-ui/select/utils.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import warning from '@douyinfe/semi-foundation/utils/warning';
 import { OptionProps } from './option';
 import { OptionGroupProps } from './optionGroup';
+import Item from 'cascader/item';
 
-const generateOption = (child: React.ReactElement, parent: any, index: number): OptionProps => {
+const generateOption = (child: React.ReactElement, parent: any, index: number, newKey?: string | number): OptionProps => {
     const childProps = child.props;
     if (!child || !childProps) {
         return null;
@@ -22,7 +23,7 @@ const generateOption = (child: React.ReactElement, parent: any, index: number): 
     // Props are collected from ReactNode, after React.Children.toArray
     // no need to determine whether the key exists in child
     // Even if the user does not explicitly declare it, React will always generate a key.
-    option._keyInJsx = child.key;
+    option._keyInJsx = newKey || child.key;
     
     return option;
 };
@@ -55,10 +56,15 @@ const getOptionsFromGroup = (selectChildren: React.ReactNode) => {
             type = 'group';
             // Avoid saving children (reactNode) by... removing other props from the group except children, causing performance problems
             let { children, ...restGroupProps } = child.props;
+            const originKeys = children.map(item => item.key);
             children = React.Children.toArray(children);
-            const childrenOption = children.map((option: React.ReactElement) => {
+            const childrenOption = children.map((option: React.ReactElement, index: number) => {
+                let newKey = option.key;
+                if (originKeys[index] === null) {
+                    newKey = child.key + '' + option.key; // if option in group and didn't set key, concat parent key to avoid conflict (default generate key just like .0, .1)
+                }
                 optionIndex++;
-                return generateOption(option, restGroupProps, optionIndex);
+                return generateOption(option, restGroupProps, optionIndex, newKey);
             });
             const group = {
                 ...child.props,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- 由于 v2.46.0 为了修复 https://github.com/DouyinFE/semi-design/pull/1889 在 Select 父级收集 子级Option的处理过程中，增加了 key的赋值逻辑
![image](https://github.com/DouyinFE/semi-design/assets/88709023/7bddaa3f-8a94-4c4d-88bd-00479d79edbc)

在 Group 场景下，如果option未声明key，按照当前逻辑，最终key如下

```
.group1
 .1
 .2
.group2
 .1
 .2
```
存在重合的 key，所以导致筛选后列表显示出错

![20231128151618_rec_](https://github.com/DouyinFE/semi-design/assets/88709023/d66fbb4f-97e0-4262-af0f-6c240e246b89)



### Changelog
🇨🇳 Chinese
- Fix: 修复 Select Group 分组场景使用 Option，未显式声明 key属性时，filter 后列表筛选错误的问题，影响范围 (v2.46.0-v2.47.0)

---

🇺🇸 English
- Fix: Fixed the problem of incorrect list filtering after filter when Option is used in Select Group grouping scenario and the key attribute is not explicitly declared. The scope of impact is (v2.46.0-v2.47.0)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
