### PR TITLE
fix: fix modal clear body original  overflow:hidden when no visible a…

### DIFF
--- a/packages/semi-ui/modal/Modal.tsx
+++ b/packages/semi-ui/modal/Modal.tsx
@@ -109,7 +109,7 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
     foundation: ModalFoundation;
 
     private readonly modalRef: LegacyRef<ModalContent>;
-    private bodyOverflow: string;
+    private bodyOverflow: string|null = null;
     private scrollBarWidth: number;
     private originBodyWidth: string;
     private _haveRendered: boolean;
@@ -122,7 +122,7 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
         };
         this.foundation = new ModalFoundation(this.adapter);
         this.modalRef = React.createRef();
-        this.bodyOverflow = '';
+
         this.scrollBarWidth = 0;
         this.originBodyWidth = '100%';
 
@@ -142,7 +142,7 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
             },
             enabledBodyScroll: () => {
                 const { getPopupContainer } = this.props;
-                if (!getPopupContainer && this.bodyOverflow !== 'hidden') {
+                if (!getPopupContainer && this.bodyOverflow !== null && this.bodyOverflow !== 'hidden') {
                     document.body.style.overflow = this.bodyOverflow;
                     document.body.style.width = this.originBodyWidth;
                 }


### PR DESCRIPTION
…nd unmount

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 modal 在不打开直接卸载时候，会将 body 上原有的 overflow: hidden 删除的问题(影响范围 2.51.0~2.51.3)

---

🇺🇸 English
- Fix: Fixed the issue where the original overflow: hidden on the body will be deleted when modal is uninstalled without opening it. (version range 2.51.0~2.51.3)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
