### PR TITLE
optimize code logic in Cascader

### DIFF
--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -391,7 +391,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
             cacheValue = this._getCacheValue(keyEntities);
         }
 
-        const selectedValue = !this._isControlledComponent() ? cacheValue : value;
+        const selectedValue = !this._isControlledComponent() ? cacheValue : (value ?? []);
         if (isValid(selectedValue)) {
             this.updateSelectedKey(selectedValue, keyEntities);
         } else {
@@ -402,8 +402,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
     // call when props.value change
     handleValueChange(value: BasicValue) {
         const { keyEntities } = this.getStates();
-        const { multiple } = this.getProps();
-        !multiple && this.updateSelectedKey(value, keyEntities);
+        this.updateSelectedKey(value, keyEntities);
     }
 
     /**

--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -391,7 +391,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
             cacheValue = this._getCacheValue(keyEntities);
         }
 
-        const selectedValue = !this._isControlledComponent() ? cacheValue : (value ?? []);
+        const selectedValue = !this._isControlledComponent() ? cacheValue : (isUndefined(value) ? [] : value);
         if (isValid(selectedValue)) {
             this.updateSelectedKey(selectedValue, keyEntities);
         } else {

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -451,9 +451,9 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
             const formatKeys = formatValuePath.map(v => getKeyByValuePath(v));
             return formatKeys;
         };
-        const needUpdateTreeData = needUpdate('treeData') || needUpdateData();
-        const needUpdateValue = needUpdate('value') || (isEmpty(prevProps) && defaultValue);
         if (multiple) {
+            const needUpdateTreeData = needUpdate('treeData') || needUpdateData();
+            const needUpdateValue = needUpdate('value') || (isEmpty(prevProps) && defaultValue);
             // when value and treedata need updated
             if (needUpdateTreeData || needUpdateValue) {
                 // update state.keyEntities
@@ -504,8 +504,11 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
     }
 
     componentDidUpdate(prevProps: CascaderProps) {
+        if (this.props.multiple) {
+            return;
+        }
         let isOptionsChanged = false;
-        if (!isEqual(prevProps.treeData, this.props.treeData) && !this.props.multiple) {
+        if (!isEqual(prevProps.treeData, this.props.treeData)) {
             isOptionsChanged = true;
             this.foundation.collectOptions();
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
用户反馈在单选时候，在同时更新 treeData，并将 value 给 undefined 的情况下，Cascader 显示还是有选中值。例子如下

```
const treeData1 = [
    {
        label: 'Node1',
        value: '0-0',
        children: [
            {
                label: 'Child Node1',
                value: '0-0-1',
                // disabled: true,
            },
            {
                label: 'Child Node2',
                value: '0-0-2',
            },
        ],
    },
    {
        label: 'Node2',
        value: '0-1',
    },
];

export const SingleValueTreeData = ()=> {
  const [value, setValue] = useState(['0-0', '0-0-1']);
  const [treeData, setTreeData] = useState(treeData1)

  const onChange = useCallback((value) => {
    console.log('onchange', value);
    setValue(value);
  }, []);

  const onButtonClick = useCallback(() => {
    setValue(undefined);
    setTreeData([
      {
        label: 'Node1',
        value: '0-0',
        children: [
            {
                label: 'Child Node1',
                value: '0-0-1',
            },
            {
                label: 'Child Node2',
                value: '0-0-2',
            },
        ],
      },
      {
          label: 'Node3',
          value: '0-2',
      }
    ]);
  }, []);

  return (
    <>
      <Button onClick={onButtonClick}>点击同时触发 value 和 treeData 改变</Button>
      <Cascader
        showClear
        // multiple
        onChange={onChange}
        value={value}
        style={{ width: 300 }}
        treeData={treeData}
        placeholder="请选择所在地区"
      />
    </>
   );
}
```

单选代码中对 value 为 undefined 不做处理( https://github.com/DouyinFE/semi-design/blob/v2.53.2/packages/semi-foundation/cascader/foundation.ts#L395)，

如果通过 onChange 控制 value 的值的话，也不会出现 undefined 的情况

用户出现问题的操作流程：在有选择项后，通过点击 clear 按钮清除所有选项，此时 onChange回调的param value 为 [], 用户并没有将 [] 给到 value，而是给了 undefined, 同时还做了一些修改 treeData 的操作，代码逻辑进入到 https://github.com/DouyinFE/semi-design/blob/v2.53.2/packages/semi-foundation/cascader/foundation.ts#L395。当前逻辑认为 value 为 undefined 是无效的，因此不会更新 selectKeys，导致从视觉 trigger中还有已选项，点击 clear 按钮无效。
问题在于用户并没有直接使用 onChange 的值更新受控 value，考虑可能出现类似的问题，因此本 PR 这种情况做兜底。如果 value 受控，值为 undefined，则将 value 作为 [] 处理。

 ## Changelog
🇨🇳 Chinese
- Fix: Cascader 代码逻辑优化 (skip changlog)

---

🇺🇸 English
- Fix: Cascader 代码逻辑优化 (skip changlog)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
