### PR TITLE
fix: fix firfox/safari dark mode style error when use :host-context

### DIFF
--- a/packages/semi-theme-default/scss/_palette.scss
+++ b/packages/semi-theme-default/scss/_palette.scss
@@ -163,7 +163,7 @@ body, body .semi-always-light, :host, :host .semi-always-light {
     --semi-yellow-9: 83,72,0;
 }
 
-body[theme-mode="dark"], body .semi-always-dark, :host-context(body[theme-mode="dark"]), :host .semi-always-dark {
+body[theme-mode="dark"], body .semi-always-dark, :host([theme-mode="dark"]), :host .semi-always-dark {
     --semi-red-0: 108,9,11;
     --semi-red-1: 144,17,16;
     --semi-red-2: 180,32,25;

--- a/packages/semi-theme-default/scss/global.scss
+++ b/packages/semi-theme-default/scss/global.scss
@@ -125,7 +125,7 @@ body, body[theme-mode="dark"] .semi-always-light, :host, :host .semi-always-ligh
     --semi-color-data-19: rgba(188, 198, 255, 1); //vchart 数据色板颜色 - 19
 }
 
-body[theme-mode="dark"], body .semi-always-dark, :host-context(body[theme-mode="dark"]), :host .semi-always-dark {
+body[theme-mode="dark"], body .semi-always-dark, :host([theme-mode="dark"]), :host .semi-always-dark {
     font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI", "PingFang SC", "Hiragino Sans GB", "Microsoft YaHei", "Helvetica Neue", Helvetica, Arial, sans-serif;
     -webkit-font-smoothing: antialiased;
     --semi-color-white: rgba(228, 231, 245, 1);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

#2142 中使用 [:host-context](https://developer.mozilla.org/en-US/docs/Web/CSS/:host-context#browser_compatibility) 处理暗色模式下的样式注入 
![image](https://github.com/DouyinFE/semi-design/assets/101110131/72b3a076-133b-48b0-9108-1b948191be2a)
由于该选择器在 firefox 以及 safari 底下未支持，导致整行的样式解析失效。因此切换到暗色模式下，使用的仍然是亮色模式的 token，导致样式错误。

将 :host-context(body[theme-mode="dark"])修改为 :host([theme-mode="dark"])。
用户想要实现暗色模式的切换，可以通过在 shadow host 上添加 theme-mode 为dark 实现。同时不影响 shadow-dom 底下的具体暗色/亮色模式
:host()在 firefox/safari/chrome 底下均支持，
![image](https://github.com/DouyinFE/semi-design/assets/101110131/34fe4ff7-7cac-4ace-a6f1-5659d2db5f7e)

修改后的测试页面
![image](https://github.com/DouyinFE/semi-design/assets/101110131/cd517cbf-11b1-41c4-bf38-87a5860ca5a5)
![image](https://github.com/DouyinFE/semi-design/assets/101110131/2040c839-0629-4126-bd67-38d0c8643914)
![image](https://github.com/DouyinFE/semi-design/assets/101110131/f5cd498e-9a75-4943-ba9d-d2dd73312823)


### Changelog
🇨🇳 Chinese
- Fix: 修复在 safari/ firefox 浏览器在暗色模式下的样式错误(影响版本：2.56.0-2.57.0)
---

🇺🇸 English
- Fix: Fix the style error in dark mode in safari/firefox browser (affected versions: 2.56.0-2.57.0)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
