### PR TITLE
fix: change the innerProps from autofocus to autoFocus to avoid warning in the development env

### DIFF
--- a/packages/semi-ui/autoComplete/index.tsx
+++ b/packages/semi-ui/autoComplete/index.tsx
@@ -168,7 +168,7 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
     static Option = Option;
 
     static __SemiComponentName__ = "AutoComplete";
-    
+
     static defaultProps = getDefaultPropsFromGlobalConfig(AutoComplete.__SemiComponentName__, {
         stopPropagation: true,
         motion: true,
@@ -406,7 +406,7 @@ class AutoComplete<T extends AutoCompleteItems> extends BaseComponent<AutoComple
         const innerProps = {
             disabled,
             placeholder,
-            autofocus: autoFocus,
+            autoFocus: autoFocus,
             onChange: this.onSearch,
             onClear: this.onInputClear,
             'aria-label': this.props['aria-label'],


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 AutoComplete 因为 autofocus 拼写导致的在开发环境下抛出 warning 的问题

---

🇺🇸 English
- Fix: fixed the issue where AutoComplete throws a warning in the development environment due to autofocus spelling errors


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
