### PR TITLE
FIX: 函数式组件下表单验证时默认的error为空对象无法通过验证的问题

### DIFF
--- a/packages/semi-foundation/form/foundation.ts
+++ b/packages/semi-foundation/form/foundation.ts
@@ -4,9 +4,7 @@ import isPromise from '../utils/isPromise';
 import { isValid } from './utils';
 import { isUndefined, isFunction, toPath } from 'lodash';
 import scrollIntoView, { Options as ScrollIntoViewOptions } from 'scroll-into-view-if-needed';
-
 import { BaseFormAdapter, FormState, CallOpts, FieldState, FieldStaff, ComponentProps, setValuesConfig, ArrayFieldStaff } from './interface';
-import isObject from 'utils/isObject';
 
 export type { BaseFormAdapter };
 
@@ -177,9 +175,7 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
             // FIX: after validateFields function if got {}, maybePromisedErrors is always be true
             // FIX: checks type of 'maybePromisedErrors' or keys‘s length
             // ⬇️ addon：maybePromisedErrors check either true
-            isObject(maybePromisedErrors) && Object.keys(maybePromisedErrors).length === 0 && (maybePromisedErrors = null)
-
-            if (!maybePromisedErrors) {
+            if (!maybePromisedErrors || ObjectUtil.empty(maybePromisedErrors)) {
                 const _values = this._adapter.cloneDeep(values);
                 resolve(_values);
                 this.injectErrorToField({});
@@ -187,9 +183,8 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
                 maybePromisedErrors.then(
                     (result: any) => {
                         // validate success，clear error
-                        // ⬇️ addon：error results check either true
-                        isObject(result) && Object.keys(result).length === 0 && (result = null)
-                        if (!result) {
+                        // ⬇ addon：error results check either true
+                        if (!result || ObjectUtil.empty(result)) {
                             const _values = this._adapter.cloneDeep(values);
                             resolve(_values);
                             this.injectErrorToField({});

--- a/packages/semi-foundation/form/foundation.ts
+++ b/packages/semi-foundation/form/foundation.ts
@@ -6,6 +6,7 @@ import { isUndefined, isFunction, toPath } from 'lodash';
 import scrollIntoView, { Options as ScrollIntoViewOptions } from 'scroll-into-view-if-needed';
 
 import { BaseFormAdapter, FormState, CallOpts, FieldState, FieldStaff, ComponentProps, setValuesConfig, ArrayFieldStaff } from './interface';
+import isObject from 'utils/isObject';
 
 export type { BaseFormAdapter };
 
@@ -173,6 +174,11 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
                 // error throw by sync validate directly
                 maybePromisedErrors = errors;
             }
+            // FIX: after validateFields function if got {}, maybePromisedErrors is always be true
+            // FIX: checks type of 'maybePromisedErrors' or keys‘s length
+            // ⬇️ addon：maybePromisedErrors check either true
+            isObject(maybePromisedErrors) && Object.keys(maybePromisedErrors).length === 0 && (maybePromisedErrors = null)
+
             if (!maybePromisedErrors) {
                 const _values = this._adapter.cloneDeep(values);
                 resolve(_values);
@@ -181,6 +187,8 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
                 maybePromisedErrors.then(
                     (result: any) => {
                         // validate success，clear error
+                        // ⬇️ addon：error results check either true
+                        isObject(result) && Object.keys(result).length === 0 && (result = null)
                         if (!result) {
                             const _values = this._adapter.cloneDeep(values);
                             resolve(_values);


### PR DESCRIPTION
### What kind of change does this PR introduce? (check at least one)

 - [✔ ] Bugfix

### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # Form 表单验证 errors 为空对象时判断为 true 导致无法提交

### Changelog
🇨🇳 Chinese
- Fix: 修复了Form 表单验证 errors 为空对象时判断为 true 导致无法提交的问题，会判断空对象为 false，使其正常通过表单验证

### Checklist
- [ ✔] Test or no need
- [ ✔] Document or no need
- [✔ ] Changelog or no need

### Additional information
<img width="801" alt="image" src="https://github.com/DouyinFE/semi-design/assets/13182485/6e8816f4-63c8-4b66-99f5-dff07819d961">


