### PR TITLE
Fix(Table): Resolved alignment issues during virtualization (#2267)

### DIFF
--- a/packages/semi-foundation/table/constants.ts
+++ b/packages/semi-foundation/table/constants.ts
@@ -20,6 +20,7 @@ const strings = {
     SORT_DIRECTIONS: ['ascend', 'descend'],
     FIXED_SET: [false, true, 'left', 'right'],
     ALIGNS: ['left', 'right', 'center'],
+    JUSTIFY_CONTENT: ['flex-start', 'flex-end', 'center'],
     SCROLL_HORIZONTAL_POSITIONS: ['left', 'middle', 'right'],
     DEFAULT_KEY_COLUMN_SELECTION: 'column-selection',
     DEFAULT_KEY_COLUMN_EXPAND: 'column-expand',

--- a/packages/semi-foundation/table/utils.ts
+++ b/packages/semi-foundation/table/utils.ts
@@ -479,6 +479,31 @@ export function getRTLAlign(align: typeof strings.ALIGNS[number], direction?: 'l
     return align;
 }
 
+export function getRTLFlexAlign(align: typeof strings.ALIGNS[number], direction?: 'ltr' | 'rtl'): typeof strings.JUSTIFY_CONTENT[number] {
+    if (direction === 'rtl') {
+        switch (align) {
+            case 'left':
+                return 'flex-end';
+            case 'right':
+                return 'flex-start';
+            default:
+                return align;
+        }
+    }
+    else
+    {
+        switch (align) {
+            case 'left':
+                return 'flex-start';
+            case 'right':
+                return 'flex-end';
+            default:
+                return align;
+        }
+    }
+}
+
+
 export function shouldShowEllipsisTitle(ellipsis: BaseEllipsis) {
     const shouldShowTitle = ellipsis === true || get(ellipsis, 'showTitle', true);
     return shouldShowTitle;

--- a/packages/semi-ui/table/TableCell.tsx
+++ b/packages/semi-ui/table/TableCell.tsx
@@ -5,7 +5,7 @@ import { get, noop, set, omit, isEqual, merge } from 'lodash';
 
 import { cssClasses, numbers } from '@douyinfe/semi-foundation/table/constants';
 import TableCellFoundation, { TableCellAdapter } from '@douyinfe/semi-foundation/table/cellFoundation';
-import { isSelectionColumn, isExpandedColumn, getRTLAlign, shouldShowEllipsisTitle } from '@douyinfe/semi-foundation/table/utils';
+import { isSelectionColumn, isExpandedColumn, getRTLAlign, shouldShowEllipsisTitle, getRTLFlexAlign } from '@douyinfe/semi-foundation/table/utils';
 
 import BaseComponent, { BaseProps } from '../_base/baseComponent';
 import Context, { TableContextProps } from './table-context';
@@ -202,7 +202,8 @@ export default class TableCell extends BaseComponent<TableCellProps, Record<stri
 
         if (column.align) {
             const textAlign = getRTLAlign(column.align, direction);
-            tdProps.style = { ...tdProps.style, textAlign };
+            const justifyContent = getRTLFlexAlign(column.align, direction);
+            tdProps.style = { ...tdProps.style, textAlign, justifyContent };
         }
 
         return { tdProps, customCellProps };

--- a/packages/semi-ui/table/_story/virtualizedFixed/index.jsx
+++ b/packages/semi-ui/table/_story/virtualizedFixed/index.jsx
@@ -15,6 +15,7 @@ const Demo = () => {
             width: 250,
             fixed: 'left',
             key: 'en_name',
+            align: 'right',
             render: (text, record, index, { expandIcon: realExpandIcon }) => {
                 return (
                     <>


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述
<!--
相关issue, 背景, 以及 reviewer 需要关注的地方
-->
- Fixes https://github.com/DouyinFE/semi-design/issues/2267
因为虚拟化的使用的是 inline-flex，所以正常的align失效，在TableCell中添加了justifyContent属性。

### 更新日志
🇨🇳 Chinese
- Fix: Table组件 virtualized后align失效的问题。

---

🇺🇸 English
- Fix: Table component virtualized align after failure problem


### 检查清单
- [ ] 已增加测试用例或无须增加
- [ ] 已补充文档或无须补充
- [ ] Changelog已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->
![image](https://github.com/DouyinFE/semi-design/assets/86901622/89325d4a-3652-4cb0-a8ed-c3d6789fde90)
![image](https://github.com/DouyinFE/semi-design/assets/86901622/782facbd-5cc9-4ea7-8ca3-eefdd93567f3)
![image](https://github.com/DouyinFE/semi-design/assets/86901622/eb5f018d-8d31-4845-9226-ba2e78aa6a6e)
![image](https://github.com/DouyinFE/semi-design/assets/86901622/72559ea0-f3c5-4021-937b-b94a1b5b6235)
