### PR TITLE
fix: Fixed when a TextArea with maxLength is input in Chinese, clicki…

### DIFF
--- a/packages/semi-foundation/input/textareaFoundation.ts
+++ b/packages/semi-foundation/input/textareaFoundation.ts
@@ -127,8 +127,9 @@ export default class TextAreaFoundation extends BaseFoundation<TextAreaAdapter> 
                     return value.slice(0, maxLength);
                 }
             }
+            return value;
         }
-        return value;
+        return undefined;
     }
 
     /**


### PR DESCRIPTION
…ng outside triggers blur, and the echoed content does not comply with the maxLength setting

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2005 

问题细节见 issue 的 comment

### Changelog
🇨🇳 Chinese
- Fix: 修复有 maxLength的 TextArea 在中文输入时，点击外部触发 blur，回显内容不符合 maxLength 设置问题 #2005 

---

🇺🇸 English
- Fix: Fixed the problem that when a TextArea with maxLength is input in Chinese, clicking outside triggers blur, and the echoed content does not comply with the maxLength setting #2005 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
