### PR TITLE
chore: cleanup vscode launch.json

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,6 @@
 {
-    // 使用 IntelliSense 了解相关属性。
-    // 悬停以查看现有属性的描述。
-    // 欲了解更多信息，请访问: https://go.microsoft.com/fwlink/?linkid=830387
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
     "version": "0.2.0",
     "configurations": [
         {
@@ -10,18 +9,15 @@
             "request": "launch",
             "runtimeArgs": [
                 "--inspect-brk",
-                "${workspaceRoot}/node_modules/.bin/jest",
-                "${workspaceRoot}/packages/semi-ui/select/", // 需要调试哪个组件，替换文件夹路径即可
+                "${workspaceRoot}/node_modules/jest/bin/jest",
+                "packages/semi-ui/select/", // Replace with the folder path of the component you want to debug
                 "--runInBand",
-                // "--coverage",
                 "--silent" // ignore warning such as componentWillReceiveProps will be abondon...
             ],
             "env": {
                 "NODE_ENV": "test",
-                // "type": "story" // 调试snapshot快照的时候用这个
-                "type": "unit"     // 调试unitTest的时候用这个
+                "type": "unit"
             },
-            "runtimeExecutable": "/Users/bytedance/.nvm/versions/node/v16.17.1/bin/node",
             "console": "integratedTerminal",
             "internalConsoleOptions": "neverOpen",
             "port": 9229
@@ -33,7 +29,7 @@
             "request": "launch",
             "runtimeArgs": [
                 "--inspect-brk",
-                "${workspaceRoot}/node_modules/.bin/jest",
+                "${workspaceRoot}/node_modules/jest/bin/jest",
                 "--runInBand",
                 "--silent" // ignore warning such as componentWillReceiveProps will be abondon...
             ],


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [x] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
As title, remove cn comment at launch.json and fix runtimeArgs field.
On my windows machine, old version config makes some error:
- Couldn't find nodejs path: 
![image](https://github.com/DouyinFE/semi-design/assets/25818722/c7ef89be-8d5b-4caf-a766-d10616b0308e)
- run `bin/jest` with nodejs emit err: 
![image](https://github.com/DouyinFE/semi-design/assets/25818722/772f4671-d3fa-4ec6-849f-f47cd4a0c636)
- Couldn't find tests with path: `${workspaceRoot}/packages/xx`



### Changelog
🇨🇳 Chinese
- Fix: 修复 ...

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
