### PR TITLE
fix: when format is HH make the default value correct

### DIFF
--- a/packages/semi-foundation/timePicker/utils/index.ts
+++ b/packages/semi-foundation/timePicker/utils/index.ts
@@ -14,7 +14,7 @@ import { zhCN as defaultLocale } from 'date-fns/locale';
 export const parseToDate = (input: string | Date | number, formatToken = strings.DEFAULT_FORMAT, dateFnsLocale = defaultLocale) => {
     if (input instanceof Date) {
         return input;
-    } else if (typeof input === 'number' || !isNaN(Number(input))) {
+    } else if (typeof input === 'number') {
         return new Date(toNumber(input));
     } else if (typeof input === 'string') {
         let curDate = new Date();

--- a/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
+++ b/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
@@ -336,3 +336,9 @@ export const Fix1716 = () => {
 Fix1716.story = {
   name: 'Fix 1716',
 };
+
+export const Fix1953 = () => {
+  return (
+    <TimePicker format={'HH'} defaultValue={'10'}/>
+  );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1953 
parseToDate 函数判断中，会将类型为 number 或者 toNumber 之后不是 Nan 的字符串等同处理，即都当成时间戳处理。
所以在 #1953 里，不管 defaultValue 是 1 还是 23，当前时间的展示结果一直为 8。

DatePicker 中并没有对时间戳兼容字符串的处理，Timepicker 应当对齐。故删除后面的判断条件。使 #1953  结果符合预期。

### Changelog
🇨🇳 Chinese
- Fix: 修复 TimePicker format 为 HH 时，defaultValue 设置不正确问题。（注意：若原先 default 或 value 传入的值类型不合法，例如数字格式的时间戳以字符串形式传入，将不再尝试进行类型转换）

---

🇺🇸 English
- Fix: fixed the issue of incorrect defaultValue setting when TimePicker format is HH.(Note: If the value type originally passed in default or value is illegal, for example, a timestamp in numeric format is passed in in string form, type conversion will no longer be attempted)


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
