### PR TITLE
fix: autoComplete throw error when clear, #2013

### DIFF
--- a/packages/semi-foundation/autoComplete/foundation.ts
+++ b/packages/semi-foundation/autoComplete/foundation.ts
@@ -262,11 +262,13 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
 
         let { data, defaultActiveFirstOption } = this.getProps();
 
-        let renderSelectedItem = this._getRenderSelectedItem();
+        let selectedOptionIndex = -1;
 
-        const options = this._generateList(data);
-
-        const selectedOptionIndex = options.findIndex(option => renderSelectedItem(option) === searchValue);
+        if (searchValue) {
+            let renderSelectedItem = this._getRenderSelectedItem();
+            const options = this._generateList(data);
+            selectedOptionIndex = options.findIndex(option => renderSelectedItem(option) === searchValue);
+        }
 
         if (selectedOptionIndex === -1 && defaultActiveFirstOption) {
             if (focusIndex !== 0) {
@@ -288,7 +290,9 @@ class AutoCompleteFoundation<P = Record<string, any>, S = Record<string, any>> e
         let { renderSelectedItem } = this.getProps();
 
         if (typeof renderSelectedItem === 'undefined') {
-            renderSelectedItem = (option: any) => option.value;
+            renderSelectedItem = (option: any) => {
+                return option?.value;
+            };
         } else if (renderSelectedItem && typeof renderSelectedItem === 'function') {
             // do nothing
         }

--- a/packages/semi-ui/autoComplete/_story/autoComplete.stories.jsx
+++ b/packages/semi-ui/autoComplete/_story/autoComplete.stories.jsx
@@ -2,343 +2,342 @@ import React, { Component, useState } from 'react';
 
 import CustomTrigger from './CustomTrigger';
 import AutoComplete from '../index';
+import { Form } from '../../index';
 import { IconSearch } from '@douyinfe/semi-icons';
 
 export default {
-  title: 'AutoComplete',
-  parameters: {
-    chromatic: { disableSnapshot: true },
-  },
-}
+    title: 'AutoComplete',
+    parameters: {
+        chromatic: { disableSnapshot: true },
+    },
+};
 
 const props = {
-  onBlur: (v, e) => {
-    console.log('onBlur');
-    console.log(v, e);
-  },
-  onFocus: (v, e) => {
-    console.log('onFocus');
-    console.log(v, e);
-  },
+    onBlur: (v, e) => {
+        console.log('onBlur');
+        console.log(v, e);
+    },
+    onFocus: (v, e) => {
+        console.log('onFocus');
+        console.log(v, e);
+    },
 };
 
 class Demo extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      data: [],
-      data2: ['mike', 'tony', 'steve'],
-    };
-    this.acref = React.createRef();
-  }
-
-  handleSearch(value) {
-    // let data =  !value ? [] : [value, value + value, value + value + value];
-    let result; // if (!value || value.indexOf('@') >= 0) {
-    //     result = [];
-    // } else {
-
-    if (value) {
-      result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
-    } else {
-      result = [];
-    } // }
-
-    this.setState({
-      data: result,
-    });
-  }
-
-  handleSearch2(value) {
-    // let data2 =  !value ? [] : [value, value + value, value + value + value];
-    let result;
-
-    if (!value || value.indexOf('@') >= 0) {
-      result = [];
-    } else {
-      result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+    constructor() {
+        super();
+        this.state = {
+            data: [],
+            data2: ['mike', 'tony', 'steve'],
+        };
+        this.acref = React.createRef();
     }
 
-    this.setState({
-      data2: result,
-    });
-  }
+    handleSearch(value) {
+        // let data =  !value ? [] : [value, value + value, value + value + value];
+        let result; // if (!value || value.indexOf('@') >= 0) {
+        //     result = [];
+        // } else {
 
-  render() {
-    const { data, data2 } = this.state;
-    return (
-      <div>
-        <AutoComplete
-          placeholder="fe"
-          className="test-ac"
-          prefix={<IconSearch />}
-          showClear
-          data={data}
-          style={{
-            width: 300,
-          }}
-          onSearch={this.handleSearch.bind(this)}
-          onSelect={v => console.log(v)}
-          {...props}
-          ref={this.acref}
-        />
-      </div>
-    );
-  }
+        if (value) {
+            result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+        } else {
+            result = [];
+        } // }
+
+        this.setState({
+            data: result,
+        });
+    }
+
+    handleSearch2(value) {
+        // let data2 =  !value ? [] : [value, value + value, value + value + value];
+        let result;
+
+        if (!value || value.indexOf('@') >= 0) {
+            result = [];
+        } else {
+            result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+        }
+
+        this.setState({
+            data2: result,
+        });
+    }
+
+    render() {
+        const { data, data2 } = this.state;
+        return (
+            <div>
+                <AutoComplete
+                    placeholder="fe"
+                    className="test-ac"
+                    prefix={<IconSearch />}
+                    showClear
+                    data={data}
+                    style={{
+                        width: 300,
+                    }}
+                    onSearch={this.handleSearch.bind(this)}
+                    onSelect={v => console.log(v)}
+                    {...props}
+                    ref={this.acref}
+                />
+            </div>
+        );
+    }
 }
 
 export const BasicUsage = () => <Demo />;
 
 class CustomOptionDemo extends Component {
-  constructor(props) {
-    super(props);
-    this.state = {
-      data: [],
-      data2: [],
-    };
-  }
-
-  search = value => {
-    let result;
-
-    if (!value) {
-      result = [];
-    } else {
-      result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
-    }
-
-    this.setState({
-      data: result,
-    });
-  };
-  renderOption = item => {
-    return (
-      <>
-        <span
-          style={{
-            color: 'pink',
-          }}
-        >
-          邮箱
-        </span>
-        : <span>{item}</span>
-      </>
-    );
-  };
-  search2 = value => {
-    let result;
-
-    if (!value) {
-      result = [];
-    } else {
-      result = ['gmail.com', '163.com', 'qq.com'].map(domain => {
-        return {
-          email: `${value}@${domain}`,
-          time: new Date().valueOf(),
-          value: `${value}@${domain}`,
+    constructor(props) {
+        super(props);
+        this.state = {
+            data: [],
+            data2: [],
         };
-      });
     }
 
-    this.setState({
-      data2: result,
-    });
-  };
-  renderObjectOption = item => {
-    return (
-      <div>
-        <span
-          style={{
-            color: 'pink',
-          }}
-        >
-          邮箱
-        </span>
-        : <span>{item.email}</span>
-        <span>time</span>: <span>{item.time}</span>
-      </div>
-    );
-  };
+    search = value => {
+        let result;
 
-  render() {
-    return (
-      <>
-        <AutoComplete
-          showClear
-          data={this.state.data}
-          renderItem={this.renderOption}
-          style={{
-            width: '250px',
-          }}
-          onSearch={this.search}
-        ></AutoComplete>
-        <br />
-        <br />
-        <AutoComplete
-          onChangeWithObject
-          style={{
-            width: '250px',
-          }}
-          renderItem={this.renderObjectOption}
-          renderSelectedItem={node => node.email}
-          data={this.state.data2}
-          onSearch={this.search2}
-        />
-      </>
-    );
-  }
+        if (!value) {
+            result = [];
+        } else {
+            result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+        }
+
+        this.setState({
+            data: result,
+        });
+    };
+    renderOption = item => {
+        return (
+            <>
+                <span
+                    style={{
+                        color: 'pink',
+                    }}
+                >
+                    邮箱
+                </span>
+                : <span>{item}</span>
+            </>
+        );
+    };
+    search2 = value => {
+        let result;
+
+        if (!value) {
+            result = [];
+        } else {
+            result = ['gmail.com', '163.com', 'qq.com'].map(domain => {
+                return {
+                    email: `${value}@${domain}`,
+                    time: new Date().valueOf(),
+                    value: `${value}@${domain}`,
+                };
+            });
+        }
+
+        this.setState({
+            data2: result,
+        });
+    };
+    renderObjectOption = item => {
+        return (
+            <div>
+                <span
+                    style={{
+                        color: 'pink',
+                    }}
+                >
+                    邮箱
+                </span>
+                : <span>{item.email}</span>
+                <span>time</span>: <span>{item.time}</span>
+            </div>
+        );
+    };
+
+    render() {
+        return (
+            <>
+                <AutoComplete
+                    showClear
+                    data={this.state.data}
+                    renderItem={this.renderOption}
+                    style={{
+                        width: '250px',
+                    }}
+                    onSearch={this.search}
+                ></AutoComplete>
+                <br />
+                <br />
+                <AutoComplete
+                    onChangeWithObject
+                    style={{
+                        width: '250px',
+                    }}
+                    renderItem={this.renderObjectOption}
+                    renderSelectedItem={node => node.email}
+                    data={this.state.data2}
+                    onSearch={this.search2}
+                />
+            </>
+        );
+    }
 }
 
 export const RenderItem = () => <CustomOptionDemo />;
 
 class WithDefaultValue extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      data: ['semi@bytedance.com', 'semi@gmail.com', 'semi@163.com'],
-    };
-    this.onSearch = this.onSearch.bind(this);
-  }
-  onSearch(value) {
-    let result;
+    constructor() {
+        super();
+        this.state = {
+            data: ['semi@bytedance.com', 'semi@gmail.com', 'semi@163.com'],
+        };
+        this.onSearch = this.onSearch.bind(this);
+    }
+    onSearch(value) {
+        let result;
 
-    if (!value) {
-      result = [];
-    } else {
-      result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+        if (!value) {
+            result = [];
+        } else {
+            result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+        }
+
+        this.setState({
+            data: result,
+        });
     }
 
-    this.setState({
-      data: result,
-    });
-  }
-
-  render() {
-    let { data } = this.state;
-    return (
-      <>
-        {/* <AutoComplete
+    render() {
+        let { data } = this.state;
+        return (
+            <>
+                {/* <AutoComplete
            defaultValue='semi@bytedance.com'
            data={data}
            onSearch={this.onSearch}
         /> */}
 
-        <AutoComplete defaultValue="semi" data={data} onSearch={this.onSearch} />
-      </>
-    );
-  }
+                <AutoComplete defaultValue="semi" data={data} onSearch={this.onSearch} />
+            </>
+        );
+    }
 }
 
 export const DefaultValue = () => <WithDefaultValue />;
 
 class ControlledMode extends React.Component {
-  constructor() {
-    super();
-    this.state = {
-      data: [],
-      dataObject: [],
-      value: '',
-    };
-    this.onSearch = this.onSearch.bind(this);
-    this.onChange = this.onChange.bind(this);
-  }
-
-  onSearch(value) {
-    let result, resultObject;
-
-    if (!value) {
-      result = [];
-      resultObject = [];
-    } else {
-      result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
-      resultObject = ['gmail.com', '163.com', 'qq.com'].map(domain => ({
-        label: `${value}@${domain}`,
-        value: `${value}@${domain}`,
-      }));
+    constructor() {
+        super();
+        this.state = {
+            data: [],
+            dataObject: [],
+            value: '',
+        };
+        this.onSearch = this.onSearch.bind(this);
+        this.onChange = this.onChange.bind(this);
     }
 
-    this.setState({
-      data: result,
-      dataObject: resultObject,
-    });
-  }
+    onSearch(value) {
+        let result, resultObject;
 
-  onChange(value) {
-    this.setState({
-      value: value,
-    });
-  }
+        if (!value) {
+            result = [];
+            resultObject = [];
+        } else {
+            result = ['gmail.com', '163.com', 'qq.com'].map(domain => `${value}@${domain}`);
+            resultObject = ['gmail.com', '163.com', 'qq.com'].map(domain => ({
+                label: `${value}@${domain}`,
+                value: `${value}@${domain}`,
+            }));
+        }
 
-  render() {
-    let { data, value, dataObject } = this.state;
-    return (
-      <>
-        <AutoComplete
-          showClear
-          value={value}
-          data={data}
-          onChange={this.onChange}
-          onSearch={this.onSearch}
-          style={{
-            width: 200,
-          }}
-        />
-        <br />
-        <AutoComplete
-          showClear
-          value={value}
-          data={dataObject}
-          onChange={this.onChange}
-          onSearch={this.onSearch}
-          style={{
-            width: 200,
-          }}
-        />
-        <br />
-        <AutoComplete
-          defaultValue={'hello semi'}
-          showClear
-          value={value}
-          data={dataObject}
-          onChange={this.onChange}
-          onSearch={this.onSearch}
-          style={{
-            width: 200,
-          }}
-        />
-      </>
-    );
-  }
+        this.setState({
+            data: result,
+            dataObject: resultObject,
+        });
+    }
+
+    onChange(value) {
+        this.setState({
+            value: value,
+        });
+    }
+
+    render() {
+        let { data, value, dataObject } = this.state;
+        return (
+            <>
+                <AutoComplete
+                    showClear
+                    value={value}
+                    data={data}
+                    onChange={this.onChange}
+                    onSearch={this.onSearch}
+                    style={{
+                        width: 200,
+                    }}
+                />
+                <br />
+                <AutoComplete
+                    showClear
+                    value={value}
+                    data={dataObject}
+                    onChange={this.onChange}
+                    onSearch={this.onSearch}
+                    style={{
+                        width: 200,
+                    }}
+                />
+                <br />
+                <AutoComplete
+                    defaultValue={'hello semi'}
+                    showClear
+                    value={value}
+                    data={dataObject}
+                    onChange={this.onChange}
+                    onSearch={this.onSearch}
+                    style={{
+                        width: 200,
+                    }}
+                />
+            </>
+        );
+    }
 }
 
 export const EmptyContent = () => {
-  let [data, setData] = useState([]);
-  const [loading, setLoading] = useState(false);
+    let [data, setData] = useState([]);
+    const [loading, setLoading] = useState(false);
 
-  const fetchData = v => {
-    setLoading(true);
-    setTimeout(() => {
-      if (!v) {
-        setData([]);
-        setLoading(false);
-        return;
-      }
+    const fetchData = v => {
+        setLoading(true);
+        setTimeout(() => {
+            if (!v) {
+                setData([]);
+                setLoading(false);
+                return;
+            }
 
-      setData(() => {
-        const res = Array.from(Array(5)).map(c => Math.random());
-        return res;
-      });
-      setLoading(false);
-    }, 1000);
-  };
+            setData(() => {
+                const res = Array.from(Array(5)).map(c => Math.random());
+                return res;
+            });
+            setLoading(false);
+        }, 1000);
+    };
 
-  return (
-    <AutoComplete loading={loading} data={data} emptyContent={'空数据'} onSearch={fetchData} />
-  );
+    return <AutoComplete loading={loading} data={data} emptyContent={'空数据'} onSearch={fetchData} />;
 };
 
 export const AutoFocus = () => {
-  return <AutoComplete autoFocus />;
+    return <AutoComplete autoFocus />;
 };
 
 export const ControlledValue = () => <ControlledMode />;
@@ -347,4 +346,28 @@ export const CustomTriggerDemo = () => <CustomTrigger />;
 
 export const Disabled = () => <AutoComplete disabled />;
 
-export const KeyDown = () => <AutoComplete onKeyDown={(e) => { console.log('onKeyDown', e.keyCode) }} />;
+export const KeyDown = () => (
+    <AutoComplete
+        onKeyDown={e => {
+            console.log('onKeyDown', e.keyCode);
+        }}
+    />
+);
+
+export const ControlledOnSelectWithObjectDemo = () => {
+    const [v, setV] = useState();
+    return (
+        <Form>
+            <AutoComplete
+                onSelectWithObject
+                data={[]}
+                showClear
+                value={v}
+                placeholder='controlled autocomplete'
+                onChange={val => setV(val)}
+                style={{ width: 200 }}
+            />
+            <Form.AutoComplete field='test' placeholder='form autocomplete' onSelectWithObject data={[]} showClear style={{ width: 200 }} />
+        </Form>
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
点击 clear icon后，存在以下调用链 

- input内容修改，触发handleSearch,  内部会调用 _modifyFocusIndex -> _getRenderSelectedItem
- props.value 变更，触发 componentDidUpdate,  调用 handleValueChange -> _getRenderSelectedItem

1 中其实如果input内容为空字符串，没有必要再去计算 focus高亮的在第几项，设为默认值即可，即置为初始值-1
2 中如果value 为 undefined，在 _getRenderSelectedItem 中不应该直接读取 option.value ，需要加 ?判断

### Changelog
🇨🇳 Chinese
- Fix: 修复配置了onSelectWithObject 的受控 AutoComplete 在点击 clear 清空按钮时报错的问题  #2013

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
