### PR TITLE
fix(notification): addNotice didn't use defaultConfig

### DIFF
--- a/packages/semi-ui/notification/index.tsx
+++ b/packages/semi-ui/notification/index.tsx
@@ -98,6 +98,7 @@ class NotificationList extends BaseComponent<NotificationListProps, Notification
     }
 
     static addNotice(notice: NoticeProps) {
+        notice = { ...defaultConfig, ...notice };
         const id = notice.id ?? getUuid('notification');
         if (!ref) {
             const { getPopupContainer } = notice;
@@ -137,23 +138,23 @@ class NotificationList extends BaseComponent<NotificationListProps, Notification
     }
 
     static info(opts: NoticeProps) {
-        return this.addNotice({ ...defaultConfig, ...opts, type: 'info' });
+        return this.addNotice({ ...opts, type: 'info' });
     }
 
     static success(opts: NoticeProps) {
-        return this.addNotice({ ...defaultConfig, ...opts, type: 'success' });
+        return this.addNotice({ ...opts, type: 'success' });
     }
 
     static error(opts: NoticeProps) {
-        return this.addNotice({ ...defaultConfig, ...opts, type: 'error' });
+        return this.addNotice({ ...opts, type: 'error' });
     }
 
     static warning(opts: NoticeProps) {
-        return this.addNotice({ ...defaultConfig, ...opts, type: 'warning' });
+        return this.addNotice({ ...opts, type: 'warning' });
     }
 
     static open(opts: NoticeProps) {
-        return this.addNotice({ ...defaultConfig, ...opts, type: 'default' });
+        return this.addNotice({ ...opts, type: 'default' });
     }
 
     static close(id: string) {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
I was using `config()` with `addNotice()`, but the config didn't work.

File `utils/notifiaction.ts`:
```ts
import { Notification } from "@douyinfe/semi-ui";

Notification.config({
  top: "60px",
  right: "10px",
});

export const addNotice = Notification.addNotice.bind(Notification);
```

And in somewhere else:
```ts
// ...
addNotice({ type: "error", /* ... */ });
// ...
addNotice({ type: "info", /* ... */ });
// ...
```

I never expected `addNotice` not using the default config until I checked the source code in this repo.


### Changelog
🇨🇳 Chinese
- Fix: `Notification.addNotice()` 现在使用通过 `Notification.config()` 设置的全局配置

---

🇺🇸 English
- Fix: `Notification.addNotice()` now uses the default config provided to `Notification.config()`


### Checklist
- [ ] Test or no need
- [x] Document or **[no need]**
- [x] **[Changelog]** or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
