### PR TITLE
fix: upload addOnPasting switch to false should not trigger process

### DIFF
--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -107,7 +107,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     destroy() {
         const { disabled, addOnPasting } = this.getProps();
         this.releaseMemory();
-        if (addOnPasting && !disabled) {
+        if (!disabled) {
             this.unbindPastingHandler();
         }
     }

--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -884,31 +884,31 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     handlePasting(e: any) {
         const isMac = this._adapter.isMac();
         const isCombineKeydown = isMac ? e.metaKey : e.ctrlKey;
+        const { addOnPasting } = this.getProps();
 
-        if (isCombineKeydown && e.code === 'KeyV' && e.target === document.body) {
-            // https://github.com/microsoft/TypeScript/issues/33923
-            const permissionName = "clipboard-read" as PermissionName;
-            // The main thread should not be blocked by clipboard, so callback writing is required here. No await here
-            navigator.permissions
-                .query({ name: permissionName })
-                .then(result => {
-                    console.log(result);
-                    if (result.state === 'granted' || result.state === 'prompt') {
-                        // user has authorized or will authorize
-                        navigator.clipboard
-                            .read()
-                            .then(clipboardItems => {
+        if (addOnPasting) {
+            if (isCombineKeydown && e.code === 'KeyV' && e.target === document.body) {
+                // https://github.com/microsoft/TypeScript/issues/33923
+                const permissionName = 'clipboard-read' as PermissionName;
+                // The main thread should not be blocked by clipboard, so callback writing is required here. No await here
+                navigator.permissions
+                    .query({ name: permissionName })
+                    .then(result => {
+                        if (result.state === 'granted' || result.state === 'prompt') {
+                            // user has authorized or will authorize
+                            navigator.clipboard.read().then(clipboardItems => {
                                 // Process the data read from the pasteboard
                                 // Check the returned data type to determine if it is image data, and process accordingly
                                 this.readFileFromClipboard(clipboardItems);
                             });
-                    } else {
-                        this._adapter.notifyPastingError(result);
-                    }
-                })
-                .catch(error => {
-                    this._adapter.notifyPastingError(error);
-                });
+                        } else {
+                            this._adapter.notifyPastingError(result);
+                        }
+                    })
+                    .catch(error => {
+                        this._adapter.notifyPastingError(error);
+                    });
+            }
         }
     }
 

--- a/packages/semi-ui/upload/_story/upload.stories.jsx
+++ b/packages/semi-ui/upload/_story/upload.stories.jsx
@@ -1,7 +1,7 @@
 /* argus-disable unPkgSensitiveInfo */
 import React, { useState } from 'react';
 import FileCard from '../fileCard';
-import { Button, Upload, Toast, Tag } from '@douyinfe/semi-ui/index';
+import { Button, Upload, Toast, Tag, Switch } from '@douyinfe/semi-ui/index';
 import { withField, Form } from '../../form/index';
 import { IconPlus, IconFile, IconUpload, IconEyeOpened, IconDownload, IconDelete } from '@douyinfe/semi-icons';
 
@@ -1252,10 +1252,12 @@ PreviewFallback.story = {
 
 
 export const PastingDemo = () => {
+  const [addOnPasting, switchAddOnPasting] = useState(true);
+
   return (
     <div style={{ width: 800, height: 500 }}>
       <Upload
-        addOnPasting
+        addOnPasting={addOnPasting}
         action={action}
         // {...commonProps}
         onChange={(e) => console.log(e)}
@@ -1271,6 +1273,12 @@ export const PastingDemo = () => {
           .then(() => alert('clear'))
           .catch(error => console.log(error))
       }}>清空clipboard</Button>
+      <Switch
+        checked={addOnPasting}
+        onChange={e => switchAddOnPasting(e)}
+      >
+
+      </Switch>
     </div>
 
   )


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

### Changelog
🇨🇳 Chinese
- Fix: 修复 Upload 将 addOnPasting 切换为 false 后，粘贴上传依然触发的问题

---

🇺🇸 English
- Fix: Fixed the problem that after Upload switches addOnPasting to false, paste upload is still triggered.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
