### PR TITLE
fix: pagination width to fit big page number

### DIFF
--- a/packages/semi-foundation/pagination/pagination.scss
+++ b/packages/semi-foundation/pagination/pagination.scss
@@ -48,6 +48,8 @@ $module: #{$prefix}-page;
         transition: background-color $transition_duration-pagination_item-bg $transition_function-pagination_item-bg $transition_delay-pagination_item-bg,
         color $transition_duration-pagination_item-text $transition_function-pagination_item-text $transition_delay-pagination_item-text;
         transform:scale($transform_scale-pagination_item);
+        width: fit-content;
+        flex-shrink: 0;
 
         &:hover {
             border-color: $color-pagination_item-border-hover;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2230

### Changelog
🇨🇳 Chinese
- Fix: 修复 Pagination 在超大页码下展示不符合预期问题

---

🇺🇸 English
- Fix: fix the problem that Pagination does not display as expected under extremely large page numbers


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
