### PR TITLE
fix: fix vertical basic step style error after setting box-sizing to …

### DIFF
--- a/packages/semi-foundation/steps/bacisSteps.scss
+++ b/packages/semi-foundation/steps/bacisSteps.scss
@@ -84,6 +84,10 @@ $basicType: #{$module}-basic;
         display: flex;
         flex-flow: column nowrap;
 
+        .#{$item}-icon {
+            box-sizing: content-box;
+        }
+
         &.#{$module}-small {
             .#{$item} {
                 .#{$item}-content {


### PR DESCRIPTION
…border-box globally

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #1985 

![image](https://github.com/DouyinFE/semi-design/assets/101110131/b1cecb61-8e0a-4fbd-ad01-6f2d8304bc4f)



### Changelog
🇨🇳 Chinese
- Fix: 修复在全局设置box-sizing 为 border-box后，vertical 的basic step 样式错误问题 #1985 

---

🇺🇸 English
- Fix: Fixed vertical basic step style error when setting box-sizing to border-box globally. #1985 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
