### PR TITLE
Feat/cascader, treeSelect support esc key to close panel

### DIFF
--- a/cypress/e2e/cascader.spec.js
+++ b/cypress/e2e/cascader.spec.js
@@ -120,7 +120,7 @@ describe('cascader', () => {
         cy.get('.semi-checkbox.semi-checkbox-checked').eq(0).should('exist');
     });
 
-    it.only('esc close panel', () => {
+    it('esc close panel', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?id=cascader--searchable');
         cy.get('.semi-cascader-selection').eq(0).trigger('click');
         cy.get('.semi-input').type('中');

--- a/cypress/e2e/cascader.spec.js
+++ b/cypress/e2e/cascader.spec.js
@@ -119,5 +119,14 @@ describe('cascader', () => {
         cy.get('.semi-cascader-selection').click();
         cy.get('.semi-checkbox.semi-checkbox-checked').eq(0).should('exist');
     });
+
+    it.only('esc close panel', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=cascader--searchable');
+        cy.get('.semi-cascader-selection').eq(0).trigger('click');
+        cy.get('.semi-input').type('中');
+        cy.get('.semi-cascader-popover').should('have.length', 1);
+        cy.get('.semi-input').type('{esc}', { force: true });
+        cy.get('.semi-cascader-popover').should('not.exist');
+    })
     
 });

--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -194,5 +194,14 @@ describe('treeSelect', () => {
         cy.get('#invisible-span').eq(0).trigger('mousedown');
         cy.get('.semi-tree-select-popover').should('not.exist');
     })
+
+    it('esc close panel', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--search-position-in-trigger-and-virtualize');
+        cy.get('.semi-input').trigger('click');
+        cy.get('.semi-input').type('中');
+        cy.get('.semi-tree-select-popover').should('have.length', 1);
+        cy.get('.semi-input').type('{esc}', { force: true });
+        cy.get('.semi-tree-select-popover').should('not.exist');
+    })
 });
 

--- a/packages/semi-foundation/cascader/constants.ts
+++ b/packages/semi-foundation/cascader/constants.ts
@@ -29,5 +29,3 @@ export {
 };
 
 export const VALUE_SPLIT = '_SEMI_CASCADER_SPLIT_';
-
-export const ESCAPE_KEY_CODE = 27;

--- a/packages/semi-foundation/cascader/constants.ts
+++ b/packages/semi-foundation/cascader/constants.ts
@@ -29,3 +29,5 @@ export {
 };
 
 export const VALUE_SPLIT = '_SEMI_CASCADER_SPLIT_';
+
+export const ESCAPE_KEY_CODE = 27;

--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -18,8 +18,9 @@ import {
     getKeysByValuePath,
     getKeyByPos
 } from './util';
-import { ESCAPE_KEY_CODE, strings } from './constants';
+import { strings } from './constants';
 import isEnterPress from '../utils/isEnterPress';
+import { ESC_KEY } from '../utils/keyCode';
 
 export interface BasicData {
     data: BasicCascaderData;
@@ -257,8 +258,8 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
         }
     }
 
-    handleKeyDown = (e) => {
-        if (e.keyCode  === ESCAPE_KEY_CODE) {
+    handleKeyDown = (e: any) => {
+        if (e.key === ESC_KEY) {
             const isOpen = this.getState('isOpen');
             isOpen && this.close(e);
         } 

--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -18,7 +18,7 @@ import {
     getKeysByValuePath,
     getKeyByPos
 } from './util';
-import { strings } from './constants';
+import { ESCAPE_KEY_CODE, strings } from './constants';
 import isEnterPress from '../utils/isEnterPress';
 
 export interface BasicData {
@@ -255,6 +255,13 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
         if (isOpen && !this._isDisabled()) {
             this.open();
         }
+    }
+
+    handleKeyDown = (e) => {
+        if (e.keyCode  === ESCAPE_KEY_CODE) {
+            const isOpen = this.getState('isOpen');
+            isOpen && this.close(e);
+        } 
     }
 
     destroy() {

--- a/packages/semi-foundation/treeSelect/constants.ts
+++ b/packages/semi-foundation/treeSelect/constants.ts
@@ -23,5 +23,3 @@ export {
     strings,
     numbers
 };
-
-export const ESCAPE_KEY_CODE = 27;

--- a/packages/semi-foundation/treeSelect/constants.ts
+++ b/packages/semi-foundation/treeSelect/constants.ts
@@ -23,3 +23,5 @@ export {
     strings,
     numbers
 };
+
+export const ESCAPE_KEY_CODE = 27;

--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -1,5 +1,5 @@
 import { isNumber, isFunction, get, isUndefined, isString, isEmpty, difference } from 'lodash';
-import { strings } from '../treeSelect/constants';
+import { ESCAPE_KEY_CODE, strings } from '../treeSelect/constants';
 import BaseFoundation, { DefaultAdapter } from '../base/foundation';
 import {
     flattenTreeData,
@@ -308,6 +308,13 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
         } else {
             return this.constructDataForValue(value);
         }
+    }
+
+    handleKeyDown = (e: any) => {
+        if (e.keyCode === ESCAPE_KEY_CODE) {
+            const isOpen = this.getState('isOpen');
+            isOpen && this.close(e);
+        } 
     }
 
     getTreeNodeProps(key: string) {

--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -1,5 +1,5 @@
 import { isNumber, isFunction, get, isUndefined, isString, isEmpty, difference } from 'lodash';
-import { ESCAPE_KEY_CODE, strings } from '../treeSelect/constants';
+import { strings } from '../treeSelect/constants';
 import BaseFoundation, { DefaultAdapter } from '../base/foundation';
 import {
     flattenTreeData,
@@ -24,6 +24,7 @@ import {
 } from '../tree/foundation';
 import { Motion } from '../utils/type';
 import isEnterPress from '../utils/isEnterPress';
+import { ESC_KEY } from '../utils/keyCode';
 
 /* Here ValidateStatus is the same as ValidateStatus in baseComponent */
 export type ValidateStatus = 'error' | 'warning' | 'default';
@@ -311,7 +312,7 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
     }
 
     handleKeyDown = (e: any) => {
-        if (e.keyCode === ESCAPE_KEY_CODE) {
+        if (e.key === ESC_KEY) {
             const isOpen = this.getState('isOpen');
             isOpen && this.close(e);
         } 

--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -699,7 +699,7 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
         const popoverCls = cls(dropdownClassName, `${prefixcls}-popover`);
         const renderData = this.foundation.getRenderData();
         const content = (
-            <div className={popoverCls} role="listbox" style={dropdownStyle}>
+            <div className={popoverCls} role="listbox" style={dropdownStyle} onKeyDown={this.foundation.handleKeyDown}>
                 {topSlot}
                 <Item
                     activeKeys={activeKeys}
@@ -1026,6 +1026,7 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                 aria-describedby={this.props['aria-describedby']}
                 aria-required={this.props['aria-required']}
                 id={id}
+                onKeyDown={this.foundation.handleKeyDown}
                 {...mouseEvent}
                 // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
                 role="combobox"

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -815,7 +815,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const style = { minWidth: dropdownMinWidth, ...dropdownStyle };
         const popoverCls = cls(dropdownClassName, `${prefixcls}-popover`);
         return (
-            <div className={popoverCls} style={style}>
+            <div className={popoverCls} style={style} onKeyDown={this.foundation.handleKeyDown}>
                 {this.renderTree()}
             </div>
         );
@@ -1166,6 +1166,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 ref={this.triggerRef}
                 onClick={this.handleClick}
                 onKeyPress={this.handleSelectionEnterPress}
+                onKeyDown={this.foundation.handleKeyDown}
                 aria-invalid={this.props['aria-invalid']}
                 aria-errormessage={this.props['aria-errormessage']}
                 aria-label={this.props['aria-label']}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # 内部需求。希望支持 esc 按键关闭 TreeSelect/Cascader 弹出层

### Changelog
🇨🇳 Chinese
- Feat: TreeSelect, Cascader 支持通过 esc 按键关闭弹出层

---

🇺🇸 English
- Feat: TreeSelect, Cascader supports closing the popup layer through the esc key


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
