### PR TITLE
fix: form labelAlign right not work when label with extra

### DIFF
--- a/packages/semi-foundation/form/form.scss
+++ b/packages/semi-foundation/form/form.scss
@@ -200,6 +200,10 @@ $rating: #{$prefix}-rating;
             display: flex;
             align-items: center;
         }
+        // labelAlign = right
+        .#{$field}-label-with-extra.#{$field}-label-right{
+            justify-content: flex-end;
+        }
         .#{$checkboxGroup},
         .#{$radioGroup} {
             padding-top: $spacing-form_label-paddingTop;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- now
![image](https://github.com/DouyinFE/semi-design/assets/88709023/5e60d9d2-b950-4d11-8be6-48925eb62ea1)

- after fix
![image](https://github.com/DouyinFE/semi-design/assets/88709023/9ee43d61-486b-44bb-beda-dbd95a92341d)



### Changelog
🇨🇳 Chinese
- Fix: 修复 Form labelAlign 设为 right时，对齐样式在 label 带 extra 情况下不生效的问题

---

🇺🇸 English
- Fix: Fixed the problem that when Form labelAlign is set to right, the alignment style does not take effect when the label has extra


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
