### PR TITLE
fix: fix split button lost className when child changed

### DIFF
--- a/packages/semi-ui/button/splitButtonGroup.tsx
+++ b/packages/semi-ui/button/splitButtonGroup.tsx
@@ -22,7 +22,7 @@ export default class SplitButtonGroup extends BaseComponent<SplitButtonGroupProp
     };
 
     componentDidMount() {
-        const addClassName = ()=>{
+        const addClassName = () => {
             const buttons = this.containerRef.current.querySelectorAll('button');
             const firstButton = buttons[0];
             const lastButton = buttons[buttons.length - 1];
@@ -36,9 +36,9 @@ export default class SplitButtonGroup extends BaseComponent<SplitButtonGroupProp
         };
         if (this.containerRef.current) {
             addClassName();
-            const mutationObserver = new MutationObserver((mutations, observer)=>{
+            const mutationObserver = new MutationObserver((mutations, observer) => {
                 for (const mutation of mutations) {
-                    if ((mutation.type === "attributes" && mutation.attributeName === "class") || (mutation.type==='childList' && Array.from( mutation.addedNodes).some(node=>node.nodeName==='BUTTON'))) {
+                    if ((mutation.type === 'attributes' && mutation.attributeName === 'class') || (mutation.type === 'childList' && Array.from(mutation.addedNodes).some(node => node.nodeName === 'BUTTON'))) {
                         addClassName();
                     }
                 }
@@ -47,7 +47,7 @@ export default class SplitButtonGroup extends BaseComponent<SplitButtonGroupProp
             this.mutationObserver = mutationObserver;
         }
     }
-    
+
     componentWillUnmount() {
         super.componentWillUnmount();
         this.mutationObserver?.disconnect();


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Split Button 在 children Button className 变化时丢失样式的问题

---

🇺🇸 English
- Fix: Fix the problem of Split Button losing style when children Button className changes


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
