### PR TITLE
fix: [TreeSelect] fix when single select, searchable, search box in t…

### DIFF
--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -455,6 +455,10 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
         this._registerClickOutsideHandler();
     }
 
+    onClickSearchItem = (e: any) => {
+        this.focusInput(true);
+    }
+
     // Scenes that may trigger blur
     //  1、clickOutSide
     //  2、click option / press enter, and then select complete（when multiple is false

--- a/packages/semi-foundation/treeSelect/treeSelect.scss
+++ b/packages/semi-foundation/treeSelect/treeSelect.scss
@@ -165,6 +165,7 @@ $module: #{$prefix}-tree-select;
             
             &-placeholder {
                 opacity: .6;
+                z-index: -1;
             }
 
             &-disabled {

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -931,7 +931,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             [`${prefixcls}-selection-TriggerSearchItem-disabled`]: disabled,
         });
         return (
-            <span className={spanCls}>
+            <span className={spanCls} onClick={this.foundation.onClickSearchItem}>
                 {renderText ? renderText : placeholder}
             </span>
         );
@@ -944,8 +944,8 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const { inputValue } = this.state;
         return (
             <>
-                {!inputValue && this.renderSingleTriggerSearchItem()}
                 {this.renderInput()}
+                {!inputValue && this.renderSingleTriggerSearchItem()}
             </>
         );
     };


### PR DESCRIPTION
…riger, tooltip of label cannot be triggered to display

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复单选，可搜索，搜索框在 trigger 的 TreeSelect，当 trigger 中的选中项想要展示 Tooltip 时(比如 label 为 ReactNode，并且有 Tooltip，或者使用 renderSelectedItem 自定义渲染已选项目， 其中有 Tooltip)， tooltip 无法被触发问题 #2291

---

🇺🇸 English
- Fix: Fix single selection, searchable, search box in trigger's TreeSelect, when the selected item in trigger wants to display the Tooltip (e.g, the label is ReactNode, and there is a Tooltip, or use renderSelectedItem to customize the rendering of the selected item, which contains a Tooltip), the tooltip cannot be triggered  #2291 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
