### PR TITLE
fix: fix the error accessing empty element in ReactResizeObserver (#2095)

### DIFF
--- a/packages/semi-ui/resizeObserver/index.tsx
+++ b/packages/semi-ui/resizeObserver/index.tsx
@@ -82,7 +82,7 @@ export default class ReactResizeObserver extends BaseComponent<ReactResizeObserv
 
     handleResizeEventTriggered = (entries: ResizeEntry[])=>{
         if (this.props.observerProperty === ObserverProperty.All) {
-            this.props.onResize(entries);
+            this.props.onResize?.(entries);
         } else {
             const finalEntries: ResizeEntry[] = [];
             for (const entry of entries) {
@@ -97,7 +97,7 @@ export default class ReactResizeObserver extends BaseComponent<ReactResizeObserv
                 }
             }
             if (finalEntries.length>0) {
-                this.props.onResize(finalEntries);
+                this.props.onResize?.(finalEntries);
             }
         }
     }


### PR DESCRIPTION
fix: fix the error accessing empty element in ReactResizeObserver (#2095)

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2095

### Changelog
🇨🇳 Chinese
- Fix: 修复 ReactResizeObserver 里访问空元素的错误

---

🇺🇸 English
- Fix: fix the error accessing empty element in ReactResizeObserver


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
