### PR TITLE
fix: Fix the omission exception when children in Typography is a temp…

### DIFF
--- a/packages/semi-ui/typography/__test__/typography.test.js
+++ b/packages/semi-ui/typography/__test__/typography.test.js
@@ -107,4 +107,21 @@ describe(`Typography`, () => {
         })
         expect(numeral.find('.price').text()).toEqual('1992.15')
     })
+
+    it('children is template string', () => {
+        const { Text } = Typography;
+        const code = 'code'; 
+
+        const typographyParagraph = mount(
+            <Text 
+                style={{  marginTop: 6, color: 'var(--semi-color-text-2)' }}
+                ellipsis={{ showTooltip: { opts: { style: { wordBreak: 'break-word' } } } }}
+                copyable={{ content: code }}
+            >
+                Key: {code}
+            </Text>
+        );
+        expect(typographyParagraph.find('.semi-typography').children().at(0).text()).toEqual('Key: code');
+    });
+
 });

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -391,11 +391,14 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
 
         const extraNode = { expand: this.expandRef.current, copy: this.copyRef && this.copyRef.current };
 
+        // Perform type conversion on children to prevent component crash due to non-string type of children
+        // https://github.com/DouyinFE/semi-design/issues/2167
+        const realChildren = Array.isArray(children) ? children.join('') : String(children);
+
         const content = getRenderText(
             this.wrapperRef.current,
             rows,
-            // Perform type conversion on children to prevent component crash due to non-string type of children
-            String(children),
+            realChildren,
             extraNode,
             ELLIPSIS_STR,
             suffix,
@@ -405,7 +408,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             this.setState({
                 isOverflowed: false,
                 ellipsisContent: content,
-                isTruncated: children !== content,
+                isTruncated: realChildren !== content,
             }, resolve);
         });
 


### PR DESCRIPTION
…late string

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2167 

### Changelog
🇨🇳 Chinese
- Fix: 修复使用 js 省略的 Typography 组件，children 为 模版字符串时的显示异常及省略异常 #2167 

---

🇺🇸 English
- Fix: Fix the display exception and omission exception when the Typography component is omitted by js and children is a template string #2167


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
