### PR TITLE
style: Explicitly set the display of the svg in the spin to inline

### DIFF
--- a/packages/semi-foundation/spin/spin.scss
+++ b/packages/semi-foundation/spin/spin.scss
@@ -27,6 +27,7 @@ $module: #{$prefix}-spin;
         color: $color-spin-bg;
 
         & > svg {
+            display: inline;
             animation: $animation_duration-spin_wrapper-spin linear infinite #{$prefix}-animation-rotate;
             animation-fill-mode: forwards;
             vertical-align: top;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # 内部 oncall
反馈 table 的 loading icon 没有居中，排查发现是 Spin 组件的 svg 的 display 受到 tailwind 的默认设置有关系
svg 的默认 display 为 inline
tailwind 中默认设置的 svg display 为 block

### Changelog
🇨🇳 Chinese
- Style: 显式设置 Spin 下的 svg 的 display 属性为 inline，防止 tailwind 默认 svg 设置对 Spin 造成影响

---

🇺🇸 English
- Style: Explicitly set the display attribute of the svg under Spin to inline to prevent the tailwind default svg setting from affecting Spin.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
