### PR TITLE
fix: fix onclose/onPreivew call twice when click the edge of closeIcon

### DIFF
--- a/packages/semi-foundation/image/previewInnerFoundation.ts
+++ b/packages/semi-foundation/image/previewInnerFoundation.ts
@@ -127,7 +127,7 @@ export default class PreviewInnerFoundation<P = Record<string, any>, S = Record<
             couldClose = false;
         }
         if (couldClose && maskClosable) {
-            this.handlePreviewClose();
+            this._adapter.notifyVisibleChange(false);
         }
     }
 
@@ -177,9 +177,10 @@ export default class PreviewInnerFoundation<P = Record<string, any>, S = Record<
         this._adapter.notifyDownload(downloadSrc, currentIndex);
     }
 
-    handlePreviewClose = () => {
+    handlePreviewClose = (e: any) => {
         this._adapter.notifyVisibleChange(false);
         this._adapter.notifyClose();
+        handlePrevent(e);
     }
 
     handleAdjustRatio = (type: RatioType) => {

--- a/packages/semi-ui/image/interface.tsx
+++ b/packages/semi-ui/image/interface.tsx
@@ -126,7 +126,7 @@ export interface HeaderProps {
     title?: string;
     titleStyle?: React.CSSProperties;
     className?: string;
-    onClose?: (e: MouseEvent) => void
+    onClose?: (e: any) => void
 }
 
 export interface FooterProps extends SliderProps {

--- a/packages/semi-ui/image/interface.tsx
+++ b/packages/semi-ui/image/interface.tsx
@@ -126,7 +126,7 @@ export interface HeaderProps {
     title?: string;
     titleStyle?: React.CSSProperties;
     className?: string;
-    onClose?: () => void
+    onClose?: (e: MouseEvent) => void
 }
 
 export interface FooterProps extends SliderProps {

--- a/packages/semi-ui/image/interface.tsx
+++ b/packages/semi-ui/image/interface.tsx
@@ -126,7 +126,7 @@ export interface HeaderProps {
     title?: string;
     titleStyle?: React.CSSProperties;
     className?: string;
-    onClose?: (e: any) => void
+    onClose?: (e: React.MouseEvent<HTMLElement>) => void
 }
 
 export interface FooterProps extends SliderProps {

--- a/packages/semi-ui/image/previewInner.tsx
+++ b/packages/semi-ui/image/previewInner.tsx
@@ -273,7 +273,7 @@ export default class PreviewInner extends BaseComponent<PreviewInnerProps, Previ
         this.foundation.handleDownload();
     }
 
-    handlePreviewClose = (e: any) => {
+    handlePreviewClose = (e: React.MouseEvent<HTMLElement>) => {
         this.foundation.handlePreviewClose(e);
     }
 

--- a/packages/semi-ui/image/previewInner.tsx
+++ b/packages/semi-ui/image/previewInner.tsx
@@ -273,8 +273,8 @@ export default class PreviewInner extends BaseComponent<PreviewInnerProps, Previ
         this.foundation.handleDownload();
     }
 
-    handlePreviewClose = () => {
-        this.foundation.handlePreviewClose();
+    handlePreviewClose = (e: MouseEvent) => {
+        this.foundation.handlePreviewClose(e);
     }
 
     handleAdjustRatio = (type: RatioType) => {

--- a/packages/semi-ui/image/previewInner.tsx
+++ b/packages/semi-ui/image/previewInner.tsx
@@ -273,7 +273,7 @@ export default class PreviewInner extends BaseComponent<PreviewInnerProps, Previ
         this.foundation.handleDownload();
     }
 
-    handlePreviewClose = (e: MouseEvent) => {
+    handlePreviewClose = (e: any) => {
         this.foundation.handlePreviewClose(e);
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

原来的代码中在 mask 的回调中有判断当前点击位置的是否为 icon /footer 部分，如果是，则不关闭预览。对于关闭按钮，点击边缘部分（即 section 中不属于 icon 的部分），则 关闭按钮和 mask 中的回调都会被触发，从而导致 onVisible 调用两次
![image](https://github.com/DouyinFE/semi-design/assets/101110131/66396b34-dad6-4d22-81ec-63b7c7aa66b7)



### Changelog
🇨🇳 Chinese
- Fix: 修复 ImagePreview 组件在预览时点击关闭按钮边缘时触发 onClose/onPreview 两次问题

---

🇺🇸 English
- Fix: Fixed the problem of triggering onClose/onPreview twice when clicking the edge of the close button in the preview state in the ImagePreview component


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
