### PR TITLE
fix: Slider bug (#2171)

### DIFF
--- a/packages/semi-ui/slider/index.tsx
+++ b/packages/semi-ui/slider/index.tsx
@@ -95,6 +95,7 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
     private maxHanleEl: React.RefObject<HTMLSpanElement>;
     private dragging: boolean[];
     private eventListenerSet: Set<() => void>;
+    private handleDownEventListenerSet: Set<() => void>;
     foundation: SliderFoundation;
 
     constructor(props: SliderProps) {
@@ -124,6 +125,7 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
         this.dragging = [false, false];
         this.foundation = new SliderFoundation(this.adapter);
         this.eventListenerSet = new Set();
+        this.handleDownEventListenerSet = new Set()
     }
 
     get adapter(): SliderAdapter {
@@ -204,9 +206,9 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
             getMinHandleEl: () => this.minHanleEl.current,
             getMaxHandleEl: () => this.maxHanleEl.current,
             onHandleDown: (e: React.MouseEvent) => {
-                this._addEventListener(document.body, 'mousemove', this.foundation.onHandleMove, false);
-                this._addEventListener(window, 'mouseup', this.foundation.onHandleUp, false);
-                this._addEventListener(document.body, 'touchmove', this.foundation.onHandleTouchMove, false);
+                this.handleDownEventListenerSet.add(this._addEventListener(document.body, 'mousemove', this.foundation.onHandleMove, false));
+                this.handleDownEventListenerSet.add(this._addEventListener(window, 'mouseup', this.foundation.onHandleUp, false));
+                this.handleDownEventListenerSet.add(this._addEventListener(document.body, 'touchmove', this.foundation.onHandleTouchMove, false));
             },
             onHandleMove: (mousePos: number, isMin: boolean, stateChangeCallback = noop, clickTrack = false, outPutValue): boolean | void => {
 
@@ -262,8 +264,8 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                 this.props.onMouseUp?.(e);
                 e.stopPropagation();
                 e.preventDefault();
-                document.body.removeEventListener('mousemove', this.foundation.onHandleMove, false);
-                document.body.removeEventListener('mouseup', this.foundation.onHandleUp, false);
+                Array.from(this.handleDownEventListenerSet).forEach((clear) => clear())
+                this.handleDownEventListenerSet.clear()
             },
             onHandleUpAfter: () => {
                 const { currentValue } = this.state;
@@ -358,9 +360,6 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                     onMouseLeave={() => {
                         this.foundation.onHandleLeave();
                     }}
-                    onMouseUp={e => {
-                        this.foundation.onHandleUp(e);
-                    }}
                     onKeyUp={e => {
                         this.foundation.onHandleUp(e);
                     }}
@@ -419,9 +418,6 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                         onMouseLeave={() => {
                             this.foundation.onHandleLeave();
                         }}
-                        onMouseUp={e => {
-                            this.foundation.onHandleUp(e);
-                        }}
                         onKeyUp={e => {
                             this.foundation.onHandleUp(e);
                         }}
@@ -474,9 +470,6 @@ export default class Slider extends BaseComponent<SliderProps, SliderState> {
                         }}
                         onMouseLeave={() => {
                             this.foundation.onHandleLeave();
-                        }}
-                        onMouseUp={e => {
-                            this.foundation.onHandleUp(e);
                         }}
                         onKeyUp={e => {
                             this.foundation.onHandleUp(e);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2171
- Bug 1: 
  > - Cause: In packages\semi-ui\slider\index.tsx, the onHandleDown method (line 206) adds event listeners for the window’s mouseup event and the body’s touchmove event. However, in onHandleUpBefore (line 261), the mouseup event for the body is removed, but the touchmove event listener for the body is not, resulting in these two events remaining in a listening state. 
  > - Fix: Since a custom this._addEventListener is used when binding event listeners, which records the listened events and returns a function to cancel the listener, the return values should be collected in onHandleDown. Then, in onHandleUpBefore, all these listeners added during onHandleDown should be removed together to ensure that all listeners added during onHandleDown are removed.
- Bug 2:
  > - Cause: The handle element has an onMouseUp listener bound, which triggers this.foundation.onHandleUp (lines 362, 423, 479). However, this.foundation.onHandleUp has already been bound as a callback for the window’s mouseup event in onHandleUpBefore (line 261), so there is no need to listen for the mouseup event on the handle element. This can cause the mouseup event triggered on the handle of another Slider component during dragging to override the callback for the window’s mouseup event, resulting in the component’s isDrag state remaining true. 
  > - Fix: Remove the onMouseUp listener from the handle element.


### Changelog
🇨🇳 Chinese
- Fix: Slider 组件的 onMouseUp 触发时机的 bug，以及拖动状态无法取消的 bug。

---

🇺🇸 English
- Fix: the issue where the onMouseUp event of the Slider component is triggered at the wrong time, as well as the issue where the dragging state of the Slider component cannot be canceled.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
