### PR TITLE
Style/image preview z index

### DIFF
--- a/packages/semi-foundation/image/constants.ts
+++ b/packages/semi-foundation/image/constants.ts
@@ -4,4 +4,8 @@ const cssClasses = {
     PREFIX: `${BASE_CLASS_PREFIX}-image`,
 } as const;
 
-export { cssClasses };
+const numbers = {
+    DEFAULT_Z_INDEX: 1070,
+};
+
+export { cssClasses, numbers };

--- a/packages/semi-ui/image/interface.tsx
+++ b/packages/semi-ui/image/interface.tsx
@@ -141,6 +141,7 @@ export interface FooterProps extends SliderProps {
     adaptiveTip?: string;
     originTip?: string;
     showTooltip?: boolean;
+    zIndex?: number;
     onZoomIn?: (zoom: number) => void;
     onZoomOut?: (zoom: number) => void;
     onPrev?: () => void;

--- a/packages/semi-ui/image/previewFooter.tsx
+++ b/packages/semi-ui/image/previewFooter.tsx
@@ -116,9 +116,9 @@ export default class Footer extends BaseComponent<FooterProps> {
     // According to showTooltip in props, decide whether to use Tooltip to pack a layer
     // 根据 props 中的 showTooltip 决定是否使用 Tooltip 包一层
     getFinalIconElement = (element: ReactNode, content: ReactNode, key: string) => {
-        const { showTooltip } = this.props;
+        const { showTooltip, zIndex } = this.props;
         return showTooltip ? (
-            <Tooltip content={content} key={`tooltip-${key}`}>
+            <Tooltip content={content} key={`tooltip-${key}`} zIndex={zIndex + 1}>
                 {element}
             </Tooltip>
         ): element;

--- a/packages/semi-ui/image/previewInner.tsx
+++ b/packages/semi-ui/image/previewInner.tsx
@@ -2,7 +2,7 @@ import React, { CSSProperties } from "react";
 import BaseComponent from "../_base/baseComponent";
 import { PreviewProps as PreviewInnerProps, PreviewInnerStates } from "./interface";
 import PropTypes from "prop-types";
-import { cssClasses } from "@douyinfe/semi-foundation/image/constants";
+import { cssClasses, numbers } from "@douyinfe/semi-foundation/image/constants";
 import cls from "classnames";
 import { isEqual, isFunction } from "lodash";
 import Portal from "../_portal";
@@ -72,7 +72,7 @@ export default class PreviewInner extends BaseComponent<PreviewInnerProps, Previ
         lazyLoad: false,
         preLoad: true,
         preLoadGap: 2,
-        zIndex: 1070,
+        zIndex: numbers.DEFAULT_Z_INDEX,
         maskClosable: true,
         viewerVisibleDelay: 10000,
         maxZoom: 5,
@@ -449,6 +449,7 @@ export default class PreviewInner extends BaseComponent<PreviewInnerProps, Previ
                             ratio={ratio}
                             prevTip={prevTip}
                             nextTip={nextTip}
+                            zIndex={zIndex}
                             zoomInTip={zoomInTip}
                             zoomOutTip={zoomOutTip}
                             rotateTip={rotateTip}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

对所有弹层进行过排序。
![image](https://github.com/DouyinFE/semi-design/assets/101110131/c41b021b-734d-4b01-87f3-cd1d113f03ae)
本次 PR 修改包括： 
imagePreivew 弹出层的 z-index 从 1000 -> 1070
在弹出层中的 tooltip 的 z-index, 统一为 弹出层的 zIndex +1，防止因为默认的Tooltip 的 z-index 低于 ImagePreivew 导致被遮盖


### Changelog
🇨🇳 Chinese
- Style: The default zIndex value of ImagePreview's preview layer is adjusted from 1000 to 1070

---

🇺🇸 English
- Style: The default zIndex value of ImagePreview's preview layer is adjusted from 1000 to 1070


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
