### PR TITLE
fix: Fix the problem of indentation error of tree when renderingFullL…

### DIFF
--- a/packages/semi-foundation/tree/rtl.scss
+++ b/packages/semi-foundation/tree/rtl.scss
@@ -20,6 +20,8 @@ $module: #{$prefix}-tree;
         }
 
         .#{$module}-option {
+            padding-left: 0;
+            padding-right: $spacing-tree_option_level1-paddingLeft;
             &-label {
                 & > .#{$prefix}-icon {
                     margin-right: 0;
@@ -39,9 +41,23 @@ $module: #{$prefix}-tree;
             }
         }
 
+        @for $i from 1 through 20 {
+            li.#{$module}-option.#{$module}-option-fullLabel-level-#{$i} {
+                padding-left: 0;
+                padding-right: $spacing-tree_option_level-paddingLeft * ($i - 1) + $spacing-tree_option_level1-paddingLeft;
+            }
+        }
+
         .#{$module}-option-label-empty {
             padding-left: auto;
             padding-right: 0;
+        }
+
+        .#{$module}-option {
+            &-switcher {
+                margin-right: 0;
+                margin-left: $spacing-tree_icon-marginRight;
+            }
         }
     }
 

--- a/packages/semi-foundation/tree/tree.scss
+++ b/packages/semi-foundation/tree/tree.scss
@@ -329,6 +329,12 @@ $module: #{$prefix}-tree;
         }
     }
 
+    @for $i from 1 through 20 {
+        li.#{$module}-option.#{$module}-option-fullLabel-level-#{$i} {
+            padding-left: $spacing-tree_option_level-paddingLeft * ($i - 1) + $spacing-tree_option_level1-paddingLeft;
+        }
+    }
+
     .#{$module}-option-empty {
         &:hover,
         &:active {

--- a/packages/semi-ui/tree/treeNode.tsx
+++ b/packages/semi-ui/tree/treeNode.tsx
@@ -355,6 +355,7 @@ export default class TreeNode extends PureComponent<TreeNodeProps, TreeNodeState
         const dragOverGapBottom = dragOverNodeKey === eventKey && dropPosition === 1;
         const nodeCls = cls(prefixcls, {
             [`${prefixcls}-level-${level + 1}`]: true,
+            [`${prefixcls}-fullLabel-level-${level + 1}`]: renderFullLabel,
             [`${prefixcls}-collapsed`]: !expanded,
             [`${prefixcls}-disabled`]: Boolean(disabled),
             [`${prefixcls}-selected`]: selected,


### PR DESCRIPTION
…abel

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tree 在支持 showLine 后， renderFullLabel 时缩进错误问题 （影响范围：v2.50.0）
- Fix: 修复 Tree 在支持 showLine 后， rtl 模式下连接线和选项文字部分重合问题（影响范围：v2.50.0）

---

🇺🇸 English
- Fix: Fix the indentation error problem when renderingFullLabel after Tree supports showLine（scope of impact: v2.50.0）
- Fix: After Tree supports showLine, the connection line and option text partially overlap in rtl mode.（scope of impact: v2.50.0）


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
