### PR TITLE
style: fix tagInput insetLabel not align with other component

### DIFF
--- a/packages/semi-foundation/tagInput/tagInput.scss
+++ b/packages/semi-foundation/tagInput/tagInput.scss
@@ -255,6 +255,15 @@ $module: #{$prefix}-tagInput;
         }
     }
 
+    &-inset-label {
+        margin-right: $spacing-tagInput_insetLabel-marginRight;
+        font-weight: $font-tagInput_insetLabel-fontWeight;
+        @include font-size-regular;
+        color: $color-tagInput_prefix-text-default;
+        flex-shrink: 0;
+        white-space: nowrap;
+    }
+
     &-prefix,
     &-suffix {
         @include all-center;
@@ -278,6 +287,12 @@ $module: #{$prefix}-tagInput;
     &-suffix {
         &-text {
             color: $color-tagInput_suffix-default;
+        }
+    }
+
+    &-with-prefix {
+        .#{$prefix}-input {
+            padding-left: 0;
         }
     }
 

--- a/packages/semi-foundation/tagInput/variables.scss
+++ b/packages/semi-foundation/tagInput/variables.scss
@@ -28,7 +28,7 @@ $color-tagInput_danger-border-hover: var(--semi-color-danger-light-hover); // �
 $color-tagInput_danger-bg-focus: var(--semi-color-danger-light-default); // 危险标签输入框背景颜色 - 选中
 $color-tagInput_danger-border-focus: var(--semi-color-danger); // 危险标签输入框描边颜色 - 选中
 $color-tagInput_sortable_item_over-bg: var(--semi-color-primary); // 拖拽经过的元素前竖线背景色
-
+$color-tagInput_prefix-text-default: var(--semi-color-text-2); // 标签输入框 prefix 文字颜色
 $color-tagInput_handler-icon-default: var(--semi-color-text-2); // 可拖拽的标签拖拽按钮颜色
 
 $spacing-tagInput_small-Y: 1px; // 小尺寸标签输入框标签顶部外边距
@@ -37,6 +37,7 @@ $spacing-tagInput_large-Y: 3px; // 大尺寸标签输入框标签顶部外边距
 $spacing-tagInput_wrapper_n_paddingX: $spacing-tight; //标签输入框标签容器水平内边距
 $spacing-tagInput_drag_handler-marginRight: 4px; // 拖拽handler icon的右外边距 
 $spacing-tagInput_tag_icon_paddingLeft: 4px; // tag中有handler icon时tag的左内边距
+$spacing-tagInput_insetLabel-marginRight: $spacing-base-tight; // Form容器中标签输入框内嵌Label的右边距
 
 $height-tagInput-large: $height-control-large; // 大尺寸标签输入框高度
 $height-tagInput-default: $height-control-default; // 默认尺寸标签输入框高度
@@ -54,3 +55,5 @@ $width-tagInput_sortable_item_over: 2px; // 拖拽经过的元素前竖线宽度
 $radius-tagInput: var(--semi-border-radius-small); // 标签输入框圆角
 
 $z-tagInput_drag_item_move: 2000 !default; // 标签输入框中正在拖拽元素的z-index
+
+$font-tagInput_insetLabel-fontWeight: 600; // prefix 文字字重

--- a/packages/semi-ui/tagInput/_story/tagInput.stories.jsx
+++ b/packages/semi-ui/tagInput/_story/tagInput.stories.jsx
@@ -457,6 +457,7 @@ export const PrefixSuffix = () => (
     <br />
     <br />
     <TagInput style={style} prefix="Prefix" showClear />
+    <TagInput style={style} insetLabel="insetLabel" showClear />
     <br />
     <br />
     <TagInput style={style} suffix={<IconGift />} />

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -565,6 +565,9 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             disabled,
             placeholder,
             validateStatus,
+            prefix,
+            insetLabel,
+            suffix,
             ...rest
         } = this.props;
 
@@ -584,6 +587,8 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             [`${prefixCls}-warning`]: validateStatus === 'warning',
             [`${prefixCls}-small`]: size === 'small',
             [`${prefixCls}-large`]: size === 'large',
+            [`${prefixCls}-with-prefix`]: !!prefix || !!insetLabel,
+            [`${prefixCls}-with-suffix`]: !!suffix,
         });
 
         const inputCls = cls(`${prefixCls}-wrapper-input`, `${prefixCls}-wrapper-input-${size}`);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
其他组件如 input、select 等支持 insetLabel的组件，在 xx-inset-label 的 classname上均会带有 font-size的声明，不会受到 body fontsize继承的影响。而tagInput表现与其他组件不一致。需要对齐。


### Changelog
🇨🇳 Chinese
- Style: 修复 TagIput 在 Form 表单中使用 insetLabel时，样式与其他组件未对齐的问题
- Design Token：TagInput 增加 $color-tagInput_prefix-text-default、$spacing-tagInput_insetLabel-marginRight、$font-tagInput_insetLabel-fontWeight 三个 Token
 
---

🇺🇸 English
- Style: fixed TagInput insetLabel style not align with other component such as Input、Select
- Design Token：TagInput add Tokens：$color-tagInput_prefix-text-default、$spacing-tagInput_insetLabel-marginRight、$font-tagInput_insetLabel-fontWeight
 

### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
