### PR TITLE
style: [Tree] Fix the problem that the line break style in renderFull…

### DIFF
--- a/packages/semi-foundation/tree/tree.scss
+++ b/packages/semi-foundation/tree/tree.scss
@@ -330,7 +330,7 @@ $module: #{$prefix}-tree;
     }
 
     @for $i from 1 through 20 {
-        li.#{$module}-option.#{$module}-option-fullLabel-level-#{$i} {
+        .#{$module}-option.#{$module}-option-fullLabel-level-#{$i} {
             padding-left: $spacing-tree_option_level-paddingLeft * ($i - 1) + $spacing-tree_option_level1-paddingLeft;
         }
     }


### PR DESCRIPTION
…Label is limited by the li tag

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tree组件中 renderFulllabel 的透传的 className 样式受到 li 标签限制问题

---

🇺🇸 English
- Fix: Fix the problem that the transparent className style of renderFulllabel in the Tree component is restricted by the li tag


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
