### PR TITLE
fix(tabs): Fixed the issue where the overflow tab did not scroll into…

### DIFF
--- a/packages/semi-ui/tabs/TabBar.tsx
+++ b/packages/semi-ui/tabs/TabBar.tsx
@@ -58,6 +58,14 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
             uuid: getUuidv4(),
         });
     }
+    
+    componentDidUpdate(prevProps) {
+        if (prevProps.activeKey !== this.props.activeKey) {
+            if (this.props.collapsible) {
+                this.scrollActiveTabItemIntoView()
+            }
+        }
+    }
 
     renderIcon(icon: ReactNode): ReactNode {
         return (
@@ -89,11 +97,6 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
 
     handleItemClick = (itemKey: string, e: MouseEvent<Element>): void => {
         this.props.onTabClick(itemKey, e);
-        if (this.props.collapsible) {
-            const key = this._getItemKey(itemKey);
-            const tabItem = document.querySelector(`[data-uuid="${this.state.uuid}"] .${cssClasses.TABS_TAB}[data-scrollkey="${key}"]`);
-            tabItem.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
-        }
     };
 
     handleKeyDown = (event: React.KeyboardEvent, itemKey: string, closable: boolean) => {
@@ -119,6 +122,16 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
         );
     };
 
+    scrollTabItemIntoViewByKey = (key: string, logicalPosition: ScrollLogicalPosition = 'nearest') => {
+        const tabItem = document.querySelector(`[data-uuid="${this.state.uuid}"] .${cssClasses.TABS_TAB}[data-scrollkey="${key}"]`);
+        tabItem?.scrollIntoView({ behavior: 'smooth', block: logicalPosition, inline: logicalPosition });
+    }
+
+    scrollActiveTabItemIntoView = (logicalPosition?: ScrollLogicalPosition) => {
+        const key = this._getItemKey(this.props.activeKey);
+        this.scrollTabItemIntoViewByKey(key, logicalPosition)
+    }
+
     renderTabComponents = (list: Array<PlainTab>): Array<ReactNode> => list.map(panel => this.renderTabItem(panel));
 
     handleArrowClick = (items: Array<OverflowItem>, pos: 'start' | 'end'): void => {
@@ -127,8 +140,7 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
             return;
         }
         const key = this._getItemKey(lastItem.itemKey);
-        const tabItem = document.querySelector(`[data-uuid="${this.state.uuid}"] .${cssClasses.TABS_TAB}[data-scrollkey="${key}"]`);
-        tabItem.scrollIntoView({ behavior: 'smooth', block: 'nearest', inline: 'nearest' });
+        this.scrollTabItemIntoViewByKey(key)
     };
 
     renderCollapse = (items: Array<OverflowItem>, icon: ReactNode, pos: 'start' | 'end'): ReactNode => {

--- a/packages/semi-ui/tabs/_story/tabs.stories.jsx
+++ b/packages/semi-ui/tabs/_story/tabs.stories.jsx
@@ -1003,3 +1003,39 @@ export const IconStyle = () => {
     </Tabs>
   )
 }
+
+export const Fix2239 = () => {
+  const [activeKey, setActiveKey] = useState('tab-0')
+  
+  return (
+    <div>
+      The overflow tab will also 'scrollIntoView' when the 'activeKey' changes.
+      <Tabs
+        style={{
+          width: '500px',
+          margin: '20px',
+        }}
+        type="card"
+        activeKey={activeKey}
+        collapsible
+        onChange={(e) => {
+          setActiveKey(e)
+        }}
+      >
+        {[...Array(10).keys()].map(i => (
+          <TabPane tab={`Tab-${i}`} itemKey={`tab-${i}`} key={i}>content of tab {i}</TabPane>
+        ))}
+      </Tabs>
+      <Button onClick={() => { setActiveKey('tab-0') }}>
+        To Tab-0
+      </Button>
+      <Button onClick={() => { setActiveKey('tab-7') }}>
+        To Tab-7
+      </Button>
+    </div>
+  );
+}
+
+Fix2239.story = {
+  name: 'Fix 2239',
+};


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述
<!--
相关issue, 背景, 以及 reviewer 需要关注的地方
-->
Fixes #2239 

### 更新日志
🇨🇳 Chinese
- Fix: 修复溢出的 tab 在 “activeKey” 变动后没有 "scrollIntoView" 的问题

---

🇺🇸 English
- Fix: Fixed the issue where the overflow tab did not scroll into view when the activeKey changed.


### 检查清单
- [ ] 已增加测试用例或无须增加
- [ ] 已补充文档或无须补充
- [ ] Changelog已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->

#### after
https://github.com/DouyinFE/semi-design/assets/48666585/b1fe045e-3d99-4742-889d-cfdb1f4565a1