### PR TITLE
fix: 修复小尺寸的input文字没有居中的问题

### DIFF
--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -32,7 +32,7 @@ $module: #{$prefix}-input;
 
 
 .#{$module}-wrapper {
-    display: inline-flex;
+    display: inline-block;
     position: relative;
     vertical-align: middle;
 
@@ -61,7 +61,7 @@ $module: #{$prefix}-input;
 
     &-small {
         height: $height-input_wrapper_small;
-        @include font-size-header-6;
+        @include font-size-regular;
         line-height: $height-input_small;
     }
 

--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -32,7 +32,7 @@ $module: #{$prefix}-input;
 
 
 .#{$module}-wrapper {
-    display: inline-block;
+    display: inline-flex;
     position: relative;
     vertical-align: middle;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
- 修复input组件在小尺寸状态下，文字没有很居中的问题，略微向下偏了一点点，改动涉及到input基础样式，看到大部分的衍生样式都把display设置成inline-flex，所以是否可以wrapper默认的display也设置成inline-flex？这样可以解决input没有在父容器居中给的问题

### Changelog
🇨🇳 Chinese
- Fix: 修复input在small size 状态下，文字略微向下偏移的问题

---

🇺🇸 English
- Fix: Fixed the problem that the text was slightly offset downwards when the input was in small size



### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
