### PR TITLE
style: Add a selector for the theme’s basic css variables to adapt to shadow dom

### DIFF
--- a/packages/semi-theme-default/scss/_palette.scss
+++ b/packages/semi-theme-default/scss/_palette.scss
@@ -1,5 +1,8 @@
 body,
-body .semi-always-light {
+body .semi-always-light, 
+:host,
+:host .semi-always-light
+ {
     --semi-amber-0: 254,251,235;
     --semi-amber-1: 252,245,206;
     --semi-amber-2: 249,232,158;
@@ -165,7 +168,10 @@ body .semi-always-light {
 }
 
 body[theme-mode="dark"],
-body .semi-always-dark {
+body .semi-always-dark,
+:host-context(body[theme-mode="dark"]),
+:host .semi-always-dark
+{
     --semi-red-0: 108,9,11;
     --semi-red-1: 144,17,16;
     --semi-red-2: 180,32,25;

--- a/packages/semi-theme-default/scss/animation.scss
+++ b/packages/semi-theme-default/scss/animation.scss
@@ -1,4 +1,4 @@
-body{
+body, :host {
 
 
   --semi-transition_duration-slowest:0ms;

--- a/packages/semi-theme-default/scss/global.scss
+++ b/packages/semi-theme-default/scss/global.scss
@@ -1,6 +1,9 @@
 @import "./_palette.scss";
 
-body, body[theme-mode="dark"] .semi-always-light {
+body, body[theme-mode="dark"] .semi-always-light,
+:host,
+:host .semi-always-light
+{
     font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     --semi-color-white: rgba(var(--semi-white), 1); // 浅色模式下深色背景内容Inverse
@@ -125,7 +128,10 @@ body, body[theme-mode="dark"] .semi-always-light {
     --semi-color-data-19:rgba(255, 207, 238, 1); //vchart 数据色板颜色 - 19
 }
 
-body[theme-mode="dark"], body .semi-always-dark {
+body[theme-mode="dark"], body .semi-always-dark,
+:host-context(body[theme-mode="dark"]),
+:host .semi-always-dark
+{
     font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     --semi-color-white: rgba(228, 231, 245, 1);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2142 

### Changelog
🇨🇳 Chinese
- Style: 通过 :host, :host-context 伪类选择器将 css variable 注入 shadow dom，保障 shadow dom 下的 Semi 组件样式正确 #2142 

---

🇺🇸 English
- Fix: Inject the css variable into the shadow dom through the :host, :host-context pseudo-class selectors to ensure that the Semi component style under the shadow dom is correct. #2142 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
