### PR TITLE
fix: fixed Nav selectedKeys bug in react 17

### DIFF
--- a/cypress/e2e/navigation.spec.js
+++ b/cypress/e2e/navigation.spec.js
@@ -12,4 +12,13 @@ describe('navigation', () => {
         cy.get('span').contains('人员管理').should('exist');
     });
 
+    it('selected keys change', () => {
+        cy.visit('http://localhost:6006/iframe.html?id=navigation--fixed-selected-keys&viewMode=story');
+        cy.get('.semi-navigation-item-text').contains('Config').click();
+        cy.get('.semi-navigation-item-selected').should('contain.text', 'Ability management');
+        cy.get('.semi-navigation-sub-title.semi-navigation-sub-title-selected').should('contain.text', "Ability");
+        cy.get('.semi-navigation-item-text').contains('Distribution').click();
+        cy.get('.semi-navigation-item-selected').should('contain.text', 'Config management');
+        cy.get('.semi-navigation-sub-title.semi-navigation-sub-title-selected').should('exist');
+    });
 });

--- a/package.json
+++ b/package.json
@@ -55,6 +55,8 @@
         "@storybook/react-webpack5": "^7.0.7",
         "@svgr/core": "^5.5.0",
         "@types/react-window": "^1.8.5",
+        "@visactor/react-vchart": "^1.7.2",
+        "@visactor/vchart-semi-theme": "^1.7.2",
         "aos": "^2.3.4",
         "camelcase": "^6.2.0",
         "chroma-js": "^2.1.2",
@@ -93,6 +95,7 @@
         "react-intl": "^3.12.1",
         "react-lazyload": "^3.2.0",
         "react-resizable": "^3.0.5",
+        "react-router-dom": "^6.22.2",
         "react-scroll-parallax": "^2.4.0",
         "react-sortable-hoc": "^2.0.0",
         "react-virtualized": "^9.22.3",
@@ -103,9 +106,7 @@
         "unist-util-remove": "^1.0.3",
         "unist-util-visit": "^2.0.3",
         "wait-on": "^6.0.1",
-        "wcag-color": "^1.1.1",
-        "@visactor/react-vchart": "^1.7.2",
-        "@visactor/vchart-semi-theme": "^1.7.2"
+        "wcag-color": "^1.1.1"
     },
     "devDependencies": {
         "@actions/core": "^1.6.0",
@@ -145,6 +146,7 @@
         "@types/react": "^18.0.5",
         "@types/react-dom": "^18.0.1",
         "@types/react-resizable": "^3.0.4",
+        "@types/react-router-dom": "^5.3.3",
         "@types/svgo": "^2.3.1",
         "@types/webpack": "^4.41.30",
         "@typescript-eslint/eslint-plugin": "^4.29.1",

--- a/packages/semi-foundation/navigation/foundation.ts
+++ b/packages/semi-foundation/navigation/foundation.ts
@@ -39,7 +39,7 @@ export interface NavigationAdapter<P = Record<string, any>, S = Record<string, a
     setItemKeysMap(map: { [key: string]: (string | number)[] }): void;
     addSelectedKeys(...keys: (string | number)[]): void;
     removeSelectedKeys(...keys: (string | number)[]): void;
-    updateSelectedKeys(keys: (string | number)[]): void;
+    updateSelectedKeys(keys: (string | number)[], includeParentKeys?: boolean): void;
     updateOpenKeys(keys: (string | number)[]): void;
     addOpenKeys(...keys: (string | number)[]): void;
     removeOpenKeys(...keys: (string | number)[]): void;
@@ -129,7 +129,8 @@ export default class NavigationFoundation<P = Record<string, any>, S = Record<st
                 items: formattedItems,
             };
         } else {
-            this._adapter.updateSelectedKeys(willSelectedKeys);
+            // already include parentSelectKeys, set second parameter to false
+            this._adapter.updateSelectedKeys(willSelectedKeys, false);
             this._adapter.setItemKeysMap(itemKeysMap);
             this._adapter.updateOpenKeys(willOpenKeys);
             this._adapter.updateItems(formattedItems);

--- a/packages/semi-ui/navigation/_story/FixedSelectedKeys/index.tsx
+++ b/packages/semi-ui/navigation/_story/FixedSelectedKeys/index.tsx
@@ -1,0 +1,145 @@
+import React from 'react';
+import { Layout, Nav } from '@douyinfe/semi-ui';
+import { BrowserRouter, useLocation, useNavigate, Routes, Route, Navigate } from 'react-router-dom';
+import { IconSemiLogo } from '@douyinfe/semi-icons';
+
+const { Header, Sider, Content } = Layout;
+
+const RouterConfig = {
+    config: {
+        itemKey: '/config',
+        text: 'Config',
+        items: [
+            {
+                itemKey: '/config/ability',
+                text: 'Ability',
+                items: [
+                    {
+                        itemKey: '/config/ability/management',
+                        text: 'Ability management',
+                    },
+                ],
+            },
+            {
+                itemKey: '/config/task',
+                text: 'Task',
+                items: [
+                    {
+                        itemKey: '/config/task/management',
+                        text: 'Word management',
+                    },
+                ],
+            },
+        ],
+    },
+    distribution: {
+        itemKey: '/distribution',
+        text: 'Distribution',
+        items: [
+            {
+                itemKey: '/distribution/queue',
+                text: 'Queue',
+                items: [
+                    {
+                        itemKey: '/distribution/queue/management',
+                        text: 'Config management',
+                    },
+                ],
+            },
+        ],
+    },
+};
+
+const AppHeader = () => {
+    const location = useLocation();
+    const navigate = useNavigate();
+
+    const selectedKeys = React.useMemo(
+        () => [
+            location.pathname
+                .split('/')
+                .slice(0, 2)
+                .join('/'),
+        ],
+        [location.pathname]
+    );
+    const HeaderItems = React.useMemo(
+        () =>
+            Object.values(RouterConfig).map(option => (
+                <Nav.Item
+                    key={option.itemKey}
+                    itemKey={option.itemKey}
+                    text={option.text}
+                    onClick={() => {
+                        if (option.itemKey) {
+                            navigate(option.itemKey);
+                        }
+                    }}
+                />
+            )),
+        [navigate]
+    );
+
+    return (
+        <Header>
+            <div>
+                <Nav mode="horizontal" selectedKeys={selectedKeys} style={{ height: '52px' }}>
+                    <Nav.Header>
+                        <IconSemiLogo style={{ fontSize: 36 }} />
+                        <span>Semi Design</span>
+                    </Nav.Header>
+                    {HeaderItems}
+                </Nav>
+            </div>
+        </Header>
+    );
+};
+
+const AppSider = () => {
+    const location = useLocation();
+
+    const selectedFirstLevelKey = React.useMemo(() => location.pathname.split('/')[1], [location.pathname]);
+    const siderItems = React.useMemo(() => {
+        const selectedKeyConfig = RouterConfig[selectedFirstLevelKey];
+        return selectedKeyConfig?.items ?? [];
+    }, [selectedFirstLevelKey]);
+
+    const selectedKey = React.useMemo(() => [location.pathname], [location.pathname]);
+
+    return (
+        <Sider>
+            <Nav selectedKeys={selectedKey} items={siderItems} />
+        </Sider>
+    );
+};
+
+const AppContent = () => {
+    return (
+        <Routes>
+            <Route path="/config/ability/management" element={<div>ability</div>} />
+            <Route path="/config/task/management" element={<div>word</div>} />
+            <Route path="/config" element={<Navigate to="/config/ability/management" replace />} />
+            <Route path="/distribution/queue/management" element={<div>config management</div>} />
+            <Route path="/distribution" element={<Navigate to="/distribution/queue/management" replace />} />
+            <Route index element={<Navigate to="/config/ability/management" replace />} />
+        </Routes>
+    );
+};
+
+export default function App() {
+    return (
+        <BrowserRouter>
+            <div style={{ width: '100%', height: '100%', display: 'flex' }}>
+                <Layout>
+                    <AppHeader />
+                    <Layout>
+                        <AppSider />
+                        <Content>
+                            <AppContent />
+                        </Content>
+                    </Layout>
+                </Layout>
+            </div>
+        </BrowserRouter>
+    );
+}

--- a/packages/semi-ui/navigation/_story/navigation.stories.jsx
+++ b/packages/semi-ui/navigation/_story/navigation.stories.jsx
@@ -13,6 +13,7 @@ import DisabledNav from './DisabledNav';
 import Button from '../../button';
 import GetPopupNav from './Popup';
 import CustomArrowIcon from './CustomIcon';
+import FixedSelectedKeys from './FixedSelectedKeys';
 
 import {
   IconMail,
@@ -35,6 +36,10 @@ import {
 
 export default {
   title: 'Navigation'
+}
+
+export {
+  FixedSelectedKeys,
 }
 
 export const Default = () => {

--- a/packages/semi-ui/navigation/index.tsx
+++ b/packages/semi-ui/navigation/index.tsx
@@ -222,6 +222,8 @@ class Nav extends BaseComponent<NavProps, NavState> {
             this.foundation.handleItemsChange(false);
             if (this.props.selectedKeys && !isEqual(prevProps.selectedKeys, this.props.selectedKeys)) {
                 this.adapter.updateSelectedKeys(this.props.selectedKeys);
+                const willOpenKeys = this.foundation.getWillOpenKeys(this.state.itemKeysMap);
+                this.adapter.updateOpenKeys(willOpenKeys);
             }
 
             if (this.props.openKeys && !isEqual(prevProps.openKeys, this.props.openKeys)) {

--- a/packages/semi-ui/navigation/index.tsx
+++ b/packages/semi-ui/navigation/index.tsx
@@ -215,24 +215,17 @@ class Nav extends BaseComponent<NavProps, NavState> {
         // override BaseComponent
     }
 
-    componentDidUpdate(prevProps: NavProps, prevState: NavState) {
+    componentDidUpdate(prevProps: NavProps) {
         if (prevProps.items !== this.props.items || prevProps.children !== this.props.children) {
             this.foundation.init();
         } else {
             this.foundation.handleItemsChange(false);
-            const { selectedKeys } = this.state;
-
             if (this.props.selectedKeys && !isEqual(prevProps.selectedKeys, this.props.selectedKeys)) {
                 this.adapter.updateSelectedKeys(this.props.selectedKeys);
             }
 
             if (this.props.openKeys && !isEqual(prevProps.openKeys, this.props.openKeys)) {
                 this.adapter.updateOpenKeys(this.props.openKeys);
-            }
-
-            if (!isEqual(selectedKeys, prevState.selectedKeys)) {
-                const parentSelectKeys = this.foundation.selectLevelZeroParentKeys(null, ...selectedKeys);
-                this.adapter.addSelectedKeys(...parentSelectKeys);
             }
         }
     }
@@ -248,7 +241,17 @@ class Nav extends BaseComponent<NavProps, NavState> {
             setItemKeysMap: itemKeysMap => this.setState({ itemKeysMap: { ...itemKeysMap } }),
             addSelectedKeys: createAddKeysFn(this, 'selectedKeys'),
             removeSelectedKeys: createRemoveKeysFn(this, 'selectedKeys'),
-            updateSelectedKeys: selectedKeys => this.setState({ selectedKeys: [...selectedKeys] }),
+            /**
+             * when `includeParentKeys` is `true`, select a nested nav item will select parent nav sub
+             */
+            updateSelectedKeys: (selectedKeys: (string | number)[], includeParentKeys = true) => {
+                let willUpdateSelectedKeys = selectedKeys;
+                if (includeParentKeys) {
+                    const parentSelectKeys = this.foundation.selectLevelZeroParentKeys(null, selectedKeys);
+                    willUpdateSelectedKeys = Array.from(new Set(selectedKeys.concat(parentSelectKeys)));
+                }
+                this.setState({ selectedKeys: willUpdateSelectedKeys });
+            },
             updateOpenKeys: openKeys => this.setState({ openKeys: [...openKeys] }),
             addOpenKeys: createAddKeysFn(this, 'openKeys'),
             removeOpenKeys: createRemoveKeysFn(this, 'openKeys'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -3600,6 +3600,11 @@
     prop-types "^15.6.1"
     react-lifecycles-compat "^3.0.4"
 
+"@remix-run/router@1.15.2":
+  version "1.15.2"
+  resolved "https://registry.yarnpkg.com/@remix-run/router/-/router-1.15.2.tgz#35726510d332ba5349c6398d13259d5da184553d"
+  integrity sha512-+Rnav+CaoTE5QJc4Jcwh5toUpnVLKYbpU6Ys0zqbakqbaLQHeglLVHPfxOiQqdNmUy5C2lXz5dwC6tQNX2JW2Q==
+
 "@resvg/resvg-js-android-arm-eabi@2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.4.1.tgz#49dc9722f95096f8aff70186deae8e148d60dce5"
@@ -5227,6 +5232,11 @@
   dependencies:
     "@types/unist" "*"
 
+"@types/history@^4.7.11":
+  version "4.7.11"
+  resolved "https://registry.yarnpkg.com/@types/history/-/history-4.7.11.tgz#56588b17ae8f50c53983a524fc3cc47437969d64"
+  integrity sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==
+
 "@types/hoist-non-react-statics@^3.3.1":
   version "3.3.1"
   resolved "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz#1124aafe5118cb591977aeb1ceaaed1070eb039f"
@@ -5482,6 +5492,23 @@
   resolved "https://registry.yarnpkg.com/@types/react-resizable/-/react-resizable-3.0.4.tgz#2f5a1b6c79dd0b8729959deefc8628ab484724cc"
   integrity sha512-+QguN9CDfC1lthq+4noG1fkxh8cqkV2Fv/Mu3mdknCCBiwwNLecnBdk1MmNNN7uJpT23Nx/aVkYsbt5NuWouFw==
   dependencies:
+    "@types/react" "*"
+
+"@types/react-router-dom@^5.3.3":
+  version "5.3.3"
+  resolved "https://registry.yarnpkg.com/@types/react-router-dom/-/react-router-dom-5.3.3.tgz#e9d6b4a66fcdbd651a5f106c2656a30088cc1e83"
+  integrity sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==
+  dependencies:
+    "@types/history" "^4.7.11"
+    "@types/react" "*"
+    "@types/react-router" "*"
+
+"@types/react-router@*":
+  version "5.1.20"
+  resolved "https://registry.yarnpkg.com/@types/react-router/-/react-router-5.1.20.tgz#88eccaa122a82405ef3efbcaaa5dcdd9f021387c"
+  integrity sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==
+  dependencies:
+    "@types/history" "^4.7.11"
     "@types/react" "*"
 
 "@types/react-transition-group@^4.4.0":
@@ -21746,6 +21773,21 @@ react-resize-detector@^7.1.2:
   integrity sha512-zXnPJ2m8+6oq9Nn8zsep/orts9vQv3elrpA+R8XTcW7DVVUJ9vwDwMXaBtykAYjMnkCIaOoK9vObyR7ZgFNlOw==
   dependencies:
     lodash "^4.17.21"
+
+react-router-dom@^6.22.2:
+  version "6.22.2"
+  resolved "https://registry.yarnpkg.com/react-router-dom/-/react-router-dom-6.22.2.tgz#8233968a8a576f3006e5549c80f3527d2598fc9c"
+  integrity sha512-WgqxD2qySEIBPZ3w0sHH+PUAiamDeszls9tzqMPBDA1YYVucTBXLU7+gtRfcSnhe92A3glPnvSxK2dhNoAVOIQ==
+  dependencies:
+    "@remix-run/router" "1.15.2"
+    react-router "6.22.2"
+
+react-router@6.22.2:
+  version "6.22.2"
+  resolved "https://registry.yarnpkg.com/react-router/-/react-router-6.22.2.tgz#27e77e4c635a5697693b922d131d773451c98a5b"
+  integrity sha512-YD3Dzprzpcq+tBMHBS822tCjnWD3iIZbTeSXMY9LPSG541EfoBGyZ3bS25KEnaZjLcmQpw2AVLkFyfgXY8uvcw==
+  dependencies:
+    "@remix-run/router" "1.15.2"
 
 react-scroll-parallax@^2.4.0:
   version "2.4.3"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

错误原因：setState 合并导致第一次 setState 失效

<img width="2056" alt="image" src="https://github.com/DouyinFE/semi-design/assets/26477537/4e322d79-40e1-459d-9012-cc79f43435c5">

原来第二个 setState 是为了解决 selectedKeys 变化后，自动加上父级 selectedKeys 问题，但是在受控场景这个方式不对

修改为：更新为 updateSelectedKeys 时自动加上父级的 key


### Changelog
🇨🇳 Chinese
- Fix: 修复 Navigation 组件在 react 17 下 selectedKeys 未生效问题
- Fix: 修复 Navigation 组件 openKeys 在 selectedKeys 更新后未生效问题

---

🇺🇸 English
- Fix: fixed Navigation component selectedKeys bug in react 17
- Fix: fixed  Navigation component openKeys does not work after selectedKeys is updated


### Checklist
- [x] Test or no need
- [x] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
