### PR TITLE
feat: 显示所有选中节点(包括父节点)

### DIFF
--- a/content/input/treeselect/index-en-US.md
+++ b/content/input/treeselect/index-en-US.md
@@ -1412,6 +1412,7 @@ function Demo() {
 | arrowIcon|Customize the right drop-down arrow Icon, when the showClear switch is turned on and there is currently a selected value, hover will give priority to the clear icon| ReactNode | | 1.15.0|
 |autoAdjustOverflow|Whether the pop-up layer automatically adjusts the direction when it is obscured (only vertical direction is supported for the time being, and the inserted parent is body)|boolean | true| 0.34.0|
 | autoExpandParent | Toggle whether to expand parent nodes automatically | boolean | false | 0.34.0 |
+| autoMergeValue | Sets the automerge value. Specifically, when enabled, when a parent node is selected, value will include that node and its children. (Works if leafOnly is false)| boolean | false | 2.60.0 | 
 | borderless        | borderless mode  >=2.33.0                                                                                                                                                                     | boolean                         |           |
 | checkRelation | In multiple, the relationship between the checked states of the nodes, optional: 'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className                | Class name                                                                          | string                                                            | -           | -       |

--- a/content/input/treeselect/index.md
+++ b/content/input/treeselect/index.md
@@ -1395,6 +1395,7 @@ function Demo() {
 | arrowIcon| 自定义右侧下拉箭头Icon，当showClear开关打开且当前有选中值时，hover会优先显示clear icon                                                                                  | ReactNode | | 1.15.0|
 | autoAdjustOverflow| 浮层被遮挡时是否自动调整方向（暂时仅支持竖直方向，且插入的父级为 body）                                                                                                     |boolean | true| 0.34.0|
 | autoExpandParent | 是否自动展开父节点                                                                                                                                  | boolean | false | 0.34.0 |
+| autoMergeValue | 设置自动合并 value。具体而言是，开启后，当某个父节点被选中时，value 将包括该节点以及该子孙节点。（在leafOnly为false的情况下生效）| boolean | false | 2.60.0 | 
 | borderless        | 无边框模式  >=2.33.0                                                                                                                            | boolean                         |           |
 | checkRelation | 多选时，节点之间选中状态的关系，可选：'related'、'unRelated'                                                                                                   | string | 'related' | 2.5.0 |
 | className | 选择框的 `className` 属性                                                                                                                        | string | - | - |

--- a/content/navigation/tree/index-en-US.md
+++ b/content/navigation/tree/index-en-US.md
@@ -2271,7 +2271,7 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 | ------------------- | --------------------- | ------------------------------------------------- | ------- | ------ |
 | autoExpandParent | Toggle whether to expand parent node automatically | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | Toggle whether allow autoExpand when drag enter node | boolean | true | 1.8.0 | 
-| autoMergeValue | Whether to automatically adjust the expansion direction of the dropdown for automatic adjustment of the expansion direction during edge occlusion（在leafOnly为false的情况下生效）| boolean | false | - | 
+| autoMergeValue | Sets the automerge value. Specifically, when enabled, when a parent node is selected, value will include that node and its children. (Works if leafOnly is false)| boolean | false | - | 
 | blockNode           | Toggle whether to display node as row     | boolean                     | true    | - |
 | checkRelation | In multiple, the relationship between the checked states of the nodes, optional: 'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className           | Class name| string                      | -       | - |

--- a/content/navigation/tree/index-en-US.md
+++ b/content/navigation/tree/index-en-US.md
@@ -2271,6 +2271,7 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 | ------------------- | --------------------- | ------------------------------------------------- | ------- | ------ |
 | autoExpandParent | Toggle whether to expand parent node automatically | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | Toggle whether allow autoExpand when drag enter node | boolean | true | 1.8.0 | 
+| autoMergeValue | Whether to automatically adjust the expansion direction of the dropdown for automatic adjustment of the expansion direction during edge occlusion（在leafOnly为false的情况下生效）| boolean | false | - | 
 | blockNode           | Toggle whether to display node as row     | boolean                     | true    | - |
 | checkRelation | In multiple, the relationship between the checked states of the nodes, optional: 'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className           | Class name| string                      | -       | - |

--- a/content/navigation/tree/index-en-US.md
+++ b/content/navigation/tree/index-en-US.md
@@ -2271,7 +2271,7 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 | ------------------- | --------------------- | ------------------------------------------------- | ------- | ------ |
 | autoExpandParent | Toggle whether to expand parent node automatically | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | Toggle whether allow autoExpand when drag enter node | boolean | true | 1.8.0 | 
-| autoMergeValue | Sets the automerge value. Specifically, when enabled, when a parent node is selected, value will include that node and its children. (Works if leafOnly is false)| boolean | false | - | 
+| autoMergeValue | Sets the automerge value. Specifically, when enabled, when a parent node is selected, value will include that node and its children. (Works if leafOnly is false)| boolean | false | 2.60.0 | 
 | blockNode           | Toggle whether to display node as row     | boolean                     | true    | - |
 | checkRelation | In multiple, the relationship between the checked states of the nodes, optional: 'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className           | Class name| string                      | -       | - |

--- a/content/navigation/tree/index.md
+++ b/content/navigation/tree/index.md
@@ -2286,7 +2286,7 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 |-------------   | ----------- | -------------- | -------------- | --------|
 | autoExpandParent | 是否自动展开父节点，默认为 false，当组件初次挂载时为 true | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | 是否允许拖拽到节点上时自动展开改节点 | boolean | true | 1.8.0 | 
-| autoMergeValue | 设置自动合并 value。具体而言是，开启后，当某个父节点被选中时，value 将包括该节点以及该子孙节点。（在leafOnly为false的情况下生效）| boolean | false | - | 
+| autoMergeValue | 设置自动合并 value。具体而言是，开启后，当某个父节点被选中时，value 将包括该节点以及该子孙节点。（在leafOnly为false的情况下生效）| boolean | false | 2.60.0 | 
 | blockNode | 行显示节点 | boolean | true | - |
 | checkRelation | 多选时，节点之间选中状态的关系，可选：'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className | 类名 | string | - | - |

--- a/content/navigation/tree/index.md
+++ b/content/navigation/tree/index.md
@@ -2287,6 +2287,7 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 | autoExpandParent | 是否自动展开父节点，默认为 false，当组件初次挂载时为 true | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | 是否允许拖拽到节点上时自动展开改节点 | boolean | true | 1.8.0 | 
 | blockNode | 行显示节点 | boolean | true | - |
+| bothParents | 多选时，显示所有选中节点(包括父节点) | boolean | false | - |
 | checkRelation | 多选时，节点之间选中状态的关系，可选：'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className | 类名 | string | - | - |
 | defaultExpandAll | 设置在初始化时是否展开所有节点。而如果后续数据(`treeData`/`treeDataSimpleJson`)发生改变，这个 api 是无法影响节点的默认展开情况的，如果有这个需要可以使用 `expandAll` | boolean | false | - |

--- a/content/navigation/tree/index.md
+++ b/content/navigation/tree/index.md
@@ -2286,8 +2286,8 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 |-------------   | ----------- | -------------- | -------------- | --------|
 | autoExpandParent | 是否自动展开父节点，默认为 false，当组件初次挂载时为 true | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | 是否允许拖拽到节点上时自动展开改节点 | boolean | true | 1.8.0 | 
+| autoMergeValue | Sets the automerge value. Specifically, when enabled, when a parent node is selected, value will include that node and its children. (Works if leafOnly is false)| boolean | false | - | 
 | blockNode | 行显示节点 | boolean | true | - |
-| bothParents | 多选时，显示所有选中节点(包括父节点) | boolean | false | - |
 | checkRelation | 多选时，节点之间选中状态的关系，可选：'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className | 类名 | string | - | - |
 | defaultExpandAll | 设置在初始化时是否展开所有节点。而如果后续数据(`treeData`/`treeDataSimpleJson`)发生改变，这个 api 是无法影响节点的默认展开情况的，如果有这个需要可以使用 `expandAll` | boolean | false | - |

--- a/content/navigation/tree/index.md
+++ b/content/navigation/tree/index.md
@@ -2286,7 +2286,7 @@ import { IconFixedStroked, IconSectionStroked, IconAbsoluteStroked, IconInnerSec
 |-------------   | ----------- | -------------- | -------------- | --------|
 | autoExpandParent | 是否自动展开父节点，默认为 false，当组件初次挂载时为 true | boolean | false | 0.34.0 |
 | autoExpandWhenDragEnter | 是否允许拖拽到节点上时自动展开改节点 | boolean | true | 1.8.0 | 
-| autoMergeValue | Sets the automerge value. Specifically, when enabled, when a parent node is selected, value will include that node and its children. (Works if leafOnly is false)| boolean | false | - | 
+| autoMergeValue | 设置自动合并 value。具体而言是，开启后，当某个父节点被选中时，value 将包括该节点以及该子孙节点。（在leafOnly为false的情况下生效）| boolean | false | - | 
 | blockNode | 行显示节点 | boolean | true | - |
 | checkRelation | 多选时，节点之间选中状态的关系，可选：'related'、'unRelated' | string | 'related' | 2.5.0 |
 | className | 类名 | string | - | - |

--- a/packages/semi-foundation/tree/foundation.ts
+++ b/packages/semi-foundation/tree/foundation.ts
@@ -460,7 +460,7 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
         let value;
         let keyList = [];
         if (checkRelation === 'related') {
-            keyList = normalizeKeyList(key, keyEntities, leafOnly, autoMergeValue, true);
+            keyList = autoMergeValue ? normalizeKeyList(key, keyEntities, leafOnly, true) : key;
         } else if (checkRelation === 'unRelated') {
             keyList = key;
         }

--- a/packages/semi-foundation/tree/foundation.ts
+++ b/packages/semi-foundation/tree/foundation.ts
@@ -474,10 +474,13 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
     }
 
     notifyChange(key: string[] | string, e: any) {
+        const bothParents = this.getProp('bothParents');
         const isMultiple = this._isMultiple();
         const { keyMaps } = this.getProps();
         const { keyEntities } = this.getStates();
-        if (this.getProp('treeDataSimpleJson')) {
+        if (bothParents) {
+            this._adapter.notifyChange(key);
+        } else if (this.getProp('treeDataSimpleJson')) {
             this.notifyJsonChange(key, e);
         } else if (isMultiple) {
             this.notifyMultipleChange(key as string[], e);

--- a/packages/semi-foundation/tree/foundation.ts
+++ b/packages/semi-foundation/tree/foundation.ts
@@ -456,11 +456,11 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
 
     notifyMultipleChange(key: string[], e: any) {
         const { keyEntities } = this.getStates();
-        const { leafOnly, checkRelation, keyMaps } = this.getProps();
+        const { leafOnly, checkRelation, keyMaps, autoMergeValue } = this.getProps();
         let value;
         let keyList = [];
         if (checkRelation === 'related') {
-            keyList = normalizeKeyList(key, keyEntities, leafOnly, true);
+            keyList = normalizeKeyList(key, keyEntities, leafOnly, autoMergeValue, true);
         } else if (checkRelation === 'unRelated') {
             keyList = key;
         }

--- a/packages/semi-foundation/tree/foundation.ts
+++ b/packages/semi-foundation/tree/foundation.ts
@@ -474,13 +474,10 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
     }
 
     notifyChange(key: string[] | string, e: any) {
-        const bothParents = this.getProp('bothParents');
         const isMultiple = this._isMultiple();
         const { keyMaps } = this.getProps();
         const { keyEntities } = this.getStates();
-        if (bothParents) {
-            this._adapter.notifyChange(key);
-        } else if (this.getProp('treeDataSimpleJson')) {
+        if (this.getProp('treeDataSimpleJson')) {
             this.notifyJsonChange(key, e);
         } else if (isMultiple) {
             this.notifyMultipleChange(key as string[], e);

--- a/packages/semi-foundation/tree/treeUtil.ts
+++ b/packages/semi-foundation/tree/treeUtil.ts
@@ -454,23 +454,27 @@ export function normalizedArr(val: any) {
 
 // flag is used to determine whether to return when the key does not belong to the keys in keyEntities
 // export function normalizeKeyList(keyList: any, keyEntities: KeyEntities, leafOnly = false) {
-export function normalizeKeyList(keyList: any, keyEntities: KeyEntities, leafOnly = false, flag?: boolean) {
+export function normalizeKeyList(keyList: any, keyEntities: KeyEntities, leafOnly = false, autoMergeValue = false, flag?: boolean) {
     const res: string[] = [];
     const keyListSet = new Set(keyList);
     if (!leafOnly) {
-        keyList.forEach((key: string) => {
-            if (!keyEntities[key]) {
-                if (flag) {
-                    res.push(key);
+        if (!autoMergeValue) {
+            keyList.forEach((key: string) => {
+                if (!keyEntities[key]) {
+                    if (flag) {
+                        res.push(key);
+                    }
+                    return;
                 }
-                return;
-            }
-            const { parent } = keyEntities[key];
-            if (parent && keyListSet.has(parent.key)) {
-                return;
-            }
-            res.push(key);
-        });
+                const { parent } = keyEntities[key];
+                if (parent && keyListSet.has(parent.key)) {
+                    return;
+                }
+                res.push(key);
+            });
+        } else {
+            return keyList;
+        }
     } else {
         keyList.forEach(key => {
             if (keyEntities[key] && !isValid(keyEntities[key].children)) {

--- a/packages/semi-foundation/tree/treeUtil.ts
+++ b/packages/semi-foundation/tree/treeUtil.ts
@@ -454,27 +454,23 @@ export function normalizedArr(val: any) {
 
 // flag is used to determine whether to return when the key does not belong to the keys in keyEntities
 // export function normalizeKeyList(keyList: any, keyEntities: KeyEntities, leafOnly = false) {
-export function normalizeKeyList(keyList: any, keyEntities: KeyEntities, leafOnly = false, autoMergeValue = false, flag?: boolean) {
+export function normalizeKeyList(keyList: any, keyEntities: KeyEntities, leafOnly = false, flag?: boolean) {
     const res: string[] = [];
     const keyListSet = new Set(keyList);
     if (!leafOnly) {
-        if (!autoMergeValue) {
-            keyList.forEach((key: string) => {
-                if (!keyEntities[key]) {
-                    if (flag) {
-                        res.push(key);
-                    }
-                    return;
+        keyList.forEach((key: string) => {
+            if (!keyEntities[key]) {
+                if (flag) {
+                    res.push(key);
                 }
-                const { parent } = keyEntities[key];
-                if (parent && keyListSet.has(parent.key)) {
-                    return;
-                }
-                res.push(key);
-            });
-        } else {
-            return keyList;
-        }
+                return;
+            }
+            const { parent } = keyEntities[key];
+            if (parent && keyListSet.has(parent.key)) {
+                return;
+            }
+            res.push(key);
+        });
     } else {
         keyList.forEach(key => {
             if (keyEntities[key] && !isValid(keyEntities[key].children)) {

--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -397,10 +397,10 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
 
     _notifyMultipleChange(key: string[], e: any) {
         const { keyEntities } = this.getStates();
-        const { leafOnly, checkRelation, keyMaps } = this.getProps();
+        const { leafOnly, checkRelation, keyMaps, autoMergeValue } = this.getProps();
         let keyList = [];
         if (checkRelation === 'related') {
-            keyList = normalizeKeyList(key, keyEntities, leafOnly, true);
+            keyList = autoMergeValue ? normalizeKeyList(key, keyEntities, leafOnly, true) : key;
         } else if (checkRelation === 'unRelated') {
             keyList = key as string[];
         }

--- a/packages/semi-ui/tree/__test__/treeMultiple.test.js
+++ b/packages/semi-ui/tree/__test__/treeMultiple.test.js
@@ -821,4 +821,25 @@ describe('Tree', () => {
         expect(spyOnChange.calledWithMatch(['fish', 'Yazhou'])).toEqual(true);
         tree.unmount();
     })
+
+    it('onChange + autoMergeValue', () => {
+        let spyOnSelect = sinon.spy(() => { });
+        let spyOnChange = sinon.spy(() => { });
+        let treeSelect = getTree({
+            defaultExpandAll: true,
+            onSelect: spyOnSelect,
+            onChange: spyOnChange,
+            autoMergeValue: false,
+        });
+        let nodeChina = treeSelect.find(`.${BASE_CLASS_PREFIX}-tree-option.${BASE_CLASS_PREFIX}-tree-option-level-2`).at(0);
+        // select China
+        nodeChina.simulate('click');
+        // onSelect & onChange
+        expect(spyOnSelect.calledOnce).toBe(true);
+        expect(spyOnChange.calledOnce).toBe(true);
+        expect(spyOnSelect.calledWithMatch('zhongguo', true, { key: "zhongguo" })).toEqual(true);
+        expect(spyOnChange.calledWithMatch(
+            ['Zhongguo', 'Beijing', 'Shanghai'],
+        )).toEqual(true);
+    });
 })

--- a/packages/semi-ui/tree/_story/tree.stories.jsx
+++ b/packages/semi-ui/tree/_story/tree.stories.jsx
@@ -3117,3 +3117,25 @@ export const CustomRenderIcon = () => {
       icon={iconFunc}
   />);
 }
+
+export const AutoMerge = () => {
+  const [value, setValue] = useState([]);
+
+  const onChange = useCallback((val) => {
+    console.log('onChange', val);
+    setValue(val);
+  }, []);
+
+  return (
+    <>
+      <Tree
+        autoMergeValue={false}
+        style={{ width: 300}}
+        multiple
+        value={value}
+        onChange={onChange}
+        treeData={treeData1}
+      />
+    </>
+  )
+}

--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -53,6 +53,7 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
 
     static propTypes = {
         blockNode: PropTypes.bool,
+        bothParents: PropTypes.bool,
         className: PropTypes.string,
         showClear: PropTypes.bool,
         defaultExpandAll: PropTypes.bool,

--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -52,8 +52,8 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
     static contextType = ConfigContext;
 
     static propTypes = {
+        autoMergeValue: PropTypes.bool,
         blockNode: PropTypes.bool,
-        bothParents: PropTypes.bool,
         className: PropTypes.string,
         showClear: PropTypes.bool,
         defaultExpandAll: PropTypes.bool,

--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -141,6 +141,7 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
         draggable: false,
         autoExpandWhenDragEnter: true,
         checkRelation: 'related',
+        autoMergeValue: true,
     };
 
     static TreeNode: typeof TreeNode;

--- a/packages/semi-ui/tree/interface.ts
+++ b/packages/semi-ui/tree/interface.ts
@@ -84,7 +84,8 @@ export interface TreeProps extends BasicTreeProps {
     onSelect?: (selectedKey: string, selected: boolean, selectedNode: TreeNodeData) => void;
     renderDraggingNode?: (nodeInstance: HTMLElement, node: TreeNodeData) => HTMLElement;
     renderFullLabel?: (renderFullLabelProps: RenderFullLabelProps) => ReactNode;
-    renderLabel?: (label?: ReactNode, treeNode?: TreeNodeData) => ReactNode
+    renderLabel?: (label?: ReactNode, treeNode?: TreeNodeData) => ReactNode;
+    autoMergeValue?: boolean
 }
 export interface OptionProps {
     index: number;

--- a/packages/semi-ui/treeSelect/__test__/treeMultiple.test.js
+++ b/packages/semi-ui/treeSelect/__test__/treeMultiple.test.js
@@ -1129,4 +1129,28 @@ describe('TreeSelect', () => {
         let selectContentNode = treeSelect.find(`.${BASE_CLASS_PREFIX}-tree-select-selection`).at(0);
         expect(selectContentNode.find(`.${BASE_CLASS_PREFIX}-tag-content`).instance().textContent).toEqual('中国');
     });
+
+    it('onChange + autoMergeValue', () => {
+        let spyOnSelect = sinon.spy(() => { });
+        let spyOnChange = sinon.spy(() => { });
+        let treeSelect = getTreeSelect({
+            defaultExpandAll: true,
+            onSelect: spyOnSelect,
+            onChange: spyOnChange,
+            autoMergeValue: false,
+        });
+        let nodeChina = treeSelect.find(`.${BASE_CLASS_PREFIX}-tree-option.${BASE_CLASS_PREFIX}-tree-option-level-2`).at(0);
+        // select China
+        nodeChina.simulate('click');
+        // onSelect & onChange
+        expect(spyOnSelect.calledOnce).toBe(true);
+        expect(spyOnChange.calledOnce).toBe(true);
+        expect(spyOnSelect.calledWithMatch('zhongguo', true, { key: "zhongguo" })).toEqual(true);
+        expect(spyOnChange.calledWithMatch(
+            ['Zhongguo', 'Beijing', 'Shanghai'],
+        )).toEqual(true);
+
+        let tagGroup = treeSelect.find(`.${BASE_CLASS_PREFIX}-tag`);
+        expect(tagGroup.length).toEqual(3);
+    });
 })

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2790,3 +2790,25 @@ export const CustomSelectAll = () => {
     </>  
   );
 };
+
+export const AutoMerge = () => {
+  const [value, setValue] = useState([]);
+
+  const onChange = useCallback((val) => {
+    console.log('onChange', val);
+    setValue(val);
+  }, []);
+
+  return (
+    <>
+      <TreeSelect
+        autoMergeValue={false}
+        style={{ width: 300}}
+        multiple
+        value={value}
+        onChange={onChange}
+        treeData={treeData1}
+      />
+    </>
+  )
+}

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -877,7 +877,6 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 content: get(item, realLabelName, null)
             });
         const tagList: Array<React.ReactNode> = [];
-        console.log('triggerRenderKeys', triggerRenderKeys);
         triggerRenderKeys.forEach((key: TreeNodeData['key'], index) => {
             const item = (keyEntities[key] && keyEntities[key].key === key) ? keyEntities[key].data : this.getDataForKeyNotInKeyEntities(key);
             const onClose = (tagContent: any, e: React.MouseEvent) => {
@@ -1109,7 +1108,6 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             if (!autoMergeValue) {
                 triggerRenderKeys =[...checkedKeys];
             } else if (checkRelation === 'related') {
-                console.log("checkedKeys", checkedKeys);
                 triggerRenderKeys = normalizeKeyList([...checkedKeys], keyEntities, leafOnly, true);
             } else if (checkRelation === 'unRelated') {
                 triggerRenderKeys = [...realCheckedKeys];

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -150,7 +150,8 @@ export interface TreeSelectProps extends Omit<BasicTreeSelectProps, OverrideComm
     onChange?: OnChange;
     onFocus?: (e: React.MouseEvent) => void;
     onVisibleChange?: (isVisible: boolean) => void;
-    onClear?: (e: React.MouseEvent | React.KeyboardEvent<HTMLDivElement>) => void
+    onClear?: (e: React.MouseEvent | React.KeyboardEvent<HTMLDivElement>) => void;
+    autoMergeValue?: boolean
 }
 
 export type OverrideCommonState =
@@ -271,6 +272,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         restTagsPopoverProps: PropTypes.object,
         preventScroll: PropTypes.bool,
         clickTriggerToHide: PropTypes.bool,
+        autoMergeValue: PropTypes.bool,
     };
 
     static defaultProps: Partial<TreeSelectProps> = {
@@ -304,6 +306,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         showRestTagsPopover: false,
         restTagsPopoverProps: {},
         clickTriggerToHide: true,
+        autoMergeValue: true,
     };
     inputRef: React.RefObject<typeof Input>;
     tagInputRef: React.RefObject<TagInput>;
@@ -855,15 +858,14 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         return showClear && (this.hasValue() || triggerSearchHasInputValue) && !disabled && (isOpen || isHovering);
     };
 
-    renderTagList = () => {
-        const { checkedKeys, keyEntities, disabledKeys, realCheckedKeys } = this.state;
+    renderTagList = (triggerRenderKeys: string[]) => {
+        const { keyEntities, disabledKeys } = this.state;
         const {
             treeNodeLabelProp,
             leafOnly,
             disabled,
             disableStrictly,
             size,
-            checkRelation,
             renderSelectedItem: propRenderSelectedItem,
             keyMaps
         } = this.props;
@@ -874,14 +876,9 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 isRenderInTag: true,
                 content: get(item, realLabelName, null)
             });
-        let renderKeys = [];
-        if (checkRelation === 'related') {
-            renderKeys = normalizeKeyList([...checkedKeys], keyEntities, leafOnly, true);
-        } else if (checkRelation === 'unRelated' && Object.keys(keyEntities).length > 0) {
-            renderKeys = [...realCheckedKeys];
-        }
         const tagList: Array<React.ReactNode> = [];
-        renderKeys.forEach((key: TreeNodeData['key'], index) => {
+        console.log('triggerRenderKeys', triggerRenderKeys);
+        triggerRenderKeys.forEach((key: TreeNodeData['key'], index) => {
             const item = (keyEntities[key] && keyEntities[key].key === key) ? keyEntities[key].data : this.getDataForKeyNotInKeyEntities(key);
             const onClose = (tagContent: any, e: React.MouseEvent) => {
                 if (e && typeof e.preventDefault === 'function') {
@@ -946,7 +943,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         );
     };
 
-    renderSelectContent = () => {
+    renderSelectContent = (triggerRenderKeys: string[]) => {
         const {
             multiple,
             placeholder,
@@ -959,7 +956,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const isTriggerPositionSearch = filterTreeNode && searchPosition === strings.SEARCH_POSITION_TRIGGER;
         // searchPosition = trigger
         if (isTriggerPositionSearch) {
-            return multiple ? this.renderTagInput() : this.renderSingleTriggerSearch();
+            return multiple ? this.renderTagInput(triggerRenderKeys) : this.renderSingleTriggerSearch();
         }
         // searchPosition = dropdown and single seleciton
         if (!multiple || !this.hasValue()) {
@@ -970,7 +967,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             return <span className={spanCls}>{renderText ? renderText : placeholder}</span>;
         }
         // searchPosition = dropdown and multiple seleciton
-        const tagList = this.renderTagList();
+        const tagList = this.renderTagList(triggerRenderKeys);
         // mode=custom to return tagList directly
         return (
             <TagGroup<'custom'>
@@ -1067,6 +1064,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             searchPosition,
             triggerRender,
             borderless,
+            autoMergeValue,
             checkRelation,
             ...rest
         } = this.props;
@@ -1106,17 +1104,20 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 className
             );
         let inner: React.ReactNode | React.ReactNode[];
-        if (useCustomTrigger) {
-            let triggerRenderKeys = [];
-            if (multiple) {
-                if (checkRelation === 'related') {
-                    triggerRenderKeys = normalizeKeyList([...checkedKeys], keyEntities, leafOnly, true);
-                } else if (checkRelation === 'unRelated') {
-                    triggerRenderKeys = [...realCheckedKeys];
-                }
-            } else {
-                triggerRenderKeys = selectedKeys;
+        let triggerRenderKeys = [];
+        if (multiple) {
+            if (!autoMergeValue) {
+                triggerRenderKeys =[...checkedKeys];
+            } else if (checkRelation === 'related') {
+                console.log("checkedKeys", checkedKeys);
+                triggerRenderKeys = normalizeKeyList([...checkedKeys], keyEntities, leafOnly, true);
+            } else if (checkRelation === 'unRelated') {
+                triggerRenderKeys = [...realCheckedKeys];
             }
+        } else {
+            triggerRenderKeys = selectedKeys;
+        }
+        if (useCustomTrigger) {
             inner = <Trigger
                 inputValue={inputValue}
                 value={triggerRenderKeys.map((key: string) => get(keyEntities, [key, 'data']))}
@@ -1133,7 +1134,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             inner = [
                 <Fragment key={'prefix'}>{prefix || insetLabel ? this.renderPrefix() : null}</Fragment>,
                 <Fragment key={'selection'}>
-                    <div className={`${prefixcls}-selection`}>{this.renderSelectContent()}</div>
+                    <div className={`${prefixcls}-selection`}>{this.renderSelectContent(triggerRenderKeys)}</div>
                 </Fragment>,
                 <Fragment key={'suffix'}>{suffix ? this.renderSuffix() : null}</Fragment>,
                 <Fragment key={'clearBtn'}>
@@ -1234,15 +1235,13 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         );
     };
 
-    renderTagInput = () => {
+    renderTagInput = (triggerRenderKeys: string[]) => {
         const {
-            leafOnly,
             disabled,
             size,
             searchAutoFocus,
             placeholder,
             maxTagCount,
-            checkRelation,
             showRestTagsPopover,
             restTagsPopoverProps,
             searchPosition,
@@ -1250,17 +1249,8 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             preventScroll
         } = this.props;
         const {
-            keyEntities,
-            checkedKeys,
             inputValue,
-            realCheckedKeys,
         } = this.state;
-        let keyList = [];
-        if (checkRelation === 'related') {
-            keyList = normalizeKeyList(checkedKeys, keyEntities, leafOnly, true);
-        } else if (checkRelation === 'unRelated') {
-            keyList = [...realCheckedKeys];
-        }
         // auto focus search input divide into two parts
         // 1. filterTreeNode && searchPosition === strings.SEARCH_POSITION_TRIGGER
         //    Implemented by passing autofocus to the underlying input's autofocus
@@ -1276,7 +1266,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 onInputChange={v => this.search(v)}
                 ref={this.tagInputRef}
                 placeholder={placeholder}
-                value={keyList}
+                value={triggerRenderKeys}
                 inputValue={inputValue}
                 size={size}
                 showRestTagsPopover={showRestTagsPopover}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1534,10 +1534,24 @@
     "@douyinfe/semi-animation-styled" "2.23.2"
     classnames "^2.2.6"
 
+"@douyinfe/semi-animation-react@2.59.1":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-react/-/semi-animation-react-2.59.1.tgz#66ef6a26a0064c4785d2a69877c0c939d5b55a88"
+  integrity sha512-TImalOl13V8QeHEOOAdwqQbwt3F59lwAFBcKvsymqnquWhAyBhOXTRaaIZSziv4sKGn1gXD7Cs7N5fBBY+pMog==
+  dependencies:
+    "@douyinfe/semi-animation" "2.59.1"
+    "@douyinfe/semi-animation-styled" "2.59.1"
+    classnames "^2.2.6"
+
 "@douyinfe/semi-animation-styled@2.23.2":
   version "2.23.2"
   resolved "https://registry.npmjs.org/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.23.2.tgz#f18bc074515441c297cc636ed98521e249d093c9"
   integrity sha512-cKaA1yGHPF76Rx7EZDZicj+1oX1su2wnqb/UGFOTquAwqWmkTfgQ+EKxCd/N704WH+RtmGf4xbrJKpBvvcEdSQ==
+
+"@douyinfe/semi-animation-styled@2.59.1":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.59.1.tgz#af8db2ebaae4fa1ed948ffd5596563e50663e67c"
+  integrity sha512-41MtvA+FJCnPoWjY1RWLz3vkJ4HP42QriUUJ+ZmRMQYUQo0dXuE2uSCa47pMaMLAvEHoY0CFoIUnYUGzdonSjw==
 
 "@douyinfe/semi-animation@2.12.0":
   version "2.12.0"
@@ -1551,6 +1565,13 @@
   version "2.33.1"
   resolved "https://registry.npmjs.org/@douyinfe/semi-animation/-/semi-animation-2.33.1.tgz#cb5e2d45355212f7e1994671fe4acc6be12f6d26"
   integrity sha512-11L+NlecZ3Xdb9/sS6WJRsLpwsOv8jpxOivX0yRXdFKlP+lFYKnbM8klASFEJBce2/CywHw0ue65M/dkhoIIBw==
+  dependencies:
+    bezier-easing "^2.1.0"
+
+"@douyinfe/semi-animation@2.59.1":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation/-/semi-animation-2.59.1.tgz#2b2ddacb87ff29ccb0b198f1641f3229db1d306e"
+  integrity sha512-vrYRe9aT5FhNl/ghjLGE4L3T29Y1nuvKQPqptde5XMhPkpGkH3A/4IjO8dXvfipdXdhZGcXyWYbtL9gknsm+rQ==
   dependencies:
     bezier-easing "^2.1.0"
 
@@ -1568,6 +1589,21 @@
     memoize-one "^5.2.1"
     scroll-into-view-if-needed "^2.2.24"
 
+"@douyinfe/semi-foundation@2.59.1":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-foundation/-/semi-foundation-2.59.1.tgz#e7d9fb01f99a3a786c1726f8fa67af7e9f07c919"
+  integrity sha512-t2CXa/5zLiBimHnmF1v/UWZgUoE9rB7SFR2qi649xyahpLQx6H9ahrbo6oqwa8GDLnSWravTeSNlvoI8Z8if7Q==
+  dependencies:
+    "@douyinfe/semi-animation" "2.59.1"
+    async-validator "^3.5.0"
+    classnames "^2.2.6"
+    date-fns "^2.29.3"
+    date-fns-tz "^1.3.8"
+    fast-copy "^3.0.1 "
+    lodash "^4.17.21"
+    memoize-one "^5.2.1"
+    scroll-into-view-if-needed "^2.2.24"
+
 "@douyinfe/semi-icons@2.33.1", "@douyinfe/semi-icons@latest":
   version "2.33.1"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.33.1.tgz#8e2871d9bc0ab7e12df74e3c71802d53d69b7425"
@@ -1575,10 +1611,22 @@
   dependencies:
     classnames "^2.2.6"
 
+"@douyinfe/semi-icons@2.59.1", "@douyinfe/semi-icons@^2.0.0":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.59.1.tgz#de5695f4d01061b5ca35807ca6a9dfd652b276ff"
+  integrity sha512-XJ30Fsbnkq0T9Z7exYKiI+GM8q3Zee1gO28H5CckA0dFHxnpNyJ4QazzTuTj5dSXAZq3uYXakmNB8wDAgV9d9A==
+  dependencies:
+    classnames "^2.2.6"
+
 "@douyinfe/semi-illustrations@2.33.1":
   version "2.33.1"
   resolved "https://registry.npmjs.org/@douyinfe/semi-illustrations/-/semi-illustrations-2.33.1.tgz#530ab851f4dc32a52221c4067c778c800b9b55d7"
   integrity sha512-tTTUN8QwnQiF++sk4VBNzfkG87aYZ4iUeqk2ys8/ymVUmCZQ7y46ys020GO1MfPHRR47OMFPI82FVcH1WQtE3g==
+
+"@douyinfe/semi-illustrations@2.59.1":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.59.1.tgz#2874a681805dbad83b2024496cfe58b46396eef0"
+  integrity sha512-EzbM+FAV862tdXNIbVwoSCfGLeIcT37/Vzm+q9cfx+DYMBqeQEQcH5qLOpRGFc4Hf796bxJtGfE/jFmDC2xdDw==
 
 "@douyinfe/semi-scss-compile@2.23.2":
   version "2.23.2"
@@ -1652,6 +1700,38 @@
   integrity sha512-YptJl5aFiV6DVU7675DNQ2seA2FsXQ+kcx9GmPwonO7vUwY0syc05KuuNnR8dSZuDBI6mOzfQm/mw80RzkZ7pg==
   dependencies:
     glob "^7.1.6"
+
+"@douyinfe/semi-theme-default@2.59.1":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.59.1.tgz#8afca4da013fab673377ca06147ea463f717e45b"
+  integrity sha512-XuB6jf5Ob0ufyFJ2xKpdNTbB0/LM8Fe9hWOIMEmux2eiHwnMzCQvfrOHphCy/g1+TbGlGK9N6kJnCyUKP+U/AQ==
+
+"@douyinfe/semi-ui@^2.0.0":
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/@douyinfe/semi-ui/-/semi-ui-2.59.1.tgz#6784816155f0d81d47ac65d6203a4c7540409a33"
+  integrity sha512-zF5Fe0d8NrNxR8tVoMiuhlnp5J6/5PvnV0kr0iBOsqW89peboF0HPNg/lr3DvzoPpCWCN++bZZAFdMAB/WGplQ==
+  dependencies:
+    "@dnd-kit/core" "^6.0.8"
+    "@dnd-kit/sortable" "^7.0.2"
+    "@dnd-kit/utilities" "^3.2.1"
+    "@douyinfe/semi-animation" "2.59.1"
+    "@douyinfe/semi-animation-react" "2.59.1"
+    "@douyinfe/semi-foundation" "2.59.1"
+    "@douyinfe/semi-icons" "2.59.1"
+    "@douyinfe/semi-illustrations" "2.59.1"
+    "@douyinfe/semi-theme-default" "2.59.1"
+    async-validator "^3.5.0"
+    classnames "^2.2.6"
+    copy-text-to-clipboard "^2.1.1"
+    date-fns "^2.29.3"
+    date-fns-tz "^1.3.8"
+    fast-copy "^3.0.1 "
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+    react-resizable "^3.0.5"
+    react-window "^1.8.2"
+    scroll-into-view-if-needed "^2.2.24"
+    utility-types "^3.10.0"
 
 "@douyinfe/semi-ui@latest":
   version "2.33.1"
@@ -11665,6 +11745,11 @@ eslint-plugin-react@^7.20.6, eslint-plugin-react@^7.24.0:
     resolve "^2.0.0-next.4"
     semver "^6.3.0"
     string.prototype.matchall "^4.0.8"
+
+eslint-plugin-semi-design@^2.33.0:
+  version "2.59.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-semi-design/-/eslint-plugin-semi-design-2.59.1.tgz#35848e8a2d030f691a3919a7dfc24f358271ff4a"
+  integrity sha512-RSWWNICk5SqHifMB83zcNlLg4sMaUz2T22s09lKar8CMsBNmL1iYtHj7pt28tsGRpiu4SzC9sHICR/qaATn+IQ==
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"


### PR DESCRIPTION
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述
<!--
相关issue, 背景, 以及 reviewer 需要关注的地方
-->
Fixes #
feature 在Tree组件中新增了 autoMerge 属性，用来在多选时，返回所有子节点时同时返回父节点
![img_v3_02ap_0639f79c-b9b8-4f64-a744-2a9c5febc77g](https://github.com/DouyinFE/semi-design/assets/58989501/2527d1ea-0e10-4efb-921a-c98f3f010774)


### 更新日志
🇨🇳 Chinese
- Feat: Tree、TreeSelect 增加 autoMergeValue API

---

🇺🇸 English
- Feat: Tree、TreeSelect add autoMergeValue API


### 检查清单
- [x] 已增加测试用例或无须增加
- [x] 已补充文档或无须补充
- [ ] Changelog已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->
![img_v3_02ap_0639f79c-b9b8-4f64-a744-2a9c5febc77g](https://github.com/DouyinFE/semi-design/assets/58989501/a7d03dc8-7614-4abb-a4d7-c318e45f3844)

