### PR TITLE
chore: remove @douyinfe/semi-theme-default deps declare

### DIFF
--- a/packages/semi-theme-default/package.json
+++ b/packages/semi-theme-default/package.json
@@ -14,11 +14,5 @@
     "author": "huangzhijing.pixel@bytedance.com",
     "license": "MIT",
     "gitHead": "eb34a4f25f002bb4cbcfa51f3df93bed868c831a",
-    "dependencies": {
-        "glob": "^7.1.6"
-    },
-    "_unpkg": true,
-    "devDependencies": {
-        "path": "^0.12.7"
-    }
+    "_unpkg": true
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [x] Other, please describe:


### PR description
theme-default 并没有显式依赖 glob 和 path模块，不需要保留这个声明。

（在新项目中执行 yarn add @douyinfe/semi-ui时，会自动安装theme-default，会有以下提示）

![image](https://github.com/DouyinFE/semi-design/assets/88709023/427b61e3-cc26-4768-8432-959652856d36)

### Changelog
🇨🇳 Chinese
- Chore: 移除@douyinfe/semi-theme-default  中不恰当的依赖声明

---

🇺🇸 English
- Chore: remove inappropriate dependency declarations in @douyinfe/semi-theme-default


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
