### PR TITLE
[WIP] fix: select multiple filter, last line tag padding higher than other

### DIFF
--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -23,9 +23,11 @@ export interface SelectAdapter<P = Record<string, any>, S = Record<string, any>>
     registerClickOutsideHandler(event: any): void;
     toggleInputShow(show: boolean, cb: () => void): void;
     closeMenu(): void;
+    checkFlexWrap(domNode: Element): boolean;
     notifyCreate(option: BasicOptionProps): void;
     getMaxLimit(): number;
     getSelections(): Map<any, any>;
+    getSelectionsDOM(): Element | null;
     notifyMaxLimit(arg: BasicOptionProps): void;
     notifyClear(): void;
     updateInputValue(inputValue: string): void;
@@ -44,6 +46,7 @@ export interface SelectAdapter<P = Record<string, any>, S = Record<string, any>>
     updateHovering(isHover: boolean): void;
     updateScrollTop(index?: number): void;
     updateOverflowItemCount(count: number): void;
+    updateSelectionWrap(flex: boolean): void;
     getContainer(): any;
     getFocusableElements(node: any): any[];
     getActiveElement(): any;
@@ -383,9 +386,20 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
     toggle2SearchInput(isShow: boolean) {
         if (isShow) {
             this._adapter.toggleInputShow(isShow, () => this.focusInput());
+            this._checkInputIsWrap();
         } else {
             // only when choose the option and close the panel, the input can be hide
             this._adapter.toggleInputShow(isShow, () => undefined);
+        }
+    }
+
+    _checkInputIsWrap() {
+        let dom = this._adapter.getSelectionsDOM();
+        console.log(dom);
+        if (dom !== null) {
+            let isFlexWrap = this._adapter.checkFlexWrap(dom);
+            console.log(isFlexWrap);
+            this._adapter.updateSelectionWrap(isFlexWrap);
         }
     }
 
@@ -480,6 +494,7 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
                 if (autoClearSearchValue) {
                     this.clearInput(event);
                 }
+                this._checkInputIsWrap();
                 this.focusInput();
             }
         } else {
@@ -498,6 +513,7 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
                     const sugInput = '';
                     options = this._filterOption(options, sugInput);
                 }
+                this._checkInputIsWrap();
                 this.focusInput();
             }
             this.updateOptionsActiveStatus(selections, options);

--- a/packages/semi-foundation/select/select.scss
+++ b/packages/semi-foundation/select/select.scss
@@ -208,6 +208,15 @@ $overflowList: #{$prefix}-overflow-list;
         align-items: center;
         height: 100%;
 
+        &-wrap {
+            .#{$prefix}-input-wrapper {
+                line-height: unset;
+                .#{$prefix}-input {
+                    // height: unset;
+                }
+            }
+        }
+
         &-collapse {
             display: inline-flex;
             flex-shrink: 0;

--- a/packages/semi-foundation/select/select.scss
+++ b/packages/semi-foundation/select/select.scss
@@ -402,13 +402,23 @@ $overflowList: #{$prefix}-overflow-list;
         overflow: hidden;
         position: relative;
 
+        &-wrap {
+            .#{$prefix}-input-wrapper {
+                height: 24px;
+                line-height: 24px;
+                .#{$prefix}-input-default {
+                    height: 24px;
+                }
+            }
+        }
+ 
         &-empty {
             .#{$prefix}-input-wrapper {
                 position: absolute;
                 top: 0;
                 left: 0;
                 height: 100%;
-                width: 100%;
+                // width: 100%; // no need to set width here, will calcuate inline style by js
             }
         }
     }

--- a/packages/semi-ui/_base/_story/index.stories.jsx
+++ b/packages/semi-ui/_base/_story/index.stories.jsx
@@ -124,11 +124,11 @@ semiGlobal.config.overrideDefaultProps = {
     },
     Select: {
         zIndex: 2000,
-        getPopupContainer: () => document.querySelector('#popupContainer')
+        // getPopupContainer: () => document.querySelector('#popupContainer')
     },
     Tooltip: {
         zIndex: 2001,
-        getPopupContainer: () => document.querySelector('#popupContainer'),
+        // getPopupContainer: () => document.querySelector('#popupContainer'),
         trigger:"click"
     },
 };

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -866,13 +866,14 @@ export const SelectFilterMultiple = () => (
     >
       <Option value={1}>opt1</Option>
       <Option value={2}>opt2</Option>
-      <Option value={3}>opt22</Option>
       <Option value={3}>opt3</Option>
       <Option value={4}>opt4</Option>
       <Option value={5}>opt5</Option>
       <Option value={6}>opt6</Option>
       <Option value={7}>opt7</Option>
       <Option value={8}>opt8</Option>
+      <Option value={9}>opt9</Option>
+      <Option value={10}>opt10</Option>
     </Select>
     {/* <Select
       filter

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -874,7 +874,7 @@ export const SelectFilterMultiple = () => (
       <Option value={7}>opt7</Option>
       <Option value={8}>opt8</Option>
     </Select>
-    <Select
+    {/* <Select
       filter
       multiple={true}
       maxTagCount={3}
@@ -892,7 +892,7 @@ export const SelectFilterMultiple = () => (
       <Option value={6}>opt6</Option>
       <Option value={7}>opt7</Option>
       <Option value={8}>opt8</Option>
-    </Select>
+    </Select> */}
   </>
 );
 

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -488,10 +488,11 @@ class Select extends BaseComponent<SelectProps, SelectState> {
                 // 多选filter 情况下，selection 的 flex 容器是否换行时子元素的input需要设置不同高度。而是否换行，需要依靠offsetTop做判断. 高度可能随 design token配置有所不同，所以也无法依靠固定数值做判断
                 let hasWrapped = false;
                 const children = container.children;
-                let lastOffsetTop = children[0].offsetTop;
+                let lastOffsetTop = (children[0] as HTMLDivElement).offsetTop;
 
                 for (let i = 1; i < children.length; i++) {
-                    if (children[i].offsetTop > lastOffsetTop) {
+                    let currentChild = children[i] as HTMLDivElement;
+                    if (currentChild.offsetTop > lastOffsetTop) {
                         hasWrapped = true;
                         break;
                     }
@@ -548,8 +549,8 @@ class Select extends BaseComponent<SelectProps, SelectState> {
             setOptionWrapperWidth: (width: number) => {
                 this.setState({ dropdownMinWidth: width });
             },
-            updateSelection: (selections: Map<OptionProps['label'], any>) => {
-                this.setState({ selections });
+            updateSelection: (selections: Map<OptionProps['label'], any>, cb?: () => void) => {
+                this.setState({ selections }, cb);
             },
             // clone Map, important!!!, prevent unexpected modify on state
             getSelections: () => new Map(this.state.selections),

--- a/packages/semi-ui/select/utils.tsx
+++ b/packages/semi-ui/select/utils.tsx
@@ -23,6 +23,7 @@ const generateOption = (child: React.ReactElement, parent: any, index: number, n
     // no need to determine whether the key exists in child
     // Even if the user does not explicitly declare it, React will always generate a key.
     option._keyInJsx = newKey || child.key;
+    console.log(option);
     
     return option;
 };


### PR DESCRIPTION
…line, #1667

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
为了解决Select多选有filter的情况下，换行之后最后一行的间距与其他不一致的问题， #1667 

问题原因：
默认情况下 input 组件的默认样式 line-height 30px  height 30px，在不换行时没有问题。但如果换行之后，同一行中tag 的 height 是 22px，input会把自己的行撑开，导致含有input 的行与其他行的高度不一致
![image](https://github.com/DouyinFE/semi-design/assets/88709023/126e8ce9-96ed-4322-a385-265b76f66d6e)


解决方案：
- 需要动态使用 JS 判断 semi-content-wrapper 这个flex 容器的children是否已经被wrap到了不止一行 ，若换行，给单独的额classname：  semi-content-wrapper-wrap，然后给这个classname下的 input-wrapper、input 覆盖一下height、line-height

![image](https://github.com/DouyinFE/semi-design/assets/88709023/52d5d275-04bd-44d6-8845-16212f6d38c3)


### Changelog
🇨🇳 Chinese
- Fix: 修复 ...

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
