### PR TITLE
fix: fix toast not center

### DIFF
--- a/packages/semi-foundation/toast/toast.scss
+++ b/packages/semi-foundation/toast/toast.scss
@@ -18,6 +18,7 @@ $icon: #{$prefix}-toast-icon;
         .#{$module}-innerWrapper{
             width: fit-content;
             height: fit-content;
+            text-align: center;
             &-hover{
                 .#{$module}-zero-height-wrapper{
                     perspective: unset;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Toast 在多条长度不同的 toast 弹出时，没有居中而是左对齐的问题

---

🇺🇸 English
- Fix: Fixed the issue where Toast is not centered but aligned to the left when multiple toasts with different lengths pop up.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
