### PR TITLE
fix: [Descriptions] foundation适配其他框架, 调整horizontal colspan值的计算自动补全剩余部分 

### DIFF
--- a/packages/semi-foundation/descriptions/foundation.ts
+++ b/packages/semi-foundation/descriptions/foundation.ts
@@ -1,6 +1,8 @@
 import BaseFoundation, { DefaultAdapter } from '../base/foundation';
 
-export interface DescriptionsAdapter<P = Record<string, any>, S = Record<string, any>> extends DefaultAdapter<P, S> {}
+export interface DescriptionsAdapter<P = Record<string, any>, S = Record<string, any>> extends DefaultAdapter<P, S> {
+    getColumns: () => any[]
+}
 
 export default class DescriptionsFoundation<P = Record<string, any>, S = Record<string, any>> extends BaseFoundation<DescriptionsAdapter<P, S>, P, S> {
     constructor(adapter: DescriptionsAdapter<P, S>) {
@@ -9,16 +11,7 @@ export default class DescriptionsFoundation<P = Record<string, any>, S = Record<
 
     getHorizontalList() {
         const { column, data, children } = this.getProps();
-        let columns;
-        if (data?.length) {
-            columns = data || [];
-        } else {
-            columns =
-                children?.map(item => ({
-                    value: item.props.children,
-                    ...item.props,
-                })) || [];
-        }
+        const columns = this._adapter.getColumns();
         const horizontalList = [];
         const curSpan = { totalSpan: 0, itemList: [] };
         for (const item of columns) {

--- a/packages/semi-foundation/descriptions/foundation.ts
+++ b/packages/semi-foundation/descriptions/foundation.ts
@@ -23,7 +23,19 @@ export default class DescriptionsFoundation<P = Record<string, any>, S = Record<
                 curSpan.totalSpan = 0;
             }
         }
-        if (curSpan.itemList.length != 0) horizontalList.push(curSpan.itemList);
+        if (curSpan.itemList.length != 0) {
+            const lastSpan = curSpan.itemList[curSpan.itemList.length - 1];
+            if (isNaN(lastSpan.span)) {
+                let total = 0;
+                curSpan.itemList.forEach(item=>{
+                    return total += !isNaN(item.span)?item.span:1;
+                });
+                if (total < column) {
+                    lastSpan.span = column - total + 1;
+                }
+            }
+            horizontalList.push(curSpan.itemList);
+        }
         return horizontalList;
     }
 }

--- a/packages/semi-ui/descriptions/__test__/descriptions.test.js
+++ b/packages/semi-ui/descriptions/__test__/descriptions.test.js
@@ -194,7 +194,7 @@ describe('Descriptions', () => {
 
     it('Descriptions layout horizontal', () => {
         const desc = mount(
-            <Descriptions layout='horizontal' align='left'>
+            <Descriptions layout='horizontal' align='left' column={4}>
                 <Descriptions.Item itemKey={<strong style={{ color: 'red' }}>实际用户数量</strong>}>1,480,000</Descriptions.Item>
                 <Descriptions.Item itemKey="7天留存">98%</Descriptions.Item>
                 <Descriptions.Item itemKey="认证状态">未认证</Descriptions.Item>
@@ -222,6 +222,12 @@ describe('Descriptions', () => {
                 .getDOMNode()
                 .textContent
         ).toEqual('1,480,000');
+
+        let totalSpan = ths.length
+        tds.forEach(item=>{
+            totalSpan += +item.getAttribute('colspan')
+        })
+        expect(totalSpan).toEqual(8);
         desc.unmount();
     });
 })

--- a/packages/semi-ui/descriptions/index.tsx
+++ b/packages/semi-ui/descriptions/index.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { isValidElement } from 'react';
 import cls from 'classnames';
 import PropTypes from 'prop-types';
 import { strings, cssClasses } from '@douyinfe/semi-foundation/descriptions/constants';
@@ -72,7 +72,23 @@ class Descriptions extends BaseComponent<DescriptionsProps> {
     }
 
     get adapter(): DescriptionsAdapter<DescriptionsProps> {
-        return { ...super.adapter };
+        return {
+            ...super.adapter,
+            getColumns: ()=>{
+                if (this.props.data?.length) {
+                    return this.props.data;
+                }
+                if (this.props.children) {
+                    return React.Children.toArray(this.props.children)?.map(item => {
+                        return isValidElement(item)?({
+                            value: item.props.children,
+                            ...item.props,
+                        }):[];
+                    });
+                }
+                return [];
+            }
+        };
     }
 
     renderChildrenList = () => {

--- a/packages/semi-ui/descriptions/item.tsx
+++ b/packages/semi-ui/descriptions/item.tsx
@@ -50,7 +50,7 @@ export default class Item extends PureComponent<DescriptionsItemProps> {
                     {itemKey}
                 </span>
             </th>
-            <td className={`${prefixCls}-item ${prefixCls}-item-td`} colSpan={span || 1}>
+            <td className={`${prefixCls}-item ${prefixCls}-item-td`} colSpan={span? ((span * 2) - 1) : 1}>
                 <span className={valCls}>
                     {typeof children === 'function' ? children() : children}
                 </span>


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Test Case
- [ ] TypeScript definition update
- [ ] Document improve
- [ ] CI/CD improve
- [ ] Branch sync
- [ ] Other, please describe:


### PR 描述
<!--
相关issue, 背景, 以及 reviewer 需要关注的地方
-->
Fixes #
1. [Descriptions] 适配其他框架 如vue默认的children不在props里面
1. [Descriptions] 当布局是horizontal时，数量不够时，td会自动补全剩余空间

### 更新日志
🇨🇳 Chinese
- Fix: [Descriptions] 适配其他框架 如vue默认的children不在props里面
- Fix: [Descriptions] 当布局是horizontal时，数量不够时，td会自动补全剩余空间

---

🇺🇸 English
- Fix: [Descriptions] Friendly to other frameworks such as vue
- Fix: [Descriptions] When the layout is horizontal and align != , the td automatically fills the remaining space


### 检查清单
- [x] 已增加测试用例或无须增加
- [x] 已补充文档或无须补充
- [x] Changelog已提供或无须提供

### 其他要求
- [x ] 本条 PR 不需要纳入 Changelog

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->
