### PR TITLE
fix: fix resize observer not defined on ssg

### DIFF
--- a/packages/semi-ui/resizeObserver/index.tsx
+++ b/packages/semi-ui/resizeObserver/index.tsx
@@ -31,7 +31,7 @@ export default class ReactResizeObserver extends BaseComponent<ReactResizeObserv
 
     constructor(props: ReactResizeObserverProps) {
         super(props);
-        if (ResizeObserver) {
+        if (globalThis['ResizeObserver']) {
             this.observer = new ResizeObserver(props.onResize);
         }
         


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 ResizeObsever 在非浏览器环境不存在的问题。问题影响范围(2.52.1,2.53.0-beta.0)

---

🇺🇸 English
- Fix: Fix the problem that ResizeObsever does not exist in non-browser environments. Problem impact scope (2.52.1,2.53.0-beta.0)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
