### PR TITLE
fix(tabs): The tab was not fully displayed when scrollIntoView

### DIFF
--- a/packages/semi-foundation/tabs/tabs.scss
+++ b/packages/semi-foundation/tabs/tabs.scss
@@ -264,7 +264,7 @@ $ignoreIcon: '.#{$prefix}-icon-checkbox_tick, .#{$prefix}-icon-radio, .#{$prefix
 
         .#{$module}-bar-arrow-start {
             margin-right: $spacing-tabs_overflow_icon-marginRight;
-            & > .#{$prefix}-button[area-disabled=true] {
+            & > .#{$prefix}-button[aria-disabled=false] {
                 color: $color-tabs_tab-pane_arrow-text-default;
                 padding: $spacing-tabs_tab-pane_arrow;
                 border: $width-tabs_tab-pane_arrow-border solid $color-tabs_tab-pane_arrow-border-default;
@@ -285,7 +285,7 @@ $ignoreIcon: '.#{$prefix}-icon-checkbox_tick, .#{$prefix}-icon-radio, .#{$prefix
 
         .#{$module}-bar-arrow-end {
             margin-left: $spacing-tabs_overflow_icon-marginLeft;
-            & > .#{$prefix}-button {
+            & > .#{$prefix}-button[aria-disabled=false] {
                 color: $color-tabs_tab-pane_arrow-text-default;
                 padding: $spacing-tabs_tab-pane_arrow;
                 border: $width-tabs_tab-pane_arrow-border solid $color-tabs_tab-pane_arrow-border-default;

--- a/packages/semi-foundation/tabs/tabs.scss
+++ b/packages/semi-foundation/tabs/tabs.scss
@@ -264,7 +264,7 @@ $ignoreIcon: '.#{$prefix}-icon-checkbox_tick, .#{$prefix}-icon-radio, .#{$prefix
 
         .#{$module}-bar-arrow-start {
             margin-right: $spacing-tabs_overflow_icon-marginRight;
-            & > .#{$prefix}-button {
+            & > .#{$prefix}-button[area-disabled=true] {
                 color: $color-tabs_tab-pane_arrow-text-default;
                 padding: $spacing-tabs_tab-pane_arrow;
                 border: $width-tabs_tab-pane_arrow-border solid $color-tabs_tab-pane_arrow-border-default;

--- a/packages/semi-ui/tabs/TabBar.tsx
+++ b/packages/semi-ui/tabs/TabBar.tsx
@@ -144,13 +144,20 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
     };
 
     renderCollapse = (items: Array<OverflowItem>, icon: ReactNode, pos: 'start' | 'end'): ReactNode => {
+        const arrowCls = cls({
+            [`${cssClasses.TABS_BAR}-arrow-${pos}`]: pos,
+            [`${cssClasses.TABS_BAR}-arrow`]: true,
+        });
+        
         if (isEmpty(items)) {
             return (
-                <Button
-                    disabled={true}
-                    icon={icon}
-                    theme="borderless"
-                />
+                <div role="presentation" className={arrowCls}>
+                    <Button
+                        disabled={true}
+                        icon={icon}
+                        theme="borderless"
+                    />
+                </div>
             );
         }
         const { dropdownClassName, dropdownStyle } = this.props;
@@ -174,11 +181,6 @@ class TabBar extends React.Component<TabBarProps, TabBarState> {
                 })}
             </Dropdown.Menu>
         );
-
-        const arrowCls = cls({
-            [`${cssClasses.TABS_BAR}-arrow-${pos}`]: pos,
-            [`${cssClasses.TABS_BAR}-arrow`]: true,
-        });
 
         const dropdownCls = cls(dropdownClassName, {
             [`${cssClasses.TABS_BAR}-dropdown`]: true,


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述
<!--
相关issue, 背景, 以及 reviewer 需要关注的地方
-->
原来按钮和 tab 列表的间距是通过 div.semi-tabs-bar-arrow 上的 margin-left/right 来实现的，而在存在溢出元素时，div.semi-tabs-bar-arrow 显示，margin 出现，在没有溢出元素时，div.semi-tabs-bar-arrow 不显示，margin 也不会出现，最终导致 tab 列表的宽度发生变化，这也是导致 tab scrollIntoView 之后显示不完全的根本原因

https://github.com/DouyinFE/semi-design/blob/08c76a5b7baaf2e8af9a670b8af1bec9a7fc4871/packages/semi-ui/tabs/TabBar.tsx#L147-L155

https://github.com/DouyinFE/semi-design/blob/08c76a5b7baaf2e8af9a670b8af1bec9a7fc4871/packages/semi-ui/tabs/TabBar.tsx#L200-L207

/
![1716209420083](https://github.com/DouyinFE/semi-design/assets/48666585/9b1eadd0-117c-4b59-8118-22a34034b6df)
![1716209449812](https://github.com/DouyinFE/semi-design/assets/48666585/46d8c896-fbe9-4e29-9d13-a0e2054c4139)


### 更新日志
🇨🇳 Chinese
- Fix: 修复 tab 在 scrollIntoView 后显示不完整的问题

---

🇺🇸 English
- Fix: Fixed the issue where the tab was not fully displayed when scrolled into view.


### 检查清单
- [ ] 已增加测试用例或无须增加
- [ ] 已补充文档或无须补充
- [ ] Changelog已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息

#### Before

https://github.com/DouyinFE/semi-design/assets/48666585/55317300-9c6d-47f1-abf8-c4d187450945

#### After

https://github.com/DouyinFE/semi-design/assets/48666585/ab84146a-0f27-4f1c-9bc2-8fe293df7f58


