### PR TITLE
fix: fixed Table header rowSelection is selected when dataSource is E…

### DIFF
--- a/cypress/e2e/table.spec.js
+++ b/cypress/e2e/table.spec.js
@@ -292,4 +292,9 @@ describe('table', () => {
         cy.visit('http://localhost:6006/iframe.html?id=table--fixed-default-expanded-grouped-rows&viewMode=story');
         cy.get('.semi-table-tbody tr').eq(1).should('have.class', 'semi-table-row-expanded');
     });
+
+    it('test header rowSelection is not selected when dataSource is empty', () => {
+        cy.visit('http://localhost:6006/iframe.html?args=&id=table--fixed-row-selection-empty&viewMode=story');
+        cy.get('.semi-table-thead .semi-checkbox-unChecked').should('exist');
+    });
 });

--- a/packages/semi-foundation/table/foundation.ts
+++ b/packages/semi-foundation/table/foundation.ts
@@ -988,7 +988,7 @@ class TableFoundation<RecordType> extends BaseFoundation<TableAdapter<RecordType
             }
             return true;
         } else {
-            const isAllSelected = allKeys.every(rowKey => selectedRowKeysSet.has(rowKey));
+            const isAllSelected = allKeys.length && allKeys.every(rowKey => selectedRowKeysSet.has(rowKey));
             return isAllSelected || false;
         }
     }

--- a/packages/semi-ui/table/_story/table.stories.jsx
+++ b/packages/semi-ui/table/_story/table.stories.jsx
@@ -113,7 +113,8 @@ export {
     InputFilter,
     FixedRowSelectionHiddenResizable,
     FixedExpandGroupRow,
-    FixedDefaultExpandedGroupedRows
+    FixedDefaultExpandedGroupedRows,
+    FixedRowSelectionEmpty
 } from './v2';
 export { default as FixSelectAll325 } from './Demos/rowSelection';
 

--- a/packages/semi-ui/table/_story/v2/FixedRowSelectionEmpty/index.tsx
+++ b/packages/semi-ui/table/_story/v2/FixedRowSelectionEmpty/index.tsx
@@ -1,0 +1,64 @@
+import React, { useMemo } from 'react';
+import { Table, Avatar } from '@douyinfe/semi-ui';
+import { IconMore } from '@douyinfe/semi-icons';
+
+export default function App() {
+    const columns = [
+        {
+            title: '标题',
+            dataIndex: 'name',
+            width: 400,
+            render: (text, record, index) => {
+                return (
+                    <div>
+                        <Avatar
+                            size="small"
+                            shape="square"
+                            src={record.nameIconSrc}
+                            style={{ marginRight: 12 }}
+                        ></Avatar>
+                        {text}
+                    </div>
+                );
+            },
+        },
+        {
+            title: '大小',
+            dataIndex: 'size',
+        },
+        {
+            title: '所有者',
+            dataIndex: 'owner',
+            render: (text, record, index) => {
+                return (
+                    <div>
+                        <Avatar size="small" color={record.avatarBg} style={{ marginRight: 4 }}>
+                            {typeof text === 'string' && text.slice(0, 1)}
+                        </Avatar>
+                        {text}
+                    </div>
+                );
+            },
+        },
+        {
+            title: '更新日期',
+            dataIndex: 'updateTime',
+        },
+        {
+            title: '',
+            dataIndex: 'operate',
+            render: () => {
+                return <IconMore />;
+            },
+        },
+    ];
+
+    const pagination = useMemo(
+        () => ({
+            pageSize: 3,
+        }),
+        []
+    );
+
+    return <Table columns={columns} dataSource={[]} rowSelection pagination={pagination} />;
+}

--- a/packages/semi-ui/table/_story/v2/index.js
+++ b/packages/semi-ui/table/_story/v2/index.js
@@ -33,3 +33,4 @@ export { default as FeatRenderFilterDropdown } from './FeatRenderFilterDropdown'
 export { default as InputFilter } from './InputFilter';
 export { default as FixedExpandGroupRow } from './FixedExpandGroupRow';
 export { default as FixedDefaultExpandedGroupedRows } from './FixedExpandGroupRow/defaultExpandedGroupedRows';
+export { default as FixedRowSelectionEmpty } from './FixedRowSelectionEmpty';


### PR DESCRIPTION
…mpty #2128

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2128，与 #2014 有关

```javascript
// 空数组 every 之后返回的是 true
[].every(_ => false); // true
````

### Changelog
🇨🇳 Chinese
- Fix: 修复 Table 表头选择状态在数据为空时错误被选中问题（影响 v2.51 ~ v2.54版本） #2128

---

🇺🇸 English
- Fix: Fix the problem that the Table header selection state is incorrectly selected when the data is empty (affects v2.51 ~ v2.54) #2128


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
