### PR TITLE
fix: [TreeSelect] Fixed the problem that showFilteredOnly does not ta…

### DIFF
--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -133,7 +133,11 @@ describe('treeSelect', () => {
         cy.get('.semi-tree-option').eq(1).children('.semi-icon-tree_triangle_down').eq(0).trigger('click');
         cy.get('.semi-tree-option').should('have.length', 6);
         cy.get('body').click();
+        // 等待弹出层收起
+        cy.wait(500);
         cy.get('.semi-tree-select-selection').eq(0).trigger('click');
+        // 等待弹出层展开
+        cy.wait(500);
         cy.get('.semi-tree-option').should('have.length', 2);
         cy.get('.semi-tree-select-inputTrigger').eq(0).children(".semi-input").eq(0).type('o');
         cy.get('.semi-tree-option').should('have.length', 4);

--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -117,5 +117,34 @@ describe('treeSelect', () => {
         cy.wait(1000);
         cy.get('.semi-checkbox').eq(0).get('.semi-checkbox-inner-checked').should("exist");
     });
+
+    it('expanded controlled + showFilteredOnly', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--issue-1542');
+        cy.get('.semi-tree-select-selection').eq(0).trigger('click');
+        cy.get('.semi-tree-select-inputTrigger').eq(0).children(".semi-input").eq(0).type('b');
+        // showFilteredOnly，因此搜索后的选项应该只有 3 项
+        cy.get('.semi-tree-option').should('have.length', 3);
+        // 清空搜索框，由 state 中的 expandedKeys 决定展示展示项，应该只有两项
+        cy.get('.semi-tree-select-inputTrigger').eq(0).children(".semi-input").eq(0).clear();
+        cy.get('.semi-tree-option').should('have.length', 2);
+        cy.get('.semi-tree-select-inputTrigger').eq(0).children(".semi-input").eq(0).type('s');
+        cy.get('.semi-tree-option').should('have.length', 9);
+        // 搜索状态下，输入框有值，被筛选的选项点击展开按钮行为正常
+        cy.get('.semi-tree-option').eq(1).children('.semi-icon-tree_triangle_down').eq(0).trigger('click');
+        cy.get('.semi-tree-option').should('have.length', 6);
+        cy.get('body').click();
+        cy.get('.semi-tree-select-selection').eq(0).trigger('click');
+        cy.get('.semi-tree-option').should('have.length', 2);
+        cy.get('.semi-tree-select-inputTrigger').eq(0).children(".semi-input").eq(0).type('o');
+        cy.get('.semi-tree-option').should('have.length', 4);
+        cy.get('.semi-tree-option').eq(3).trigger('click');
+        cy.wait(1000);
+        cy.get('.semi-tree-select-selection').eq(0).trigger('click');
+        cy.wait(1000);
+        // 此时展开项目由选中项和原来的 state 中的 expandedKeys 决定
+        cy.get('.semi-tree-option').should('have.length', 4);
+        cy.get('.semi-icon-tree_triangle_down').eq(0).trigger('click');
+        cy.get('.semi-tree-option').should('have.length', 6);
+    });
 });
 

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2664,7 +2664,8 @@ export const Issue1542 = () => {
   }, [expandedKeys]);
 
   const onSearch = useCallback((inputValue, filteredExpandedKeys) => {
-    setExpandedKeys([...filteredExpandedKeys, ...expandedKeys]);
+    const set = new Set([...filteredExpandedKeys, ...expandedKeys]);
+    setExpandedKeys(Array.from(set));
   }, [setExpandedKeys]);
 
   return (

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useMemo, useRef, useCallback, useEffect } from 'react';
-import { Icon, Input, Button, Form, Popover, Tag, Typography, CheckboxGroup, TagInput, Switch } from '../../index';
+import { Icon, Input, Button, Form, Popover, Tag, Typography, CheckboxGroup, TagInput, Switch, Tree } from '../../index';
 import TreeSelect from '../index';
 import { flattenDeep, cloneDeep } from 'lodash';
 import CustomTrigger from './CustomTrigger';
@@ -279,6 +279,67 @@ const specialTreeData = [
       },
     ],
   },
+];
+
+const treeDataEn = [
+  {
+      label: 'Asia',
+      value: 'Asia',
+      key: '0',
+      children: [
+          {
+              label: 'China',
+              value: 'China',
+              key: '0-0',
+              children: [
+                  {
+                      label: 'Beijing',
+                      value: 'Beijing',
+                      key: '0-0-0',
+                  },
+                  {
+                      label: 'Shanghai',
+                      value: 'Shanghai',
+                      key: '0-0-1',
+                  },
+                  {
+                      label: 'Chengdu',
+                      value: 'Chengdu',
+                      key: '0-0-2',
+                  },
+              ],
+          },
+          {
+              label: 'Japan',
+              value: 'Japan',
+              key: '0-1',
+              children: [
+                  {
+                      label: 'Osaka',
+                      value: 'Osaka',
+                      key: '0-1-0'
+                  }
+              ]
+          },
+      ],
+  },
+  {
+      label: 'North America',
+      value: 'North America',
+      key: '1',
+      children: [
+          {
+              label: 'United States',
+              value: 'United States',
+              key: '1-0'
+          },
+          {
+              label: 'Canada',
+              value: 'Canada',
+              key: '1-1'
+          }
+      ]
+  }
 ];
 
 export const TreeSelectWrapper = () => (
@@ -1382,66 +1443,7 @@ DisabledStrictly.story = {
 
 
 export const CheckRelationDemo = () => {
-  const treeData = [
-    {
-        label: 'Asia',
-        value: 'Asia',
-        key: '0',
-        children: [
-            {
-                label: 'China',
-                value: 'China',
-                key: '0-0',
-                children: [
-                    {
-                        label: 'Beijing',
-                        value: 'Beijing',
-                        key: '0-0-0',
-                    },
-                    {
-                        label: 'Shanghai',
-                        value: 'Shanghai',
-                        key: '0-0-1',
-                    },
-                    {
-                        label: 'Chengdu',
-                        value: 'Chengdu',
-                        key: '0-0-2',
-                    },
-                ],
-            },
-            {
-                label: 'Japan',
-                value: 'Japan',
-                key: '0-1',
-                children: [
-                    {
-                        label: 'Osaka',
-                        value: 'Osaka',
-                        key: '0-1-0'
-                    }
-                ]
-            },
-        ],
-    },
-    {
-        label: 'North America',
-        value: 'North America',
-        key: '1',
-        children: [
-            {
-                label: 'United States',
-                value: 'United States',
-                key: '1-0'
-            },
-            {
-                label: 'Canada',
-                value: 'Canada',
-                key: '1-1'
-            }
-        ]
-    }
-  ];
+  const treeData = treeDataEn;
   const [value, setValue] = useState('China');
   const [value2, setValue2] = useState();
   const [value3, setValue3] = useState();
@@ -2653,3 +2655,32 @@ export const KeyMaps = () => {
     </> 
   );
 }
+
+export const Issue1542 = () => {
+  const [expandedKeys, setExpandedKeys] = useState([]);
+  const treeData = treeDataEn;
+  const onExpand = useCallback((expandedKeys) => {
+    setExpandedKeys(expandedKeys);
+  }, [expandedKeys]);
+
+  const onSearch = useCallback((inputValue, filteredExpandedKeys) => {
+    setExpandedKeys([...filteredExpandedKeys, ...expandedKeys]);
+  }, [setExpandedKeys]);
+
+  return (
+    <>
+      <TreeSelect
+          // multiple
+          style={{ width: 300 }}
+          dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+          treeData={treeData}
+          filterTreeNode
+          searchPosition='trigger'
+          showFilteredOnly
+          expandedKeys={expandedKeys}
+          onExpand={onExpand}
+          onSearch={onSearch}
+      />
+    </>  
+  );
+};

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -25,6 +25,7 @@ import {
     calcDisabledKeys,
     normalizeValue,
     updateKeys,
+    filterTreeData
 } from '@douyinfe/semi-foundation/tree/treeUtil';
 import { cssClasses, strings } from '@douyinfe/semi-foundation/treeSelect/constants';
 import { numbers as popoverNumbers } from '@douyinfe/semi-foundation/popover/constants';
@@ -305,7 +306,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
     triggerRef: React.RefObject<HTMLDivElement>;
     optionsRef: React.RefObject<any>;
     clickOutsideHandler: any;
-    _flattenNodes: TreeState['flattenNodes'];
+    // _flattenNodes: TreeState['flattenNodes'];
     onNodeClick: any;
     onNodeDoubleClick: any;
     onMotionEnd: any;
@@ -325,6 +326,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             keyEntities: {},
             treeData: [],
             flattenNodes: [],
+            cachedFlattenNodes: undefined,
             selectedKeys: [],
             checkedKeys: new Set(),
             halfCheckedKeys: new Set(),
@@ -371,7 +373,8 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         };
         const needUpdateTreeData = needUpdate('treeData');
         const needUpdateExpandedKeys = needUpdate('expandedKeys');
-
+        const isExpandControlled = 'expandedKeys' in props;
+        const isSearching = Boolean(props.filterTreeNode && prevState.inputValue && prevState.inputValue.length);
         // TreeNode
         if (needUpdateTreeData) {
             treeData = props.treeData;
@@ -397,50 +400,135 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             }
         }
         const expandAllWhenDataChange = needUpdateTreeData && props.expandAll;
-        // expandedKeys
-        if (needUpdateExpandedKeys || (prevProps && needUpdate('autoExpandParent'))) {
-            newState.expandedKeys = calcExpandedKeys(
-                props.expandedKeys,
-                keyEntities,
-                props.autoExpandParent || !prevProps
-            );
-            // only show animation when treeData does not change
-            if (prevProps && props.motion && !treeData) {
-                const { motionKeys, motionType } = calcMotionKeys(
-                    prevState.expandedKeys,
-                    newState.expandedKeys,
-                    keyEntities
+        if (!isSearching) {
+            // expandedKeys
+            if (needUpdateExpandedKeys || (prevProps && needUpdate('autoExpandParent'))) {
+                newState.expandedKeys = calcExpandedKeys(
+                    props.expandedKeys,
+                    keyEntities,
+                    props.autoExpandParent || !prevProps
                 );
-                newState.motionKeys = new Set(motionKeys);
-                newState.motionType = motionType;
+                // only show animation when treeData does not change
+                if (prevProps && props.motion && !treeData) {
+                    const { motionKeys, motionType } = calcMotionKeys(
+                        prevState.expandedKeys,
+                        newState.expandedKeys,
+                        keyEntities
+                    );
+                    newState.motionKeys = new Set(motionKeys);
+                    newState.motionType = motionType;
+                    if (motionType === 'hide') {
+                        // cache flatten nodes: expandedKeys changed may not be triggered by interaction
+                        newState.cachedFlattenNodes = cloneDeep(prevState.flattenNodes);
+                    }
+                }
+            } else if ((!prevProps && (props.defaultExpandAll || props.expandAll)) || expandAllWhenDataChange) {
+                newState.expandedKeys = new Set(Object.keys(keyEntities));
+            } else if (!prevProps && props.defaultExpandedKeys) {
+                newState.expandedKeys = calcExpandedKeys(props.defaultExpandedKeys, keyEntities);
+            } else if (!prevProps && props.defaultValue) {
+                newState.expandedKeys = calcExpandedKeysForValues(
+                    normalizeValue(props.defaultValue, withObject, keyMaps),
+                    keyEntities,
+                    props.multiple,
+                    valueEntities
+                );
+            } else if (!prevProps && props.value) {
+                newState.expandedKeys = calcExpandedKeysForValues(
+                    normalizeValue(props.value, withObject, keyMaps),
+                    keyEntities,
+                    props.multiple,
+                    valueEntities
+                );
+            } else if ((!isExpandControlled && needUpdateTreeData) && props.value) {
+                // 当 treeData 已经设置具体的值，并且设置了 props.loadData ，则认为 treeData 的更新是因为 loadData 导致的
+                // 如果是因为 loadData 导致 treeData改变， 此时在这里重新计算 key 会导致为未选中的展开项目被收起
+                // 所以此时不需要重新计算 expandedKeys，因为在点击展开按钮时候已经把被展开的项添加到 expandedKeys 中
+                // When treeData has a specific value and props.loadData is set, it is considered that the update of treeData is caused by loadData
+                // If the treeData is changed because of loadData, recalculating the key here will cause the unselected expanded items to be collapsed
+                // So there is no need to recalculate expandedKeys at this time, because the expanded item has been added to expandedKeys when the expand button is clicked
+                if (!(prevState.treeData && prevState.treeData?.length > 0 && props.loadData)) {
+                    newState.expandedKeys = calcExpandedKeysForValues(
+                        props.value,
+                        keyEntities,
+                        props.multiple,
+                        valueEntities
+                    );
+                }
             }
-        } else if ((!prevProps && (props.defaultExpandAll || props.expandAll)) || expandAllWhenDataChange) {
-            newState.expandedKeys = new Set(Object.keys(keyEntities));
-        } else if (!prevProps && props.defaultExpandedKeys) {
-            newState.expandedKeys = calcExpandedKeys(props.defaultExpandedKeys, keyEntities);
-        } else if (!prevProps && props.defaultValue) {
-            newState.expandedKeys = calcExpandedKeysForValues(
-                normalizeValue(props.defaultValue, withObject, keyMaps),
-                keyEntities,
-                props.multiple,
-                valueEntities
-            );
-        } else if (!prevProps && props.value) {
-            newState.expandedKeys = calcExpandedKeysForValues(
-                normalizeValue(props.value, withObject, keyMaps),
-                keyEntities,
-                props.multiple,
-                valueEntities
-            );
-        }
-        // flattenNodes
-        if (treeData || needUpdateExpandedKeys) {
-            const flattenNodes = flattenTreeData(
-                treeData || prevState.treeData,
-                newState.expandedKeys || prevState.expandedKeys,
-                keyMaps,
-            );
-            newState.flattenNodes = flattenNodes;
+
+            if (!newState.expandedKeys) {
+                delete newState.expandedKeys;
+            }
+
+            if (treeData || newState.expandedKeys) {
+                const flattenNodes = flattenTreeData(
+                    treeData || prevState.treeData,
+                    newState.expandedKeys || prevState.expandedKeys,
+                    keyMaps
+                );
+                newState.flattenNodes = flattenNodes;
+            }
+        } else {
+            let filteredState;
+            // treeData changed while searching
+            if (treeData) {
+                // Get filter data
+                filteredState = filterTreeData({
+                    treeData,
+                    inputValue: prevState.inputValue,
+                    filterTreeNode: props.filterTreeNode,
+                    filterProps: props.treeNodeFilterProp,
+                    showFilteredOnly: props.showFilteredOnly,
+                    keyEntities: newState.keyEntities,
+                    prevExpandedKeys: [...prevState.filteredExpandedKeys],
+                    keyMaps: keyMaps
+                });
+                newState.flattenNodes = filteredState.flattenNodes;
+                newState.motionKeys = new Set([]);
+                newState.filteredKeys = filteredState.filteredKeys;
+                newState.filteredShownKeys = filteredState.filteredShownKeys;
+                newState.filteredExpandedKeys = filteredState.filteredExpandedKeys;
+            }
+
+            // expandedKeys changed while searching
+            if (props.expandedKeys) {
+                newState.filteredExpandedKeys = calcExpandedKeys(
+                    props.expandedKeys,
+                    keyEntities,
+                    props.autoExpandParent || !prevProps
+                );
+
+                if (prevProps && props.motion) {
+                    const prevKeys = prevState ? prevState.filteredExpandedKeys : new Set([]);
+                    // only show animation when treeData does not change
+                    if (!treeData) {
+                        const motionResult = calcMotionKeys(
+                            prevKeys,
+                            newState.filteredExpandedKeys,
+                            keyEntities
+                        );
+
+                        let { motionKeys } = motionResult;
+                        const { motionType } = motionResult;
+                        if (props.showFilteredOnly) {
+                            motionKeys = motionKeys.filter(key => prevState.filteredShownKeys.has(key));
+                        }
+                        if (motionType === 'hide') {
+                            // cache flatten nodes: expandedKeys changed may not be triggered by interaction
+                            newState.cachedFlattenNodes = cloneDeep(prevState.flattenNodes);
+                        }
+                        newState.motionKeys = new Set(motionKeys);
+                        newState.motionType = motionType;
+                    }
+                }
+                newState.flattenNodes = flattenTreeData(
+                    treeData || prevState.treeData,
+                    newState.filteredExpandedKeys || prevState.filteredExpandedKeys,
+                    keyMaps,
+                    props.showFilteredOnly && prevState.filteredShownKeys
+                );
+            }
         }
 
         // selectedKeys: single mode controlled
@@ -588,7 +676,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 this.props.onSearch && this.props.onSearch(input, filteredExpandedKeys);
             },
             cacheFlattenNodes: bool => {
-                this._flattenNodes = bool ? cloneDeep(this.state.flattenNodes) : null;
+                this.setState({ cachedFlattenNodes: bool ? cloneDeep(this.state.flattenNodes) : undefined });
             },
             notifyLoad: (newLoadedKeys, data) => {
                 const { onLoad } = this.props;
@@ -1304,12 +1392,25 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
     /* Event handler function after popover is closed */
     handlePopoverClose = isVisible => {
         const { filterTreeNode, searchAutoFocus, searchPosition } = this.props;
-        if (isVisible === false && Boolean(filterTreeNode)) {
-            this.foundation.clearInput();
+        // 将 inputValue 清空，如果有选中值的话，选中项能够快速回显
+        // Clear the inputValue. If there is a selected value, the selected item can be quickly echoed.
+        if (isVisible === false && filterTreeNode) {
+            this.foundation.clearInputValue();
         }
         if (filterTreeNode && searchPosition === strings.SEARCH_POSITION_DROPDOWN && isVisible && searchAutoFocus) {
             this.foundation.focusInput(true);
         }
+    }
+
+    afterClose = () => {
+        // flattenNode 的变化将导致弹出层面板中的选项数目变化
+        // 在弹层完全收起之后，再通过 clearInput 重新计算 state 中的 expandedKey， flattenNode
+        // 防止在弹出层未收起时弹层面板中选项数目变化导致视觉上出现弹层闪动问题
+        // Changes to flattenNode will cause the number of options in the popup panel to change
+        // After the pop-up layer is completely closed, recalculate the expandedKey and flattenNode in the state through clearInput.
+        // Prevent the pop-up layer from flickering visually due to changes in the number of options in the pop-up panel when the pop-up layer is not collapsed.
+        const { filterTreeNode } = this.props;
+        filterTreeNode && this.foundation.clearInput();
     }
 
     renderTreeNode = (treeNode: FlattenNode, ind: number, style: React.CSSProperties) => {
@@ -1334,7 +1435,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
     };
 
     renderNodeList = () => {
-        const { flattenNodes, motionKeys, motionType, filteredKeys } = this.state;
+        const { flattenNodes, cachedFlattenNodes, motionKeys, motionType, filteredKeys } = this.state;
         const { direction } = this.context;
         const { virtualize, motionExpand } = this.props;
         const isExpandControlled = 'expandedKeys' in this.props;
@@ -1342,7 +1443,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             return (
                 <NodeList
                     flattenNodes={flattenNodes}
-                    flattenList={this._flattenNodes}
+                    flattenList={cachedFlattenNodes}
                     motionKeys={motionExpand ? motionKeys : new Set([])}
                     motionType={motionType}
                     // When motionKeys is empty, but filteredKeys is not empty (that is, the search hits), this situation should be distinguished from ordinary motionKeys
@@ -1493,6 +1594,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 mouseLeaveDelay={mouseLeaveDelay}
                 mouseEnterDelay={mouseEnterDelay}
                 onVisibleChange={this.handlePopoverClose}
+                afterClose={this.afterClose}
             >
                 {selection}
             </Popover>


### PR DESCRIPTION
…ke effect in TreeSelect controlled expandedKeys

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1542 

### Changelog
🇨🇳 Chinese
- Fix: 修复受控 expandedKeys 的 TreeSelect 中，showFilteredOnly 不生效问题 #1542 

---

🇺🇸 English
- Fix: Fixed the problem that showFilteredOnly does not take effect in TreeSelect controlled expandedKeys #1542 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
