### PR TITLE
fix: fix modal footerfill button marginleft

### DIFF
--- a/packages/semi-ui/modal/Modal.tsx
+++ b/packages/semi-ui/modal/Modal.tsx
@@ -286,7 +286,7 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
                         autoFocus={true}
                         {...this.props.cancelButtonProps}
                         style={{
-                        ...footerFill ? {marginLeft: "unset"}:{},
+                            ...footerFill ? { marginLeft: "unset" }:{},
                             ...this.props.cancelButtonProps?.style
                         }}
                         x-semi-children-alias="cancelText"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Modal footerFill 打开后，取消按钮带有左边距的问题 #2173 

---

🇺🇸 English
- Fix: Fixed the issue where the Cancel button has a left margin after Modal footerFill is opened. #2173


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
