### PR TITLE
fix: when using timeZone and disabledHours at the same time in timepicker display value does not meet expectations

### DIFF
--- a/cypress/e2e/timePicker.spec.js
+++ b/cypress/e2e/timePicker.spec.js
@@ -61,4 +61,13 @@ describe('timePicker', () => {
         cy.get('body').click('right');
         cy.get('.semi-input-default').eq(1).should('have.value', '10:24:18');
     });
+
+    it('timezone + disabledHours', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=timepicker--fix-2082&args=&viewMode=story');
+        cy.get('.semi-input-default').eq(0).click();
+        cy.get('.semi-timepicker-panel-list-hour').eq(0).contains('07').click({ force: true });
+        cy.get('.semi-timepicker-panel-list-minute').eq(0).contains('10').click({ force: true });
+        cy.get('body').click('right');
+        cy.get('.semi-input-default').eq(0).should('have.value', '07:10');
+    });
 });

--- a/packages/semi-foundation/timePicker/foundation.ts
+++ b/packages/semi-foundation/timePicker/foundation.ts
@@ -202,8 +202,8 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
         const { value, timeZone, __prevTimeZone } = props;
         
         let dates = this.parseValue(value);
-        const invalid = this.validateDates(dates);
 
+        let invalid = dates.some(d => isNaN(Number(d)));
         if (!invalid) {
             if (this.isValidTimeZone(timeZone)) {
                 dates = dates.map(date =>
@@ -213,6 +213,9 @@ class TimePickerFoundation<P = Record<string, any>, S = Record<string, any>> ext
                     )
                 );
             }
+            invalid = dates.some(d =>
+                this.isDisabledHMS({ hours: d.getHours(), minutes: d.getMinutes(), seconds: d.getSeconds() })
+            );
         }
         const inputValue = this.formatValue(dates);
 

--- a/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
+++ b/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
@@ -1,6 +1,6 @@
 import React, { Component, useState } from 'react';
 import TimePickerPanel from '../index';
-import { TimePicker as BasicTimePicker, Button, Form, Popover } from '../../index';
+import { TimePicker as BasicTimePicker, Button, Form, Popover, ConfigProvider } from '../../index';
 import { strings } from '@douyinfe/semi-foundation/timePicker/constants';
 import { get } from 'lodash';
 
@@ -355,4 +355,23 @@ export const Fix1953 = () => {
   return (
     <TimePicker format={'HH'} defaultValue={'10'}/>
   );
+};
+
+export const Fix2082 = () => {
+  const [date, setDate] = useState(new Date());
+    return ( 
+        <ConfigProvider timeZone={10}>
+            <div style={{ width: 300 }}>
+                <h5 style={{ margin: 10 }}>TimePicker:</h5>
+                <TimePicker  
+                  disabledHours={v => [5]}   
+                  format="HH:mm" 
+                  value={date} 
+                  onChange={(date, dateString) => {
+                    console.log('日期', date);
+                    setDate(date)} }
+                />
+            </div>
+        </ConfigProvider>
+    );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2082 
判断 hours 是否合法时，需要用当前 Timepicker 下 timezone 时区的选择值去判断。
如当前选择 7:14， 比较 hour 的值也应该为 7 。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Timepicker 中同时使用 timeZone 和 disabledHours 时显示值不符合预期问题

---

🇺🇸 English
- Fix: the problem that when using timeZone and disabledHours at the same time in Timepicker, the displayed value does not meet the expectations


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
