### PR TITLE
fix: When the image is loaded for the first time, zoom is calculated,…

### DIFF
--- a/packages/semi-foundation/image/previewImageFoundation.ts
+++ b/packages/semi-foundation/image/previewImageFoundation.ts
@@ -86,7 +86,9 @@ export default class PreviewImageFoundation<P = Record<string, any>, S = Record<
             this.setState({
                 loading: false,
             } as any);
-            this.handleResizeImage();
+            // 图片初次加载，计算 zoom，zoom 改变不需要通过回调透出
+            // When the image is loaded for the first time, zoom is calculated, and zoom changes do not need to be exposed through callbacks.
+            this.handleResizeImage(false);
         }
         const { src, onLoad } = this.getProps();
         onLoad && onLoad(src);
@@ -100,7 +102,7 @@ export default class PreviewImageFoundation<P = Record<string, any>, S = Record<
         onError && onError(src);
     }
 
-    handleResizeImage = () => {
+    handleResizeImage = (notify: boolean = true) => {
         const horizontal = !this._isImageVertical();
         const { currZoom } = this.getStates();
         const imgWidth = horizontal ? this.originImageWidth : this.originImageHeight;
@@ -120,7 +122,7 @@ export default class PreviewImageFoundation<P = Record<string, any>, S = Record<
             if (currZoom === _zoom) {
                 this.calculatePreviewImage(_zoom, null);
             } else {
-                onZoom(_zoom);
+                onZoom(_zoom, notify);
             }
         }
     }

--- a/packages/semi-foundation/image/previewInnerFoundation.ts
+++ b/packages/semi-foundation/image/previewInnerFoundation.ts
@@ -166,7 +166,6 @@ export default class PreviewInnerFoundation<P = Record<string, any>, S = Record<
             direction,
             rotation: 0,
         } as any);
-        this._adapter.notifyRotateChange(0);
     }
 
     handleDownload = () => {

--- a/packages/semi-foundation/image/previewInnerFoundation.ts
+++ b/packages/semi-foundation/image/previewInnerFoundation.ts
@@ -199,10 +199,10 @@ export default class PreviewInnerFoundation<P = Record<string, any>, S = Record<
         this._adapter.notifyRotateChange(newRotation);
     }
 
-    handleZoomImage = (newZoom: number) => {
+    handleZoomImage = (newZoom: number, notify: boolean = true) => {
         const { zoom } = this.getStates();
         if (zoom !== newZoom) {
-            this._adapter.notifyZoom(newZoom, newZoom > zoom);
+            notify && this._adapter.notifyZoom(newZoom, newZoom > zoom);
             this.setState({
                 zoom: newZoom,
             } as any);

--- a/packages/semi-ui/image/previewInner.tsx
+++ b/packages/semi-ui/image/previewInner.tsx
@@ -285,8 +285,8 @@ export default class PreviewInner extends BaseComponent<PreviewInnerProps, Previ
         this.foundation.handleRotateImage(direction);
     }
 
-    handleZoomImage = (newZoom: number) => {
-        this.foundation.handleZoomImage(newZoom);
+    handleZoomImage = (newZoom: number, notify: boolean = true) => {
+        this.foundation.handleZoomImage(newZoom, notify);
     }
 
     handleMouseUp = (e): void => {


### PR DESCRIPTION
… and zoom changes do not need to be exposed through callbacks

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2000 

### Changelog
🇨🇳 Chinese
- Fix: ImagePreview 中图片初次加载，zoom 改变不需要通过 onZoomIn/onZoomOut 回调透出 #2000 
- Fix: 修复在图片预览时切换图片触发意外的 onRotateLeft 回调

---

🇺🇸 English
- Fix: When images in ImagePreview is loaded for the first time, Zoom changes do not need to be exposed through onZoomIn/onZoomOut 
callbacks #2000 
-Fix: Fixed the issue of unexpected onRotateLeft callback being triggered when switching Images during Image preview


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
