### PR TITLE
Fix/cascader rendertrigger

### DIFF
--- a/content/input/cascader/index.md
+++ b/content/input/cascader/index.md
@@ -1666,7 +1666,7 @@ interface TriggerRenderProps {
     disabled: boolean;
     /**
      * 已选中的 node 在 treeData 中的层级位置，如下例子，
-     * 当选中浙江省-杭州市-萧山区时，此处 value 为 '0-0-0'
+     * 当选中浙江省-杭州市-萧山区时，此处 value 为 '0-0-1'
      */
     value?: string | Set<string>;
     /* 当前 Input 框的输入值 */

--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -56,6 +56,8 @@ export interface BasicEntity {
     parentKey?: string;
     /* key path */
     path: Array<string>;
+    /* pos in treeData */
+    pos: string;
     /* value path */
     valuePath: Array<string>
 }

--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -1029,20 +1029,6 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
         this._adapter.notifyListScroll(e, { panelIndex: ind, activeNode: data });
     }
 
-    handleTagRemove(e: any, tagValuePath: string[]) {
-        const { keyEntities } = this.getStates();
-        const { disabled } = this.getProps();
-        if (disabled) {
-            /* istanbul ignore next */
-            return;
-        }
-        const removedItem = (Object.values(keyEntities) as BasicEntity[])
-            .filter(item => isEqual(item.valuePath, tagValuePath))[0];
-        !isEmpty(removedItem) &&
-        !removedItem.data.disabled &&
-        this._handleMultipleSelect(removedItem);
-    }
-
     handleTagRemoveByKey = (key: string) => {
         const { keyEntities } = this.getStates();
         const { disabled } = this.getProps();

--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -15,7 +15,8 @@ import {
     normalizedArr,
     isValid,
     calcMergeType,
-    getKeysByValuePath
+    getKeysByValuePath,
+    getKeyByPos
 } from './util';
 import { strings } from './constants';
 import isEnterPress from '../utils/isEnterPress';
@@ -1040,5 +1041,22 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
         !isEmpty(removedItem) &&
         !removedItem.data.disabled &&
         this._handleMultipleSelect(removedItem);
+    }
+
+    handleTagRemoveByKey = (key: string) => {
+        const { keyEntities } = this.getStates();
+        const { disabled } = this.getProps();
+        if (disabled) {
+            /* istanbul ignore next */
+            return;
+        }
+        const removedItem = keyEntities[key] ?? {};
+        !removedItem?.data?.disable && this._handleMultipleSelect(removedItem);
+    }
+
+    handleTagRemoveInTrigger = (pos: string) => {
+        const { treeData } = this.getStates();
+        const key = getKeyByPos(pos, treeData);
+        this.handleTagRemoveByKey(key);
     }
 }

--- a/packages/semi-foundation/cascader/util.ts
+++ b/packages/semi-foundation/cascader/util.ts
@@ -31,10 +31,12 @@ function traverseDataNodes(treeNodes: any, callback: any) {
         // Process node if is not root
         if (node) {
             const key = parent ? `${parent.key}${VALUE_SPLIT}${node.value}` : node.value;
+            const pos = parent ? getPosition(parent.pos, ind) : `${ind}`;
             item = {
                 data: { ...node },
                 ind,
                 key,
+                pos,
                 level: parent ? parent.level + 1 : 0,
                 parentKey: parent ? parent.key : null,
                 path: parent ? [...parent.path, key] : [key],

--- a/packages/semi-foundation/cascader/util.ts
+++ b/packages/semi-foundation/cascader/util.ts
@@ -76,6 +76,17 @@ export function getValuePathByKey(key: string) {
     return key.split(VALUE_SPLIT);
 }
 
+export function getKeyByPos(pos: string, treeData: any) {
+    const posArr = pos.split('-').map(item => Number(item));
+    let resultData = treeData;
+    let valuePath = [];
+    posArr.forEach((item, index) => {
+        resultData = index === 0 ? resultData[item] : resultData?.children?.[item];
+        valuePath.push(resultData?.value);
+    });
+    return getKeyByValuePath(valuePath);
+}
+
 export function convertDataToEntities(dataNodes: any) {
     const keyEntities: any = {};
 

--- a/packages/semi-ui/cascader/__test__/cascader.test.js
+++ b/packages/semi-ui/cascader/__test__/cascader.test.js
@@ -1257,7 +1257,7 @@ describe('Cascader', () => {
         const args = firstCall.args[0]; 
         /* check arguments of triggerRender */
         expect(args.value.size).toEqual(1);
-        expect(args.value).toEqual(new Set(['Asia']));
+        expect(args.value).toEqual(new Set('0'));
         cascaderAutoMerge.unmount();
 
         const spyTriggerRender2 = sinon.spy(() => <span>123</span>);
@@ -1272,7 +1272,7 @@ describe('Cascader', () => {
         const args2 = firstCall2.args[0]; 
         /* check arguments of triggerRender */
         expect(args2.value.size).toEqual(4);
-        expect(args2.value).toEqual(new Set(["Asia","Asia_SEMI_CASCADER_SPLIT_China","Asia_SEMI_CASCADER_SPLIT_China_SEMI_CASCADER_SPLIT_Beijing","Asia_SEMI_CASCADER_SPLIT_China_SEMI_CASCADER_SPLIT_Shanghai"]));
+        expect(args2.value).toEqual(new Set(['0','0-0','0-0-1','0-0-0']));
         cascaderNoAutoMerge.unmount();
     });
 

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -17,7 +17,7 @@ import { numbers as popoverNumbers } from '@douyinfe/semi-foundation/popover/con
 import { isSet, isEqual, isString, isEmpty, isFunction, isNumber, noop, flatten, isObject } from 'lodash';
 import '@douyinfe/semi-foundation/cascader/cascader.scss';
 import { IconClear, IconChevronDown } from '@douyinfe/semi-icons';
-import { convertDataToEntities, calcMergeType, getKeyByValuePath } from '@douyinfe/semi-foundation/cascader/util';
+import { convertDataToEntities, calcMergeType, getKeyByValuePath, getKeyByPos } from '@douyinfe/semi-foundation/cascader/util';
 import { calcCheckedKeys, normalizeKeyList, calcDisabledKeys } from '@douyinfe/semi-foundation/tree/treeUtil';
 import ConfigContext, { ContextValue } from '../configProvider/context';
 import BaseComponent, { ValidateStatus } from '../_base/baseComponent';
@@ -514,13 +514,14 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
         this.foundation.handleInputChange(value);
     };
 
-    handleTagRemove = (e: any, tagValuePath: Array<string | number>) => {
-        this.foundation.handleTagRemove(e, tagValuePath);
-    };
+    handleTagRemoveInTrigger = (pos: string) => {
+        this.foundation.handleTagRemoveInTrigger(pos);
+    }
 
-    handleRemoveByKey = (key) => {
-        const { keyEntities } = this.state;
-        this.handleTagRemove(null, keyEntities[key].valuePath);
+    handleTagClose = (tagChildren: React.ReactNode, e: React.MouseEvent<HTMLElement>, tagKey: string | number) => {
+        // When value has not changed, prevent clicking tag closeBtn to close tag
+        e.preventDefault();
+        this.foundation.handleTagRemoveByKey(tagKey);
     }
 
     renderTagItem = (nodeKey: string, idx: number) => {
@@ -542,13 +543,10 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                         size={size === 'default' ? 'large' : size}
                         key={`tag-${nodeKey}-${idx}`}
                         color="white"
+                        tagKey={nodeKey}
                         className={tagCls}
                         closable
-                        onClose={(tagChildren, e) => {
-                            // When value has not changed, prevent clicking tag closeBtn to close tag
-                            e.preventDefault();
-                            this.handleTagRemove(e, keyEntities[nodeKey].valuePath);
-                        }}
+                        onClose={this.handleTagClose}
                     >
                         {keyEntities[nodeKey].data[displayProp]}
                     </Tag>
@@ -556,6 +554,10 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
             }
         }
         return null;
+    };
+
+    onRemoveInTagInput = (v: string) => {
+        this.foundation.handleTagRemoveByKey(v);
     };
 
     renderTagInput() {
@@ -573,11 +575,11 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                 showRestTagsPopover={showRestTagsPopover}
                 restTagsPopoverProps={restTagsPopoverProps}
                 maxTagCount={maxTagCount}
-                renderTagItem={(value, index) => this.renderTagItem(value, index)}
+                renderTagItem={this.renderTagItem}
                 inputValue={inputValue}
                 onInputChange={this.handleInputChange}
                 // TODO Modify logic, not modify type
-                onRemove={v => this.handleTagRemove(null, (v as unknown) as (string | number)[])}
+                onRemove={this.onRemoveInTagInput}
                 placeholder={placeholder}
                 expandRestTagsOnClick={false}
             />
@@ -859,7 +861,7 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                 componentName={'Cascader'}
                 componentProps={{ ...this.props }}
                 onSearch={this.handleInputChange}
-                onRemove={this.handleRemoveByKey}
+                onRemove={this.handleTagRemoveInTrigger}
             />
         );
     };

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -834,16 +834,18 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
 
     renderCustomTrigger = () => {
         const { disabled, triggerRender, multiple } = this.props;
-        const { selectedKeys, inputValue, inputPlaceHolder, resolvedCheckedKeys, checkedKeys } = this.state;
+        const { selectedKeys, inputValue, inputPlaceHolder, resolvedCheckedKeys, checkedKeys, keyEntities } = this.state;
         let realValue;
         if (multiple) {
             if (this.mergeType === strings.NONE_MERGE_TYPE) {
-                realValue = checkedKeys;
+                realValue = new Set();
+                checkedKeys.forEach(key => { realValue.add(keyEntities[key]?.pos); });
             } else {
-                realValue = resolvedCheckedKeys;
+                realValue = new Set();
+                resolvedCheckedKeys.forEach(key => { realValue.add(keyEntities[key]?.pos); });
             }
         } else {
-            realValue = [...selectedKeys][0];
+            realValue = keyEntities[[...selectedKeys][0]]?.pos;
         }
         return (
             <Trigger


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # 本问题由于 https://github.com/DouyinFE/semi-design/pull/1999 的修改导致，为提高在大数据 treeData 的 Cascader 的性能，key 的生成规则发生改变。对于 如下 treeData
```
const treeData = [
        {
            label: '浙江省',
            value: 'zhejiang',
            children: [
                {
                    label: '杭州市',
                    value: 'hangzhou',
                    children: [
                        {
                            label: '西湖区',
                            value: 'xihu',
                        },
                        {
                            label: '萧山区',
                            value: 'xiaoshan',
                        }
                    ],
                }
            ],
        }
    ];
```

原来：和 TreeData 的中的位置有关，比如[浙江, 杭州, 西湖]，key 为 0-0-0；
#1999 修改后： 将 value 用特殊字符连接，对于[浙江, 杭州, 西湖]， key 为 zhejiang_SEMI_CASCADER_SPLIT_hangzhou
_SEMI_CASCADER_SPLIT_xihu；

修改后能够快速通过 key 找到 value，在受控时提升组件性能。

但是在根据原来 key 和 pos 关联的性质，原来的代码中有将 keyEntities中的 key 的值作为  triggerRender  中的  value 参数
![image](https://github.com/DouyinFE/semi-design/assets/101110131/14366a68-c3bd-4c36-b232-8cb5b14b3acb)
，由于 key 的生成规则，变化，因此不再适合通过 keyEntities中的 key 的值作为  triggerRender  中的  value ，而是应该将真正的 pos 给到value。

因此本 PR 中的修改为：
1. **保证triggerRender 使用显示正确**：在 keyEntities 中增加 pos，用于保存 data 在 treeData 中的位置，将 pos 作为 triggerRender 的 value 值
2. **保证 triggerRender 中删除正确**：在 triggerRender 的删除回调 onRemove 的具体执行函数中，增加从 pos 找 key的逻辑


### Changelog
🇨🇳 Chinese
- Fix: 修复 Cascader 在 keyEntities 中的 key 生成规则变化后，triggerRender 的参数中的value 参数和原来不一致问题（影响范围 2.51.0~2.51.3）

---

🇺🇸 English
- Fix: Fixed the problem that after Cascader's key generation rules in keyEntities changed, the value parameter in triggerRender's parameters was inconsistent with the original one (Affected Scope 2.51.0~2.51.3)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
