### PR TITLE
clickOutsideHandler 注册捕获类型的事件，以避免被其它组件阻止传播

### DIFF
--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -368,7 +368,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                         cb();
                     }
                 };
-                window.addEventListener('mousedown', this.clickOutsideHandler);
+                window.addEventListener('mousedown', this.clickOutsideHandler, { capture: true });
             },
             unregisterClickOutsideHandler: () => {
                 if (this.clickOutsideHandler) {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
如果一个组件捕获事件并阻止传播，则 tooltip 将不会因为点击外部区域而被关闭。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tooltip 不会正确关闭

---

🇺🇸 English
- Fix: close Tooltip even if event is stoped propagation


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
