### PR TITLE
Chore：fix jest error which cause by remark-gfm、mdx-js

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,25 @@ let ModuleNeedCompile2Cjs = [
     'lodash-es',
     'react-dnd',
     'dnd-core',
-    'react-dnd-html5-backend'
+    'react-dnd-html5-backend',
+    'lottie'
+    // 'remark-gfm',
+    // 'mdast-util-gfm',
+    // 'mdast-util-find-and-replace',
+    // 'mdast-util-to-markdown',
+    // 'mdast-util-phrasing',
+    // 'micromark-util-character',
+    // 'micromark-util-normalize-identifier',
+    // 'unist-util-visit-parents',
+    // 'unist-util-stringify-position',
+    // 'decode-named-character-reference'
+    // 'devlop',
+    // 'vfile',
+    // 'vfile-location',
+    // 'vfile-message',
+    // 'markdown-extensions',
+    // '@mdx-js/mdx',
+    // 'mdast-util-mdx',
 ].join('|');
 
 let config = {
@@ -22,11 +40,25 @@ let config = {
     // 忽略出lodash-es、react-dnd、dnd-core外的node_modules中的所有内容，即node_modules中只有lodash-es、react-dnd、dnd-core需要被babel-jest处理
     transformIgnorePatterns: [`<rootDir>/node_modules/(?!(${ModuleNeedCompile2Cjs}))`],
     snapshotSerializers: ['enzyme-to-json/serializer'],
+    moduleFileExtensions: ['js', 'json', 'jsx', 'ts', 'tsx', 'node'],
     // moduleDirectories: ["node_modules"],
     moduleNameMapper: {
         '\\.(css|scss)$': '<rootDir>/test/__mocks__/styleMock.js',
         '\\.(jpg|jpeg|png|gif|eot|otf|webp|ttf|woff|woff2|mp4|webm|wav|mp3|m4a|aac|oga)$':
             '<rootDir>/test/__mocks__/fileMock.js',
+        // 'vfile': '<rootDir>/packages/semi-foundation/node_modules/vfile',
+        // 'remark-mdx': '<rootDir>/packages/semi-foundation/node_modules/remark-mdx',
+        // 'unist-util-is': '<rootDir>/packages/semi-foundation/node_modules/unist-util-is',
+        // 'unist-util-visit': '<rootDir>/packages/semi-foundation/node_modules/unist-util-visit',
+        // 'vfile/do-not-use-conditional-minpath': '<rootDir>/packages/semi-foundation/node_modules/vfile/lib/minpath.js',
+        // 'vfile/do-not-use-conditional-minproc': '<rootDir>/packages/semi-foundation/node_modules/vfile/lib/minproc.js',
+        // 'vfile/do-not-use-conditional-minurl': '<rootDir>/packages/semi-foundation/node_modules/vfile/lib/minurl.js',
+        // 'devlop': '<rootDir>/test/__mocks__/devlop.js',
+        // 'unist-util-visit-parents/do-not-use-color': '<rootDir>/node_modules/unist-util-visit-parents/lib/color.node.js',
+        
+        '@mdx-js/mdx': '<rootDir>/test/__mocks__/mdx-3.0.1-cjs.js',
+        'remark-gfm': '<rootDir>/test/__mocks__/remark-gfm-4.0.0-cjs.js',
+
         '@douyinfe/semi-ui(.*)$': '<rootDir>/packages/semi-ui/$1',
         '@douyinfe/semi-foundation(.*)$': '<rootDir>/packages/semi-foundation/$1',
         '@douyinfe/semi-illustrations(.*)$': '<rootDir>/packages/semi-illustrations/src/$1',

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
         "gatsby-source-filesystem": "^2.11.1",
         "grapheme-splitter": "^1.0.4",
         "immutability-helper": "^3.1.1",
+        "jest-canvas-mock": "^2.5.2",
         "lodash-es": "^4.17.21",
         "memoize-one": "^5.2.1",
         "normalize.css": "^8.0.1",

--- a/test/__mocks__/devlop.js
+++ b/test/__mocks__/devlop.js
@@ -1,0 +1,45 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all) => {
+    for (var name in all)
+        __defProp(target, name, { get: all[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+    if (from && typeof from === "object" || typeof from === "function") {
+        for (let key of __getOwnPropNames(from))
+            if (!__hasOwnProp.call(to, key) && key !== except)
+                __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+    }
+    return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// devlop.js
+var devlop_exports = {};
+__export(devlop_exports, {
+    deprecate: () => deprecate,
+    equal: () => equal,
+    ok: () => ok,
+    unreachable: () => unreachable
+});
+module.exports = __toCommonJS(devlop_exports);
+
+// node_modules/devlop/lib/default.js
+function deprecate(fn) {
+    return fn;
+}
+function equal() {
+}
+function ok() {
+}
+function unreachable() {
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+    deprecate,
+    equal,
+    ok,
+    unreachable
+});

--- a/test/__mocks__/mdx-3.0.1-cjs.js
+++ b/test/__mocks__/mdx-3.0.1-cjs.js
@@ -1,0 +1,28811 @@
+var __create = Object.create;
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __getProtoOf = Object.getPrototypeOf;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __commonJS = (cb, mod) => function __require() {
+  return mod || (0, cb[__getOwnPropNames(cb)[0]])((mod = { exports: {} }).exports, mod), mod.exports;
+};
+var __export = (target, all3) => {
+  for (var name2 in all3)
+    __defProp(target, name2, { get: all3[name2], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toESM = (mod, isNodeMode, target) => (target = mod != null ? __create(__getProtoOf(mod)) : {}, __copyProps(
+  // If the importer is in node compatibility mode or this is not an ESM
+  // file that has been converted to a CommonJS file using a Babel-
+  // compatible transform (i.e. "__esModule" has not been set), then set
+  // "default" to the CommonJS "module.exports" for node compatibility.
+  isNodeMode || !mod || !mod.__esModule ? __defProp(target, "default", { value: mod, enumerable: true }) : target,
+  mod
+));
+
+var PATH = require('path');
+var PROCESS = require('process');
+var URL = require('url');
+
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// node_modules/micromark-extension-mdxjs/node_modules/acorn-jsx/xhtml.js
+var require_xhtml = __commonJS({
+  "node_modules/micromark-extension-mdxjs/node_modules/acorn-jsx/xhtml.js"(exports2, module2) {
+    module2.exports = {
+      quot: '"',
+      amp: "&",
+      apos: "'",
+      lt: "<",
+      gt: ">",
+      nbsp: "\xA0",
+      iexcl: "\xA1",
+      cent: "\xA2",
+      pound: "\xA3",
+      curren: "\xA4",
+      yen: "\xA5",
+      brvbar: "\xA6",
+      sect: "\xA7",
+      uml: "\xA8",
+      copy: "\xA9",
+      ordf: "\xAA",
+      laquo: "\xAB",
+      not: "\xAC",
+      shy: "\xAD",
+      reg: "\xAE",
+      macr: "\xAF",
+      deg: "\xB0",
+      plusmn: "\xB1",
+      sup2: "\xB2",
+      sup3: "\xB3",
+      acute: "\xB4",
+      micro: "\xB5",
+      para: "\xB6",
+      middot: "\xB7",
+      cedil: "\xB8",
+      sup1: "\xB9",
+      ordm: "\xBA",
+      raquo: "\xBB",
+      frac14: "\xBC",
+      frac12: "\xBD",
+      frac34: "\xBE",
+      iquest: "\xBF",
+      Agrave: "\xC0",
+      Aacute: "\xC1",
+      Acirc: "\xC2",
+      Atilde: "\xC3",
+      Auml: "\xC4",
+      Aring: "\xC5",
+      AElig: "\xC6",
+      Ccedil: "\xC7",
+      Egrave: "\xC8",
+      Eacute: "\xC9",
+      Ecirc: "\xCA",
+      Euml: "\xCB",
+      Igrave: "\xCC",
+      Iacute: "\xCD",
+      Icirc: "\xCE",
+      Iuml: "\xCF",
+      ETH: "\xD0",
+      Ntilde: "\xD1",
+      Ograve: "\xD2",
+      Oacute: "\xD3",
+      Ocirc: "\xD4",
+      Otilde: "\xD5",
+      Ouml: "\xD6",
+      times: "\xD7",
+      Oslash: "\xD8",
+      Ugrave: "\xD9",
+      Uacute: "\xDA",
+      Ucirc: "\xDB",
+      Uuml: "\xDC",
+      Yacute: "\xDD",
+      THORN: "\xDE",
+      szlig: "\xDF",
+      agrave: "\xE0",
+      aacute: "\xE1",
+      acirc: "\xE2",
+      atilde: "\xE3",
+      auml: "\xE4",
+      aring: "\xE5",
+      aelig: "\xE6",
+      ccedil: "\xE7",
+      egrave: "\xE8",
+      eacute: "\xE9",
+      ecirc: "\xEA",
+      euml: "\xEB",
+      igrave: "\xEC",
+      iacute: "\xED",
+      icirc: "\xEE",
+      iuml: "\xEF",
+      eth: "\xF0",
+      ntilde: "\xF1",
+      ograve: "\xF2",
+      oacute: "\xF3",
+      ocirc: "\xF4",
+      otilde: "\xF5",
+      ouml: "\xF6",
+      divide: "\xF7",
+      oslash: "\xF8",
+      ugrave: "\xF9",
+      uacute: "\xFA",
+      ucirc: "\xFB",
+      uuml: "\xFC",
+      yacute: "\xFD",
+      thorn: "\xFE",
+      yuml: "\xFF",
+      OElig: "\u0152",
+      oelig: "\u0153",
+      Scaron: "\u0160",
+      scaron: "\u0161",
+      Yuml: "\u0178",
+      fnof: "\u0192",
+      circ: "\u02C6",
+      tilde: "\u02DC",
+      Alpha: "\u0391",
+      Beta: "\u0392",
+      Gamma: "\u0393",
+      Delta: "\u0394",
+      Epsilon: "\u0395",
+      Zeta: "\u0396",
+      Eta: "\u0397",
+      Theta: "\u0398",
+      Iota: "\u0399",
+      Kappa: "\u039A",
+      Lambda: "\u039B",
+      Mu: "\u039C",
+      Nu: "\u039D",
+      Xi: "\u039E",
+      Omicron: "\u039F",
+      Pi: "\u03A0",
+      Rho: "\u03A1",
+      Sigma: "\u03A3",
+      Tau: "\u03A4",
+      Upsilon: "\u03A5",
+      Phi: "\u03A6",
+      Chi: "\u03A7",
+      Psi: "\u03A8",
+      Omega: "\u03A9",
+      alpha: "\u03B1",
+      beta: "\u03B2",
+      gamma: "\u03B3",
+      delta: "\u03B4",
+      epsilon: "\u03B5",
+      zeta: "\u03B6",
+      eta: "\u03B7",
+      theta: "\u03B8",
+      iota: "\u03B9",
+      kappa: "\u03BA",
+      lambda: "\u03BB",
+      mu: "\u03BC",
+      nu: "\u03BD",
+      xi: "\u03BE",
+      omicron: "\u03BF",
+      pi: "\u03C0",
+      rho: "\u03C1",
+      sigmaf: "\u03C2",
+      sigma: "\u03C3",
+      tau: "\u03C4",
+      upsilon: "\u03C5",
+      phi: "\u03C6",
+      chi: "\u03C7",
+      psi: "\u03C8",
+      omega: "\u03C9",
+      thetasym: "\u03D1",
+      upsih: "\u03D2",
+      piv: "\u03D6",
+      ensp: "\u2002",
+      emsp: "\u2003",
+      thinsp: "\u2009",
+      zwnj: "\u200C",
+      zwj: "\u200D",
+      lrm: "\u200E",
+      rlm: "\u200F",
+      ndash: "\u2013",
+      mdash: "\u2014",
+      lsquo: "\u2018",
+      rsquo: "\u2019",
+      sbquo: "\u201A",
+      ldquo: "\u201C",
+      rdquo: "\u201D",
+      bdquo: "\u201E",
+      dagger: "\u2020",
+      Dagger: "\u2021",
+      bull: "\u2022",
+      hellip: "\u2026",
+      permil: "\u2030",
+      prime: "\u2032",
+      Prime: "\u2033",
+      lsaquo: "\u2039",
+      rsaquo: "\u203A",
+      oline: "\u203E",
+      frasl: "\u2044",
+      euro: "\u20AC",
+      image: "\u2111",
+      weierp: "\u2118",
+      real: "\u211C",
+      trade: "\u2122",
+      alefsym: "\u2135",
+      larr: "\u2190",
+      uarr: "\u2191",
+      rarr: "\u2192",
+      darr: "\u2193",
+      harr: "\u2194",
+      crarr: "\u21B5",
+      lArr: "\u21D0",
+      uArr: "\u21D1",
+      rArr: "\u21D2",
+      dArr: "\u21D3",
+      hArr: "\u21D4",
+      forall: "\u2200",
+      part: "\u2202",
+      exist: "\u2203",
+      empty: "\u2205",
+      nabla: "\u2207",
+      isin: "\u2208",
+      notin: "\u2209",
+      ni: "\u220B",
+      prod: "\u220F",
+      sum: "\u2211",
+      minus: "\u2212",
+      lowast: "\u2217",
+      radic: "\u221A",
+      prop: "\u221D",
+      infin: "\u221E",
+      ang: "\u2220",
+      and: "\u2227",
+      or: "\u2228",
+      cap: "\u2229",
+      cup: "\u222A",
+      "int": "\u222B",
+      there4: "\u2234",
+      sim: "\u223C",
+      cong: "\u2245",
+      asymp: "\u2248",
+      ne: "\u2260",
+      equiv: "\u2261",
+      le: "\u2264",
+      ge: "\u2265",
+      sub: "\u2282",
+      sup: "\u2283",
+      nsub: "\u2284",
+      sube: "\u2286",
+      supe: "\u2287",
+      oplus: "\u2295",
+      otimes: "\u2297",
+      perp: "\u22A5",
+      sdot: "\u22C5",
+      lceil: "\u2308",
+      rceil: "\u2309",
+      lfloor: "\u230A",
+      rfloor: "\u230B",
+      lang: "\u2329",
+      rang: "\u232A",
+      loz: "\u25CA",
+      spades: "\u2660",
+      clubs: "\u2663",
+      hearts: "\u2665",
+      diams: "\u2666"
+    };
+  }
+});
+
+// node_modules/micromark-extension-mdxjs/node_modules/acorn-jsx/node_modules/acorn/dist/acorn.js
+var require_acorn = __commonJS({
+  "node_modules/micromark-extension-mdxjs/node_modules/acorn-jsx/node_modules/acorn/dist/acorn.js"(exports2, module2) {
+    (function(global, factory) {
+      typeof exports2 === "object" && typeof module2 !== "undefined" ? factory(exports2) : typeof define === "function" && define.amd ? define(["exports"], factory) : (global = global || self, factory(global.acorn = {}));
+    })(exports2, function(exports3) {
+      "use strict";
+      var reservedWords2 = {
+        3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
+        5: "class enum extends super const export import",
+        6: "enum",
+        strict: "implements interface let package private protected public static yield",
+        strictBind: "eval arguments"
+      };
+      var ecma5AndLessKeywords2 = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+      var keywords2 = {
+        5: ecma5AndLessKeywords2,
+        "5module": ecma5AndLessKeywords2 + " export import",
+        6: ecma5AndLessKeywords2 + " const class extends export import super"
+      };
+      var keywordRelationalOperator2 = /^in(stanceof)?$/;
+      var nonASCIIidentifierStartChars2 = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u08A0-\u08B4\u08B6-\u08C7\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u170C\u170E-\u1711\u1720-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4B\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2C2E\u2C30-\u2C5E\u2C60-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\u9FFC\uA000-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7BF\uA7C2-\uA7CA\uA7F5-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+      var nonASCIIidentifierChars2 = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u08D3-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECD\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1714\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u1810-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF\u1AC0\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DF9\u1DFB-\u1DFF\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F";
+      var nonASCIIidentifierStart2 = new RegExp("[" + nonASCIIidentifierStartChars2 + "]");
+      var nonASCIIidentifier2 = new RegExp("[" + nonASCIIidentifierStartChars2 + nonASCIIidentifierChars2 + "]");
+      nonASCIIidentifierStartChars2 = nonASCIIidentifierChars2 = null;
+      var astralIdentifierStartCodes2 = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 157, 310, 10, 21, 11, 7, 153, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 107, 20, 28, 22, 13, 52, 76, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 85, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 230, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 35, 56, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 190, 0, 80, 921, 103, 110, 18, 195, 2749, 1070, 4050, 582, 8634, 568, 8, 30, 114, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8952, 286, 50, 2, 18, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 2357, 44, 11, 6, 17, 0, 370, 43, 1301, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42717, 35, 4148, 12, 221, 3, 5761, 15, 7472, 3104, 541, 1507, 4938];
+      var astralIdentifierCodes2 = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 154, 10, 176, 2, 54, 14, 32, 9, 16, 3, 46, 10, 54, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 161, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 19306, 9, 135, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 5319, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 262, 6, 10, 9, 419, 13, 1495, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+      function isInAstralSet2(code2, set) {
+        var pos = 65536;
+        for (var i = 0; i < set.length; i += 2) {
+          pos += set[i];
+          if (pos > code2) {
+            return false;
+          }
+          pos += set[i + 1];
+          if (pos >= code2) {
+            return true;
+          }
+        }
+      }
+      function isIdentifierStart2(code2, astral) {
+        if (code2 < 65) {
+          return code2 === 36;
+        }
+        if (code2 < 91) {
+          return true;
+        }
+        if (code2 < 97) {
+          return code2 === 95;
+        }
+        if (code2 < 123) {
+          return true;
+        }
+        if (code2 <= 65535) {
+          return code2 >= 170 && nonASCIIidentifierStart2.test(String.fromCharCode(code2));
+        }
+        if (astral === false) {
+          return false;
+        }
+        return isInAstralSet2(code2, astralIdentifierStartCodes2);
+      }
+      function isIdentifierChar2(code2, astral) {
+        if (code2 < 48) {
+          return code2 === 36;
+        }
+        if (code2 < 58) {
+          return true;
+        }
+        if (code2 < 65) {
+          return false;
+        }
+        if (code2 < 91) {
+          return true;
+        }
+        if (code2 < 97) {
+          return code2 === 95;
+        }
+        if (code2 < 123) {
+          return true;
+        }
+        if (code2 <= 65535) {
+          return code2 >= 170 && nonASCIIidentifier2.test(String.fromCharCode(code2));
+        }
+        if (astral === false) {
+          return false;
+        }
+        return isInAstralSet2(code2, astralIdentifierStartCodes2) || isInAstralSet2(code2, astralIdentifierCodes2);
+      }
+      var TokenType3 = function TokenType4(label, conf) {
+        if (conf === void 0) conf = {};
+        this.label = label;
+        this.keyword = conf.keyword;
+        this.beforeExpr = !!conf.beforeExpr;
+        this.startsExpr = !!conf.startsExpr;
+        this.isLoop = !!conf.isLoop;
+        this.isAssign = !!conf.isAssign;
+        this.prefix = !!conf.prefix;
+        this.postfix = !!conf.postfix;
+        this.binop = conf.binop || null;
+        this.updateContext = null;
+      };
+      function binop2(name2, prec) {
+        return new TokenType3(name2, { beforeExpr: true, binop: prec });
+      }
+      var beforeExpr2 = { beforeExpr: true }, startsExpr2 = { startsExpr: true };
+      var keywords$12 = {};
+      function kw2(name2, options) {
+        if (options === void 0) options = {};
+        options.keyword = name2;
+        return keywords$12[name2] = new TokenType3(name2, options);
+      }
+      var types2 = {
+        num: new TokenType3("num", startsExpr2),
+        regexp: new TokenType3("regexp", startsExpr2),
+        string: new TokenType3("string", startsExpr2),
+        name: new TokenType3("name", startsExpr2),
+        eof: new TokenType3("eof"),
+        // Punctuation token types.
+        bracketL: new TokenType3("[", { beforeExpr: true, startsExpr: true }),
+        bracketR: new TokenType3("]"),
+        braceL: new TokenType3("{", { beforeExpr: true, startsExpr: true }),
+        braceR: new TokenType3("}"),
+        parenL: new TokenType3("(", { beforeExpr: true, startsExpr: true }),
+        parenR: new TokenType3(")"),
+        comma: new TokenType3(",", beforeExpr2),
+        semi: new TokenType3(";", beforeExpr2),
+        colon: new TokenType3(":", beforeExpr2),
+        dot: new TokenType3("."),
+        question: new TokenType3("?", beforeExpr2),
+        questionDot: new TokenType3("?."),
+        arrow: new TokenType3("=>", beforeExpr2),
+        template: new TokenType3("template"),
+        invalidTemplate: new TokenType3("invalidTemplate"),
+        ellipsis: new TokenType3("...", beforeExpr2),
+        backQuote: new TokenType3("`", startsExpr2),
+        dollarBraceL: new TokenType3("${", { beforeExpr: true, startsExpr: true }),
+        // Operators. These carry several kinds of properties to help the
+        // parser use them properly (the presence of these properties is
+        // what categorizes them as operators).
+        //
+        // `binop`, when present, specifies that this operator is a binary
+        // operator, and will refer to its precedence.
+        //
+        // `prefix` and `postfix` mark the operator as a prefix or postfix
+        // unary operator.
+        //
+        // `isAssign` marks all of `=`, `+=`, `-=` etcetera, which act as
+        // binary operators with a very low precedence, that should result
+        // in AssignmentExpression nodes.
+        eq: new TokenType3("=", { beforeExpr: true, isAssign: true }),
+        assign: new TokenType3("_=", { beforeExpr: true, isAssign: true }),
+        incDec: new TokenType3("++/--", { prefix: true, postfix: true, startsExpr: true }),
+        prefix: new TokenType3("!/~", { beforeExpr: true, prefix: true, startsExpr: true }),
+        logicalOR: binop2("||", 1),
+        logicalAND: binop2("&&", 2),
+        bitwiseOR: binop2("|", 3),
+        bitwiseXOR: binop2("^", 4),
+        bitwiseAND: binop2("&", 5),
+        equality: binop2("==/!=/===/!==", 6),
+        relational: binop2("</>/<=/>=", 7),
+        bitShift: binop2("<</>>/>>>", 8),
+        plusMin: new TokenType3("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+        modulo: binop2("%", 10),
+        star: binop2("*", 10),
+        slash: binop2("/", 10),
+        starstar: new TokenType3("**", { beforeExpr: true }),
+        coalesce: binop2("??", 1),
+        // Keyword token types.
+        _break: kw2("break"),
+        _case: kw2("case", beforeExpr2),
+        _catch: kw2("catch"),
+        _continue: kw2("continue"),
+        _debugger: kw2("debugger"),
+        _default: kw2("default", beforeExpr2),
+        _do: kw2("do", { isLoop: true, beforeExpr: true }),
+        _else: kw2("else", beforeExpr2),
+        _finally: kw2("finally"),
+        _for: kw2("for", { isLoop: true }),
+        _function: kw2("function", startsExpr2),
+        _if: kw2("if"),
+        _return: kw2("return", beforeExpr2),
+        _switch: kw2("switch"),
+        _throw: kw2("throw", beforeExpr2),
+        _try: kw2("try"),
+        _var: kw2("var"),
+        _const: kw2("const"),
+        _while: kw2("while", { isLoop: true }),
+        _with: kw2("with"),
+        _new: kw2("new", { beforeExpr: true, startsExpr: true }),
+        _this: kw2("this", startsExpr2),
+        _super: kw2("super", startsExpr2),
+        _class: kw2("class", startsExpr2),
+        _extends: kw2("extends", beforeExpr2),
+        _export: kw2("export"),
+        _import: kw2("import", startsExpr2),
+        _null: kw2("null", startsExpr2),
+        _true: kw2("true", startsExpr2),
+        _false: kw2("false", startsExpr2),
+        _in: kw2("in", { beforeExpr: true, binop: 7 }),
+        _instanceof: kw2("instanceof", { beforeExpr: true, binop: 7 }),
+        _typeof: kw2("typeof", { beforeExpr: true, prefix: true, startsExpr: true }),
+        _void: kw2("void", { beforeExpr: true, prefix: true, startsExpr: true }),
+        _delete: kw2("delete", { beforeExpr: true, prefix: true, startsExpr: true })
+      };
+      var lineBreak2 = /\r\n?|\n|\u2028|\u2029/;
+      var lineBreakG2 = new RegExp(lineBreak2.source, "g");
+      function isNewLine2(code2, ecma2019String) {
+        return code2 === 10 || code2 === 13 || !ecma2019String && (code2 === 8232 || code2 === 8233);
+      }
+      var nonASCIIwhitespace2 = /[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+      var skipWhiteSpace2 = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+      var ref2 = Object.prototype;
+      var hasOwnProperty3 = ref2.hasOwnProperty;
+      var toString4 = ref2.toString;
+      function has(obj, propName) {
+        return hasOwnProperty3.call(obj, propName);
+      }
+      var isArray2 = Array.isArray || function(obj) {
+        return toString4.call(obj) === "[object Array]";
+      };
+      function wordsRegexp2(words) {
+        return new RegExp("^(?:" + words.replace(/ /g, "|") + ")$");
+      }
+      var Position3 = function Position4(line, col) {
+        this.line = line;
+        this.column = col;
+      };
+      Position3.prototype.offset = function offset2(n) {
+        return new Position3(this.line, this.column + n);
+      };
+      var SourceLocation3 = function SourceLocation4(p, start2, end) {
+        this.start = start2;
+        this.end = end;
+        if (p.sourceFile !== null) {
+          this.source = p.sourceFile;
+        }
+      };
+      function getLineInfo2(input, offset2) {
+        for (var line = 1, cur = 0; ; ) {
+          lineBreakG2.lastIndex = cur;
+          var match = lineBreakG2.exec(input);
+          if (match && match.index < offset2) {
+            ++line;
+            cur = match.index + match[0].length;
+          } else {
+            return new Position3(line, offset2 - cur);
+          }
+        }
+      }
+      var defaultOptions2 = {
+        // `ecmaVersion` indicates the ECMAScript version to parse. Must be
+        // either 3, 5, 6 (2015), 7 (2016), 8 (2017), 9 (2018), or 10
+        // (2019). This influences support for strict mode, the set of
+        // reserved words, and support for new syntax features. The default
+        // is 10.
+        ecmaVersion: 10,
+        // `sourceType` indicates the mode the code should be parsed in.
+        // Can be either `"script"` or `"module"`. This influences global
+        // strict mode and parsing of `import` and `export` declarations.
+        sourceType: "script",
+        // `onInsertedSemicolon` can be a callback that will be called
+        // when a semicolon is automatically inserted. It will be passed
+        // the position of the comma as an offset, and if `locations` is
+        // enabled, it is given the location as a `{line, column}` object
+        // as second argument.
+        onInsertedSemicolon: null,
+        // `onTrailingComma` is similar to `onInsertedSemicolon`, but for
+        // trailing commas.
+        onTrailingComma: null,
+        // By default, reserved words are only enforced if ecmaVersion >= 5.
+        // Set `allowReserved` to a boolean value to explicitly turn this on
+        // an off. When this option has the value "never", reserved words
+        // and keywords can also not be used as property names.
+        allowReserved: null,
+        // When enabled, a return at the top level is not considered an
+        // error.
+        allowReturnOutsideFunction: false,
+        // When enabled, import/export statements are not constrained to
+        // appearing at the top of the program.
+        allowImportExportEverywhere: false,
+        // When enabled, await identifiers are allowed to appear at the top-level scope,
+        // but they are still not allowed in non-async functions.
+        allowAwaitOutsideFunction: false,
+        // When enabled, hashbang directive in the beginning of file
+        // is allowed and treated as a line comment.
+        allowHashBang: false,
+        // When `locations` is on, `loc` properties holding objects with
+        // `start` and `end` properties in `{line, column}` form (with
+        // line being 1-based and column 0-based) will be attached to the
+        // nodes.
+        locations: false,
+        // A function can be passed as `onToken` option, which will
+        // cause Acorn to call that function with object in the same
+        // format as tokens returned from `tokenizer().getToken()`. Note
+        // that you are not allowed to call the parser from the
+        // callback—that will corrupt its internal state.
+        onToken: null,
+        // A function can be passed as `onComment` option, which will
+        // cause Acorn to call that function with `(block, text, start,
+        // end)` parameters whenever a comment is skipped. `block` is a
+        // boolean indicating whether this is a block (`/* */`) comment,
+        // `text` is the content of the comment, and `start` and `end` are
+        // character offsets that denote the start and end of the comment.
+        // When the `locations` option is on, two more parameters are
+        // passed, the full `{line, column}` locations of the start and
+        // end of the comments. Note that you are not allowed to call the
+        // parser from the callback—that will corrupt its internal state.
+        onComment: null,
+        // Nodes have their start and end characters offsets recorded in
+        // `start` and `end` properties (directly on the node, rather than
+        // the `loc` object, which holds line/column data. To also add a
+        // [semi-standardized][range] `range` property holding a `[start,
+        // end]` array with the same numbers, set the `ranges` option to
+        // `true`.
+        //
+        // [range]: https://bugzilla.mozilla.org/show_bug.cgi?id=745678
+        ranges: false,
+        // It is possible to parse multiple files into a single AST by
+        // passing the tree produced by parsing the first file as
+        // `program` option in subsequent parses. This will add the
+        // toplevel forms of the parsed file to the `Program` (top) node
+        // of an existing parse tree.
+        program: null,
+        // When `locations` is on, you can pass this to record the source
+        // file in every node's `loc` object.
+        sourceFile: null,
+        // This value, if given, is stored in every node, whether
+        // `locations` is on or off.
+        directSourceFile: null,
+        // When enabled, parenthesized expressions are represented by
+        // (non-standard) ParenthesizedExpression nodes
+        preserveParens: false
+      };
+      function getOptions2(opts) {
+        var options = {};
+        for (var opt in defaultOptions2) {
+          options[opt] = opts && has(opts, opt) ? opts[opt] : defaultOptions2[opt];
+        }
+        if (options.ecmaVersion >= 2015) {
+          options.ecmaVersion -= 2009;
+        }
+        if (options.allowReserved == null) {
+          options.allowReserved = options.ecmaVersion < 5;
+        }
+        if (isArray2(options.onToken)) {
+          var tokens = options.onToken;
+          options.onToken = function(token) {
+            return tokens.push(token);
+          };
+        }
+        if (isArray2(options.onComment)) {
+          options.onComment = pushComment2(options, options.onComment);
+        }
+        return options;
+      }
+      function pushComment2(options, array) {
+        return function(block, text5, start2, end, startLoc, endLoc) {
+          var comment2 = {
+            type: block ? "Block" : "Line",
+            value: text5,
+            start: start2,
+            end
+          };
+          if (options.locations) {
+            comment2.loc = new SourceLocation3(this, startLoc, endLoc);
+          }
+          if (options.ranges) {
+            comment2.range = [start2, end];
+          }
+          array.push(comment2);
+        };
+      }
+      var SCOPE_TOP2 = 1, SCOPE_FUNCTION2 = 2, SCOPE_VAR2 = SCOPE_TOP2 | SCOPE_FUNCTION2, SCOPE_ASYNC2 = 4, SCOPE_GENERATOR2 = 8, SCOPE_ARROW2 = 16, SCOPE_SIMPLE_CATCH2 = 32, SCOPE_SUPER2 = 64, SCOPE_DIRECT_SUPER2 = 128;
+      function functionFlags2(async, generator) {
+        return SCOPE_FUNCTION2 | (async ? SCOPE_ASYNC2 : 0) | (generator ? SCOPE_GENERATOR2 : 0);
+      }
+      var BIND_NONE2 = 0, BIND_VAR2 = 1, BIND_LEXICAL2 = 2, BIND_FUNCTION2 = 3, BIND_SIMPLE_CATCH2 = 4, BIND_OUTSIDE2 = 5;
+      var Parser3 = function Parser4(options, input, startPos) {
+        this.options = options = getOptions2(options);
+        this.sourceFile = options.sourceFile;
+        this.keywords = wordsRegexp2(keywords2[options.ecmaVersion >= 6 ? 6 : options.sourceType === "module" ? "5module" : 5]);
+        var reserved = "";
+        if (options.allowReserved !== true) {
+          for (var v = options.ecmaVersion; ; v--) {
+            if (reserved = reservedWords2[v]) {
+              break;
+            }
+          }
+          if (options.sourceType === "module") {
+            reserved += " await";
+          }
+        }
+        this.reservedWords = wordsRegexp2(reserved);
+        var reservedStrict = (reserved ? reserved + " " : "") + reservedWords2.strict;
+        this.reservedWordsStrict = wordsRegexp2(reservedStrict);
+        this.reservedWordsStrictBind = wordsRegexp2(reservedStrict + " " + reservedWords2.strictBind);
+        this.input = String(input);
+        this.containsEsc = false;
+        if (startPos) {
+          this.pos = startPos;
+          this.lineStart = this.input.lastIndexOf("\n", startPos - 1) + 1;
+          this.curLine = this.input.slice(0, this.lineStart).split(lineBreak2).length;
+        } else {
+          this.pos = this.lineStart = 0;
+          this.curLine = 1;
+        }
+        this.type = types2.eof;
+        this.value = null;
+        this.start = this.end = this.pos;
+        this.startLoc = this.endLoc = this.curPosition();
+        this.lastTokEndLoc = this.lastTokStartLoc = null;
+        this.lastTokStart = this.lastTokEnd = this.pos;
+        this.context = this.initialContext();
+        this.exprAllowed = true;
+        this.inModule = options.sourceType === "module";
+        this.strict = this.inModule || this.strictDirective(this.pos);
+        this.potentialArrowAt = -1;
+        this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+        this.labels = [];
+        this.undefinedExports = {};
+        if (this.pos === 0 && options.allowHashBang && this.input.slice(0, 2) === "#!") {
+          this.skipLineComment(2);
+        }
+        this.scopeStack = [];
+        this.enterScope(SCOPE_TOP2);
+        this.regexpState = null;
+      };
+      var prototypeAccessors2 = { inFunction: { configurable: true }, inGenerator: { configurable: true }, inAsync: { configurable: true }, allowSuper: { configurable: true }, allowDirectSuper: { configurable: true }, treatFunctionsAsVar: { configurable: true } };
+      Parser3.prototype.parse = function parse5() {
+        var node2 = this.options.program || this.startNode();
+        this.nextToken();
+        return this.parseTopLevel(node2);
+      };
+      prototypeAccessors2.inFunction.get = function() {
+        return (this.currentVarScope().flags & SCOPE_FUNCTION2) > 0;
+      };
+      prototypeAccessors2.inGenerator.get = function() {
+        return (this.currentVarScope().flags & SCOPE_GENERATOR2) > 0;
+      };
+      prototypeAccessors2.inAsync.get = function() {
+        return (this.currentVarScope().flags & SCOPE_ASYNC2) > 0;
+      };
+      prototypeAccessors2.allowSuper.get = function() {
+        return (this.currentThisScope().flags & SCOPE_SUPER2) > 0;
+      };
+      prototypeAccessors2.allowDirectSuper.get = function() {
+        return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER2) > 0;
+      };
+      prototypeAccessors2.treatFunctionsAsVar.get = function() {
+        return this.treatFunctionsAsVarInScope(this.currentScope());
+      };
+      Parser3.prototype.inNonArrowFunction = function inNonArrowFunction() {
+        return (this.currentThisScope().flags & SCOPE_FUNCTION2) > 0;
+      };
+      Parser3.extend = function extend3() {
+        var plugins = [], len = arguments.length;
+        while (len--) plugins[len] = arguments[len];
+        var cls = this;
+        for (var i = 0; i < plugins.length; i++) {
+          cls = plugins[i](cls);
+        }
+        return cls;
+      };
+      Parser3.parse = function parse5(input, options) {
+        return new this(options, input).parse();
+      };
+      Parser3.parseExpressionAt = function parseExpressionAt3(input, pos, options) {
+        var parser = new this(options, input, pos);
+        parser.nextToken();
+        return parser.parseExpression();
+      };
+      Parser3.tokenizer = function tokenizer3(input, options) {
+        return new this(options, input);
+      };
+      Object.defineProperties(Parser3.prototype, prototypeAccessors2);
+      var pp2 = Parser3.prototype;
+      var literal2 = /^(?:'((?:\\.|[^'\\])*?)'|"((?:\\.|[^"\\])*?)")/;
+      pp2.strictDirective = function(start2) {
+        for (; ; ) {
+          skipWhiteSpace2.lastIndex = start2;
+          start2 += skipWhiteSpace2.exec(this.input)[0].length;
+          var match = literal2.exec(this.input.slice(start2));
+          if (!match) {
+            return false;
+          }
+          if ((match[1] || match[2]) === "use strict") {
+            skipWhiteSpace2.lastIndex = start2 + match[0].length;
+            var spaceAfter = skipWhiteSpace2.exec(this.input), end = spaceAfter.index + spaceAfter[0].length;
+            var next = this.input.charAt(end);
+            return next === ";" || next === "}" || lineBreak2.test(spaceAfter[0]) && !(/[(`.[+\-/*%<>=,?^&]/.test(next) || next === "!" && this.input.charAt(end + 1) === "=");
+          }
+          start2 += match[0].length;
+          skipWhiteSpace2.lastIndex = start2;
+          start2 += skipWhiteSpace2.exec(this.input)[0].length;
+          if (this.input[start2] === ";") {
+            start2++;
+          }
+        }
+      };
+      pp2.eat = function(type) {
+        if (this.type === type) {
+          this.next();
+          return true;
+        } else {
+          return false;
+        }
+      };
+      pp2.isContextual = function(name2) {
+        return this.type === types2.name && this.value === name2 && !this.containsEsc;
+      };
+      pp2.eatContextual = function(name2) {
+        if (!this.isContextual(name2)) {
+          return false;
+        }
+        this.next();
+        return true;
+      };
+      pp2.expectContextual = function(name2) {
+        if (!this.eatContextual(name2)) {
+          this.unexpected();
+        }
+      };
+      pp2.canInsertSemicolon = function() {
+        return this.type === types2.eof || this.type === types2.braceR || lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+      };
+      pp2.insertSemicolon = function() {
+        if (this.canInsertSemicolon()) {
+          if (this.options.onInsertedSemicolon) {
+            this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+          }
+          return true;
+        }
+      };
+      pp2.semicolon = function() {
+        if (!this.eat(types2.semi) && !this.insertSemicolon()) {
+          this.unexpected();
+        }
+      };
+      pp2.afterTrailingComma = function(tokType, notNext) {
+        if (this.type === tokType) {
+          if (this.options.onTrailingComma) {
+            this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+          }
+          if (!notNext) {
+            this.next();
+          }
+          return true;
+        }
+      };
+      pp2.expect = function(type) {
+        this.eat(type) || this.unexpected();
+      };
+      pp2.unexpected = function(pos) {
+        this.raise(pos != null ? pos : this.start, "Unexpected token");
+      };
+      function DestructuringErrors3() {
+        this.shorthandAssign = this.trailingComma = this.parenthesizedAssign = this.parenthesizedBind = this.doubleProto = -1;
+      }
+      pp2.checkPatternErrors = function(refDestructuringErrors, isAssign) {
+        if (!refDestructuringErrors) {
+          return;
+        }
+        if (refDestructuringErrors.trailingComma > -1) {
+          this.raiseRecoverable(refDestructuringErrors.trailingComma, "Comma is not permitted after the rest element");
+        }
+        var parens = isAssign ? refDestructuringErrors.parenthesizedAssign : refDestructuringErrors.parenthesizedBind;
+        if (parens > -1) {
+          this.raiseRecoverable(parens, "Parenthesized pattern");
+        }
+      };
+      pp2.checkExpressionErrors = function(refDestructuringErrors, andThrow) {
+        if (!refDestructuringErrors) {
+          return false;
+        }
+        var shorthandAssign = refDestructuringErrors.shorthandAssign;
+        var doubleProto = refDestructuringErrors.doubleProto;
+        if (!andThrow) {
+          return shorthandAssign >= 0 || doubleProto >= 0;
+        }
+        if (shorthandAssign >= 0) {
+          this.raise(shorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+        }
+        if (doubleProto >= 0) {
+          this.raiseRecoverable(doubleProto, "Redefinition of __proto__ property");
+        }
+      };
+      pp2.checkYieldAwaitInDefaultParams = function() {
+        if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+          this.raise(this.yieldPos, "Yield expression cannot be a default value");
+        }
+        if (this.awaitPos) {
+          this.raise(this.awaitPos, "Await expression cannot be a default value");
+        }
+      };
+      pp2.isSimpleAssignTarget = function(expr) {
+        if (expr.type === "ParenthesizedExpression") {
+          return this.isSimpleAssignTarget(expr.expression);
+        }
+        return expr.type === "Identifier" || expr.type === "MemberExpression";
+      };
+      var pp$12 = Parser3.prototype;
+      pp$12.parseTopLevel = function(node2) {
+        var exports4 = {};
+        if (!node2.body) {
+          node2.body = [];
+        }
+        while (this.type !== types2.eof) {
+          var stmt = this.parseStatement(null, true, exports4);
+          node2.body.push(stmt);
+        }
+        if (this.inModule) {
+          for (var i = 0, list3 = Object.keys(this.undefinedExports); i < list3.length; i += 1) {
+            var name2 = list3[i];
+            this.raiseRecoverable(this.undefinedExports[name2].start, "Export '" + name2 + "' is not defined");
+          }
+        }
+        this.adaptDirectivePrologue(node2.body);
+        this.next();
+        node2.sourceType = this.options.sourceType;
+        return this.finishNode(node2, "Program");
+      };
+      var loopLabel2 = { kind: "loop" }, switchLabel2 = { kind: "switch" };
+      pp$12.isLet = function(context) {
+        if (this.options.ecmaVersion < 6 || !this.isContextual("let")) {
+          return false;
+        }
+        skipWhiteSpace2.lastIndex = this.pos;
+        var skip = skipWhiteSpace2.exec(this.input);
+        var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+        if (nextCh === 91) {
+          return true;
+        }
+        if (context) {
+          return false;
+        }
+        if (nextCh === 123) {
+          return true;
+        }
+        if (isIdentifierStart2(nextCh, true)) {
+          var pos = next + 1;
+          while (isIdentifierChar2(this.input.charCodeAt(pos), true)) {
+            ++pos;
+          }
+          var ident = this.input.slice(next, pos);
+          if (!keywordRelationalOperator2.test(ident)) {
+            return true;
+          }
+        }
+        return false;
+      };
+      pp$12.isAsyncFunction = function() {
+        if (this.options.ecmaVersion < 8 || !this.isContextual("async")) {
+          return false;
+        }
+        skipWhiteSpace2.lastIndex = this.pos;
+        var skip = skipWhiteSpace2.exec(this.input);
+        var next = this.pos + skip[0].length;
+        return !lineBreak2.test(this.input.slice(this.pos, next)) && this.input.slice(next, next + 8) === "function" && (next + 8 === this.input.length || !isIdentifierChar2(this.input.charAt(next + 8)));
+      };
+      pp$12.parseStatement = function(context, topLevel, exports4) {
+        var starttype = this.type, node2 = this.startNode(), kind;
+        if (this.isLet(context)) {
+          starttype = types2._var;
+          kind = "let";
+        }
+        switch (starttype) {
+          case types2._break:
+          case types2._continue:
+            return this.parseBreakContinueStatement(node2, starttype.keyword);
+          case types2._debugger:
+            return this.parseDebuggerStatement(node2);
+          case types2._do:
+            return this.parseDoStatement(node2);
+          case types2._for:
+            return this.parseForStatement(node2);
+          case types2._function:
+            if (context && (this.strict || context !== "if" && context !== "label") && this.options.ecmaVersion >= 6) {
+              this.unexpected();
+            }
+            return this.parseFunctionStatement(node2, false, !context);
+          case types2._class:
+            if (context) {
+              this.unexpected();
+            }
+            return this.parseClass(node2, true);
+          case types2._if:
+            return this.parseIfStatement(node2);
+          case types2._return:
+            return this.parseReturnStatement(node2);
+          case types2._switch:
+            return this.parseSwitchStatement(node2);
+          case types2._throw:
+            return this.parseThrowStatement(node2);
+          case types2._try:
+            return this.parseTryStatement(node2);
+          case types2._const:
+          case types2._var:
+            kind = kind || this.value;
+            if (context && kind !== "var") {
+              this.unexpected();
+            }
+            return this.parseVarStatement(node2, kind);
+          case types2._while:
+            return this.parseWhileStatement(node2);
+          case types2._with:
+            return this.parseWithStatement(node2);
+          case types2.braceL:
+            return this.parseBlock(true, node2);
+          case types2.semi:
+            return this.parseEmptyStatement(node2);
+          case types2._export:
+          case types2._import:
+            if (this.options.ecmaVersion > 10 && starttype === types2._import) {
+              skipWhiteSpace2.lastIndex = this.pos;
+              var skip = skipWhiteSpace2.exec(this.input);
+              var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+              if (nextCh === 40 || nextCh === 46) {
+                return this.parseExpressionStatement(node2, this.parseExpression());
+              }
+            }
+            if (!this.options.allowImportExportEverywhere) {
+              if (!topLevel) {
+                this.raise(this.start, "'import' and 'export' may only appear at the top level");
+              }
+              if (!this.inModule) {
+                this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+              }
+            }
+            return starttype === types2._import ? this.parseImport(node2) : this.parseExport(node2, exports4);
+          default:
+            if (this.isAsyncFunction()) {
+              if (context) {
+                this.unexpected();
+              }
+              this.next();
+              return this.parseFunctionStatement(node2, true, !context);
+            }
+            var maybeName = this.value, expr = this.parseExpression();
+            if (starttype === types2.name && expr.type === "Identifier" && this.eat(types2.colon)) {
+              return this.parseLabeledStatement(node2, maybeName, expr, context);
+            } else {
+              return this.parseExpressionStatement(node2, expr);
+            }
+        }
+      };
+      pp$12.parseBreakContinueStatement = function(node2, keyword) {
+        var isBreak = keyword === "break";
+        this.next();
+        if (this.eat(types2.semi) || this.insertSemicolon()) {
+          node2.label = null;
+        } else if (this.type !== types2.name) {
+          this.unexpected();
+        } else {
+          node2.label = this.parseIdent();
+          this.semicolon();
+        }
+        var i = 0;
+        for (; i < this.labels.length; ++i) {
+          var lab = this.labels[i];
+          if (node2.label == null || lab.name === node2.label.name) {
+            if (lab.kind != null && (isBreak || lab.kind === "loop")) {
+              break;
+            }
+            if (node2.label && isBreak) {
+              break;
+            }
+          }
+        }
+        if (i === this.labels.length) {
+          this.raise(node2.start, "Unsyntactic " + keyword);
+        }
+        return this.finishNode(node2, isBreak ? "BreakStatement" : "ContinueStatement");
+      };
+      pp$12.parseDebuggerStatement = function(node2) {
+        this.next();
+        this.semicolon();
+        return this.finishNode(node2, "DebuggerStatement");
+      };
+      pp$12.parseDoStatement = function(node2) {
+        this.next();
+        this.labels.push(loopLabel2);
+        node2.body = this.parseStatement("do");
+        this.labels.pop();
+        this.expect(types2._while);
+        node2.test = this.parseParenExpression();
+        if (this.options.ecmaVersion >= 6) {
+          this.eat(types2.semi);
+        } else {
+          this.semicolon();
+        }
+        return this.finishNode(node2, "DoWhileStatement");
+      };
+      pp$12.parseForStatement = function(node2) {
+        this.next();
+        var awaitAt = this.options.ecmaVersion >= 9 && (this.inAsync || !this.inFunction && this.options.allowAwaitOutsideFunction) && this.eatContextual("await") ? this.lastTokStart : -1;
+        this.labels.push(loopLabel2);
+        this.enterScope(0);
+        this.expect(types2.parenL);
+        if (this.type === types2.semi) {
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+          return this.parseFor(node2, null);
+        }
+        var isLet = this.isLet();
+        if (this.type === types2._var || this.type === types2._const || isLet) {
+          var init$1 = this.startNode(), kind = isLet ? "let" : this.value;
+          this.next();
+          this.parseVar(init$1, true, kind);
+          this.finishNode(init$1, "VariableDeclaration");
+          if ((this.type === types2._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && init$1.declarations.length === 1) {
+            if (this.options.ecmaVersion >= 9) {
+              if (this.type === types2._in) {
+                if (awaitAt > -1) {
+                  this.unexpected(awaitAt);
+                }
+              } else {
+                node2.await = awaitAt > -1;
+              }
+            }
+            return this.parseForIn(node2, init$1);
+          }
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+          return this.parseFor(node2, init$1);
+        }
+        var refDestructuringErrors = new DestructuringErrors3();
+        var init = this.parseExpression(true, refDestructuringErrors);
+        if (this.type === types2._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) {
+          if (this.options.ecmaVersion >= 9) {
+            if (this.type === types2._in) {
+              if (awaitAt > -1) {
+                this.unexpected(awaitAt);
+              }
+            } else {
+              node2.await = awaitAt > -1;
+            }
+          }
+          this.toAssignable(init, false, refDestructuringErrors);
+          this.checkLVal(init);
+          return this.parseForIn(node2, init);
+        } else {
+          this.checkExpressionErrors(refDestructuringErrors, true);
+        }
+        if (awaitAt > -1) {
+          this.unexpected(awaitAt);
+        }
+        return this.parseFor(node2, init);
+      };
+      pp$12.parseFunctionStatement = function(node2, isAsync, declarationPosition) {
+        this.next();
+        return this.parseFunction(node2, FUNC_STATEMENT2 | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT2), false, isAsync);
+      };
+      pp$12.parseIfStatement = function(node2) {
+        this.next();
+        node2.test = this.parseParenExpression();
+        node2.consequent = this.parseStatement("if");
+        node2.alternate = this.eat(types2._else) ? this.parseStatement("if") : null;
+        return this.finishNode(node2, "IfStatement");
+      };
+      pp$12.parseReturnStatement = function(node2) {
+        if (!this.inFunction && !this.options.allowReturnOutsideFunction) {
+          this.raise(this.start, "'return' outside of function");
+        }
+        this.next();
+        if (this.eat(types2.semi) || this.insertSemicolon()) {
+          node2.argument = null;
+        } else {
+          node2.argument = this.parseExpression();
+          this.semicolon();
+        }
+        return this.finishNode(node2, "ReturnStatement");
+      };
+      pp$12.parseSwitchStatement = function(node2) {
+        this.next();
+        node2.discriminant = this.parseParenExpression();
+        node2.cases = [];
+        this.expect(types2.braceL);
+        this.labels.push(switchLabel2);
+        this.enterScope(0);
+        var cur;
+        for (var sawDefault = false; this.type !== types2.braceR; ) {
+          if (this.type === types2._case || this.type === types2._default) {
+            var isCase = this.type === types2._case;
+            if (cur) {
+              this.finishNode(cur, "SwitchCase");
+            }
+            node2.cases.push(cur = this.startNode());
+            cur.consequent = [];
+            this.next();
+            if (isCase) {
+              cur.test = this.parseExpression();
+            } else {
+              if (sawDefault) {
+                this.raiseRecoverable(this.lastTokStart, "Multiple default clauses");
+              }
+              sawDefault = true;
+              cur.test = null;
+            }
+            this.expect(types2.colon);
+          } else {
+            if (!cur) {
+              this.unexpected();
+            }
+            cur.consequent.push(this.parseStatement(null));
+          }
+        }
+        this.exitScope();
+        if (cur) {
+          this.finishNode(cur, "SwitchCase");
+        }
+        this.next();
+        this.labels.pop();
+        return this.finishNode(node2, "SwitchStatement");
+      };
+      pp$12.parseThrowStatement = function(node2) {
+        this.next();
+        if (lineBreak2.test(this.input.slice(this.lastTokEnd, this.start))) {
+          this.raise(this.lastTokEnd, "Illegal newline after throw");
+        }
+        node2.argument = this.parseExpression();
+        this.semicolon();
+        return this.finishNode(node2, "ThrowStatement");
+      };
+      var empty6 = [];
+      pp$12.parseTryStatement = function(node2) {
+        this.next();
+        node2.block = this.parseBlock();
+        node2.handler = null;
+        if (this.type === types2._catch) {
+          var clause = this.startNode();
+          this.next();
+          if (this.eat(types2.parenL)) {
+            clause.param = this.parseBindingAtom();
+            var simple = clause.param.type === "Identifier";
+            this.enterScope(simple ? SCOPE_SIMPLE_CATCH2 : 0);
+            this.checkLVal(clause.param, simple ? BIND_SIMPLE_CATCH2 : BIND_LEXICAL2);
+            this.expect(types2.parenR);
+          } else {
+            if (this.options.ecmaVersion < 10) {
+              this.unexpected();
+            }
+            clause.param = null;
+            this.enterScope(0);
+          }
+          clause.body = this.parseBlock(false);
+          this.exitScope();
+          node2.handler = this.finishNode(clause, "CatchClause");
+        }
+        node2.finalizer = this.eat(types2._finally) ? this.parseBlock() : null;
+        if (!node2.handler && !node2.finalizer) {
+          this.raise(node2.start, "Missing catch or finally clause");
+        }
+        return this.finishNode(node2, "TryStatement");
+      };
+      pp$12.parseVarStatement = function(node2, kind) {
+        this.next();
+        this.parseVar(node2, false, kind);
+        this.semicolon();
+        return this.finishNode(node2, "VariableDeclaration");
+      };
+      pp$12.parseWhileStatement = function(node2) {
+        this.next();
+        node2.test = this.parseParenExpression();
+        this.labels.push(loopLabel2);
+        node2.body = this.parseStatement("while");
+        this.labels.pop();
+        return this.finishNode(node2, "WhileStatement");
+      };
+      pp$12.parseWithStatement = function(node2) {
+        if (this.strict) {
+          this.raise(this.start, "'with' in strict mode");
+        }
+        this.next();
+        node2.object = this.parseParenExpression();
+        node2.body = this.parseStatement("with");
+        return this.finishNode(node2, "WithStatement");
+      };
+      pp$12.parseEmptyStatement = function(node2) {
+        this.next();
+        return this.finishNode(node2, "EmptyStatement");
+      };
+      pp$12.parseLabeledStatement = function(node2, maybeName, expr, context) {
+        for (var i$1 = 0, list3 = this.labels; i$1 < list3.length; i$1 += 1) {
+          var label = list3[i$1];
+          if (label.name === maybeName) {
+            this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+          }
+        }
+        var kind = this.type.isLoop ? "loop" : this.type === types2._switch ? "switch" : null;
+        for (var i = this.labels.length - 1; i >= 0; i--) {
+          var label$1 = this.labels[i];
+          if (label$1.statementStart === node2.start) {
+            label$1.statementStart = this.start;
+            label$1.kind = kind;
+          } else {
+            break;
+          }
+        }
+        this.labels.push({ name: maybeName, kind, statementStart: this.start });
+        node2.body = this.parseStatement(context ? context.indexOf("label") === -1 ? context + "label" : context : "label");
+        this.labels.pop();
+        node2.label = expr;
+        return this.finishNode(node2, "LabeledStatement");
+      };
+      pp$12.parseExpressionStatement = function(node2, expr) {
+        node2.expression = expr;
+        this.semicolon();
+        return this.finishNode(node2, "ExpressionStatement");
+      };
+      pp$12.parseBlock = function(createNewLexicalScope, node2, exitStrict) {
+        if (createNewLexicalScope === void 0) createNewLexicalScope = true;
+        if (node2 === void 0) node2 = this.startNode();
+        node2.body = [];
+        this.expect(types2.braceL);
+        if (createNewLexicalScope) {
+          this.enterScope(0);
+        }
+        while (this.type !== types2.braceR) {
+          var stmt = this.parseStatement(null);
+          node2.body.push(stmt);
+        }
+        if (exitStrict) {
+          this.strict = false;
+        }
+        this.next();
+        if (createNewLexicalScope) {
+          this.exitScope();
+        }
+        return this.finishNode(node2, "BlockStatement");
+      };
+      pp$12.parseFor = function(node2, init) {
+        node2.init = init;
+        this.expect(types2.semi);
+        node2.test = this.type === types2.semi ? null : this.parseExpression();
+        this.expect(types2.semi);
+        node2.update = this.type === types2.parenR ? null : this.parseExpression();
+        this.expect(types2.parenR);
+        node2.body = this.parseStatement("for");
+        this.exitScope();
+        this.labels.pop();
+        return this.finishNode(node2, "ForStatement");
+      };
+      pp$12.parseForIn = function(node2, init) {
+        var isForIn = this.type === types2._in;
+        this.next();
+        if (init.type === "VariableDeclaration" && init.declarations[0].init != null && (!isForIn || this.options.ecmaVersion < 8 || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")) {
+          this.raise(
+            init.start,
+            (isForIn ? "for-in" : "for-of") + " loop variable declaration may not have an initializer"
+          );
+        } else if (init.type === "AssignmentPattern") {
+          this.raise(init.start, "Invalid left-hand side in for-loop");
+        }
+        node2.left = init;
+        node2.right = isForIn ? this.parseExpression() : this.parseMaybeAssign();
+        this.expect(types2.parenR);
+        node2.body = this.parseStatement("for");
+        this.exitScope();
+        this.labels.pop();
+        return this.finishNode(node2, isForIn ? "ForInStatement" : "ForOfStatement");
+      };
+      pp$12.parseVar = function(node2, isFor, kind) {
+        node2.declarations = [];
+        node2.kind = kind;
+        for (; ; ) {
+          var decl = this.startNode();
+          this.parseVarId(decl, kind);
+          if (this.eat(types2.eq)) {
+            decl.init = this.parseMaybeAssign(isFor);
+          } else if (kind === "const" && !(this.type === types2._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+            this.unexpected();
+          } else if (decl.id.type !== "Identifier" && !(isFor && (this.type === types2._in || this.isContextual("of")))) {
+            this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+          } else {
+            decl.init = null;
+          }
+          node2.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+          if (!this.eat(types2.comma)) {
+            break;
+          }
+        }
+        return node2;
+      };
+      pp$12.parseVarId = function(decl, kind) {
+        decl.id = this.parseBindingAtom();
+        this.checkLVal(decl.id, kind === "var" ? BIND_VAR2 : BIND_LEXICAL2, false);
+      };
+      var FUNC_STATEMENT2 = 1, FUNC_HANGING_STATEMENT2 = 2, FUNC_NULLABLE_ID2 = 4;
+      pp$12.parseFunction = function(node2, statement, allowExpressionBody, isAsync) {
+        this.initFunction(node2);
+        if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
+          if (this.type === types2.star && statement & FUNC_HANGING_STATEMENT2) {
+            this.unexpected();
+          }
+          node2.generator = this.eat(types2.star);
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node2.async = !!isAsync;
+        }
+        if (statement & FUNC_STATEMENT2) {
+          node2.id = statement & FUNC_NULLABLE_ID2 && this.type !== types2.name ? null : this.parseIdent();
+          if (node2.id && !(statement & FUNC_HANGING_STATEMENT2)) {
+            this.checkLVal(node2.id, this.strict || node2.generator || node2.async ? this.treatFunctionsAsVar ? BIND_VAR2 : BIND_LEXICAL2 : BIND_FUNCTION2);
+          }
+        }
+        var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        this.enterScope(functionFlags2(node2.async, node2.generator));
+        if (!(statement & FUNC_STATEMENT2)) {
+          node2.id = this.type === types2.name ? this.parseIdent() : null;
+        }
+        this.parseFunctionParams(node2);
+        this.parseFunctionBody(node2, allowExpressionBody, false);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node2, statement & FUNC_STATEMENT2 ? "FunctionDeclaration" : "FunctionExpression");
+      };
+      pp$12.parseFunctionParams = function(node2) {
+        this.expect(types2.parenL);
+        node2.params = this.parseBindingList(types2.parenR, false, this.options.ecmaVersion >= 8);
+        this.checkYieldAwaitInDefaultParams();
+      };
+      pp$12.parseClass = function(node2, isStatement) {
+        this.next();
+        var oldStrict = this.strict;
+        this.strict = true;
+        this.parseClassId(node2, isStatement);
+        this.parseClassSuper(node2);
+        var classBody = this.startNode();
+        var hadConstructor = false;
+        classBody.body = [];
+        this.expect(types2.braceL);
+        while (this.type !== types2.braceR) {
+          var element2 = this.parseClassElement(node2.superClass !== null);
+          if (element2) {
+            classBody.body.push(element2);
+            if (element2.type === "MethodDefinition" && element2.kind === "constructor") {
+              if (hadConstructor) {
+                this.raise(element2.start, "Duplicate constructor in the same class");
+              }
+              hadConstructor = true;
+            }
+          }
+        }
+        this.strict = oldStrict;
+        this.next();
+        node2.body = this.finishNode(classBody, "ClassBody");
+        return this.finishNode(node2, isStatement ? "ClassDeclaration" : "ClassExpression");
+      };
+      pp$12.parseClassElement = function(constructorAllowsSuper) {
+        var this$1 = this;
+        if (this.eat(types2.semi)) {
+          return null;
+        }
+        var method = this.startNode();
+        var tryContextual = function(k, noLineBreak) {
+          if (noLineBreak === void 0) noLineBreak = false;
+          var start2 = this$1.start, startLoc = this$1.startLoc;
+          if (!this$1.eatContextual(k)) {
+            return false;
+          }
+          if (this$1.type !== types2.parenL && (!noLineBreak || !this$1.canInsertSemicolon())) {
+            return true;
+          }
+          if (method.key) {
+            this$1.unexpected();
+          }
+          method.computed = false;
+          method.key = this$1.startNodeAt(start2, startLoc);
+          method.key.name = k;
+          this$1.finishNode(method.key, "Identifier");
+          return false;
+        };
+        method.kind = "method";
+        method.static = tryContextual("static");
+        var isGenerator = this.eat(types2.star);
+        var isAsync = false;
+        if (!isGenerator) {
+          if (this.options.ecmaVersion >= 8 && tryContextual("async", true)) {
+            isAsync = true;
+            isGenerator = this.options.ecmaVersion >= 9 && this.eat(types2.star);
+          } else if (tryContextual("get")) {
+            method.kind = "get";
+          } else if (tryContextual("set")) {
+            method.kind = "set";
+          }
+        }
+        if (!method.key) {
+          this.parsePropertyName(method);
+        }
+        var key = method.key;
+        var allowsDirectSuper = false;
+        if (!method.computed && !method.static && (key.type === "Identifier" && key.name === "constructor" || key.type === "Literal" && key.value === "constructor")) {
+          if (method.kind !== "method") {
+            this.raise(key.start, "Constructor can't have get/set modifier");
+          }
+          if (isGenerator) {
+            this.raise(key.start, "Constructor can't be a generator");
+          }
+          if (isAsync) {
+            this.raise(key.start, "Constructor can't be an async method");
+          }
+          method.kind = "constructor";
+          allowsDirectSuper = constructorAllowsSuper;
+        } else if (method.static && key.type === "Identifier" && key.name === "prototype") {
+          this.raise(key.start, "Classes may not have a static property named prototype");
+        }
+        this.parseClassMethod(method, isGenerator, isAsync, allowsDirectSuper);
+        if (method.kind === "get" && method.value.params.length !== 0) {
+          this.raiseRecoverable(method.value.start, "getter should have no params");
+        }
+        if (method.kind === "set" && method.value.params.length !== 1) {
+          this.raiseRecoverable(method.value.start, "setter should have exactly one param");
+        }
+        if (method.kind === "set" && method.value.params[0].type === "RestElement") {
+          this.raiseRecoverable(method.value.params[0].start, "Setter cannot use rest params");
+        }
+        return method;
+      };
+      pp$12.parseClassMethod = function(method, isGenerator, isAsync, allowsDirectSuper) {
+        method.value = this.parseMethod(isGenerator, isAsync, allowsDirectSuper);
+        return this.finishNode(method, "MethodDefinition");
+      };
+      pp$12.parseClassId = function(node2, isStatement) {
+        if (this.type === types2.name) {
+          node2.id = this.parseIdent();
+          if (isStatement) {
+            this.checkLVal(node2.id, BIND_LEXICAL2, false);
+          }
+        } else {
+          if (isStatement === true) {
+            this.unexpected();
+          }
+          node2.id = null;
+        }
+      };
+      pp$12.parseClassSuper = function(node2) {
+        node2.superClass = this.eat(types2._extends) ? this.parseExprSubscripts() : null;
+      };
+      pp$12.parseExport = function(node2, exports4) {
+        this.next();
+        if (this.eat(types2.star)) {
+          if (this.options.ecmaVersion >= 11) {
+            if (this.eatContextual("as")) {
+              node2.exported = this.parseIdent(true);
+              this.checkExport(exports4, node2.exported.name, this.lastTokStart);
+            } else {
+              node2.exported = null;
+            }
+          }
+          this.expectContextual("from");
+          if (this.type !== types2.string) {
+            this.unexpected();
+          }
+          node2.source = this.parseExprAtom();
+          this.semicolon();
+          return this.finishNode(node2, "ExportAllDeclaration");
+        }
+        if (this.eat(types2._default)) {
+          this.checkExport(exports4, "default", this.lastTokStart);
+          var isAsync;
+          if (this.type === types2._function || (isAsync = this.isAsyncFunction())) {
+            var fNode = this.startNode();
+            this.next();
+            if (isAsync) {
+              this.next();
+            }
+            node2.declaration = this.parseFunction(fNode, FUNC_STATEMENT2 | FUNC_NULLABLE_ID2, false, isAsync);
+          } else if (this.type === types2._class) {
+            var cNode = this.startNode();
+            node2.declaration = this.parseClass(cNode, "nullableID");
+          } else {
+            node2.declaration = this.parseMaybeAssign();
+            this.semicolon();
+          }
+          return this.finishNode(node2, "ExportDefaultDeclaration");
+        }
+        if (this.shouldParseExportStatement()) {
+          node2.declaration = this.parseStatement(null);
+          if (node2.declaration.type === "VariableDeclaration") {
+            this.checkVariableExport(exports4, node2.declaration.declarations);
+          } else {
+            this.checkExport(exports4, node2.declaration.id.name, node2.declaration.id.start);
+          }
+          node2.specifiers = [];
+          node2.source = null;
+        } else {
+          node2.declaration = null;
+          node2.specifiers = this.parseExportSpecifiers(exports4);
+          if (this.eatContextual("from")) {
+            if (this.type !== types2.string) {
+              this.unexpected();
+            }
+            node2.source = this.parseExprAtom();
+          } else {
+            for (var i = 0, list3 = node2.specifiers; i < list3.length; i += 1) {
+              var spec = list3[i];
+              this.checkUnreserved(spec.local);
+              this.checkLocalExport(spec.local);
+            }
+            node2.source = null;
+          }
+          this.semicolon();
+        }
+        return this.finishNode(node2, "ExportNamedDeclaration");
+      };
+      pp$12.checkExport = function(exports4, name2, pos) {
+        if (!exports4) {
+          return;
+        }
+        if (has(exports4, name2)) {
+          this.raiseRecoverable(pos, "Duplicate export '" + name2 + "'");
+        }
+        exports4[name2] = true;
+      };
+      pp$12.checkPatternExport = function(exports4, pat) {
+        var type = pat.type;
+        if (type === "Identifier") {
+          this.checkExport(exports4, pat.name, pat.start);
+        } else if (type === "ObjectPattern") {
+          for (var i = 0, list3 = pat.properties; i < list3.length; i += 1) {
+            var prop = list3[i];
+            this.checkPatternExport(exports4, prop);
+          }
+        } else if (type === "ArrayPattern") {
+          for (var i$1 = 0, list$1 = pat.elements; i$1 < list$1.length; i$1 += 1) {
+            var elt = list$1[i$1];
+            if (elt) {
+              this.checkPatternExport(exports4, elt);
+            }
+          }
+        } else if (type === "Property") {
+          this.checkPatternExport(exports4, pat.value);
+        } else if (type === "AssignmentPattern") {
+          this.checkPatternExport(exports4, pat.left);
+        } else if (type === "RestElement") {
+          this.checkPatternExport(exports4, pat.argument);
+        } else if (type === "ParenthesizedExpression") {
+          this.checkPatternExport(exports4, pat.expression);
+        }
+      };
+      pp$12.checkVariableExport = function(exports4, decls) {
+        if (!exports4) {
+          return;
+        }
+        for (var i = 0, list3 = decls; i < list3.length; i += 1) {
+          var decl = list3[i];
+          this.checkPatternExport(exports4, decl.id);
+        }
+      };
+      pp$12.shouldParseExportStatement = function() {
+        return this.type.keyword === "var" || this.type.keyword === "const" || this.type.keyword === "class" || this.type.keyword === "function" || this.isLet() || this.isAsyncFunction();
+      };
+      pp$12.parseExportSpecifiers = function(exports4) {
+        var nodes = [], first = true;
+        this.expect(types2.braceL);
+        while (!this.eat(types2.braceR)) {
+          if (!first) {
+            this.expect(types2.comma);
+            if (this.afterTrailingComma(types2.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var node2 = this.startNode();
+          node2.local = this.parseIdent(true);
+          node2.exported = this.eatContextual("as") ? this.parseIdent(true) : node2.local;
+          this.checkExport(exports4, node2.exported.name, node2.exported.start);
+          nodes.push(this.finishNode(node2, "ExportSpecifier"));
+        }
+        return nodes;
+      };
+      pp$12.parseImport = function(node2) {
+        this.next();
+        if (this.type === types2.string) {
+          node2.specifiers = empty6;
+          node2.source = this.parseExprAtom();
+        } else {
+          node2.specifiers = this.parseImportSpecifiers();
+          this.expectContextual("from");
+          node2.source = this.type === types2.string ? this.parseExprAtom() : this.unexpected();
+        }
+        this.semicolon();
+        return this.finishNode(node2, "ImportDeclaration");
+      };
+      pp$12.parseImportSpecifiers = function() {
+        var nodes = [], first = true;
+        if (this.type === types2.name) {
+          var node2 = this.startNode();
+          node2.local = this.parseIdent();
+          this.checkLVal(node2.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node2, "ImportDefaultSpecifier"));
+          if (!this.eat(types2.comma)) {
+            return nodes;
+          }
+        }
+        if (this.type === types2.star) {
+          var node$1 = this.startNode();
+          this.next();
+          this.expectContextual("as");
+          node$1.local = this.parseIdent();
+          this.checkLVal(node$1.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node$1, "ImportNamespaceSpecifier"));
+          return nodes;
+        }
+        this.expect(types2.braceL);
+        while (!this.eat(types2.braceR)) {
+          if (!first) {
+            this.expect(types2.comma);
+            if (this.afterTrailingComma(types2.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var node$2 = this.startNode();
+          node$2.imported = this.parseIdent(true);
+          if (this.eatContextual("as")) {
+            node$2.local = this.parseIdent();
+          } else {
+            this.checkUnreserved(node$2.imported);
+            node$2.local = node$2.imported;
+          }
+          this.checkLVal(node$2.local, BIND_LEXICAL2);
+          nodes.push(this.finishNode(node$2, "ImportSpecifier"));
+        }
+        return nodes;
+      };
+      pp$12.adaptDirectivePrologue = function(statements) {
+        for (var i = 0; i < statements.length && this.isDirectiveCandidate(statements[i]); ++i) {
+          statements[i].directive = statements[i].expression.raw.slice(1, -1);
+        }
+      };
+      pp$12.isDirectiveCandidate = function(statement) {
+        return statement.type === "ExpressionStatement" && statement.expression.type === "Literal" && typeof statement.expression.value === "string" && // Reject parenthesized strings.
+        (this.input[statement.start] === '"' || this.input[statement.start] === "'");
+      };
+      var pp$22 = Parser3.prototype;
+      pp$22.toAssignable = function(node2, isBinding, refDestructuringErrors) {
+        if (this.options.ecmaVersion >= 6 && node2) {
+          switch (node2.type) {
+            case "Identifier":
+              if (this.inAsync && node2.name === "await") {
+                this.raise(node2.start, "Cannot use 'await' as identifier inside an async function");
+              }
+              break;
+            case "ObjectPattern":
+            case "ArrayPattern":
+            case "RestElement":
+              break;
+            case "ObjectExpression":
+              node2.type = "ObjectPattern";
+              if (refDestructuringErrors) {
+                this.checkPatternErrors(refDestructuringErrors, true);
+              }
+              for (var i = 0, list3 = node2.properties; i < list3.length; i += 1) {
+                var prop = list3[i];
+                this.toAssignable(prop, isBinding);
+                if (prop.type === "RestElement" && (prop.argument.type === "ArrayPattern" || prop.argument.type === "ObjectPattern")) {
+                  this.raise(prop.argument.start, "Unexpected token");
+                }
+              }
+              break;
+            case "Property":
+              if (node2.kind !== "init") {
+                this.raise(node2.key.start, "Object pattern can't contain getter or setter");
+              }
+              this.toAssignable(node2.value, isBinding);
+              break;
+            case "ArrayExpression":
+              node2.type = "ArrayPattern";
+              if (refDestructuringErrors) {
+                this.checkPatternErrors(refDestructuringErrors, true);
+              }
+              this.toAssignableList(node2.elements, isBinding);
+              break;
+            case "SpreadElement":
+              node2.type = "RestElement";
+              this.toAssignable(node2.argument, isBinding);
+              if (node2.argument.type === "AssignmentPattern") {
+                this.raise(node2.argument.start, "Rest elements cannot have a default value");
+              }
+              break;
+            case "AssignmentExpression":
+              if (node2.operator !== "=") {
+                this.raise(node2.left.end, "Only '=' operator can be used for specifying default value.");
+              }
+              node2.type = "AssignmentPattern";
+              delete node2.operator;
+              this.toAssignable(node2.left, isBinding);
+            case "AssignmentPattern":
+              break;
+            case "ParenthesizedExpression":
+              this.toAssignable(node2.expression, isBinding, refDestructuringErrors);
+              break;
+            case "ChainExpression":
+              this.raiseRecoverable(node2.start, "Optional chaining cannot appear in left-hand side");
+              break;
+            case "MemberExpression":
+              if (!isBinding) {
+                break;
+              }
+            default:
+              this.raise(node2.start, "Assigning to rvalue");
+          }
+        } else if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        return node2;
+      };
+      pp$22.toAssignableList = function(exprList, isBinding) {
+        var end = exprList.length;
+        for (var i = 0; i < end; i++) {
+          var elt = exprList[i];
+          if (elt) {
+            this.toAssignable(elt, isBinding);
+          }
+        }
+        if (end) {
+          var last = exprList[end - 1];
+          if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier") {
+            this.unexpected(last.argument.start);
+          }
+        }
+        return exprList;
+      };
+      pp$22.parseSpread = function(refDestructuringErrors) {
+        var node2 = this.startNode();
+        this.next();
+        node2.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+        return this.finishNode(node2, "SpreadElement");
+      };
+      pp$22.parseRestBinding = function() {
+        var node2 = this.startNode();
+        this.next();
+        if (this.options.ecmaVersion === 6 && this.type !== types2.name) {
+          this.unexpected();
+        }
+        node2.argument = this.parseBindingAtom();
+        return this.finishNode(node2, "RestElement");
+      };
+      pp$22.parseBindingAtom = function() {
+        if (this.options.ecmaVersion >= 6) {
+          switch (this.type) {
+            case types2.bracketL:
+              var node2 = this.startNode();
+              this.next();
+              node2.elements = this.parseBindingList(types2.bracketR, true, true);
+              return this.finishNode(node2, "ArrayPattern");
+            case types2.braceL:
+              return this.parseObj(true);
+          }
+        }
+        return this.parseIdent();
+      };
+      pp$22.parseBindingList = function(close, allowEmpty, allowTrailingComma) {
+        var elts = [], first = true;
+        while (!this.eat(close)) {
+          if (first) {
+            first = false;
+          } else {
+            this.expect(types2.comma);
+          }
+          if (allowEmpty && this.type === types2.comma) {
+            elts.push(null);
+          } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+            break;
+          } else if (this.type === types2.ellipsis) {
+            var rest = this.parseRestBinding();
+            this.parseBindingListItem(rest);
+            elts.push(rest);
+            if (this.type === types2.comma) {
+              this.raise(this.start, "Comma is not permitted after the rest element");
+            }
+            this.expect(close);
+            break;
+          } else {
+            var elem = this.parseMaybeDefault(this.start, this.startLoc);
+            this.parseBindingListItem(elem);
+            elts.push(elem);
+          }
+        }
+        return elts;
+      };
+      pp$22.parseBindingListItem = function(param) {
+        return param;
+      };
+      pp$22.parseMaybeDefault = function(startPos, startLoc, left) {
+        left = left || this.parseBindingAtom();
+        if (this.options.ecmaVersion < 6 || !this.eat(types2.eq)) {
+          return left;
+        }
+        var node2 = this.startNodeAt(startPos, startLoc);
+        node2.left = left;
+        node2.right = this.parseMaybeAssign();
+        return this.finishNode(node2, "AssignmentPattern");
+      };
+      pp$22.checkLVal = function(expr, bindingType, checkClashes) {
+        if (bindingType === void 0) bindingType = BIND_NONE2;
+        switch (expr.type) {
+          case "Identifier":
+            if (bindingType === BIND_LEXICAL2 && expr.name === "let") {
+              this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name");
+            }
+            if (this.strict && this.reservedWordsStrictBind.test(expr.name)) {
+              this.raiseRecoverable(expr.start, (bindingType ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+            }
+            if (checkClashes) {
+              if (has(checkClashes, expr.name)) {
+                this.raiseRecoverable(expr.start, "Argument name clash");
+              }
+              checkClashes[expr.name] = true;
+            }
+            if (bindingType !== BIND_NONE2 && bindingType !== BIND_OUTSIDE2) {
+              this.declareName(expr.name, bindingType, expr.start);
+            }
+            break;
+          case "ChainExpression":
+            this.raiseRecoverable(expr.start, "Optional chaining cannot appear in left-hand side");
+            break;
+          case "MemberExpression":
+            if (bindingType) {
+              this.raiseRecoverable(expr.start, "Binding member expression");
+            }
+            break;
+          case "ObjectPattern":
+            for (var i = 0, list3 = expr.properties; i < list3.length; i += 1) {
+              var prop = list3[i];
+              this.checkLVal(prop, bindingType, checkClashes);
+            }
+            break;
+          case "Property":
+            this.checkLVal(expr.value, bindingType, checkClashes);
+            break;
+          case "ArrayPattern":
+            for (var i$1 = 0, list$1 = expr.elements; i$1 < list$1.length; i$1 += 1) {
+              var elem = list$1[i$1];
+              if (elem) {
+                this.checkLVal(elem, bindingType, checkClashes);
+              }
+            }
+            break;
+          case "AssignmentPattern":
+            this.checkLVal(expr.left, bindingType, checkClashes);
+            break;
+          case "RestElement":
+            this.checkLVal(expr.argument, bindingType, checkClashes);
+            break;
+          case "ParenthesizedExpression":
+            this.checkLVal(expr.expression, bindingType, checkClashes);
+            break;
+          default:
+            this.raise(expr.start, (bindingType ? "Binding" : "Assigning to") + " rvalue");
+        }
+      };
+      var pp$32 = Parser3.prototype;
+      pp$32.checkPropClash = function(prop, propHash, refDestructuringErrors) {
+        if (this.options.ecmaVersion >= 9 && prop.type === "SpreadElement") {
+          return;
+        }
+        if (this.options.ecmaVersion >= 6 && (prop.computed || prop.method || prop.shorthand)) {
+          return;
+        }
+        var key = prop.key;
+        var name2;
+        switch (key.type) {
+          case "Identifier":
+            name2 = key.name;
+            break;
+          case "Literal":
+            name2 = String(key.value);
+            break;
+          default:
+            return;
+        }
+        var kind = prop.kind;
+        if (this.options.ecmaVersion >= 6) {
+          if (name2 === "__proto__" && kind === "init") {
+            if (propHash.proto) {
+              if (refDestructuringErrors) {
+                if (refDestructuringErrors.doubleProto < 0) {
+                  refDestructuringErrors.doubleProto = key.start;
+                }
+              } else {
+                this.raiseRecoverable(key.start, "Redefinition of __proto__ property");
+              }
+            }
+            propHash.proto = true;
+          }
+          return;
+        }
+        name2 = "$" + name2;
+        var other = propHash[name2];
+        if (other) {
+          var redefinition;
+          if (kind === "init") {
+            redefinition = this.strict && other.init || other.get || other.set;
+          } else {
+            redefinition = other.init || other[kind];
+          }
+          if (redefinition) {
+            this.raiseRecoverable(key.start, "Redefinition of property");
+          }
+        } else {
+          other = propHash[name2] = {
+            init: false,
+            get: false,
+            set: false
+          };
+        }
+        other[kind] = true;
+      };
+      pp$32.parseExpression = function(noIn, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseMaybeAssign(noIn, refDestructuringErrors);
+        if (this.type === types2.comma) {
+          var node2 = this.startNodeAt(startPos, startLoc);
+          node2.expressions = [expr];
+          while (this.eat(types2.comma)) {
+            node2.expressions.push(this.parseMaybeAssign(noIn, refDestructuringErrors));
+          }
+          return this.finishNode(node2, "SequenceExpression");
+        }
+        return expr;
+      };
+      pp$32.parseMaybeAssign = function(noIn, refDestructuringErrors, afterLeftParse) {
+        if (this.isContextual("yield")) {
+          if (this.inGenerator) {
+            return this.parseYield(noIn);
+          } else {
+            this.exprAllowed = false;
+          }
+        }
+        var ownDestructuringErrors = false, oldParenAssign = -1, oldTrailingComma = -1;
+        if (refDestructuringErrors) {
+          oldParenAssign = refDestructuringErrors.parenthesizedAssign;
+          oldTrailingComma = refDestructuringErrors.trailingComma;
+          refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = -1;
+        } else {
+          refDestructuringErrors = new DestructuringErrors3();
+          ownDestructuringErrors = true;
+        }
+        var startPos = this.start, startLoc = this.startLoc;
+        if (this.type === types2.parenL || this.type === types2.name) {
+          this.potentialArrowAt = this.start;
+        }
+        var left = this.parseMaybeConditional(noIn, refDestructuringErrors);
+        if (afterLeftParse) {
+          left = afterLeftParse.call(this, left, startPos, startLoc);
+        }
+        if (this.type.isAssign) {
+          var node2 = this.startNodeAt(startPos, startLoc);
+          node2.operator = this.value;
+          node2.left = this.type === types2.eq ? this.toAssignable(left, false, refDestructuringErrors) : left;
+          if (!ownDestructuringErrors) {
+            refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = refDestructuringErrors.doubleProto = -1;
+          }
+          if (refDestructuringErrors.shorthandAssign >= node2.left.start) {
+            refDestructuringErrors.shorthandAssign = -1;
+          }
+          this.checkLVal(left);
+          this.next();
+          node2.right = this.parseMaybeAssign(noIn);
+          return this.finishNode(node2, "AssignmentExpression");
+        } else {
+          if (ownDestructuringErrors) {
+            this.checkExpressionErrors(refDestructuringErrors, true);
+          }
+        }
+        if (oldParenAssign > -1) {
+          refDestructuringErrors.parenthesizedAssign = oldParenAssign;
+        }
+        if (oldTrailingComma > -1) {
+          refDestructuringErrors.trailingComma = oldTrailingComma;
+        }
+        return left;
+      };
+      pp$32.parseMaybeConditional = function(noIn, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseExprOps(noIn, refDestructuringErrors);
+        if (this.checkExpressionErrors(refDestructuringErrors)) {
+          return expr;
+        }
+        if (this.eat(types2.question)) {
+          var node2 = this.startNodeAt(startPos, startLoc);
+          node2.test = expr;
+          node2.consequent = this.parseMaybeAssign();
+          this.expect(types2.colon);
+          node2.alternate = this.parseMaybeAssign(noIn);
+          return this.finishNode(node2, "ConditionalExpression");
+        }
+        return expr;
+      };
+      pp$32.parseExprOps = function(noIn, refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseMaybeUnary(refDestructuringErrors, false);
+        if (this.checkExpressionErrors(refDestructuringErrors)) {
+          return expr;
+        }
+        return expr.start === startPos && expr.type === "ArrowFunctionExpression" ? expr : this.parseExprOp(expr, startPos, startLoc, -1, noIn);
+      };
+      pp$32.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, noIn) {
+        var prec = this.type.binop;
+        if (prec != null && (!noIn || this.type !== types2._in)) {
+          if (prec > minPrec) {
+            var logical = this.type === types2.logicalOR || this.type === types2.logicalAND;
+            var coalesce = this.type === types2.coalesce;
+            if (coalesce) {
+              prec = types2.logicalAND.binop;
+            }
+            var op = this.value;
+            this.next();
+            var startPos = this.start, startLoc = this.startLoc;
+            var right = this.parseExprOp(this.parseMaybeUnary(null, false), startPos, startLoc, prec, noIn);
+            var node2 = this.buildBinary(leftStartPos, leftStartLoc, left, right, op, logical || coalesce);
+            if (logical && this.type === types2.coalesce || coalesce && (this.type === types2.logicalOR || this.type === types2.logicalAND)) {
+              this.raiseRecoverable(this.start, "Logical expressions and coalesce expressions cannot be mixed. Wrap either by parentheses");
+            }
+            return this.parseExprOp(node2, leftStartPos, leftStartLoc, minPrec, noIn);
+          }
+        }
+        return left;
+      };
+      pp$32.buildBinary = function(startPos, startLoc, left, right, op, logical) {
+        var node2 = this.startNodeAt(startPos, startLoc);
+        node2.left = left;
+        node2.operator = op;
+        node2.right = right;
+        return this.finishNode(node2, logical ? "LogicalExpression" : "BinaryExpression");
+      };
+      pp$32.parseMaybeUnary = function(refDestructuringErrors, sawUnary) {
+        var startPos = this.start, startLoc = this.startLoc, expr;
+        if (this.isContextual("await") && (this.inAsync || !this.inFunction && this.options.allowAwaitOutsideFunction)) {
+          expr = this.parseAwait();
+          sawUnary = true;
+        } else if (this.type.prefix) {
+          var node2 = this.startNode(), update = this.type === types2.incDec;
+          node2.operator = this.value;
+          node2.prefix = true;
+          this.next();
+          node2.argument = this.parseMaybeUnary(null, true);
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          if (update) {
+            this.checkLVal(node2.argument);
+          } else if (this.strict && node2.operator === "delete" && node2.argument.type === "Identifier") {
+            this.raiseRecoverable(node2.start, "Deleting local variable in strict mode");
+          } else {
+            sawUnary = true;
+          }
+          expr = this.finishNode(node2, update ? "UpdateExpression" : "UnaryExpression");
+        } else {
+          expr = this.parseExprSubscripts(refDestructuringErrors);
+          if (this.checkExpressionErrors(refDestructuringErrors)) {
+            return expr;
+          }
+          while (this.type.postfix && !this.canInsertSemicolon()) {
+            var node$1 = this.startNodeAt(startPos, startLoc);
+            node$1.operator = this.value;
+            node$1.prefix = false;
+            node$1.argument = expr;
+            this.checkLVal(expr);
+            this.next();
+            expr = this.finishNode(node$1, "UpdateExpression");
+          }
+        }
+        if (!sawUnary && this.eat(types2.starstar)) {
+          return this.buildBinary(startPos, startLoc, expr, this.parseMaybeUnary(null, false), "**", false);
+        } else {
+          return expr;
+        }
+      };
+      pp$32.parseExprSubscripts = function(refDestructuringErrors) {
+        var startPos = this.start, startLoc = this.startLoc;
+        var expr = this.parseExprAtom(refDestructuringErrors);
+        if (expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")") {
+          return expr;
+        }
+        var result = this.parseSubscripts(expr, startPos, startLoc);
+        if (refDestructuringErrors && result.type === "MemberExpression") {
+          if (refDestructuringErrors.parenthesizedAssign >= result.start) {
+            refDestructuringErrors.parenthesizedAssign = -1;
+          }
+          if (refDestructuringErrors.parenthesizedBind >= result.start) {
+            refDestructuringErrors.parenthesizedBind = -1;
+          }
+        }
+        return result;
+      };
+      pp$32.parseSubscripts = function(base, startPos, startLoc, noCalls) {
+        var maybeAsyncArrow = this.options.ecmaVersion >= 8 && base.type === "Identifier" && base.name === "async" && this.lastTokEnd === base.end && !this.canInsertSemicolon() && base.end - base.start === 5 && this.potentialArrowAt === base.start;
+        var optionalChained = false;
+        while (true) {
+          var element2 = this.parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained);
+          if (element2.optional) {
+            optionalChained = true;
+          }
+          if (element2 === base || element2.type === "ArrowFunctionExpression") {
+            if (optionalChained) {
+              var chainNode = this.startNodeAt(startPos, startLoc);
+              chainNode.expression = element2;
+              element2 = this.finishNode(chainNode, "ChainExpression");
+            }
+            return element2;
+          }
+          base = element2;
+        }
+      };
+      pp$32.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained) {
+        var optionalSupported = this.options.ecmaVersion >= 11;
+        var optional = optionalSupported && this.eat(types2.questionDot);
+        if (noCalls && optional) {
+          this.raise(this.lastTokStart, "Optional chaining cannot appear in the callee of new expressions");
+        }
+        var computed = this.eat(types2.bracketL);
+        if (computed || optional && this.type !== types2.parenL && this.type !== types2.backQuote || this.eat(types2.dot)) {
+          var node2 = this.startNodeAt(startPos, startLoc);
+          node2.object = base;
+          node2.property = computed ? this.parseExpression() : this.parseIdent(this.options.allowReserved !== "never");
+          node2.computed = !!computed;
+          if (computed) {
+            this.expect(types2.bracketR);
+          }
+          if (optionalSupported) {
+            node2.optional = optional;
+          }
+          base = this.finishNode(node2, "MemberExpression");
+        } else if (!noCalls && this.eat(types2.parenL)) {
+          var refDestructuringErrors = new DestructuringErrors3(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+          this.yieldPos = 0;
+          this.awaitPos = 0;
+          this.awaitIdentPos = 0;
+          var exprList = this.parseExprList(types2.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors);
+          if (maybeAsyncArrow && !optional && !this.canInsertSemicolon() && this.eat(types2.arrow)) {
+            this.checkPatternErrors(refDestructuringErrors, false);
+            this.checkYieldAwaitInDefaultParams();
+            if (this.awaitIdentPos > 0) {
+              this.raise(this.awaitIdentPos, "Cannot use 'await' as identifier inside an async function");
+            }
+            this.yieldPos = oldYieldPos;
+            this.awaitPos = oldAwaitPos;
+            this.awaitIdentPos = oldAwaitIdentPos;
+            return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, true);
+          }
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          this.yieldPos = oldYieldPos || this.yieldPos;
+          this.awaitPos = oldAwaitPos || this.awaitPos;
+          this.awaitIdentPos = oldAwaitIdentPos || this.awaitIdentPos;
+          var node$1 = this.startNodeAt(startPos, startLoc);
+          node$1.callee = base;
+          node$1.arguments = exprList;
+          if (optionalSupported) {
+            node$1.optional = optional;
+          }
+          base = this.finishNode(node$1, "CallExpression");
+        } else if (this.type === types2.backQuote) {
+          if (optional || optionalChained) {
+            this.raise(this.start, "Optional chaining cannot appear in the tag of tagged template expressions");
+          }
+          var node$2 = this.startNodeAt(startPos, startLoc);
+          node$2.tag = base;
+          node$2.quasi = this.parseTemplate({ isTagged: true });
+          base = this.finishNode(node$2, "TaggedTemplateExpression");
+        }
+        return base;
+      };
+      pp$32.parseExprAtom = function(refDestructuringErrors) {
+        if (this.type === types2.slash) {
+          this.readRegexp();
+        }
+        var node2, canBeArrow = this.potentialArrowAt === this.start;
+        switch (this.type) {
+          case types2._super:
+            if (!this.allowSuper) {
+              this.raise(this.start, "'super' keyword outside a method");
+            }
+            node2 = this.startNode();
+            this.next();
+            if (this.type === types2.parenL && !this.allowDirectSuper) {
+              this.raise(node2.start, "super() call outside constructor of a subclass");
+            }
+            if (this.type !== types2.dot && this.type !== types2.bracketL && this.type !== types2.parenL) {
+              this.unexpected();
+            }
+            return this.finishNode(node2, "Super");
+          case types2._this:
+            node2 = this.startNode();
+            this.next();
+            return this.finishNode(node2, "ThisExpression");
+          case types2.name:
+            var startPos = this.start, startLoc = this.startLoc, containsEsc = this.containsEsc;
+            var id = this.parseIdent(false);
+            if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === "async" && !this.canInsertSemicolon() && this.eat(types2._function)) {
+              return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true);
+            }
+            if (canBeArrow && !this.canInsertSemicolon()) {
+              if (this.eat(types2.arrow)) {
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false);
+              }
+              if (this.options.ecmaVersion >= 8 && id.name === "async" && this.type === types2.name && !containsEsc) {
+                id = this.parseIdent(false);
+                if (this.canInsertSemicolon() || !this.eat(types2.arrow)) {
+                  this.unexpected();
+                }
+                return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true);
+              }
+            }
+            return id;
+          case types2.regexp:
+            var value = this.value;
+            node2 = this.parseLiteral(value.value);
+            node2.regex = { pattern: value.pattern, flags: value.flags };
+            return node2;
+          case types2.num:
+          case types2.string:
+            return this.parseLiteral(this.value);
+          case types2._null:
+          case types2._true:
+          case types2._false:
+            node2 = this.startNode();
+            node2.value = this.type === types2._null ? null : this.type === types2._true;
+            node2.raw = this.type.keyword;
+            this.next();
+            return this.finishNode(node2, "Literal");
+          case types2.parenL:
+            var start2 = this.start, expr = this.parseParenAndDistinguishExpression(canBeArrow);
+            if (refDestructuringErrors) {
+              if (refDestructuringErrors.parenthesizedAssign < 0 && !this.isSimpleAssignTarget(expr)) {
+                refDestructuringErrors.parenthesizedAssign = start2;
+              }
+              if (refDestructuringErrors.parenthesizedBind < 0) {
+                refDestructuringErrors.parenthesizedBind = start2;
+              }
+            }
+            return expr;
+          case types2.bracketL:
+            node2 = this.startNode();
+            this.next();
+            node2.elements = this.parseExprList(types2.bracketR, true, true, refDestructuringErrors);
+            return this.finishNode(node2, "ArrayExpression");
+          case types2.braceL:
+            return this.parseObj(false, refDestructuringErrors);
+          case types2._function:
+            node2 = this.startNode();
+            this.next();
+            return this.parseFunction(node2, 0);
+          case types2._class:
+            return this.parseClass(this.startNode(), false);
+          case types2._new:
+            return this.parseNew();
+          case types2.backQuote:
+            return this.parseTemplate();
+          case types2._import:
+            if (this.options.ecmaVersion >= 11) {
+              return this.parseExprImport();
+            } else {
+              return this.unexpected();
+            }
+          default:
+            this.unexpected();
+        }
+      };
+      pp$32.parseExprImport = function() {
+        var node2 = this.startNode();
+        if (this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword import");
+        }
+        var meta = this.parseIdent(true);
+        switch (this.type) {
+          case types2.parenL:
+            return this.parseDynamicImport(node2);
+          case types2.dot:
+            node2.meta = meta;
+            return this.parseImportMeta(node2);
+          default:
+            this.unexpected();
+        }
+      };
+      pp$32.parseDynamicImport = function(node2) {
+        this.next();
+        node2.source = this.parseMaybeAssign();
+        if (!this.eat(types2.parenR)) {
+          var errorPos = this.start;
+          if (this.eat(types2.comma) && this.eat(types2.parenR)) {
+            this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+          } else {
+            this.unexpected(errorPos);
+          }
+        }
+        return this.finishNode(node2, "ImportExpression");
+      };
+      pp$32.parseImportMeta = function(node2) {
+        this.next();
+        var containsEsc = this.containsEsc;
+        node2.property = this.parseIdent(true);
+        if (node2.property.name !== "meta") {
+          this.raiseRecoverable(node2.property.start, "The only valid meta property for import is 'import.meta'");
+        }
+        if (containsEsc) {
+          this.raiseRecoverable(node2.start, "'import.meta' must not contain escaped characters");
+        }
+        if (this.options.sourceType !== "module") {
+          this.raiseRecoverable(node2.start, "Cannot use 'import.meta' outside a module");
+        }
+        return this.finishNode(node2, "MetaProperty");
+      };
+      pp$32.parseLiteral = function(value) {
+        var node2 = this.startNode();
+        node2.value = value;
+        node2.raw = this.input.slice(this.start, this.end);
+        if (node2.raw.charCodeAt(node2.raw.length - 1) === 110) {
+          node2.bigint = node2.raw.slice(0, -1).replace(/_/g, "");
+        }
+        this.next();
+        return this.finishNode(node2, "Literal");
+      };
+      pp$32.parseParenExpression = function() {
+        this.expect(types2.parenL);
+        var val = this.parseExpression();
+        this.expect(types2.parenR);
+        return val;
+      };
+      pp$32.parseParenAndDistinguishExpression = function(canBeArrow) {
+        var startPos = this.start, startLoc = this.startLoc, val, allowTrailingComma = this.options.ecmaVersion >= 8;
+        if (this.options.ecmaVersion >= 6) {
+          this.next();
+          var innerStartPos = this.start, innerStartLoc = this.startLoc;
+          var exprList = [], first = true, lastIsComma = false;
+          var refDestructuringErrors = new DestructuringErrors3(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, spreadStart;
+          this.yieldPos = 0;
+          this.awaitPos = 0;
+          while (this.type !== types2.parenR) {
+            first ? first = false : this.expect(types2.comma);
+            if (allowTrailingComma && this.afterTrailingComma(types2.parenR, true)) {
+              lastIsComma = true;
+              break;
+            } else if (this.type === types2.ellipsis) {
+              spreadStart = this.start;
+              exprList.push(this.parseParenItem(this.parseRestBinding()));
+              if (this.type === types2.comma) {
+                this.raise(this.start, "Comma is not permitted after the rest element");
+              }
+              break;
+            } else {
+              exprList.push(this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem));
+            }
+          }
+          var innerEndPos = this.start, innerEndLoc = this.startLoc;
+          this.expect(types2.parenR);
+          if (canBeArrow && !this.canInsertSemicolon() && this.eat(types2.arrow)) {
+            this.checkPatternErrors(refDestructuringErrors, false);
+            this.checkYieldAwaitInDefaultParams();
+            this.yieldPos = oldYieldPos;
+            this.awaitPos = oldAwaitPos;
+            return this.parseParenArrowList(startPos, startLoc, exprList);
+          }
+          if (!exprList.length || lastIsComma) {
+            this.unexpected(this.lastTokStart);
+          }
+          if (spreadStart) {
+            this.unexpected(spreadStart);
+          }
+          this.checkExpressionErrors(refDestructuringErrors, true);
+          this.yieldPos = oldYieldPos || this.yieldPos;
+          this.awaitPos = oldAwaitPos || this.awaitPos;
+          if (exprList.length > 1) {
+            val = this.startNodeAt(innerStartPos, innerStartLoc);
+            val.expressions = exprList;
+            this.finishNodeAt(val, "SequenceExpression", innerEndPos, innerEndLoc);
+          } else {
+            val = exprList[0];
+          }
+        } else {
+          val = this.parseParenExpression();
+        }
+        if (this.options.preserveParens) {
+          var par = this.startNodeAt(startPos, startLoc);
+          par.expression = val;
+          return this.finishNode(par, "ParenthesizedExpression");
+        } else {
+          return val;
+        }
+      };
+      pp$32.parseParenItem = function(item) {
+        return item;
+      };
+      pp$32.parseParenArrowList = function(startPos, startLoc, exprList) {
+        return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList);
+      };
+      var empty$12 = [];
+      pp$32.parseNew = function() {
+        if (this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword new");
+        }
+        var node2 = this.startNode();
+        var meta = this.parseIdent(true);
+        if (this.options.ecmaVersion >= 6 && this.eat(types2.dot)) {
+          node2.meta = meta;
+          var containsEsc = this.containsEsc;
+          node2.property = this.parseIdent(true);
+          if (node2.property.name !== "target") {
+            this.raiseRecoverable(node2.property.start, "The only valid meta property for new is 'new.target'");
+          }
+          if (containsEsc) {
+            this.raiseRecoverable(node2.start, "'new.target' must not contain escaped characters");
+          }
+          if (!this.inNonArrowFunction()) {
+            this.raiseRecoverable(node2.start, "'new.target' can only be used in functions");
+          }
+          return this.finishNode(node2, "MetaProperty");
+        }
+        var startPos = this.start, startLoc = this.startLoc, isImport = this.type === types2._import;
+        node2.callee = this.parseSubscripts(this.parseExprAtom(), startPos, startLoc, true);
+        if (isImport && node2.callee.type === "ImportExpression") {
+          this.raise(startPos, "Cannot use new with import()");
+        }
+        if (this.eat(types2.parenL)) {
+          node2.arguments = this.parseExprList(types2.parenR, this.options.ecmaVersion >= 8, false);
+        } else {
+          node2.arguments = empty$12;
+        }
+        return this.finishNode(node2, "NewExpression");
+      };
+      pp$32.parseTemplateElement = function(ref3) {
+        var isTagged = ref3.isTagged;
+        var elem = this.startNode();
+        if (this.type === types2.invalidTemplate) {
+          if (!isTagged) {
+            this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
+          }
+          elem.value = {
+            raw: this.value,
+            cooked: null
+          };
+        } else {
+          elem.value = {
+            raw: this.input.slice(this.start, this.end).replace(/\r\n?/g, "\n"),
+            cooked: this.value
+          };
+        }
+        this.next();
+        elem.tail = this.type === types2.backQuote;
+        return this.finishNode(elem, "TemplateElement");
+      };
+      pp$32.parseTemplate = function(ref3) {
+        if (ref3 === void 0) ref3 = {};
+        var isTagged = ref3.isTagged;
+        if (isTagged === void 0) isTagged = false;
+        var node2 = this.startNode();
+        this.next();
+        node2.expressions = [];
+        var curElt = this.parseTemplateElement({ isTagged });
+        node2.quasis = [curElt];
+        while (!curElt.tail) {
+          if (this.type === types2.eof) {
+            this.raise(this.pos, "Unterminated template literal");
+          }
+          this.expect(types2.dollarBraceL);
+          node2.expressions.push(this.parseExpression());
+          this.expect(types2.braceR);
+          node2.quasis.push(curElt = this.parseTemplateElement({ isTagged }));
+        }
+        this.next();
+        return this.finishNode(node2, "TemplateLiteral");
+      };
+      pp$32.isAsyncProp = function(prop) {
+        return !prop.computed && prop.key.type === "Identifier" && prop.key.name === "async" && (this.type === types2.name || this.type === types2.num || this.type === types2.string || this.type === types2.bracketL || this.type.keyword || this.options.ecmaVersion >= 9 && this.type === types2.star) && !lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+      };
+      pp$32.parseObj = function(isPattern, refDestructuringErrors) {
+        var node2 = this.startNode(), first = true, propHash = {};
+        node2.properties = [];
+        this.next();
+        while (!this.eat(types2.braceR)) {
+          if (!first) {
+            this.expect(types2.comma);
+            if (this.options.ecmaVersion >= 5 && this.afterTrailingComma(types2.braceR)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var prop = this.parseProperty(isPattern, refDestructuringErrors);
+          if (!isPattern) {
+            this.checkPropClash(prop, propHash, refDestructuringErrors);
+          }
+          node2.properties.push(prop);
+        }
+        return this.finishNode(node2, isPattern ? "ObjectPattern" : "ObjectExpression");
+      };
+      pp$32.parseProperty = function(isPattern, refDestructuringErrors) {
+        var prop = this.startNode(), isGenerator, isAsync, startPos, startLoc;
+        if (this.options.ecmaVersion >= 9 && this.eat(types2.ellipsis)) {
+          if (isPattern) {
+            prop.argument = this.parseIdent(false);
+            if (this.type === types2.comma) {
+              this.raise(this.start, "Comma is not permitted after the rest element");
+            }
+            return this.finishNode(prop, "RestElement");
+          }
+          if (this.type === types2.parenL && refDestructuringErrors) {
+            if (refDestructuringErrors.parenthesizedAssign < 0) {
+              refDestructuringErrors.parenthesizedAssign = this.start;
+            }
+            if (refDestructuringErrors.parenthesizedBind < 0) {
+              refDestructuringErrors.parenthesizedBind = this.start;
+            }
+          }
+          prop.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+          if (this.type === types2.comma && refDestructuringErrors && refDestructuringErrors.trailingComma < 0) {
+            refDestructuringErrors.trailingComma = this.start;
+          }
+          return this.finishNode(prop, "SpreadElement");
+        }
+        if (this.options.ecmaVersion >= 6) {
+          prop.method = false;
+          prop.shorthand = false;
+          if (isPattern || refDestructuringErrors) {
+            startPos = this.start;
+            startLoc = this.startLoc;
+          }
+          if (!isPattern) {
+            isGenerator = this.eat(types2.star);
+          }
+        }
+        var containsEsc = this.containsEsc;
+        this.parsePropertyName(prop);
+        if (!isPattern && !containsEsc && this.options.ecmaVersion >= 8 && !isGenerator && this.isAsyncProp(prop)) {
+          isAsync = true;
+          isGenerator = this.options.ecmaVersion >= 9 && this.eat(types2.star);
+          this.parsePropertyName(prop, refDestructuringErrors);
+        } else {
+          isAsync = false;
+        }
+        this.parsePropertyValue(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc);
+        return this.finishNode(prop, "Property");
+      };
+      pp$32.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc) {
+        if ((isGenerator || isAsync) && this.type === types2.colon) {
+          this.unexpected();
+        }
+        if (this.eat(types2.colon)) {
+          prop.value = isPattern ? this.parseMaybeDefault(this.start, this.startLoc) : this.parseMaybeAssign(false, refDestructuringErrors);
+          prop.kind = "init";
+        } else if (this.options.ecmaVersion >= 6 && this.type === types2.parenL) {
+          if (isPattern) {
+            this.unexpected();
+          }
+          prop.kind = "init";
+          prop.method = true;
+          prop.value = this.parseMethod(isGenerator, isAsync);
+        } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types2.comma && this.type !== types2.braceR && this.type !== types2.eq)) {
+          if (isGenerator || isAsync) {
+            this.unexpected();
+          }
+          prop.kind = prop.key.name;
+          this.parsePropertyName(prop);
+          prop.value = this.parseMethod(false);
+          var paramCount = prop.kind === "get" ? 0 : 1;
+          if (prop.value.params.length !== paramCount) {
+            var start2 = prop.value.start;
+            if (prop.kind === "get") {
+              this.raiseRecoverable(start2, "getter should have no params");
+            } else {
+              this.raiseRecoverable(start2, "setter should have exactly one param");
+            }
+          } else {
+            if (prop.kind === "set" && prop.value.params[0].type === "RestElement") {
+              this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params");
+            }
+          }
+        } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+          if (isGenerator || isAsync) {
+            this.unexpected();
+          }
+          this.checkUnreserved(prop.key);
+          if (prop.key.name === "await" && !this.awaitIdentPos) {
+            this.awaitIdentPos = startPos;
+          }
+          prop.kind = "init";
+          if (isPattern) {
+            prop.value = this.parseMaybeDefault(startPos, startLoc, prop.key);
+          } else if (this.type === types2.eq && refDestructuringErrors) {
+            if (refDestructuringErrors.shorthandAssign < 0) {
+              refDestructuringErrors.shorthandAssign = this.start;
+            }
+            prop.value = this.parseMaybeDefault(startPos, startLoc, prop.key);
+          } else {
+            prop.value = prop.key;
+          }
+          prop.shorthand = true;
+        } else {
+          this.unexpected();
+        }
+      };
+      pp$32.parsePropertyName = function(prop) {
+        if (this.options.ecmaVersion >= 6) {
+          if (this.eat(types2.bracketL)) {
+            prop.computed = true;
+            prop.key = this.parseMaybeAssign();
+            this.expect(types2.bracketR);
+            return prop.key;
+          } else {
+            prop.computed = false;
+          }
+        }
+        return prop.key = this.type === types2.num || this.type === types2.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+      };
+      pp$32.initFunction = function(node2) {
+        node2.id = null;
+        if (this.options.ecmaVersion >= 6) {
+          node2.generator = node2.expression = false;
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node2.async = false;
+        }
+      };
+      pp$32.parseMethod = function(isGenerator, isAsync, allowDirectSuper) {
+        var node2 = this.startNode(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.initFunction(node2);
+        if (this.options.ecmaVersion >= 6) {
+          node2.generator = isGenerator;
+        }
+        if (this.options.ecmaVersion >= 8) {
+          node2.async = !!isAsync;
+        }
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        this.enterScope(functionFlags2(isAsync, node2.generator) | SCOPE_SUPER2 | (allowDirectSuper ? SCOPE_DIRECT_SUPER2 : 0));
+        this.expect(types2.parenL);
+        node2.params = this.parseBindingList(types2.parenR, false, this.options.ecmaVersion >= 8);
+        this.checkYieldAwaitInDefaultParams();
+        this.parseFunctionBody(node2, false, true);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node2, "FunctionExpression");
+      };
+      pp$32.parseArrowExpression = function(node2, params, isAsync) {
+        var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+        this.enterScope(functionFlags2(isAsync, false) | SCOPE_ARROW2);
+        this.initFunction(node2);
+        if (this.options.ecmaVersion >= 8) {
+          node2.async = !!isAsync;
+        }
+        this.yieldPos = 0;
+        this.awaitPos = 0;
+        this.awaitIdentPos = 0;
+        node2.params = this.toAssignableList(params, true);
+        this.parseFunctionBody(node2, true, false);
+        this.yieldPos = oldYieldPos;
+        this.awaitPos = oldAwaitPos;
+        this.awaitIdentPos = oldAwaitIdentPos;
+        return this.finishNode(node2, "ArrowFunctionExpression");
+      };
+      pp$32.parseFunctionBody = function(node2, isArrowFunction, isMethod) {
+        var isExpression = isArrowFunction && this.type !== types2.braceL;
+        var oldStrict = this.strict, useStrict = false;
+        if (isExpression) {
+          node2.body = this.parseMaybeAssign();
+          node2.expression = true;
+          this.checkParams(node2, false);
+        } else {
+          var nonSimple = this.options.ecmaVersion >= 7 && !this.isSimpleParamList(node2.params);
+          if (!oldStrict || nonSimple) {
+            useStrict = this.strictDirective(this.end);
+            if (useStrict && nonSimple) {
+              this.raiseRecoverable(node2.start, "Illegal 'use strict' directive in function with non-simple parameter list");
+            }
+          }
+          var oldLabels = this.labels;
+          this.labels = [];
+          if (useStrict) {
+            this.strict = true;
+          }
+          this.checkParams(node2, !oldStrict && !useStrict && !isArrowFunction && !isMethod && this.isSimpleParamList(node2.params));
+          if (this.strict && node2.id) {
+            this.checkLVal(node2.id, BIND_OUTSIDE2);
+          }
+          node2.body = this.parseBlock(false, void 0, useStrict && !oldStrict);
+          node2.expression = false;
+          this.adaptDirectivePrologue(node2.body.body);
+          this.labels = oldLabels;
+        }
+        this.exitScope();
+      };
+      pp$32.isSimpleParamList = function(params) {
+        for (var i = 0, list3 = params; i < list3.length; i += 1) {
+          var param = list3[i];
+          if (param.type !== "Identifier") {
+            return false;
+          }
+        }
+        return true;
+      };
+      pp$32.checkParams = function(node2, allowDuplicates) {
+        var nameHash = {};
+        for (var i = 0, list3 = node2.params; i < list3.length; i += 1) {
+          var param = list3[i];
+          this.checkLVal(param, BIND_VAR2, allowDuplicates ? null : nameHash);
+        }
+      };
+      pp$32.parseExprList = function(close, allowTrailingComma, allowEmpty, refDestructuringErrors) {
+        var elts = [], first = true;
+        while (!this.eat(close)) {
+          if (!first) {
+            this.expect(types2.comma);
+            if (allowTrailingComma && this.afterTrailingComma(close)) {
+              break;
+            }
+          } else {
+            first = false;
+          }
+          var elt = void 0;
+          if (allowEmpty && this.type === types2.comma) {
+            elt = null;
+          } else if (this.type === types2.ellipsis) {
+            elt = this.parseSpread(refDestructuringErrors);
+            if (refDestructuringErrors && this.type === types2.comma && refDestructuringErrors.trailingComma < 0) {
+              refDestructuringErrors.trailingComma = this.start;
+            }
+          } else {
+            elt = this.parseMaybeAssign(false, refDestructuringErrors);
+          }
+          elts.push(elt);
+        }
+        return elts;
+      };
+      pp$32.checkUnreserved = function(ref3) {
+        var start2 = ref3.start;
+        var end = ref3.end;
+        var name2 = ref3.name;
+        if (this.inGenerator && name2 === "yield") {
+          this.raiseRecoverable(start2, "Cannot use 'yield' as identifier inside a generator");
+        }
+        if (this.inAsync && name2 === "await") {
+          this.raiseRecoverable(start2, "Cannot use 'await' as identifier inside an async function");
+        }
+        if (this.keywords.test(name2)) {
+          this.raise(start2, "Unexpected keyword '" + name2 + "'");
+        }
+        if (this.options.ecmaVersion < 6 && this.input.slice(start2, end).indexOf("\\") !== -1) {
+          return;
+        }
+        var re2 = this.strict ? this.reservedWordsStrict : this.reservedWords;
+        if (re2.test(name2)) {
+          if (!this.inAsync && name2 === "await") {
+            this.raiseRecoverable(start2, "Cannot use keyword 'await' outside an async function");
+          }
+          this.raiseRecoverable(start2, "The keyword '" + name2 + "' is reserved");
+        }
+      };
+      pp$32.parseIdent = function(liberal, isBinding) {
+        var node2 = this.startNode();
+        if (this.type === types2.name) {
+          node2.name = this.value;
+        } else if (this.type.keyword) {
+          node2.name = this.type.keyword;
+          if ((node2.name === "class" || node2.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
+            this.context.pop();
+          }
+        } else {
+          this.unexpected();
+        }
+        this.next(!!liberal);
+        this.finishNode(node2, "Identifier");
+        if (!liberal) {
+          this.checkUnreserved(node2);
+          if (node2.name === "await" && !this.awaitIdentPos) {
+            this.awaitIdentPos = node2.start;
+          }
+        }
+        return node2;
+      };
+      pp$32.parseYield = function(noIn) {
+        if (!this.yieldPos) {
+          this.yieldPos = this.start;
+        }
+        var node2 = this.startNode();
+        this.next();
+        if (this.type === types2.semi || this.canInsertSemicolon() || this.type !== types2.star && !this.type.startsExpr) {
+          node2.delegate = false;
+          node2.argument = null;
+        } else {
+          node2.delegate = this.eat(types2.star);
+          node2.argument = this.parseMaybeAssign(noIn);
+        }
+        return this.finishNode(node2, "YieldExpression");
+      };
+      pp$32.parseAwait = function() {
+        if (!this.awaitPos) {
+          this.awaitPos = this.start;
+        }
+        var node2 = this.startNode();
+        this.next();
+        node2.argument = this.parseMaybeUnary(null, false);
+        return this.finishNode(node2, "AwaitExpression");
+      };
+      var pp$42 = Parser3.prototype;
+      pp$42.raise = function(pos, message) {
+        var loc = getLineInfo2(this.input, pos);
+        message += " (" + loc.line + ":" + loc.column + ")";
+        var err = new SyntaxError(message);
+        err.pos = pos;
+        err.loc = loc;
+        err.raisedAt = this.pos;
+        throw err;
+      };
+      pp$42.raiseRecoverable = pp$42.raise;
+      pp$42.curPosition = function() {
+        if (this.options.locations) {
+          return new Position3(this.curLine, this.pos - this.lineStart);
+        }
+      };
+      var pp$52 = Parser3.prototype;
+      var Scope4 = function Scope5(flags) {
+        this.flags = flags;
+        this.var = [];
+        this.lexical = [];
+        this.functions = [];
+      };
+      pp$52.enterScope = function(flags) {
+        this.scopeStack.push(new Scope4(flags));
+      };
+      pp$52.exitScope = function() {
+        this.scopeStack.pop();
+      };
+      pp$52.treatFunctionsAsVarInScope = function(scope) {
+        return scope.flags & SCOPE_FUNCTION2 || !this.inModule && scope.flags & SCOPE_TOP2;
+      };
+      pp$52.declareName = function(name2, bindingType, pos) {
+        var redeclared = false;
+        if (bindingType === BIND_LEXICAL2) {
+          var scope = this.currentScope();
+          redeclared = scope.lexical.indexOf(name2) > -1 || scope.functions.indexOf(name2) > -1 || scope.var.indexOf(name2) > -1;
+          scope.lexical.push(name2);
+          if (this.inModule && scope.flags & SCOPE_TOP2) {
+            delete this.undefinedExports[name2];
+          }
+        } else if (bindingType === BIND_SIMPLE_CATCH2) {
+          var scope$1 = this.currentScope();
+          scope$1.lexical.push(name2);
+        } else if (bindingType === BIND_FUNCTION2) {
+          var scope$2 = this.currentScope();
+          if (this.treatFunctionsAsVar) {
+            redeclared = scope$2.lexical.indexOf(name2) > -1;
+          } else {
+            redeclared = scope$2.lexical.indexOf(name2) > -1 || scope$2.var.indexOf(name2) > -1;
+          }
+          scope$2.functions.push(name2);
+        } else {
+          for (var i = this.scopeStack.length - 1; i >= 0; --i) {
+            var scope$3 = this.scopeStack[i];
+            if (scope$3.lexical.indexOf(name2) > -1 && !(scope$3.flags & SCOPE_SIMPLE_CATCH2 && scope$3.lexical[0] === name2) || !this.treatFunctionsAsVarInScope(scope$3) && scope$3.functions.indexOf(name2) > -1) {
+              redeclared = true;
+              break;
+            }
+            scope$3.var.push(name2);
+            if (this.inModule && scope$3.flags & SCOPE_TOP2) {
+              delete this.undefinedExports[name2];
+            }
+            if (scope$3.flags & SCOPE_VAR2) {
+              break;
+            }
+          }
+        }
+        if (redeclared) {
+          this.raiseRecoverable(pos, "Identifier '" + name2 + "' has already been declared");
+        }
+      };
+      pp$52.checkLocalExport = function(id) {
+        if (this.scopeStack[0].lexical.indexOf(id.name) === -1 && this.scopeStack[0].var.indexOf(id.name) === -1) {
+          this.undefinedExports[id.name] = id;
+        }
+      };
+      pp$52.currentScope = function() {
+        return this.scopeStack[this.scopeStack.length - 1];
+      };
+      pp$52.currentVarScope = function() {
+        for (var i = this.scopeStack.length - 1; ; i--) {
+          var scope = this.scopeStack[i];
+          if (scope.flags & SCOPE_VAR2) {
+            return scope;
+          }
+        }
+      };
+      pp$52.currentThisScope = function() {
+        for (var i = this.scopeStack.length - 1; ; i--) {
+          var scope = this.scopeStack[i];
+          if (scope.flags & SCOPE_VAR2 && !(scope.flags & SCOPE_ARROW2)) {
+            return scope;
+          }
+        }
+      };
+      var Node3 = function Node4(parser, pos, loc) {
+        this.type = "";
+        this.start = pos;
+        this.end = 0;
+        if (parser.options.locations) {
+          this.loc = new SourceLocation3(parser, loc);
+        }
+        if (parser.options.directSourceFile) {
+          this.sourceFile = parser.options.directSourceFile;
+        }
+        if (parser.options.ranges) {
+          this.range = [pos, 0];
+        }
+      };
+      var pp$62 = Parser3.prototype;
+      pp$62.startNode = function() {
+        return new Node3(this, this.start, this.startLoc);
+      };
+      pp$62.startNodeAt = function(pos, loc) {
+        return new Node3(this, pos, loc);
+      };
+      function finishNodeAt2(node2, type, pos, loc) {
+        node2.type = type;
+        node2.end = pos;
+        if (this.options.locations) {
+          node2.loc.end = loc;
+        }
+        if (this.options.ranges) {
+          node2.range[1] = pos;
+        }
+        return node2;
+      }
+      pp$62.finishNode = function(node2, type) {
+        return finishNodeAt2.call(this, node2, type, this.lastTokEnd, this.lastTokEndLoc);
+      };
+      pp$62.finishNodeAt = function(node2, type, pos, loc) {
+        return finishNodeAt2.call(this, node2, type, pos, loc);
+      };
+      var TokContext3 = function TokContext4(token, isExpr, preserveSpace, override, generator) {
+        this.token = token;
+        this.isExpr = !!isExpr;
+        this.preserveSpace = !!preserveSpace;
+        this.override = override;
+        this.generator = !!generator;
+      };
+      var types$12 = {
+        b_stat: new TokContext3("{", false),
+        b_expr: new TokContext3("{", true),
+        b_tmpl: new TokContext3("${", false),
+        p_stat: new TokContext3("(", false),
+        p_expr: new TokContext3("(", true),
+        q_tmpl: new TokContext3("`", true, true, function(p) {
+          return p.tryReadTemplateToken();
+        }),
+        f_stat: new TokContext3("function", false),
+        f_expr: new TokContext3("function", true),
+        f_expr_gen: new TokContext3("function", true, false, null, true),
+        f_gen: new TokContext3("function", false, false, null, true)
+      };
+      var pp$72 = Parser3.prototype;
+      pp$72.initialContext = function() {
+        return [types$12.b_stat];
+      };
+      pp$72.braceIsBlock = function(prevType) {
+        var parent = this.curContext();
+        if (parent === types$12.f_expr || parent === types$12.f_stat) {
+          return true;
+        }
+        if (prevType === types2.colon && (parent === types$12.b_stat || parent === types$12.b_expr)) {
+          return !parent.isExpr;
+        }
+        if (prevType === types2._return || prevType === types2.name && this.exprAllowed) {
+          return lineBreak2.test(this.input.slice(this.lastTokEnd, this.start));
+        }
+        if (prevType === types2._else || prevType === types2.semi || prevType === types2.eof || prevType === types2.parenR || prevType === types2.arrow) {
+          return true;
+        }
+        if (prevType === types2.braceL) {
+          return parent === types$12.b_stat;
+        }
+        if (prevType === types2._var || prevType === types2._const || prevType === types2.name) {
+          return false;
+        }
+        return !this.exprAllowed;
+      };
+      pp$72.inGeneratorContext = function() {
+        for (var i = this.context.length - 1; i >= 1; i--) {
+          var context = this.context[i];
+          if (context.token === "function") {
+            return context.generator;
+          }
+        }
+        return false;
+      };
+      pp$72.updateContext = function(prevType) {
+        var update, type = this.type;
+        if (type.keyword && prevType === types2.dot) {
+          this.exprAllowed = false;
+        } else if (update = type.updateContext) {
+          update.call(this, prevType);
+        } else {
+          this.exprAllowed = type.beforeExpr;
+        }
+      };
+      types2.parenR.updateContext = types2.braceR.updateContext = function() {
+        if (this.context.length === 1) {
+          this.exprAllowed = true;
+          return;
+        }
+        var out = this.context.pop();
+        if (out === types$12.b_stat && this.curContext().token === "function") {
+          out = this.context.pop();
+        }
+        this.exprAllowed = !out.isExpr;
+      };
+      types2.braceL.updateContext = function(prevType) {
+        this.context.push(this.braceIsBlock(prevType) ? types$12.b_stat : types$12.b_expr);
+        this.exprAllowed = true;
+      };
+      types2.dollarBraceL.updateContext = function() {
+        this.context.push(types$12.b_tmpl);
+        this.exprAllowed = true;
+      };
+      types2.parenL.updateContext = function(prevType) {
+        var statementParens = prevType === types2._if || prevType === types2._for || prevType === types2._with || prevType === types2._while;
+        this.context.push(statementParens ? types$12.p_stat : types$12.p_expr);
+        this.exprAllowed = true;
+      };
+      types2.incDec.updateContext = function() {
+      };
+      types2._function.updateContext = types2._class.updateContext = function(prevType) {
+        if (prevType.beforeExpr && prevType !== types2.semi && prevType !== types2._else && !(prevType === types2._return && lineBreak2.test(this.input.slice(this.lastTokEnd, this.start))) && !((prevType === types2.colon || prevType === types2.braceL) && this.curContext() === types$12.b_stat)) {
+          this.context.push(types$12.f_expr);
+        } else {
+          this.context.push(types$12.f_stat);
+        }
+        this.exprAllowed = false;
+      };
+      types2.backQuote.updateContext = function() {
+        if (this.curContext() === types$12.q_tmpl) {
+          this.context.pop();
+        } else {
+          this.context.push(types$12.q_tmpl);
+        }
+        this.exprAllowed = false;
+      };
+      types2.star.updateContext = function(prevType) {
+        if (prevType === types2._function) {
+          var index2 = this.context.length - 1;
+          if (this.context[index2] === types$12.f_expr) {
+            this.context[index2] = types$12.f_expr_gen;
+          } else {
+            this.context[index2] = types$12.f_gen;
+          }
+        }
+        this.exprAllowed = true;
+      };
+      types2.name.updateContext = function(prevType) {
+        var allowed = false;
+        if (this.options.ecmaVersion >= 6 && prevType !== types2.dot) {
+          if (this.value === "of" && !this.exprAllowed || this.value === "yield" && this.inGeneratorContext()) {
+            allowed = true;
+          }
+        }
+        this.exprAllowed = allowed;
+      };
+      var ecma9BinaryProperties2 = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
+      var ecma10BinaryProperties2 = ecma9BinaryProperties2 + " Extended_Pictographic";
+      var ecma11BinaryProperties2 = ecma10BinaryProperties2;
+      var unicodeBinaryProperties2 = {
+        9: ecma9BinaryProperties2,
+        10: ecma10BinaryProperties2,
+        11: ecma11BinaryProperties2
+      };
+      var unicodeGeneralCategoryValues2 = "Cased_Letter LC Close_Punctuation Pe Connector_Punctuation Pc Control Cc cntrl Currency_Symbol Sc Dash_Punctuation Pd Decimal_Number Nd digit Enclosing_Mark Me Final_Punctuation Pf Format Cf Initial_Punctuation Pi Letter L Letter_Number Nl Line_Separator Zl Lowercase_Letter Ll Mark M Combining_Mark Math_Symbol Sm Modifier_Letter Lm Modifier_Symbol Sk Nonspacing_Mark Mn Number N Open_Punctuation Ps Other C Other_Letter Lo Other_Number No Other_Punctuation Po Other_Symbol So Paragraph_Separator Zp Private_Use Co Punctuation P punct Separator Z Space_Separator Zs Spacing_Mark Mc Surrogate Cs Symbol S Titlecase_Letter Lt Unassigned Cn Uppercase_Letter Lu";
+      var ecma9ScriptValues2 = "Adlam Adlm Ahom Ahom Anatolian_Hieroglyphs Hluw Arabic Arab Armenian Armn Avestan Avst Balinese Bali Bamum Bamu Bassa_Vah Bass Batak Batk Bengali Beng Bhaiksuki Bhks Bopomofo Bopo Brahmi Brah Braille Brai Buginese Bugi Buhid Buhd Canadian_Aboriginal Cans Carian Cari Caucasian_Albanian Aghb Chakma Cakm Cham Cham Cherokee Cher Common Zyyy Coptic Copt Qaac Cuneiform Xsux Cypriot Cprt Cyrillic Cyrl Deseret Dsrt Devanagari Deva Duployan Dupl Egyptian_Hieroglyphs Egyp Elbasan Elba Ethiopic Ethi Georgian Geor Glagolitic Glag Gothic Goth Grantha Gran Greek Grek Gujarati Gujr Gurmukhi Guru Han Hani Hangul Hang Hanunoo Hano Hatran Hatr Hebrew Hebr Hiragana Hira Imperial_Aramaic Armi Inherited Zinh Qaai Inscriptional_Pahlavi Phli Inscriptional_Parthian Prti Javanese Java Kaithi Kthi Kannada Knda Katakana Kana Kayah_Li Kali Kharoshthi Khar Khmer Khmr Khojki Khoj Khudawadi Sind Lao Laoo Latin Latn Lepcha Lepc Limbu Limb Linear_A Lina Linear_B Linb Lisu Lisu Lycian Lyci Lydian Lydi Mahajani Mahj Malayalam Mlym Mandaic Mand Manichaean Mani Marchen Marc Masaram_Gondi Gonm Meetei_Mayek Mtei Mende_Kikakui Mend Meroitic_Cursive Merc Meroitic_Hieroglyphs Mero Miao Plrd Modi Modi Mongolian Mong Mro Mroo Multani Mult Myanmar Mymr Nabataean Nbat New_Tai_Lue Talu Newa Newa Nko Nkoo Nushu Nshu Ogham Ogam Ol_Chiki Olck Old_Hungarian Hung Old_Italic Ital Old_North_Arabian Narb Old_Permic Perm Old_Persian Xpeo Old_South_Arabian Sarb Old_Turkic Orkh Oriya Orya Osage Osge Osmanya Osma Pahawh_Hmong Hmng Palmyrene Palm Pau_Cin_Hau Pauc Phags_Pa Phag Phoenician Phnx Psalter_Pahlavi Phlp Rejang Rjng Runic Runr Samaritan Samr Saurashtra Saur Sharada Shrd Shavian Shaw Siddham Sidd SignWriting Sgnw Sinhala Sinh Sora_Sompeng Sora Soyombo Soyo Sundanese Sund Syloti_Nagri Sylo Syriac Syrc Tagalog Tglg Tagbanwa Tagb Tai_Le Tale Tai_Tham Lana Tai_Viet Tavt Takri Takr Tamil Taml Tangut Tang Telugu Telu Thaana Thaa Thai Thai Tibetan Tibt Tifinagh Tfng Tirhuta Tirh Ugaritic Ugar Vai Vaii Warang_Citi Wara Yi Yiii Zanabazar_Square Zanb";
+      var ecma10ScriptValues2 = ecma9ScriptValues2 + " Dogra Dogr Gunjala_Gondi Gong Hanifi_Rohingya Rohg Makasar Maka Medefaidrin Medf Old_Sogdian Sogo Sogdian Sogd";
+      var ecma11ScriptValues2 = ecma10ScriptValues2 + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
+      var unicodeScriptValues2 = {
+        9: ecma9ScriptValues2,
+        10: ecma10ScriptValues2,
+        11: ecma11ScriptValues2
+      };
+      var data2 = {};
+      function buildUnicodeData2(ecmaVersion) {
+        var d = data2[ecmaVersion] = {
+          binary: wordsRegexp2(unicodeBinaryProperties2[ecmaVersion] + " " + unicodeGeneralCategoryValues2),
+          nonBinary: {
+            General_Category: wordsRegexp2(unicodeGeneralCategoryValues2),
+            Script: wordsRegexp2(unicodeScriptValues2[ecmaVersion])
+          }
+        };
+        d.nonBinary.Script_Extensions = d.nonBinary.Script;
+        d.nonBinary.gc = d.nonBinary.General_Category;
+        d.nonBinary.sc = d.nonBinary.Script;
+        d.nonBinary.scx = d.nonBinary.Script_Extensions;
+      }
+      buildUnicodeData2(9);
+      buildUnicodeData2(10);
+      buildUnicodeData2(11);
+      var pp$82 = Parser3.prototype;
+      var RegExpValidationState3 = function RegExpValidationState4(parser) {
+        this.parser = parser;
+        this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "");
+        this.unicodeProperties = data2[parser.options.ecmaVersion >= 11 ? 11 : parser.options.ecmaVersion];
+        this.source = "";
+        this.flags = "";
+        this.start = 0;
+        this.switchU = false;
+        this.switchN = false;
+        this.pos = 0;
+        this.lastIntValue = 0;
+        this.lastStringValue = "";
+        this.lastAssertionIsQuantifiable = false;
+        this.numCapturingParens = 0;
+        this.maxBackReference = 0;
+        this.groupNames = [];
+        this.backReferenceNames = [];
+      };
+      RegExpValidationState3.prototype.reset = function reset2(start2, pattern, flags) {
+        var unicode = flags.indexOf("u") !== -1;
+        this.start = start2 | 0;
+        this.source = pattern + "";
+        this.flags = flags;
+        this.switchU = unicode && this.parser.options.ecmaVersion >= 6;
+        this.switchN = unicode && this.parser.options.ecmaVersion >= 9;
+      };
+      RegExpValidationState3.prototype.raise = function raise2(message) {
+        this.parser.raiseRecoverable(this.start, "Invalid regular expression: /" + this.source + "/: " + message);
+      };
+      RegExpValidationState3.prototype.at = function at2(i, forceU) {
+        if (forceU === void 0) forceU = false;
+        var s = this.source;
+        var l = s.length;
+        if (i >= l) {
+          return -1;
+        }
+        var c = s.charCodeAt(i);
+        if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l) {
+          return c;
+        }
+        var next = s.charCodeAt(i + 1);
+        return next >= 56320 && next <= 57343 ? (c << 10) + next - 56613888 : c;
+      };
+      RegExpValidationState3.prototype.nextIndex = function nextIndex2(i, forceU) {
+        if (forceU === void 0) forceU = false;
+        var s = this.source;
+        var l = s.length;
+        if (i >= l) {
+          return l;
+        }
+        var c = s.charCodeAt(i), next;
+        if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l || (next = s.charCodeAt(i + 1)) < 56320 || next > 57343) {
+          return i + 1;
+        }
+        return i + 2;
+      };
+      RegExpValidationState3.prototype.current = function current2(forceU) {
+        if (forceU === void 0) forceU = false;
+        return this.at(this.pos, forceU);
+      };
+      RegExpValidationState3.prototype.lookahead = function lookahead2(forceU) {
+        if (forceU === void 0) forceU = false;
+        return this.at(this.nextIndex(this.pos, forceU), forceU);
+      };
+      RegExpValidationState3.prototype.advance = function advance2(forceU) {
+        if (forceU === void 0) forceU = false;
+        this.pos = this.nextIndex(this.pos, forceU);
+      };
+      RegExpValidationState3.prototype.eat = function eat2(ch, forceU) {
+        if (forceU === void 0) forceU = false;
+        if (this.current(forceU) === ch) {
+          this.advance(forceU);
+          return true;
+        }
+        return false;
+      };
+      function codePointToString2(ch) {
+        if (ch <= 65535) {
+          return String.fromCharCode(ch);
+        }
+        ch -= 65536;
+        return String.fromCharCode((ch >> 10) + 55296, (ch & 1023) + 56320);
+      }
+      pp$82.validateRegExpFlags = function(state) {
+        var validFlags = state.validFlags;
+        var flags = state.flags;
+        for (var i = 0; i < flags.length; i++) {
+          var flag = flags.charAt(i);
+          if (validFlags.indexOf(flag) === -1) {
+            this.raise(state.start, "Invalid regular expression flag");
+          }
+          if (flags.indexOf(flag, i + 1) > -1) {
+            this.raise(state.start, "Duplicate regular expression flag");
+          }
+        }
+      };
+      pp$82.validateRegExpPattern = function(state) {
+        this.regexp_pattern(state);
+        if (!state.switchN && this.options.ecmaVersion >= 9 && state.groupNames.length > 0) {
+          state.switchN = true;
+          this.regexp_pattern(state);
+        }
+      };
+      pp$82.regexp_pattern = function(state) {
+        state.pos = 0;
+        state.lastIntValue = 0;
+        state.lastStringValue = "";
+        state.lastAssertionIsQuantifiable = false;
+        state.numCapturingParens = 0;
+        state.maxBackReference = 0;
+        state.groupNames.length = 0;
+        state.backReferenceNames.length = 0;
+        this.regexp_disjunction(state);
+        if (state.pos !== state.source.length) {
+          if (state.eat(
+            41
+            /* ) */
+          )) {
+            state.raise("Unmatched ')'");
+          }
+          if (state.eat(
+            93
+            /* ] */
+          ) || state.eat(
+            125
+            /* } */
+          )) {
+            state.raise("Lone quantifier brackets");
+          }
+        }
+        if (state.maxBackReference > state.numCapturingParens) {
+          state.raise("Invalid escape");
+        }
+        for (var i = 0, list3 = state.backReferenceNames; i < list3.length; i += 1) {
+          var name2 = list3[i];
+          if (state.groupNames.indexOf(name2) === -1) {
+            state.raise("Invalid named capture referenced");
+          }
+        }
+      };
+      pp$82.regexp_disjunction = function(state) {
+        this.regexp_alternative(state);
+        while (state.eat(
+          124
+          /* | */
+        )) {
+          this.regexp_alternative(state);
+        }
+        if (this.regexp_eatQuantifier(state, true)) {
+          state.raise("Nothing to repeat");
+        }
+        if (state.eat(
+          123
+          /* { */
+        )) {
+          state.raise("Lone quantifier brackets");
+        }
+      };
+      pp$82.regexp_alternative = function(state) {
+        while (state.pos < state.source.length && this.regexp_eatTerm(state)) {
+        }
+      };
+      pp$82.regexp_eatTerm = function(state) {
+        if (this.regexp_eatAssertion(state)) {
+          if (state.lastAssertionIsQuantifiable && this.regexp_eatQuantifier(state)) {
+            if (state.switchU) {
+              state.raise("Invalid quantifier");
+            }
+          }
+          return true;
+        }
+        if (state.switchU ? this.regexp_eatAtom(state) : this.regexp_eatExtendedAtom(state)) {
+          this.regexp_eatQuantifier(state);
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatAssertion = function(state) {
+        var start2 = state.pos;
+        state.lastAssertionIsQuantifiable = false;
+        if (state.eat(
+          94
+          /* ^ */
+        ) || state.eat(
+          36
+          /* $ */
+        )) {
+          return true;
+        }
+        if (state.eat(
+          92
+          /* \ */
+        )) {
+          if (state.eat(
+            66
+            /* B */
+          ) || state.eat(
+            98
+            /* b */
+          )) {
+            return true;
+          }
+          state.pos = start2;
+        }
+        if (state.eat(
+          40
+          /* ( */
+        ) && state.eat(
+          63
+          /* ? */
+        )) {
+          var lookbehind = false;
+          if (this.options.ecmaVersion >= 9) {
+            lookbehind = state.eat(
+              60
+              /* < */
+            );
+          }
+          if (state.eat(
+            61
+            /* = */
+          ) || state.eat(
+            33
+            /* ! */
+          )) {
+            this.regexp_disjunction(state);
+            if (!state.eat(
+              41
+              /* ) */
+            )) {
+              state.raise("Unterminated group");
+            }
+            state.lastAssertionIsQuantifiable = !lookbehind;
+            return true;
+          }
+        }
+        state.pos = start2;
+        return false;
+      };
+      pp$82.regexp_eatQuantifier = function(state, noError) {
+        if (noError === void 0) noError = false;
+        if (this.regexp_eatQuantifierPrefix(state, noError)) {
+          state.eat(
+            63
+            /* ? */
+          );
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatQuantifierPrefix = function(state, noError) {
+        return state.eat(
+          42
+          /* * */
+        ) || state.eat(
+          43
+          /* + */
+        ) || state.eat(
+          63
+          /* ? */
+        ) || this.regexp_eatBracedQuantifier(state, noError);
+      };
+      pp$82.regexp_eatBracedQuantifier = function(state, noError) {
+        var start2 = state.pos;
+        if (state.eat(
+          123
+          /* { */
+        )) {
+          var min = 0, max = -1;
+          if (this.regexp_eatDecimalDigits(state)) {
+            min = state.lastIntValue;
+            if (state.eat(
+              44
+              /* , */
+            ) && this.regexp_eatDecimalDigits(state)) {
+              max = state.lastIntValue;
+            }
+            if (state.eat(
+              125
+              /* } */
+            )) {
+              if (max !== -1 && max < min && !noError) {
+                state.raise("numbers out of order in {} quantifier");
+              }
+              return true;
+            }
+          }
+          if (state.switchU && !noError) {
+            state.raise("Incomplete quantifier");
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      pp$82.regexp_eatAtom = function(state) {
+        return this.regexp_eatPatternCharacters(state) || state.eat(
+          46
+          /* . */
+        ) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state);
+      };
+      pp$82.regexp_eatReverseSolidusAtomEscape = function(state) {
+        var start2 = state.pos;
+        if (state.eat(
+          92
+          /* \ */
+        )) {
+          if (this.regexp_eatAtomEscape(state)) {
+            return true;
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      pp$82.regexp_eatUncapturingGroup = function(state) {
+        var start2 = state.pos;
+        if (state.eat(
+          40
+          /* ( */
+        )) {
+          if (state.eat(
+            63
+            /* ? */
+          ) && state.eat(
+            58
+            /* : */
+          )) {
+            this.regexp_disjunction(state);
+            if (state.eat(
+              41
+              /* ) */
+            )) {
+              return true;
+            }
+            state.raise("Unterminated group");
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      pp$82.regexp_eatCapturingGroup = function(state) {
+        if (state.eat(
+          40
+          /* ( */
+        )) {
+          if (this.options.ecmaVersion >= 9) {
+            this.regexp_groupSpecifier(state);
+          } else if (state.current() === 63) {
+            state.raise("Invalid group");
+          }
+          this.regexp_disjunction(state);
+          if (state.eat(
+            41
+            /* ) */
+          )) {
+            state.numCapturingParens += 1;
+            return true;
+          }
+          state.raise("Unterminated group");
+        }
+        return false;
+      };
+      pp$82.regexp_eatExtendedAtom = function(state) {
+        return state.eat(
+          46
+          /* . */
+        ) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state) || this.regexp_eatInvalidBracedQuantifier(state) || this.regexp_eatExtendedPatternCharacter(state);
+      };
+      pp$82.regexp_eatInvalidBracedQuantifier = function(state) {
+        if (this.regexp_eatBracedQuantifier(state, true)) {
+          state.raise("Nothing to repeat");
+        }
+        return false;
+      };
+      pp$82.regexp_eatSyntaxCharacter = function(state) {
+        var ch = state.current();
+        if (isSyntaxCharacter2(ch)) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      function isSyntaxCharacter2(ch) {
+        return ch === 36 || ch >= 40 && ch <= 43 || ch === 46 || ch === 63 || ch >= 91 && ch <= 94 || ch >= 123 && ch <= 125;
+      }
+      pp$82.regexp_eatPatternCharacters = function(state) {
+        var start2 = state.pos;
+        var ch = 0;
+        while ((ch = state.current()) !== -1 && !isSyntaxCharacter2(ch)) {
+          state.advance();
+        }
+        return state.pos !== start2;
+      };
+      pp$82.regexp_eatExtendedPatternCharacter = function(state) {
+        var ch = state.current();
+        if (ch !== -1 && ch !== 36 && !(ch >= 40 && ch <= 43) && ch !== 46 && ch !== 63 && ch !== 91 && ch !== 94 && ch !== 124) {
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_groupSpecifier = function(state) {
+        if (state.eat(
+          63
+          /* ? */
+        )) {
+          if (this.regexp_eatGroupName(state)) {
+            if (state.groupNames.indexOf(state.lastStringValue) !== -1) {
+              state.raise("Duplicate capture group name");
+            }
+            state.groupNames.push(state.lastStringValue);
+            return;
+          }
+          state.raise("Invalid group");
+        }
+      };
+      pp$82.regexp_eatGroupName = function(state) {
+        state.lastStringValue = "";
+        if (state.eat(
+          60
+          /* < */
+        )) {
+          if (this.regexp_eatRegExpIdentifierName(state) && state.eat(
+            62
+            /* > */
+          )) {
+            return true;
+          }
+          state.raise("Invalid capture group name");
+        }
+        return false;
+      };
+      pp$82.regexp_eatRegExpIdentifierName = function(state) {
+        state.lastStringValue = "";
+        if (this.regexp_eatRegExpIdentifierStart(state)) {
+          state.lastStringValue += codePointToString2(state.lastIntValue);
+          while (this.regexp_eatRegExpIdentifierPart(state)) {
+            state.lastStringValue += codePointToString2(state.lastIntValue);
+          }
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatRegExpIdentifierStart = function(state) {
+        var start2 = state.pos;
+        var forceU = this.options.ecmaVersion >= 11;
+        var ch = state.current(forceU);
+        state.advance(forceU);
+        if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+          ch = state.lastIntValue;
+        }
+        if (isRegExpIdentifierStart2(ch)) {
+          state.lastIntValue = ch;
+          return true;
+        }
+        state.pos = start2;
+        return false;
+      };
+      function isRegExpIdentifierStart2(ch) {
+        return isIdentifierStart2(ch, true) || ch === 36 || ch === 95;
+      }
+      pp$82.regexp_eatRegExpIdentifierPart = function(state) {
+        var start2 = state.pos;
+        var forceU = this.options.ecmaVersion >= 11;
+        var ch = state.current(forceU);
+        state.advance(forceU);
+        if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+          ch = state.lastIntValue;
+        }
+        if (isRegExpIdentifierPart2(ch)) {
+          state.lastIntValue = ch;
+          return true;
+        }
+        state.pos = start2;
+        return false;
+      };
+      function isRegExpIdentifierPart2(ch) {
+        return isIdentifierChar2(ch, true) || ch === 36 || ch === 95 || ch === 8204 || ch === 8205;
+      }
+      pp$82.regexp_eatAtomEscape = function(state) {
+        if (this.regexp_eatBackReference(state) || this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state) || state.switchN && this.regexp_eatKGroupName(state)) {
+          return true;
+        }
+        if (state.switchU) {
+          if (state.current() === 99) {
+            state.raise("Invalid unicode escape");
+          }
+          state.raise("Invalid escape");
+        }
+        return false;
+      };
+      pp$82.regexp_eatBackReference = function(state) {
+        var start2 = state.pos;
+        if (this.regexp_eatDecimalEscape(state)) {
+          var n = state.lastIntValue;
+          if (state.switchU) {
+            if (n > state.maxBackReference) {
+              state.maxBackReference = n;
+            }
+            return true;
+          }
+          if (n <= state.numCapturingParens) {
+            return true;
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      pp$82.regexp_eatKGroupName = function(state) {
+        if (state.eat(
+          107
+          /* k */
+        )) {
+          if (this.regexp_eatGroupName(state)) {
+            state.backReferenceNames.push(state.lastStringValue);
+            return true;
+          }
+          state.raise("Invalid named reference");
+        }
+        return false;
+      };
+      pp$82.regexp_eatCharacterEscape = function(state) {
+        return this.regexp_eatControlEscape(state) || this.regexp_eatCControlLetter(state) || this.regexp_eatZero(state) || this.regexp_eatHexEscapeSequence(state) || this.regexp_eatRegExpUnicodeEscapeSequence(state, false) || !state.switchU && this.regexp_eatLegacyOctalEscapeSequence(state) || this.regexp_eatIdentityEscape(state);
+      };
+      pp$82.regexp_eatCControlLetter = function(state) {
+        var start2 = state.pos;
+        if (state.eat(
+          99
+          /* c */
+        )) {
+          if (this.regexp_eatControlLetter(state)) {
+            return true;
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      pp$82.regexp_eatZero = function(state) {
+        if (state.current() === 48 && !isDecimalDigit2(state.lookahead())) {
+          state.lastIntValue = 0;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatControlEscape = function(state) {
+        var ch = state.current();
+        if (ch === 116) {
+          state.lastIntValue = 9;
+          state.advance();
+          return true;
+        }
+        if (ch === 110) {
+          state.lastIntValue = 10;
+          state.advance();
+          return true;
+        }
+        if (ch === 118) {
+          state.lastIntValue = 11;
+          state.advance();
+          return true;
+        }
+        if (ch === 102) {
+          state.lastIntValue = 12;
+          state.advance();
+          return true;
+        }
+        if (ch === 114) {
+          state.lastIntValue = 13;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatControlLetter = function(state) {
+        var ch = state.current();
+        if (isControlLetter2(ch)) {
+          state.lastIntValue = ch % 32;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      function isControlLetter2(ch) {
+        return ch >= 65 && ch <= 90 || ch >= 97 && ch <= 122;
+      }
+      pp$82.regexp_eatRegExpUnicodeEscapeSequence = function(state, forceU) {
+        if (forceU === void 0) forceU = false;
+        var start2 = state.pos;
+        var switchU = forceU || state.switchU;
+        if (state.eat(
+          117
+          /* u */
+        )) {
+          if (this.regexp_eatFixedHexDigits(state, 4)) {
+            var lead = state.lastIntValue;
+            if (switchU && lead >= 55296 && lead <= 56319) {
+              var leadSurrogateEnd = state.pos;
+              if (state.eat(
+                92
+                /* \ */
+              ) && state.eat(
+                117
+                /* u */
+              ) && this.regexp_eatFixedHexDigits(state, 4)) {
+                var trail = state.lastIntValue;
+                if (trail >= 56320 && trail <= 57343) {
+                  state.lastIntValue = (lead - 55296) * 1024 + (trail - 56320) + 65536;
+                  return true;
+                }
+              }
+              state.pos = leadSurrogateEnd;
+              state.lastIntValue = lead;
+            }
+            return true;
+          }
+          if (switchU && state.eat(
+            123
+            /* { */
+          ) && this.regexp_eatHexDigits(state) && state.eat(
+            125
+            /* } */
+          ) && isValidUnicode2(state.lastIntValue)) {
+            return true;
+          }
+          if (switchU) {
+            state.raise("Invalid unicode escape");
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      function isValidUnicode2(ch) {
+        return ch >= 0 && ch <= 1114111;
+      }
+      pp$82.regexp_eatIdentityEscape = function(state) {
+        if (state.switchU) {
+          if (this.regexp_eatSyntaxCharacter(state)) {
+            return true;
+          }
+          if (state.eat(
+            47
+            /* / */
+          )) {
+            state.lastIntValue = 47;
+            return true;
+          }
+          return false;
+        }
+        var ch = state.current();
+        if (ch !== 99 && (!state.switchN || ch !== 107)) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatDecimalEscape = function(state) {
+        state.lastIntValue = 0;
+        var ch = state.current();
+        if (ch >= 49 && ch <= 57) {
+          do {
+            state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+            state.advance();
+          } while ((ch = state.current()) >= 48 && ch <= 57);
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatCharacterClassEscape = function(state) {
+        var ch = state.current();
+        if (isCharacterClassEscape2(ch)) {
+          state.lastIntValue = -1;
+          state.advance();
+          return true;
+        }
+        if (state.switchU && this.options.ecmaVersion >= 9 && (ch === 80 || ch === 112)) {
+          state.lastIntValue = -1;
+          state.advance();
+          if (state.eat(
+            123
+            /* { */
+          ) && this.regexp_eatUnicodePropertyValueExpression(state) && state.eat(
+            125
+            /* } */
+          )) {
+            return true;
+          }
+          state.raise("Invalid property name");
+        }
+        return false;
+      };
+      function isCharacterClassEscape2(ch) {
+        return ch === 100 || ch === 68 || ch === 115 || ch === 83 || ch === 119 || ch === 87;
+      }
+      pp$82.regexp_eatUnicodePropertyValueExpression = function(state) {
+        var start2 = state.pos;
+        if (this.regexp_eatUnicodePropertyName(state) && state.eat(
+          61
+          /* = */
+        )) {
+          var name2 = state.lastStringValue;
+          if (this.regexp_eatUnicodePropertyValue(state)) {
+            var value = state.lastStringValue;
+            this.regexp_validateUnicodePropertyNameAndValue(state, name2, value);
+            return true;
+          }
+        }
+        state.pos = start2;
+        if (this.regexp_eatLoneUnicodePropertyNameOrValue(state)) {
+          var nameOrValue = state.lastStringValue;
+          this.regexp_validateUnicodePropertyNameOrValue(state, nameOrValue);
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_validateUnicodePropertyNameAndValue = function(state, name2, value) {
+        if (!has(state.unicodeProperties.nonBinary, name2)) {
+          state.raise("Invalid property name");
+        }
+        if (!state.unicodeProperties.nonBinary[name2].test(value)) {
+          state.raise("Invalid property value");
+        }
+      };
+      pp$82.regexp_validateUnicodePropertyNameOrValue = function(state, nameOrValue) {
+        if (!state.unicodeProperties.binary.test(nameOrValue)) {
+          state.raise("Invalid property name");
+        }
+      };
+      pp$82.regexp_eatUnicodePropertyName = function(state) {
+        var ch = 0;
+        state.lastStringValue = "";
+        while (isUnicodePropertyNameCharacter2(ch = state.current())) {
+          state.lastStringValue += codePointToString2(ch);
+          state.advance();
+        }
+        return state.lastStringValue !== "";
+      };
+      function isUnicodePropertyNameCharacter2(ch) {
+        return isControlLetter2(ch) || ch === 95;
+      }
+      pp$82.regexp_eatUnicodePropertyValue = function(state) {
+        var ch = 0;
+        state.lastStringValue = "";
+        while (isUnicodePropertyValueCharacter2(ch = state.current())) {
+          state.lastStringValue += codePointToString2(ch);
+          state.advance();
+        }
+        return state.lastStringValue !== "";
+      };
+      function isUnicodePropertyValueCharacter2(ch) {
+        return isUnicodePropertyNameCharacter2(ch) || isDecimalDigit2(ch);
+      }
+      pp$82.regexp_eatLoneUnicodePropertyNameOrValue = function(state) {
+        return this.regexp_eatUnicodePropertyValue(state);
+      };
+      pp$82.regexp_eatCharacterClass = function(state) {
+        if (state.eat(
+          91
+          /* [ */
+        )) {
+          state.eat(
+            94
+            /* ^ */
+          );
+          this.regexp_classRanges(state);
+          if (state.eat(
+            93
+            /* ] */
+          )) {
+            return true;
+          }
+          state.raise("Unterminated character class");
+        }
+        return false;
+      };
+      pp$82.regexp_classRanges = function(state) {
+        while (this.regexp_eatClassAtom(state)) {
+          var left = state.lastIntValue;
+          if (state.eat(
+            45
+            /* - */
+          ) && this.regexp_eatClassAtom(state)) {
+            var right = state.lastIntValue;
+            if (state.switchU && (left === -1 || right === -1)) {
+              state.raise("Invalid character class");
+            }
+            if (left !== -1 && right !== -1 && left > right) {
+              state.raise("Range out of order in character class");
+            }
+          }
+        }
+      };
+      pp$82.regexp_eatClassAtom = function(state) {
+        var start2 = state.pos;
+        if (state.eat(
+          92
+          /* \ */
+        )) {
+          if (this.regexp_eatClassEscape(state)) {
+            return true;
+          }
+          if (state.switchU) {
+            var ch$1 = state.current();
+            if (ch$1 === 99 || isOctalDigit2(ch$1)) {
+              state.raise("Invalid class escape");
+            }
+            state.raise("Invalid escape");
+          }
+          state.pos = start2;
+        }
+        var ch = state.current();
+        if (ch !== 93) {
+          state.lastIntValue = ch;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatClassEscape = function(state) {
+        var start2 = state.pos;
+        if (state.eat(
+          98
+          /* b */
+        )) {
+          state.lastIntValue = 8;
+          return true;
+        }
+        if (state.switchU && state.eat(
+          45
+          /* - */
+        )) {
+          state.lastIntValue = 45;
+          return true;
+        }
+        if (!state.switchU && state.eat(
+          99
+          /* c */
+        )) {
+          if (this.regexp_eatClassControlLetter(state)) {
+            return true;
+          }
+          state.pos = start2;
+        }
+        return this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state);
+      };
+      pp$82.regexp_eatClassControlLetter = function(state) {
+        var ch = state.current();
+        if (isDecimalDigit2(ch) || ch === 95) {
+          state.lastIntValue = ch % 32;
+          state.advance();
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatHexEscapeSequence = function(state) {
+        var start2 = state.pos;
+        if (state.eat(
+          120
+          /* x */
+        )) {
+          if (this.regexp_eatFixedHexDigits(state, 2)) {
+            return true;
+          }
+          if (state.switchU) {
+            state.raise("Invalid escape");
+          }
+          state.pos = start2;
+        }
+        return false;
+      };
+      pp$82.regexp_eatDecimalDigits = function(state) {
+        var start2 = state.pos;
+        var ch = 0;
+        state.lastIntValue = 0;
+        while (isDecimalDigit2(ch = state.current())) {
+          state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+          state.advance();
+        }
+        return state.pos !== start2;
+      };
+      function isDecimalDigit2(ch) {
+        return ch >= 48 && ch <= 57;
+      }
+      pp$82.regexp_eatHexDigits = function(state) {
+        var start2 = state.pos;
+        var ch = 0;
+        state.lastIntValue = 0;
+        while (isHexDigit2(ch = state.current())) {
+          state.lastIntValue = 16 * state.lastIntValue + hexToInt2(ch);
+          state.advance();
+        }
+        return state.pos !== start2;
+      };
+      function isHexDigit2(ch) {
+        return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+      }
+      function hexToInt2(ch) {
+        if (ch >= 65 && ch <= 70) {
+          return 10 + (ch - 65);
+        }
+        if (ch >= 97 && ch <= 102) {
+          return 10 + (ch - 97);
+        }
+        return ch - 48;
+      }
+      pp$82.regexp_eatLegacyOctalEscapeSequence = function(state) {
+        if (this.regexp_eatOctalDigit(state)) {
+          var n1 = state.lastIntValue;
+          if (this.regexp_eatOctalDigit(state)) {
+            var n2 = state.lastIntValue;
+            if (n1 <= 3 && this.regexp_eatOctalDigit(state)) {
+              state.lastIntValue = n1 * 64 + n2 * 8 + state.lastIntValue;
+            } else {
+              state.lastIntValue = n1 * 8 + n2;
+            }
+          } else {
+            state.lastIntValue = n1;
+          }
+          return true;
+        }
+        return false;
+      };
+      pp$82.regexp_eatOctalDigit = function(state) {
+        var ch = state.current();
+        if (isOctalDigit2(ch)) {
+          state.lastIntValue = ch - 48;
+          state.advance();
+          return true;
+        }
+        state.lastIntValue = 0;
+        return false;
+      };
+      function isOctalDigit2(ch) {
+        return ch >= 48 && ch <= 55;
+      }
+      pp$82.regexp_eatFixedHexDigits = function(state, length) {
+        var start2 = state.pos;
+        state.lastIntValue = 0;
+        for (var i = 0; i < length; ++i) {
+          var ch = state.current();
+          if (!isHexDigit2(ch)) {
+            state.pos = start2;
+            return false;
+          }
+          state.lastIntValue = 16 * state.lastIntValue + hexToInt2(ch);
+          state.advance();
+        }
+        return true;
+      };
+      var Token3 = function Token4(p) {
+        this.type = p.type;
+        this.value = p.value;
+        this.start = p.start;
+        this.end = p.end;
+        if (p.options.locations) {
+          this.loc = new SourceLocation3(p, p.startLoc, p.endLoc);
+        }
+        if (p.options.ranges) {
+          this.range = [p.start, p.end];
+        }
+      };
+      var pp$92 = Parser3.prototype;
+      pp$92.next = function(ignoreEscapeSequenceInKeyword) {
+        if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc) {
+          this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword);
+        }
+        if (this.options.onToken) {
+          this.options.onToken(new Token3(this));
+        }
+        this.lastTokEnd = this.end;
+        this.lastTokStart = this.start;
+        this.lastTokEndLoc = this.endLoc;
+        this.lastTokStartLoc = this.startLoc;
+        this.nextToken();
+      };
+      pp$92.getToken = function() {
+        this.next();
+        return new Token3(this);
+      };
+      if (typeof Symbol !== "undefined") {
+        pp$92[Symbol.iterator] = function() {
+          var this$1 = this;
+          return {
+            next: function() {
+              var token = this$1.getToken();
+              return {
+                done: token.type === types2.eof,
+                value: token
+              };
+            }
+          };
+        };
+      }
+      pp$92.curContext = function() {
+        return this.context[this.context.length - 1];
+      };
+      pp$92.nextToken = function() {
+        var curContext = this.curContext();
+        if (!curContext || !curContext.preserveSpace) {
+          this.skipSpace();
+        }
+        this.start = this.pos;
+        if (this.options.locations) {
+          this.startLoc = this.curPosition();
+        }
+        if (this.pos >= this.input.length) {
+          return this.finishToken(types2.eof);
+        }
+        if (curContext.override) {
+          return curContext.override(this);
+        } else {
+          this.readToken(this.fullCharCodeAtPos());
+        }
+      };
+      pp$92.readToken = function(code2) {
+        if (isIdentifierStart2(code2, this.options.ecmaVersion >= 6) || code2 === 92) {
+          return this.readWord();
+        }
+        return this.getTokenFromCode(code2);
+      };
+      pp$92.fullCharCodeAtPos = function() {
+        var code2 = this.input.charCodeAt(this.pos);
+        if (code2 <= 55295 || code2 >= 57344) {
+          return code2;
+        }
+        var next = this.input.charCodeAt(this.pos + 1);
+        return (code2 << 10) + next - 56613888;
+      };
+      pp$92.skipBlockComment = function() {
+        var startLoc = this.options.onComment && this.curPosition();
+        var start2 = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+        if (end === -1) {
+          this.raise(this.pos - 2, "Unterminated comment");
+        }
+        this.pos = end + 2;
+        if (this.options.locations) {
+          lineBreakG2.lastIndex = start2;
+          var match;
+          while ((match = lineBreakG2.exec(this.input)) && match.index < this.pos) {
+            ++this.curLine;
+            this.lineStart = match.index + match[0].length;
+          }
+        }
+        if (this.options.onComment) {
+          this.options.onComment(
+            true,
+            this.input.slice(start2 + 2, end),
+            start2,
+            this.pos,
+            startLoc,
+            this.curPosition()
+          );
+        }
+      };
+      pp$92.skipLineComment = function(startSkip) {
+        var start2 = this.pos;
+        var startLoc = this.options.onComment && this.curPosition();
+        var ch = this.input.charCodeAt(this.pos += startSkip);
+        while (this.pos < this.input.length && !isNewLine2(ch)) {
+          ch = this.input.charCodeAt(++this.pos);
+        }
+        if (this.options.onComment) {
+          this.options.onComment(
+            false,
+            this.input.slice(start2 + startSkip, this.pos),
+            start2,
+            this.pos,
+            startLoc,
+            this.curPosition()
+          );
+        }
+      };
+      pp$92.skipSpace = function() {
+        loop: while (this.pos < this.input.length) {
+          var ch = this.input.charCodeAt(this.pos);
+          switch (ch) {
+            case 32:
+            case 160:
+              ++this.pos;
+              break;
+            case 13:
+              if (this.input.charCodeAt(this.pos + 1) === 10) {
+                ++this.pos;
+              }
+            case 10:
+            case 8232:
+            case 8233:
+              ++this.pos;
+              if (this.options.locations) {
+                ++this.curLine;
+                this.lineStart = this.pos;
+              }
+              break;
+            case 47:
+              switch (this.input.charCodeAt(this.pos + 1)) {
+                case 42:
+                  this.skipBlockComment();
+                  break;
+                case 47:
+                  this.skipLineComment(2);
+                  break;
+                default:
+                  break loop;
+              }
+              break;
+            default:
+              if (ch > 8 && ch < 14 || ch >= 5760 && nonASCIIwhitespace2.test(String.fromCharCode(ch))) {
+                ++this.pos;
+              } else {
+                break loop;
+              }
+          }
+        }
+      };
+      pp$92.finishToken = function(type, val) {
+        this.end = this.pos;
+        if (this.options.locations) {
+          this.endLoc = this.curPosition();
+        }
+        var prevType = this.type;
+        this.type = type;
+        this.value = val;
+        this.updateContext(prevType);
+      };
+      pp$92.readToken_dot = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next >= 48 && next <= 57) {
+          return this.readNumber(true);
+        }
+        var next2 = this.input.charCodeAt(this.pos + 2);
+        if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+          this.pos += 3;
+          return this.finishToken(types2.ellipsis);
+        } else {
+          ++this.pos;
+          return this.finishToken(types2.dot);
+        }
+      };
+      pp$92.readToken_slash = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (this.exprAllowed) {
+          ++this.pos;
+          return this.readRegexp();
+        }
+        if (next === 61) {
+          return this.finishOp(types2.assign, 2);
+        }
+        return this.finishOp(types2.slash, 1);
+      };
+      pp$92.readToken_mult_modulo_exp = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        var size = 1;
+        var tokentype = code2 === 42 ? types2.star : types2.modulo;
+        if (this.options.ecmaVersion >= 7 && code2 === 42 && next === 42) {
+          ++size;
+          tokentype = types2.starstar;
+          next = this.input.charCodeAt(this.pos + 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types2.assign, size + 1);
+        }
+        return this.finishOp(tokentype, size);
+      };
+      pp$92.readToken_pipe_amp = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === code2) {
+          if (this.options.ecmaVersion >= 12) {
+            var next2 = this.input.charCodeAt(this.pos + 2);
+            if (next2 === 61) {
+              return this.finishOp(types2.assign, 3);
+            }
+          }
+          return this.finishOp(code2 === 124 ? types2.logicalOR : types2.logicalAND, 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types2.assign, 2);
+        }
+        return this.finishOp(code2 === 124 ? types2.bitwiseOR : types2.bitwiseAND, 1);
+      };
+      pp$92.readToken_caret = function() {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 61) {
+          return this.finishOp(types2.assign, 2);
+        }
+        return this.finishOp(types2.bitwiseXOR, 1);
+      };
+      pp$92.readToken_plus_min = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === code2) {
+          if (next === 45 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 62 && (this.lastTokEnd === 0 || lineBreak2.test(this.input.slice(this.lastTokEnd, this.pos)))) {
+            this.skipLineComment(3);
+            this.skipSpace();
+            return this.nextToken();
+          }
+          return this.finishOp(types2.incDec, 2);
+        }
+        if (next === 61) {
+          return this.finishOp(types2.assign, 2);
+        }
+        return this.finishOp(types2.plusMin, 1);
+      };
+      pp$92.readToken_lt_gt = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        var size = 1;
+        if (next === code2) {
+          size = code2 === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+          if (this.input.charCodeAt(this.pos + size) === 61) {
+            return this.finishOp(types2.assign, size + 1);
+          }
+          return this.finishOp(types2.bitShift, size);
+        }
+        if (next === 33 && code2 === 60 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 45 && this.input.charCodeAt(this.pos + 3) === 45) {
+          this.skipLineComment(4);
+          this.skipSpace();
+          return this.nextToken();
+        }
+        if (next === 61) {
+          size = 2;
+        }
+        return this.finishOp(types2.relational, size);
+      };
+      pp$92.readToken_eq_excl = function(code2) {
+        var next = this.input.charCodeAt(this.pos + 1);
+        if (next === 61) {
+          return this.finishOp(types2.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+        }
+        if (code2 === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+          this.pos += 2;
+          return this.finishToken(types2.arrow);
+        }
+        return this.finishOp(code2 === 61 ? types2.eq : types2.prefix, 1);
+      };
+      pp$92.readToken_question = function() {
+        var ecmaVersion = this.options.ecmaVersion;
+        if (ecmaVersion >= 11) {
+          var next = this.input.charCodeAt(this.pos + 1);
+          if (next === 46) {
+            var next2 = this.input.charCodeAt(this.pos + 2);
+            if (next2 < 48 || next2 > 57) {
+              return this.finishOp(types2.questionDot, 2);
+            }
+          }
+          if (next === 63) {
+            if (ecmaVersion >= 12) {
+              var next2$1 = this.input.charCodeAt(this.pos + 2);
+              if (next2$1 === 61) {
+                return this.finishOp(types2.assign, 3);
+              }
+            }
+            return this.finishOp(types2.coalesce, 2);
+          }
+        }
+        return this.finishOp(types2.question, 1);
+      };
+      pp$92.getTokenFromCode = function(code2) {
+        switch (code2) {
+          case 46:
+            return this.readToken_dot();
+          case 40:
+            ++this.pos;
+            return this.finishToken(types2.parenL);
+          case 41:
+            ++this.pos;
+            return this.finishToken(types2.parenR);
+          case 59:
+            ++this.pos;
+            return this.finishToken(types2.semi);
+          case 44:
+            ++this.pos;
+            return this.finishToken(types2.comma);
+          case 91:
+            ++this.pos;
+            return this.finishToken(types2.bracketL);
+          case 93:
+            ++this.pos;
+            return this.finishToken(types2.bracketR);
+          case 123:
+            ++this.pos;
+            return this.finishToken(types2.braceL);
+          case 125:
+            ++this.pos;
+            return this.finishToken(types2.braceR);
+          case 58:
+            ++this.pos;
+            return this.finishToken(types2.colon);
+          case 96:
+            if (this.options.ecmaVersion < 6) {
+              break;
+            }
+            ++this.pos;
+            return this.finishToken(types2.backQuote);
+          case 48:
+            var next = this.input.charCodeAt(this.pos + 1);
+            if (next === 120 || next === 88) {
+              return this.readRadixNumber(16);
+            }
+            if (this.options.ecmaVersion >= 6) {
+              if (next === 111 || next === 79) {
+                return this.readRadixNumber(8);
+              }
+              if (next === 98 || next === 66) {
+                return this.readRadixNumber(2);
+              }
+            }
+          case 49:
+          case 50:
+          case 51:
+          case 52:
+          case 53:
+          case 54:
+          case 55:
+          case 56:
+          case 57:
+            return this.readNumber(false);
+          case 34:
+          case 39:
+            return this.readString(code2);
+          case 47:
+            return this.readToken_slash();
+          case 37:
+          case 42:
+            return this.readToken_mult_modulo_exp(code2);
+          case 124:
+          case 38:
+            return this.readToken_pipe_amp(code2);
+          case 94:
+            return this.readToken_caret();
+          case 43:
+          case 45:
+            return this.readToken_plus_min(code2);
+          case 60:
+          case 62:
+            return this.readToken_lt_gt(code2);
+          case 61:
+          case 33:
+            return this.readToken_eq_excl(code2);
+          case 63:
+            return this.readToken_question();
+          case 126:
+            return this.finishOp(types2.prefix, 1);
+        }
+        this.raise(this.pos, "Unexpected character '" + codePointToString$1(code2) + "'");
+      };
+      pp$92.finishOp = function(type, size) {
+        var str = this.input.slice(this.pos, this.pos + size);
+        this.pos += size;
+        return this.finishToken(type, str);
+      };
+      pp$92.readRegexp = function() {
+        var escaped, inClass, start2 = this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(start2, "Unterminated regular expression");
+          }
+          var ch = this.input.charAt(this.pos);
+          if (lineBreak2.test(ch)) {
+            this.raise(start2, "Unterminated regular expression");
+          }
+          if (!escaped) {
+            if (ch === "[") {
+              inClass = true;
+            } else if (ch === "]" && inClass) {
+              inClass = false;
+            } else if (ch === "/" && !inClass) {
+              break;
+            }
+            escaped = ch === "\\";
+          } else {
+            escaped = false;
+          }
+          ++this.pos;
+        }
+        var pattern = this.input.slice(start2, this.pos);
+        ++this.pos;
+        var flagsStart = this.pos;
+        var flags = this.readWord1();
+        if (this.containsEsc) {
+          this.unexpected(flagsStart);
+        }
+        var state = this.regexpState || (this.regexpState = new RegExpValidationState3(this));
+        state.reset(start2, pattern, flags);
+        this.validateRegExpFlags(state);
+        this.validateRegExpPattern(state);
+        var value = null;
+        try {
+          value = new RegExp(pattern, flags);
+        } catch (e) {
+        }
+        return this.finishToken(types2.regexp, { pattern, flags, value });
+      };
+      pp$92.readInt = function(radix, len, maybeLegacyOctalNumericLiteral) {
+        var allowSeparators = this.options.ecmaVersion >= 12 && len === void 0;
+        var isLegacyOctalNumericLiteral = maybeLegacyOctalNumericLiteral && this.input.charCodeAt(this.pos) === 48;
+        var start2 = this.pos, total = 0, lastCode = 0;
+        for (var i = 0, e = len == null ? Infinity : len; i < e; ++i, ++this.pos) {
+          var code2 = this.input.charCodeAt(this.pos), val = void 0;
+          if (allowSeparators && code2 === 95) {
+            if (isLegacyOctalNumericLiteral) {
+              this.raiseRecoverable(this.pos, "Numeric separator is not allowed in legacy octal numeric literals");
+            }
+            if (lastCode === 95) {
+              this.raiseRecoverable(this.pos, "Numeric separator must be exactly one underscore");
+            }
+            if (i === 0) {
+              this.raiseRecoverable(this.pos, "Numeric separator is not allowed at the first of digits");
+            }
+            lastCode = code2;
+            continue;
+          }
+          if (code2 >= 97) {
+            val = code2 - 97 + 10;
+          } else if (code2 >= 65) {
+            val = code2 - 65 + 10;
+          } else if (code2 >= 48 && code2 <= 57) {
+            val = code2 - 48;
+          } else {
+            val = Infinity;
+          }
+          if (val >= radix) {
+            break;
+          }
+          lastCode = code2;
+          total = total * radix + val;
+        }
+        if (allowSeparators && lastCode === 95) {
+          this.raiseRecoverable(this.pos - 1, "Numeric separator is not allowed at the last of digits");
+        }
+        if (this.pos === start2 || len != null && this.pos - start2 !== len) {
+          return null;
+        }
+        return total;
+      };
+      function stringToNumber2(str, isLegacyOctalNumericLiteral) {
+        if (isLegacyOctalNumericLiteral) {
+          return parseInt(str, 8);
+        }
+        return parseFloat(str.replace(/_/g, ""));
+      }
+      function stringToBigInt2(str) {
+        if (typeof BigInt !== "function") {
+          return null;
+        }
+        return BigInt(str.replace(/_/g, ""));
+      }
+      pp$92.readRadixNumber = function(radix) {
+        var start2 = this.pos;
+        this.pos += 2;
+        var val = this.readInt(radix);
+        if (val == null) {
+          this.raise(this.start + 2, "Expected number in radix " + radix);
+        }
+        if (this.options.ecmaVersion >= 11 && this.input.charCodeAt(this.pos) === 110) {
+          val = stringToBigInt2(this.input.slice(start2, this.pos));
+          ++this.pos;
+        } else if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+          this.raise(this.pos, "Identifier directly after number");
+        }
+        return this.finishToken(types2.num, val);
+      };
+      pp$92.readNumber = function(startsWithDot) {
+        var start2 = this.pos;
+        if (!startsWithDot && this.readInt(10, void 0, true) === null) {
+          this.raise(start2, "Invalid number");
+        }
+        var octal = this.pos - start2 >= 2 && this.input.charCodeAt(start2) === 48;
+        if (octal && this.strict) {
+          this.raise(start2, "Invalid number");
+        }
+        var next = this.input.charCodeAt(this.pos);
+        if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
+          var val$1 = stringToBigInt2(this.input.slice(start2, this.pos));
+          ++this.pos;
+          if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+            this.raise(this.pos, "Identifier directly after number");
+          }
+          return this.finishToken(types2.num, val$1);
+        }
+        if (octal && /[89]/.test(this.input.slice(start2, this.pos))) {
+          octal = false;
+        }
+        if (next === 46 && !octal) {
+          ++this.pos;
+          this.readInt(10);
+          next = this.input.charCodeAt(this.pos);
+        }
+        if ((next === 69 || next === 101) && !octal) {
+          next = this.input.charCodeAt(++this.pos);
+          if (next === 43 || next === 45) {
+            ++this.pos;
+          }
+          if (this.readInt(10) === null) {
+            this.raise(start2, "Invalid number");
+          }
+        }
+        if (isIdentifierStart2(this.fullCharCodeAtPos())) {
+          this.raise(this.pos, "Identifier directly after number");
+        }
+        var val = stringToNumber2(this.input.slice(start2, this.pos), octal);
+        return this.finishToken(types2.num, val);
+      };
+      pp$92.readCodePoint = function() {
+        var ch = this.input.charCodeAt(this.pos), code2;
+        if (ch === 123) {
+          if (this.options.ecmaVersion < 6) {
+            this.unexpected();
+          }
+          var codePos = ++this.pos;
+          code2 = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+          ++this.pos;
+          if (code2 > 1114111) {
+            this.invalidStringToken(codePos, "Code point out of bounds");
+          }
+        } else {
+          code2 = this.readHexChar(4);
+        }
+        return code2;
+      };
+      function codePointToString$1(code2) {
+        if (code2 <= 65535) {
+          return String.fromCharCode(code2);
+        }
+        code2 -= 65536;
+        return String.fromCharCode((code2 >> 10) + 55296, (code2 & 1023) + 56320);
+      }
+      pp$92.readString = function(quote) {
+        var out = "", chunkStart = ++this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(this.start, "Unterminated string constant");
+          }
+          var ch = this.input.charCodeAt(this.pos);
+          if (ch === quote) {
+            break;
+          }
+          if (ch === 92) {
+            out += this.input.slice(chunkStart, this.pos);
+            out += this.readEscapedChar(false);
+            chunkStart = this.pos;
+          } else {
+            if (isNewLine2(ch, this.options.ecmaVersion >= 10)) {
+              this.raise(this.start, "Unterminated string constant");
+            }
+            ++this.pos;
+          }
+        }
+        out += this.input.slice(chunkStart, this.pos++);
+        return this.finishToken(types2.string, out);
+      };
+      var INVALID_TEMPLATE_ESCAPE_ERROR2 = {};
+      pp$92.tryReadTemplateToken = function() {
+        this.inTemplateElement = true;
+        try {
+          this.readTmplToken();
+        } catch (err) {
+          if (err === INVALID_TEMPLATE_ESCAPE_ERROR2) {
+            this.readInvalidTemplateToken();
+          } else {
+            throw err;
+          }
+        }
+        this.inTemplateElement = false;
+      };
+      pp$92.invalidStringToken = function(position3, message) {
+        if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+          throw INVALID_TEMPLATE_ESCAPE_ERROR2;
+        } else {
+          this.raise(position3, message);
+        }
+      };
+      pp$92.readTmplToken = function() {
+        var out = "", chunkStart = this.pos;
+        for (; ; ) {
+          if (this.pos >= this.input.length) {
+            this.raise(this.start, "Unterminated template");
+          }
+          var ch = this.input.charCodeAt(this.pos);
+          if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+            if (this.pos === this.start && (this.type === types2.template || this.type === types2.invalidTemplate)) {
+              if (ch === 36) {
+                this.pos += 2;
+                return this.finishToken(types2.dollarBraceL);
+              } else {
+                ++this.pos;
+                return this.finishToken(types2.backQuote);
+              }
+            }
+            out += this.input.slice(chunkStart, this.pos);
+            return this.finishToken(types2.template, out);
+          }
+          if (ch === 92) {
+            out += this.input.slice(chunkStart, this.pos);
+            out += this.readEscapedChar(true);
+            chunkStart = this.pos;
+          } else if (isNewLine2(ch)) {
+            out += this.input.slice(chunkStart, this.pos);
+            ++this.pos;
+            switch (ch) {
+              case 13:
+                if (this.input.charCodeAt(this.pos) === 10) {
+                  ++this.pos;
+                }
+              case 10:
+                out += "\n";
+                break;
+              default:
+                out += String.fromCharCode(ch);
+                break;
+            }
+            if (this.options.locations) {
+              ++this.curLine;
+              this.lineStart = this.pos;
+            }
+            chunkStart = this.pos;
+          } else {
+            ++this.pos;
+          }
+        }
+      };
+      pp$92.readInvalidTemplateToken = function() {
+        for (; this.pos < this.input.length; this.pos++) {
+          switch (this.input[this.pos]) {
+            case "\\":
+              ++this.pos;
+              break;
+            case "$":
+              if (this.input[this.pos + 1] !== "{") {
+                break;
+              }
+            case "`":
+              return this.finishToken(types2.invalidTemplate, this.input.slice(this.start, this.pos));
+          }
+        }
+        this.raise(this.start, "Unterminated template");
+      };
+      pp$92.readEscapedChar = function(inTemplate) {
+        var ch = this.input.charCodeAt(++this.pos);
+        ++this.pos;
+        switch (ch) {
+          case 110:
+            return "\n";
+          case 114:
+            return "\r";
+          case 120:
+            return String.fromCharCode(this.readHexChar(2));
+          case 117:
+            return codePointToString$1(this.readCodePoint());
+          case 116:
+            return "	";
+          case 98:
+            return "\b";
+          case 118:
+            return "\v";
+          case 102:
+            return "\f";
+          case 13:
+            if (this.input.charCodeAt(this.pos) === 10) {
+              ++this.pos;
+            }
+          case 10:
+            if (this.options.locations) {
+              this.lineStart = this.pos;
+              ++this.curLine;
+            }
+            return "";
+          case 56:
+          case 57:
+            if (inTemplate) {
+              var codePos = this.pos - 1;
+              this.invalidStringToken(
+                codePos,
+                "Invalid escape sequence in template string"
+              );
+              return null;
+            }
+          default:
+            if (ch >= 48 && ch <= 55) {
+              var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+              var octal = parseInt(octalStr, 8);
+              if (octal > 255) {
+                octalStr = octalStr.slice(0, -1);
+                octal = parseInt(octalStr, 8);
+              }
+              this.pos += octalStr.length - 1;
+              ch = this.input.charCodeAt(this.pos);
+              if ((octalStr !== "0" || ch === 56 || ch === 57) && (this.strict || inTemplate)) {
+                this.invalidStringToken(
+                  this.pos - 1 - octalStr.length,
+                  inTemplate ? "Octal literal in template string" : "Octal literal in strict mode"
+                );
+              }
+              return String.fromCharCode(octal);
+            }
+            if (isNewLine2(ch)) {
+              return "";
+            }
+            return String.fromCharCode(ch);
+        }
+      };
+      pp$92.readHexChar = function(len) {
+        var codePos = this.pos;
+        var n = this.readInt(16, len);
+        if (n === null) {
+          this.invalidStringToken(codePos, "Bad character escape sequence");
+        }
+        return n;
+      };
+      pp$92.readWord1 = function() {
+        this.containsEsc = false;
+        var word = "", first = true, chunkStart = this.pos;
+        var astral = this.options.ecmaVersion >= 6;
+        while (this.pos < this.input.length) {
+          var ch = this.fullCharCodeAtPos();
+          if (isIdentifierChar2(ch, astral)) {
+            this.pos += ch <= 65535 ? 1 : 2;
+          } else if (ch === 92) {
+            this.containsEsc = true;
+            word += this.input.slice(chunkStart, this.pos);
+            var escStart = this.pos;
+            if (this.input.charCodeAt(++this.pos) !== 117) {
+              this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+            }
+            ++this.pos;
+            var esc = this.readCodePoint();
+            if (!(first ? isIdentifierStart2 : isIdentifierChar2)(esc, astral)) {
+              this.invalidStringToken(escStart, "Invalid Unicode escape");
+            }
+            word += codePointToString$1(esc);
+            chunkStart = this.pos;
+          } else {
+            break;
+          }
+          first = false;
+        }
+        return word + this.input.slice(chunkStart, this.pos);
+      };
+      pp$92.readWord = function() {
+        var word = this.readWord1();
+        var type = types2.name;
+        if (this.keywords.test(word)) {
+          type = keywords$12[word];
+        }
+        return this.finishToken(type, word);
+      };
+      var version2 = "7.4.1";
+      Parser3.acorn = {
+        Parser: Parser3,
+        version: version2,
+        defaultOptions: defaultOptions2,
+        Position: Position3,
+        SourceLocation: SourceLocation3,
+        getLineInfo: getLineInfo2,
+        Node: Node3,
+        TokenType: TokenType3,
+        tokTypes: types2,
+        keywordTypes: keywords$12,
+        TokContext: TokContext3,
+        tokContexts: types$12,
+        isIdentifierChar: isIdentifierChar2,
+        isIdentifierStart: isIdentifierStart2,
+        Token: Token3,
+        isNewLine: isNewLine2,
+        lineBreak: lineBreak2,
+        lineBreakG: lineBreakG2,
+        nonASCIIwhitespace: nonASCIIwhitespace2
+      };
+      function parse4(input, options) {
+        return Parser3.parse(input, options);
+      }
+      function parseExpressionAt2(input, pos, options) {
+        return Parser3.parseExpressionAt(input, pos, options);
+      }
+      function tokenizer2(input, options) {
+        return Parser3.tokenizer(input, options);
+      }
+      exports3.Node = Node3;
+      exports3.Parser = Parser3;
+      exports3.Position = Position3;
+      exports3.SourceLocation = SourceLocation3;
+      exports3.TokContext = TokContext3;
+      exports3.Token = Token3;
+      exports3.TokenType = TokenType3;
+      exports3.defaultOptions = defaultOptions2;
+      exports3.getLineInfo = getLineInfo2;
+      exports3.isIdentifierChar = isIdentifierChar2;
+      exports3.isIdentifierStart = isIdentifierStart2;
+      exports3.isNewLine = isNewLine2;
+      exports3.keywordTypes = keywords$12;
+      exports3.lineBreak = lineBreak2;
+      exports3.lineBreakG = lineBreakG2;
+      exports3.nonASCIIwhitespace = nonASCIIwhitespace2;
+      exports3.parse = parse4;
+      exports3.parseExpressionAt = parseExpressionAt2;
+      exports3.tokContexts = types$12;
+      exports3.tokTypes = types2;
+      exports3.tokenizer = tokenizer2;
+      exports3.version = version2;
+      Object.defineProperty(exports3, "__esModule", { value: true });
+    });
+  }
+});
+
+// node_modules/micromark-extension-mdxjs/node_modules/acorn-jsx/index.js
+var require_acorn_jsx = __commonJS({
+  "node_modules/micromark-extension-mdxjs/node_modules/acorn-jsx/index.js"(exports2, module2) {
+    "use strict";
+    var XHTMLEntities = require_xhtml();
+    var hexNumber = /^[\da-fA-F]+$/;
+    var decimalNumber = /^\d+$/;
+    var acornJsxMap = /* @__PURE__ */ new WeakMap();
+    function getJsxTokens(acorn) {
+      acorn = acorn.Parser.acorn || acorn;
+      let acornJsx2 = acornJsxMap.get(acorn);
+      if (!acornJsx2) {
+        const tt = acorn.tokTypes;
+        const TokContext3 = acorn.TokContext;
+        const TokenType3 = acorn.TokenType;
+        const tc_oTag = new TokContext3("<tag", false);
+        const tc_cTag = new TokContext3("</tag", false);
+        const tc_expr = new TokContext3("<tag>...</tag>", true, true);
+        const tokContexts = {
+          tc_oTag,
+          tc_cTag,
+          tc_expr
+        };
+        const tokTypes = {
+          jsxName: new TokenType3("jsxName"),
+          jsxText: new TokenType3("jsxText", { beforeExpr: true }),
+          jsxTagStart: new TokenType3("jsxTagStart", { startsExpr: true }),
+          jsxTagEnd: new TokenType3("jsxTagEnd")
+        };
+        tokTypes.jsxTagStart.updateContext = function() {
+          this.context.push(tc_expr);
+          this.context.push(tc_oTag);
+          this.exprAllowed = false;
+        };
+        tokTypes.jsxTagEnd.updateContext = function(prevType) {
+          let out = this.context.pop();
+          if (out === tc_oTag && prevType === tt.slash || out === tc_cTag) {
+            this.context.pop();
+            this.exprAllowed = this.curContext() === tc_expr;
+          } else {
+            this.exprAllowed = true;
+          }
+        };
+        acornJsx2 = { tokContexts, tokTypes };
+        acornJsxMap.set(acorn, acornJsx2);
+      }
+      return acornJsx2;
+    }
+    function getQualifiedJSXName(object) {
+      if (!object)
+        return object;
+      if (object.type === "JSXIdentifier")
+        return object.name;
+      if (object.type === "JSXNamespacedName")
+        return object.namespace.name + ":" + object.name.name;
+      if (object.type === "JSXMemberExpression")
+        return getQualifiedJSXName(object.object) + "." + getQualifiedJSXName(object.property);
+    }
+    module2.exports = function(options) {
+      options = options || {};
+      return function(Parser3) {
+        return plugin({
+          allowNamespaces: options.allowNamespaces !== false,
+          allowNamespacedObjects: !!options.allowNamespacedObjects
+        }, Parser3);
+      };
+    };
+    Object.defineProperty(module2.exports, "tokTypes", {
+      get: function get_tokTypes() {
+        return getJsxTokens(require_acorn()).tokTypes;
+      },
+      configurable: true,
+      enumerable: true
+    });
+    function plugin(options, Parser3) {
+      const acorn = Parser3.acorn || require_acorn();
+      const acornJsx2 = getJsxTokens(acorn);
+      const tt = acorn.tokTypes;
+      const tok = acornJsx2.tokTypes;
+      const tokContexts = acorn.tokContexts;
+      const tc_oTag = acornJsx2.tokContexts.tc_oTag;
+      const tc_cTag = acornJsx2.tokContexts.tc_cTag;
+      const tc_expr = acornJsx2.tokContexts.tc_expr;
+      const isNewLine2 = acorn.isNewLine;
+      const isIdentifierStart2 = acorn.isIdentifierStart;
+      const isIdentifierChar2 = acorn.isIdentifierChar;
+      return class extends Parser3 {
+        // Expose actual `tokTypes` and `tokContexts` to other plugins.
+        static get acornJsx() {
+          return acornJsx2;
+        }
+        // Reads inline JSX contents token.
+        jsx_readToken() {
+          let out = "", chunkStart = this.pos;
+          for (; ; ) {
+            if (this.pos >= this.input.length)
+              this.raise(this.start, "Unterminated JSX contents");
+            let ch = this.input.charCodeAt(this.pos);
+            switch (ch) {
+              case 60:
+              case 123:
+                if (this.pos === this.start) {
+                  if (ch === 60 && this.exprAllowed) {
+                    ++this.pos;
+                    return this.finishToken(tok.jsxTagStart);
+                  }
+                  return this.getTokenFromCode(ch);
+                }
+                out += this.input.slice(chunkStart, this.pos);
+                return this.finishToken(tok.jsxText, out);
+              case 38:
+                out += this.input.slice(chunkStart, this.pos);
+                out += this.jsx_readEntity();
+                chunkStart = this.pos;
+                break;
+              case 62:
+              case 125:
+                this.raise(
+                  this.pos,
+                  "Unexpected token `" + this.input[this.pos] + "`. Did you mean `" + (ch === 62 ? "&gt;" : "&rbrace;") + '` or `{"' + this.input[this.pos] + '"}`?'
+                );
+              default:
+                if (isNewLine2(ch)) {
+                  out += this.input.slice(chunkStart, this.pos);
+                  out += this.jsx_readNewLine(true);
+                  chunkStart = this.pos;
+                } else {
+                  ++this.pos;
+                }
+            }
+          }
+        }
+        jsx_readNewLine(normalizeCRLF) {
+          let ch = this.input.charCodeAt(this.pos);
+          let out;
+          ++this.pos;
+          if (ch === 13 && this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+            out = normalizeCRLF ? "\n" : "\r\n";
+          } else {
+            out = String.fromCharCode(ch);
+          }
+          if (this.options.locations) {
+            ++this.curLine;
+            this.lineStart = this.pos;
+          }
+          return out;
+        }
+        jsx_readString(quote) {
+          let out = "", chunkStart = ++this.pos;
+          for (; ; ) {
+            if (this.pos >= this.input.length)
+              this.raise(this.start, "Unterminated string constant");
+            let ch = this.input.charCodeAt(this.pos);
+            if (ch === quote) break;
+            if (ch === 38) {
+              out += this.input.slice(chunkStart, this.pos);
+              out += this.jsx_readEntity();
+              chunkStart = this.pos;
+            } else if (isNewLine2(ch)) {
+              out += this.input.slice(chunkStart, this.pos);
+              out += this.jsx_readNewLine(false);
+              chunkStart = this.pos;
+            } else {
+              ++this.pos;
+            }
+          }
+          out += this.input.slice(chunkStart, this.pos++);
+          return this.finishToken(tt.string, out);
+        }
+        jsx_readEntity() {
+          let str = "", count = 0, entity;
+          let ch = this.input[this.pos];
+          if (ch !== "&")
+            this.raise(this.pos, "Entity must start with an ampersand");
+          let startPos = ++this.pos;
+          while (this.pos < this.input.length && count++ < 10) {
+            ch = this.input[this.pos++];
+            if (ch === ";") {
+              if (str[0] === "#") {
+                if (str[1] === "x") {
+                  str = str.substr(2);
+                  if (hexNumber.test(str))
+                    entity = String.fromCharCode(parseInt(str, 16));
+                } else {
+                  str = str.substr(1);
+                  if (decimalNumber.test(str))
+                    entity = String.fromCharCode(parseInt(str, 10));
+                }
+              } else {
+                entity = XHTMLEntities[str];
+              }
+              break;
+            }
+            str += ch;
+          }
+          if (!entity) {
+            this.pos = startPos;
+            return "&";
+          }
+          return entity;
+        }
+        // Read a JSX identifier (valid tag or attribute name).
+        //
+        // Optimized version since JSX identifiers can't contain
+        // escape characters and so can be read as single slice.
+        // Also assumes that first character was already checked
+        // by isIdentifierStart in readToken.
+        jsx_readWord() {
+          let ch, start2 = this.pos;
+          do {
+            ch = this.input.charCodeAt(++this.pos);
+          } while (isIdentifierChar2(ch) || ch === 45);
+          return this.finishToken(tok.jsxName, this.input.slice(start2, this.pos));
+        }
+        // Parse next token as JSX identifier
+        jsx_parseIdentifier() {
+          let node2 = this.startNode();
+          if (this.type === tok.jsxName)
+            node2.name = this.value;
+          else if (this.type.keyword)
+            node2.name = this.type.keyword;
+          else
+            this.unexpected();
+          this.next();
+          return this.finishNode(node2, "JSXIdentifier");
+        }
+        // Parse namespaced identifier.
+        jsx_parseNamespacedName() {
+          let startPos = this.start, startLoc = this.startLoc;
+          let name2 = this.jsx_parseIdentifier();
+          if (!options.allowNamespaces || !this.eat(tt.colon)) return name2;
+          var node2 = this.startNodeAt(startPos, startLoc);
+          node2.namespace = name2;
+          node2.name = this.jsx_parseIdentifier();
+          return this.finishNode(node2, "JSXNamespacedName");
+        }
+        // Parses element name in any form - namespaced, member
+        // or single identifier.
+        jsx_parseElementName() {
+          if (this.type === tok.jsxTagEnd) return "";
+          let startPos = this.start, startLoc = this.startLoc;
+          let node2 = this.jsx_parseNamespacedName();
+          if (this.type === tt.dot && node2.type === "JSXNamespacedName" && !options.allowNamespacedObjects) {
+            this.unexpected();
+          }
+          while (this.eat(tt.dot)) {
+            let newNode = this.startNodeAt(startPos, startLoc);
+            newNode.object = node2;
+            newNode.property = this.jsx_parseIdentifier();
+            node2 = this.finishNode(newNode, "JSXMemberExpression");
+          }
+          return node2;
+        }
+        // Parses any type of JSX attribute value.
+        jsx_parseAttributeValue() {
+          switch (this.type) {
+            case tt.braceL:
+              let node2 = this.jsx_parseExpressionContainer();
+              if (node2.expression.type === "JSXEmptyExpression")
+                this.raise(node2.start, "JSX attributes must only be assigned a non-empty expression");
+              return node2;
+            case tok.jsxTagStart:
+            case tt.string:
+              return this.parseExprAtom();
+            default:
+              this.raise(this.start, "JSX value should be either an expression or a quoted JSX text");
+          }
+        }
+        // JSXEmptyExpression is unique type since it doesn't actually parse anything,
+        // and so it should start at the end of last read token (left brace) and finish
+        // at the beginning of the next one (right brace).
+        jsx_parseEmptyExpression() {
+          let node2 = this.startNodeAt(this.lastTokEnd, this.lastTokEndLoc);
+          return this.finishNodeAt(node2, "JSXEmptyExpression", this.start, this.startLoc);
+        }
+        // Parses JSX expression enclosed into curly brackets.
+        jsx_parseExpressionContainer() {
+          let node2 = this.startNode();
+          this.next();
+          node2.expression = this.type === tt.braceR ? this.jsx_parseEmptyExpression() : this.parseExpression();
+          this.expect(tt.braceR);
+          return this.finishNode(node2, "JSXExpressionContainer");
+        }
+        // Parses following JSX attribute name-value pair.
+        jsx_parseAttribute() {
+          let node2 = this.startNode();
+          if (this.eat(tt.braceL)) {
+            this.expect(tt.ellipsis);
+            node2.argument = this.parseMaybeAssign();
+            this.expect(tt.braceR);
+            return this.finishNode(node2, "JSXSpreadAttribute");
+          }
+          node2.name = this.jsx_parseNamespacedName();
+          node2.value = this.eat(tt.eq) ? this.jsx_parseAttributeValue() : null;
+          return this.finishNode(node2, "JSXAttribute");
+        }
+        // Parses JSX opening tag starting after '<'.
+        jsx_parseOpeningElementAt(startPos, startLoc) {
+          let node2 = this.startNodeAt(startPos, startLoc);
+          node2.attributes = [];
+          let nodeName = this.jsx_parseElementName();
+          if (nodeName) node2.name = nodeName;
+          while (this.type !== tt.slash && this.type !== tok.jsxTagEnd)
+            node2.attributes.push(this.jsx_parseAttribute());
+          node2.selfClosing = this.eat(tt.slash);
+          this.expect(tok.jsxTagEnd);
+          return this.finishNode(node2, nodeName ? "JSXOpeningElement" : "JSXOpeningFragment");
+        }
+        // Parses JSX closing tag starting after '</'.
+        jsx_parseClosingElementAt(startPos, startLoc) {
+          let node2 = this.startNodeAt(startPos, startLoc);
+          let nodeName = this.jsx_parseElementName();
+          if (nodeName) node2.name = nodeName;
+          this.expect(tok.jsxTagEnd);
+          return this.finishNode(node2, nodeName ? "JSXClosingElement" : "JSXClosingFragment");
+        }
+        // Parses entire JSX element, including it's opening tag
+        // (starting after '<'), attributes, contents and closing tag.
+        jsx_parseElementAt(startPos, startLoc) {
+          let node2 = this.startNodeAt(startPos, startLoc);
+          let children = [];
+          let openingElement = this.jsx_parseOpeningElementAt(startPos, startLoc);
+          let closingElement = null;
+          if (!openingElement.selfClosing) {
+            contents: for (; ; ) {
+              switch (this.type) {
+                case tok.jsxTagStart:
+                  startPos = this.start;
+                  startLoc = this.startLoc;
+                  this.next();
+                  if (this.eat(tt.slash)) {
+                    closingElement = this.jsx_parseClosingElementAt(startPos, startLoc);
+                    break contents;
+                  }
+                  children.push(this.jsx_parseElementAt(startPos, startLoc));
+                  break;
+                case tok.jsxText:
+                  children.push(this.parseExprAtom());
+                  break;
+                case tt.braceL:
+                  children.push(this.jsx_parseExpressionContainer());
+                  break;
+                default:
+                  this.unexpected();
+              }
+            }
+            if (getQualifiedJSXName(closingElement.name) !== getQualifiedJSXName(openingElement.name)) {
+              this.raise(
+                closingElement.start,
+                "Expected corresponding JSX closing tag for <" + getQualifiedJSXName(openingElement.name) + ">"
+              );
+            }
+          }
+          let fragmentOrElement = openingElement.name ? "Element" : "Fragment";
+          node2["opening" + fragmentOrElement] = openingElement;
+          node2["closing" + fragmentOrElement] = closingElement;
+          node2.children = children;
+          if (this.type === tt.relational && this.value === "<") {
+            this.raise(this.start, "Adjacent JSX elements must be wrapped in an enclosing tag");
+          }
+          return this.finishNode(node2, "JSX" + fragmentOrElement);
+        }
+        // Parse JSX text
+        jsx_parseText() {
+          let node2 = this.parseLiteral(this.value);
+          node2.type = "JSXText";
+          return node2;
+        }
+        // Parses entire JSX element from current position.
+        jsx_parseElement() {
+          let startPos = this.start, startLoc = this.startLoc;
+          this.next();
+          return this.jsx_parseElementAt(startPos, startLoc);
+        }
+        parseExprAtom(refShortHandDefaultPos) {
+          if (this.type === tok.jsxText)
+            return this.jsx_parseText();
+          else if (this.type === tok.jsxTagStart)
+            return this.jsx_parseElement();
+          else
+            return super.parseExprAtom(refShortHandDefaultPos);
+        }
+        readToken(code2) {
+          let context = this.curContext();
+          if (context === tc_expr) return this.jsx_readToken();
+          if (context === tc_oTag || context === tc_cTag) {
+            if (isIdentifierStart2(code2)) return this.jsx_readWord();
+            if (code2 == 62) {
+              ++this.pos;
+              return this.finishToken(tok.jsxTagEnd);
+            }
+            if ((code2 === 34 || code2 === 39) && context == tc_oTag)
+              return this.jsx_readString(code2);
+          }
+          if (code2 === 60 && this.exprAllowed && this.input.charCodeAt(this.pos + 1) !== 33) {
+            ++this.pos;
+            return this.finishToken(tok.jsxTagStart);
+          }
+          return super.readToken(code2);
+        }
+        updateContext(prevType) {
+          if (this.type == tt.braceL) {
+            var curContext = this.curContext();
+            if (curContext == tc_oTag) this.context.push(tokContexts.b_expr);
+            else if (curContext == tc_expr) this.context.push(tokContexts.b_tmpl);
+            else super.updateContext(prevType);
+            this.exprAllowed = true;
+          } else if (this.type === tt.slash && prevType === tok.jsxTagStart) {
+            this.context.length -= 2;
+            this.context.push(tc_cTag);
+            this.exprAllowed = false;
+          } else {
+            return super.updateContext(prevType);
+          }
+        }
+      };
+    }
+  }
+});
+
+// node_modules/extend/index.js
+var require_extend = __commonJS({
+  "node_modules/extend/index.js"(exports2, module2) {
+    "use strict";
+    var hasOwn2 = Object.prototype.hasOwnProperty;
+    var toStr = Object.prototype.toString;
+    var defineProperty = Object.defineProperty;
+    var gOPD = Object.getOwnPropertyDescriptor;
+    var isArray2 = function isArray3(arr) {
+      if (typeof Array.isArray === "function") {
+        return Array.isArray(arr);
+      }
+      return toStr.call(arr) === "[object Array]";
+    };
+    var isPlainObject2 = function isPlainObject3(obj) {
+      if (!obj || toStr.call(obj) !== "[object Object]") {
+        return false;
+      }
+      var hasOwnConstructor = hasOwn2.call(obj, "constructor");
+      var hasIsPrototypeOf = obj.constructor && obj.constructor.prototype && hasOwn2.call(obj.constructor.prototype, "isPrototypeOf");
+      if (obj.constructor && !hasOwnConstructor && !hasIsPrototypeOf) {
+        return false;
+      }
+      var key;
+      for (key in obj) {
+      }
+      return typeof key === "undefined" || hasOwn2.call(obj, key);
+    };
+    var setProperty = function setProperty2(target, options) {
+      if (defineProperty && options.name === "__proto__") {
+        defineProperty(target, options.name, {
+          enumerable: true,
+          configurable: true,
+          value: options.newValue,
+          writable: true
+        });
+      } else {
+        target[options.name] = options.newValue;
+      }
+    };
+    var getProperty = function getProperty2(obj, name2) {
+      if (name2 === "__proto__") {
+        if (!hasOwn2.call(obj, name2)) {
+          return void 0;
+        } else if (gOPD) {
+          return gOPD(obj, name2).value;
+        }
+      }
+      return obj[name2];
+    };
+    module2.exports = function extend3() {
+      var options, name2, src, copy, copyIsArray, clone;
+      var target = arguments[0];
+      var i = 1;
+      var length = arguments.length;
+      var deep = false;
+      if (typeof target === "boolean") {
+        deep = target;
+        target = arguments[1] || {};
+        i = 2;
+      }
+      if (target == null || typeof target !== "object" && typeof target !== "function") {
+        target = {};
+      }
+      for (; i < length; ++i) {
+        options = arguments[i];
+        if (options != null) {
+          for (name2 in options) {
+            src = getProperty(target, name2);
+            copy = getProperty(options, name2);
+            if (target !== copy) {
+              if (deep && copy && (isPlainObject2(copy) || (copyIsArray = isArray2(copy)))) {
+                if (copyIsArray) {
+                  copyIsArray = false;
+                  clone = src && isArray2(src) ? src : [];
+                } else {
+                  clone = src && isPlainObject2(src) ? src : {};
+                }
+                setProperty(target, { name: name2, newValue: extend3(deep, clone, copy) });
+              } else if (typeof copy !== "undefined") {
+                setProperty(target, { name: name2, newValue: copy });
+              }
+            }
+          }
+        }
+      }
+      return target;
+    };
+  }
+});
+
+// node_modules/inline-style-parser/index.js
+var require_inline_style_parser = __commonJS({
+  "node_modules/inline-style-parser/index.js"(exports2, module2) {
+    var COMMENT_REGEX = /\/\*[^*]*\*+([^/*][^*]*\*+)*\//g;
+    var NEWLINE_REGEX = /\n/g;
+    var WHITESPACE_REGEX = /^\s*/;
+    var PROPERTY_REGEX = /^(\*?[-#/*\\\w]+(\[[0-9a-z_-]+\])?)\s*/;
+    var COLON_REGEX = /^:\s*/;
+    var VALUE_REGEX = /^((?:'(?:\\'|.)*?'|"(?:\\"|.)*?"|\([^)]*?\)|[^};])+)/;
+    var SEMICOLON_REGEX = /^[;\s]*/;
+    var TRIM_REGEX = /^\s+|\s+$/g;
+    var NEWLINE = "\n";
+    var FORWARD_SLASH = "/";
+    var ASTERISK = "*";
+    var EMPTY_STRING = "";
+    var TYPE_COMMENT = "comment";
+    var TYPE_DECLARATION = "declaration";
+    module2.exports = function(style, options) {
+      if (typeof style !== "string") {
+        throw new TypeError("First argument must be a string");
+      }
+      if (!style) return [];
+      options = options || {};
+      var lineno = 1;
+      var column = 1;
+      function updatePosition(str) {
+        var lines = str.match(NEWLINE_REGEX);
+        if (lines) lineno += lines.length;
+        var i = str.lastIndexOf(NEWLINE);
+        column = ~i ? str.length - i : column + str.length;
+      }
+      function position3() {
+        var start2 = { line: lineno, column };
+        return function(node2) {
+          node2.position = new Position3(start2);
+          whitespace2();
+          return node2;
+        };
+      }
+      function Position3(start2) {
+        this.start = start2;
+        this.end = { line: lineno, column };
+        this.source = options.source;
+      }
+      Position3.prototype.content = style;
+      var errorsList = [];
+      function error(msg) {
+        var err = new Error(
+          options.source + ":" + lineno + ":" + column + ": " + msg
+        );
+        err.reason = msg;
+        err.filename = options.source;
+        err.line = lineno;
+        err.column = column;
+        err.source = style;
+        if (options.silent) {
+          errorsList.push(err);
+        } else {
+          throw err;
+        }
+      }
+      function match(re2) {
+        var m = re2.exec(style);
+        if (!m) return;
+        var str = m[0];
+        updatePosition(str);
+        style = style.slice(str.length);
+        return m;
+      }
+      function whitespace2() {
+        match(WHITESPACE_REGEX);
+      }
+      function comments(rules) {
+        var c;
+        rules = rules || [];
+        while (c = comment2()) {
+          if (c !== false) {
+            rules.push(c);
+          }
+        }
+        return rules;
+      }
+      function comment2() {
+        var pos = position3();
+        if (FORWARD_SLASH != style.charAt(0) || ASTERISK != style.charAt(1)) return;
+        var i = 2;
+        while (EMPTY_STRING != style.charAt(i) && (ASTERISK != style.charAt(i) || FORWARD_SLASH != style.charAt(i + 1))) {
+          ++i;
+        }
+        i += 2;
+        if (EMPTY_STRING === style.charAt(i - 1)) {
+          return error("End of comment missing");
+        }
+        var str = style.slice(2, i - 2);
+        column += 2;
+        updatePosition(str);
+        style = style.slice(i);
+        column += 2;
+        return pos({
+          type: TYPE_COMMENT,
+          comment: str
+        });
+      }
+      function declaration() {
+        var pos = position3();
+        var prop = match(PROPERTY_REGEX);
+        if (!prop) return;
+        comment2();
+        if (!match(COLON_REGEX)) return error("property missing ':'");
+        var val = match(VALUE_REGEX);
+        var ret = pos({
+          type: TYPE_DECLARATION,
+          property: trim(prop[0].replace(COMMENT_REGEX, EMPTY_STRING)),
+          value: val ? trim(val[0].replace(COMMENT_REGEX, EMPTY_STRING)) : EMPTY_STRING
+        });
+        match(SEMICOLON_REGEX);
+        return ret;
+      }
+      function declarations() {
+        var decls = [];
+        comments(decls);
+        var decl;
+        while (decl = declaration()) {
+          if (decl !== false) {
+            decls.push(decl);
+            comments(decls);
+          }
+        }
+        return decls;
+      }
+      whitespace2();
+      return declarations();
+    };
+    function trim(str) {
+      return str ? str.replace(TRIM_REGEX, EMPTY_STRING) : EMPTY_STRING;
+    }
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/style-to-object/index.js
+var require_style_to_object = __commonJS({
+  "node_modules/hast-util-to-estree/node_modules/style-to-object/index.js"(exports2, module2) {
+    var parse4 = require_inline_style_parser();
+    function StyleToObject2(style, iterator) {
+      var output = null;
+      if (!style || typeof style !== "string") {
+        return output;
+      }
+      var declaration;
+      var declarations = parse4(style);
+      var hasIterator = typeof iterator === "function";
+      var property;
+      var value;
+      for (var i = 0, len = declarations.length; i < len; i++) {
+        declaration = declarations[i];
+        property = declaration.property;
+        value = declaration.value;
+        if (hasIterator) {
+          iterator(property, value, declaration);
+        } else if (value) {
+          output || (output = {});
+          output[property] = value;
+        }
+      }
+      return output;
+    }
+    module2.exports = StyleToObject2;
+    module2.exports.default = StyleToObject2;
+  }
+});
+
+// mdx.js
+var mdx_exports = {};
+__export(mdx_exports, {
+  compile: () => compile,
+  compileSync: () => compileSync,
+  createProcessor: () => createProcessor,
+  evaluate: () => evaluate,
+  evaluateSync: () => evaluateSync,
+  nodeTypes: () => nodeTypes,
+  run: () => run,
+  runSync: () => runSync
+});
+module.exports = __toCommonJS(mdx_exports);
+
+// node_modules/unist-util-stringify-position/lib/index.js
+function stringifyPosition(value) {
+  if (!value || typeof value !== "object") {
+    return "";
+  }
+  if ("position" in value || "type" in value) {
+    return position(value.position);
+  }
+  if ("start" in value || "end" in value) {
+    return position(value);
+  }
+  if ("line" in value || "column" in value) {
+    return point(value);
+  }
+  return "";
+}
+function point(point4) {
+  return index(point4 && point4.line) + ":" + index(point4 && point4.column);
+}
+function position(pos) {
+  return point(pos && pos.start) + "-" + point(pos && pos.end);
+}
+function index(value) {
+  return value && typeof value === "number" ? value : 1;
+}
+
+// node_modules/vfile-message/lib/index.js
+var VFileMessage = class extends Error {
+  /**
+   * Create a message for `reason`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Options | null | undefined} [options]
+   * @returns
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | Options | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns
+   *   Instance of `VFileMessage`.
+   */
+  // eslint-disable-next-line complexity
+  constructor(causeOrReason, optionsOrParentOrPlace, origin) {
+    super();
+    if (typeof optionsOrParentOrPlace === "string") {
+      origin = optionsOrParentOrPlace;
+      optionsOrParentOrPlace = void 0;
+    }
+    let reason = "";
+    let options = {};
+    let legacyCause = false;
+    if (optionsOrParentOrPlace) {
+      if ("line" in optionsOrParentOrPlace && "column" in optionsOrParentOrPlace) {
+        options = { place: optionsOrParentOrPlace };
+      } else if ("start" in optionsOrParentOrPlace && "end" in optionsOrParentOrPlace) {
+        options = { place: optionsOrParentOrPlace };
+      } else if ("type" in optionsOrParentOrPlace) {
+        options = {
+          ancestors: [optionsOrParentOrPlace],
+          place: optionsOrParentOrPlace.position
+        };
+      } else {
+        options = { ...optionsOrParentOrPlace };
+      }
+    }
+    if (typeof causeOrReason === "string") {
+      reason = causeOrReason;
+    } else if (!options.cause && causeOrReason) {
+      legacyCause = true;
+      reason = causeOrReason.message;
+      options.cause = causeOrReason;
+    }
+    if (!options.ruleId && !options.source && typeof origin === "string") {
+      const index2 = origin.indexOf(":");
+      if (index2 === -1) {
+        options.ruleId = origin;
+      } else {
+        options.source = origin.slice(0, index2);
+        options.ruleId = origin.slice(index2 + 1);
+      }
+    }
+    if (!options.place && options.ancestors && options.ancestors) {
+      const parent = options.ancestors[options.ancestors.length - 1];
+      if (parent) {
+        options.place = parent.position;
+      }
+    }
+    const start2 = options.place && "start" in options.place ? options.place.start : options.place;
+    this.ancestors = options.ancestors || void 0;
+    this.cause = options.cause || void 0;
+    this.column = start2 ? start2.column : void 0;
+    this.fatal = void 0;
+    this.file;
+    this.message = reason;
+    this.line = start2 ? start2.line : void 0;
+    this.name = stringifyPosition(options.place) || "1:1";
+    this.place = options.place || void 0;
+    this.reason = this.message;
+    this.ruleId = options.ruleId || void 0;
+    this.source = options.source || void 0;
+    this.stack = legacyCause && options.cause && typeof options.cause.stack === "string" ? options.cause.stack : "";
+    this.actual;
+    this.expected;
+    this.note;
+    this.url;
+  }
+};
+VFileMessage.prototype.file = "";
+VFileMessage.prototype.name = "";
+VFileMessage.prototype.reason = "";
+VFileMessage.prototype.message = "";
+VFileMessage.prototype.stack = "";
+VFileMessage.prototype.column = void 0;
+VFileMessage.prototype.line = void 0;
+VFileMessage.prototype.ancestors = void 0;
+VFileMessage.prototype.cause = void 0;
+VFileMessage.prototype.fatal = void 0;
+VFileMessage.prototype.place = void 0;
+VFileMessage.prototype.ruleId = void 0;
+VFileMessage.prototype.source = void 0;
+
+// node_modules/@mdx-js/mdx/node_modules/vfile/lib/minpath.js
+// var import_node_path = __toESM(require("node:path"), 1);
+
+// node_modules/@mdx-js/mdx/node_modules/vfile/lib/minproc.js
+// var import_node_process = __toESM(require("node:process"), 1);
+
+// node_modules/@mdx-js/mdx/node_modules/vfile/lib/minurl.js
+// var URL = require("node:url");
+
+// node_modules/@mdx-js/mdx/node_modules/vfile/lib/minurl.shared.js
+function isUrl(fileUrlOrPath) {
+  return Boolean(
+    fileUrlOrPath !== null && typeof fileUrlOrPath === "object" && "href" in fileUrlOrPath && fileUrlOrPath.href && "protocol" in fileUrlOrPath && fileUrlOrPath.protocol && // @ts-expect-error: indexing is fine.
+    fileUrlOrPath.auth === void 0
+  );
+}
+
+// node_modules/@mdx-js/mdx/node_modules/vfile/lib/index.js
+var order = (
+  /** @type {const} */
+  [
+    "history",
+    "path",
+    "basename",
+    "stem",
+    "extname",
+    "dirname"
+  ]
+);
+var VFile = class {
+  /**
+   * Create a new virtual file.
+   *
+   * `options` is treated as:
+   *
+   * *   `string` or `Uint8Array` — `{value: options}`
+   * *   `URL` — `{path: options}`
+   * *   `VFile` — shallow copies its data over to the new file
+   * *   `object` — all fields are shallow copied over to the new file
+   *
+   * Path related fields are set in the following order (least specific to
+   * most specific): `history`, `path`, `basename`, `stem`, `extname`,
+   * `dirname`.
+   *
+   * You cannot set `dirname` or `extname` without setting either `history`,
+   * `path`, `basename`, or `stem` too.
+   *
+   * @param {Compatible | null | undefined} [value]
+   *   File value.
+   * @returns
+   *   New instance.
+   */
+  constructor(value) {
+    let options;
+    if (!value) {
+      options = {};
+    } else if (isUrl(value)) {
+      options = { path: value };
+    } else if (typeof value === "string" || isUint8Array(value)) {
+      options = { value };
+    } else {
+      options = value;
+    }
+    this.cwd = PROCESS.cwd();
+    this.data = {};
+    this.history = [];
+    this.messages = [];
+    this.value;
+    this.map;
+    this.result;
+    this.stored;
+    let index2 = -1;
+    while (++index2 < order.length) {
+      const prop2 = order[index2];
+      if (prop2 in options && options[prop2] !== void 0 && options[prop2] !== null) {
+        this[prop2] = prop2 === "history" ? [...options[prop2]] : options[prop2];
+      }
+    }
+    let prop;
+    for (prop in options) {
+      if (!order.includes(prop)) {
+        this[prop] = options[prop];
+      }
+    }
+  }
+  /**
+   * Get the basename (including extname) (example: `'index.min.js'`).
+   *
+   * @returns {string | undefined}
+   *   Basename.
+   */
+  get basename() {
+    return typeof this.path === "string" ? PATH.basename(this.path) : void 0;
+  }
+  /**
+   * Set basename (including extname) (`'index.min.js'`).
+   *
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be nullified (use `file.path = file.dirname` instead).
+   *
+   * @param {string} basename
+   *   Basename.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set basename(basename) {
+    assertNonEmpty(basename, "basename");
+    assertPart(basename, "basename");
+    this.path = PATH.join(this.dirname || "", basename);
+  }
+  /**
+   * Get the parent path (example: `'~'`).
+   *
+   * @returns {string | undefined}
+   *   Dirname.
+   */
+  get dirname() {
+    return typeof this.path === "string" ? PATH.dirname(this.path) : void 0;
+  }
+  /**
+   * Set the parent path (example: `'~'`).
+   *
+   * Cannot be set if there’s no `path` yet.
+   *
+   * @param {string | undefined} dirname
+   *   Dirname.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set dirname(dirname) {
+    assertPath(this.basename, "dirname");
+    this.path = PATH.join(dirname || "", this.basename);
+  }
+  /**
+   * Get the extname (including dot) (example: `'.js'`).
+   *
+   * @returns {string | undefined}
+   *   Extname.
+   */
+  get extname() {
+    return typeof this.path === "string" ? PATH.extname(this.path) : void 0;
+  }
+  /**
+   * Set the extname (including dot) (example: `'.js'`).
+   *
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be set if there’s no `path` yet.
+   *
+   * @param {string | undefined} extname
+   *   Extname.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set extname(extname) {
+    assertPart(extname, "extname");
+    assertPath(this.dirname, "extname");
+    if (extname) {
+      if (extname.codePointAt(0) !== 46) {
+        throw new Error("`extname` must start with `.`");
+      }
+      if (extname.includes(".", 1)) {
+        throw new Error("`extname` cannot contain multiple dots");
+      }
+    }
+    this.path = PATH.join(this.dirname, this.stem + (extname || ""));
+  }
+  /**
+   * Get the full path (example: `'~/index.min.js'`).
+   *
+   * @returns {string}
+   *   Path.
+   */
+  get path() {
+    return this.history[this.history.length - 1];
+  }
+  /**
+   * Set the full path (example: `'~/index.min.js'`).
+   *
+   * Cannot be nullified.
+   * You can set a file URL (a `URL` object with a `file:` protocol) which will
+   * be turned into a path with `url.fileURLToPath`.
+   *
+   * @param {URL | string} path
+   *   Path.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set path(path) {
+    if (isUrl(path)) {
+      path = (0, URL.fileURLToPath)(path);
+    }
+    assertNonEmpty(path, "path");
+    if (this.path !== path) {
+      this.history.push(path);
+    }
+  }
+  /**
+   * Get the stem (basename w/o extname) (example: `'index.min'`).
+   *
+   * @returns {string | undefined}
+   *   Stem.
+   */
+  get stem() {
+    return typeof this.path === "string" ? PATH.basename(this.path, this.extname) : void 0;
+  }
+  /**
+   * Set the stem (basename w/o extname) (example: `'index.min'`).
+   *
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be nullified (use `file.path = file.dirname` instead).
+   *
+   * @param {string} stem
+   *   Stem.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set stem(stem) {
+    assertNonEmpty(stem, "stem");
+    assertPart(stem, "stem");
+    this.path = PATH.join(this.dirname || "", stem + (this.extname || ""));
+  }
+  // Normal prototypal methods.
+  /**
+   * Create a fatal message for `reason` associated with the file.
+   *
+   * The `fatal` field of the message is set to `true` (error; file not usable)
+   * and the `file` field is set to the current file path.
+   * The message is added to the `messages` field on `file`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {MessageOptions | null | undefined} [options]
+   * @returns {never}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | MessageOptions | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns {never}
+   *   Never.
+   * @throws {VFileMessage}
+   *   Message.
+   */
+  fail(causeOrReason, optionsOrParentOrPlace, origin) {
+    const message = this.message(causeOrReason, optionsOrParentOrPlace, origin);
+    message.fatal = true;
+    throw message;
+  }
+  /**
+   * Create an info message for `reason` associated with the file.
+   *
+   * The `fatal` field of the message is set to `undefined` (info; change
+   * likely not needed) and the `file` field is set to the current file path.
+   * The message is added to the `messages` field on `file`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {MessageOptions | null | undefined} [options]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | MessageOptions | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns {VFileMessage}
+   *   Message.
+   */
+  info(causeOrReason, optionsOrParentOrPlace, origin) {
+    const message = this.message(causeOrReason, optionsOrParentOrPlace, origin);
+    message.fatal = void 0;
+    return message;
+  }
+  /**
+   * Create a message for `reason` associated with the file.
+   *
+   * The `fatal` field of the message is set to `false` (warning; change may be
+   * needed) and the `file` field is set to the current file path.
+   * The message is added to the `messages` field on `file`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {MessageOptions | null | undefined} [options]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | MessageOptions | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns {VFileMessage}
+   *   Message.
+   */
+  message(causeOrReason, optionsOrParentOrPlace, origin) {
+    const message = new VFileMessage(
+      // @ts-expect-error: the overloads are fine.
+      causeOrReason,
+      optionsOrParentOrPlace,
+      origin
+    );
+    if (this.path) {
+      message.name = this.path + ":" + message.name;
+      message.file = this.path;
+    }
+    message.fatal = false;
+    this.messages.push(message);
+    return message;
+  }
+  /**
+   * Serialize the file.
+   *
+   * > **Note**: which encodings are supported depends on the engine.
+   * > For info on Node.js, see:
+   * > <https://nodejs.org/api/util.html#whatwg-supported-encodings>.
+   *
+   * @param {string | null | undefined} [encoding='utf8']
+   *   Character encoding to understand `value` as when it’s a `Uint8Array`
+   *   (default: `'utf-8'`).
+   * @returns {string}
+   *   Serialized file.
+   */
+  toString(encoding) {
+    if (this.value === void 0) {
+      return "";
+    }
+    if (typeof this.value === "string") {
+      return this.value;
+    }
+    const decoder = new TextDecoder(encoding || void 0);
+    return decoder.decode(this.value);
+  }
+};
+function assertPart(part, name2) {
+  if (part && part.includes(PATH.sep)) {
+    throw new Error(
+      "`" + name2 + "` cannot be a path: did not expect `" + PATH.sep + "`"
+    );
+  }
+}
+function assertNonEmpty(part, name2) {
+  if (!part) {
+    throw new Error("`" + name2 + "` cannot be empty");
+  }
+}
+function assertPath(path, name2) {
+  if (!path) {
+    throw new Error("Setting `" + name2 + "` requires `path` to be set too");
+  }
+}
+function isUint8Array(value) {
+  return Boolean(
+    value && typeof value === "object" && "byteLength" in value && "byteOffset" in value
+  );
+}
+
+// node_modules/markdown-extensions/index.js
+var markdownExtension = [
+  "md",
+  "markdown",
+  "mdown",
+  "mkdn",
+  "mkd",
+  "mdwn",
+  "mkdown",
+  "ron"
+];
+var markdown_extensions_default = markdownExtension;
+
+// node_modules/@mdx-js/mdx/lib/util/extnames.js
+var md = markdown_extensions_default.map(function(d) {
+  return "." + d;
+});
+
+// node_modules/@mdx-js/mdx/lib/util/resolve-file-and-options.js
+function resolveFileAndOptions(vfileCompatible, options) {
+  const file = looksLikeAVFile(vfileCompatible) ? vfileCompatible : new VFile(vfileCompatible);
+  const { format, ...rest } = options || {};
+  return {
+    file,
+    options: {
+      format: format === "md" || format === "mdx" ? format : file.extname && (rest.mdExtensions || md).includes(file.extname) ? "md" : "mdx",
+      ...rest
+    }
+  };
+}
+function looksLikeAVFile(value) {
+  return Boolean(
+    value && typeof value === "object" && "message" in value && "messages" in value
+  );
+}
+
+// node_modules/devlop/lib/default.js
+function ok() {
+}
+function unreachable() {
+}
+
+// node_modules/mdast-util-mdx-expression/lib/index.js
+function mdxExpressionFromMarkdown() {
+  return {
+    enter: {
+      mdxFlowExpression: enterMdxFlowExpression,
+      mdxTextExpression: enterMdxTextExpression
+    },
+    exit: {
+      mdxFlowExpression: exitMdxExpression,
+      mdxFlowExpressionChunk: exitMdxExpressionData,
+      mdxTextExpression: exitMdxExpression,
+      mdxTextExpressionChunk: exitMdxExpressionData
+    }
+  };
+}
+function mdxExpressionToMarkdown() {
+  return {
+    handlers: {
+      mdxFlowExpression: handleMdxExpression,
+      mdxTextExpression: handleMdxExpression
+    },
+    unsafe: [
+      { character: "{", inConstruct: ["phrasing"] },
+      { atBreak: true, character: "{" }
+    ]
+  };
+}
+function enterMdxFlowExpression(token) {
+  this.enter({ type: "mdxFlowExpression", value: "" }, token);
+  this.buffer();
+}
+function enterMdxTextExpression(token) {
+  this.enter({ type: "mdxTextExpression", value: "" }, token);
+  this.buffer();
+}
+function exitMdxExpression(token) {
+  const value = this.resume();
+  const estree = token.estree;
+  const node2 = this.stack[this.stack.length - 1];
+  ok(node2.type === "mdxFlowExpression" || node2.type === "mdxTextExpression");
+  this.exit(token);
+  node2.value = value;
+  if (estree) {
+    node2.data = { estree };
+  }
+}
+function exitMdxExpressionData(token) {
+  this.config.enter.data.call(this, token);
+  this.config.exit.data.call(this, token);
+}
+function handleMdxExpression(node2) {
+  const value = node2.value || "";
+  return "{" + value + "}";
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/ccount/index.js
+function ccount(value, character) {
+  const source = String(value);
+  if (typeof character !== "string") {
+    throw new TypeError("Expected character");
+  }
+  let count = 0;
+  let index2 = source.indexOf(character);
+  while (index2 !== -1) {
+    count++;
+    index2 = source.indexOf(character, index2 + character.length);
+  }
+  return count;
+}
+
+// node_modules/character-entities-legacy/index.js
+var characterEntitiesLegacy = [
+  "AElig",
+  "AMP",
+  "Aacute",
+  "Acirc",
+  "Agrave",
+  "Aring",
+  "Atilde",
+  "Auml",
+  "COPY",
+  "Ccedil",
+  "ETH",
+  "Eacute",
+  "Ecirc",
+  "Egrave",
+  "Euml",
+  "GT",
+  "Iacute",
+  "Icirc",
+  "Igrave",
+  "Iuml",
+  "LT",
+  "Ntilde",
+  "Oacute",
+  "Ocirc",
+  "Ograve",
+  "Oslash",
+  "Otilde",
+  "Ouml",
+  "QUOT",
+  "REG",
+  "THORN",
+  "Uacute",
+  "Ucirc",
+  "Ugrave",
+  "Uuml",
+  "Yacute",
+  "aacute",
+  "acirc",
+  "acute",
+  "aelig",
+  "agrave",
+  "amp",
+  "aring",
+  "atilde",
+  "auml",
+  "brvbar",
+  "ccedil",
+  "cedil",
+  "cent",
+  "copy",
+  "curren",
+  "deg",
+  "divide",
+  "eacute",
+  "ecirc",
+  "egrave",
+  "eth",
+  "euml",
+  "frac12",
+  "frac14",
+  "frac34",
+  "gt",
+  "iacute",
+  "icirc",
+  "iexcl",
+  "igrave",
+  "iquest",
+  "iuml",
+  "laquo",
+  "lt",
+  "macr",
+  "micro",
+  "middot",
+  "nbsp",
+  "not",
+  "ntilde",
+  "oacute",
+  "ocirc",
+  "ograve",
+  "ordf",
+  "ordm",
+  "oslash",
+  "otilde",
+  "ouml",
+  "para",
+  "plusmn",
+  "pound",
+  "quot",
+  "raquo",
+  "reg",
+  "sect",
+  "shy",
+  "sup1",
+  "sup2",
+  "sup3",
+  "szlig",
+  "thorn",
+  "times",
+  "uacute",
+  "ucirc",
+  "ugrave",
+  "uml",
+  "uuml",
+  "yacute",
+  "yen",
+  "yuml"
+];
+
+// node_modules/mdast-util-mdx-jsx/node_modules/character-reference-invalid/index.js
+var characterReferenceInvalid = {
+  0: "\uFFFD",
+  128: "\u20AC",
+  130: "\u201A",
+  131: "\u0192",
+  132: "\u201E",
+  133: "\u2026",
+  134: "\u2020",
+  135: "\u2021",
+  136: "\u02C6",
+  137: "\u2030",
+  138: "\u0160",
+  139: "\u2039",
+  140: "\u0152",
+  142: "\u017D",
+  145: "\u2018",
+  146: "\u2019",
+  147: "\u201C",
+  148: "\u201D",
+  149: "\u2022",
+  150: "\u2013",
+  151: "\u2014",
+  152: "\u02DC",
+  153: "\u2122",
+  154: "\u0161",
+  155: "\u203A",
+  156: "\u0153",
+  158: "\u017E",
+  159: "\u0178"
+};
+
+// node_modules/mdast-util-mdx-jsx/node_modules/is-decimal/index.js
+function isDecimal(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 48 && code2 <= 57;
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/is-hexadecimal/index.js
+function isHexadecimal(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 97 && code2 <= 102 || code2 >= 65 && code2 <= 70 || code2 >= 48 && code2 <= 57;
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/is-alphabetical/index.js
+function isAlphabetical(character) {
+  const code2 = typeof character === "string" ? character.charCodeAt(0) : character;
+  return code2 >= 97 && code2 <= 122 || code2 >= 65 && code2 <= 90;
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/is-alphanumerical/index.js
+function isAlphanumerical(character) {
+  return isAlphabetical(character) || isDecimal(character);
+}
+
+// node_modules/character-entities/index.js
+var characterEntities = {
+  AElig: "\xC6",
+  AMP: "&",
+  Aacute: "\xC1",
+  Abreve: "\u0102",
+  Acirc: "\xC2",
+  Acy: "\u0410",
+  Afr: "\u{1D504}",
+  Agrave: "\xC0",
+  Alpha: "\u0391",
+  Amacr: "\u0100",
+  And: "\u2A53",
+  Aogon: "\u0104",
+  Aopf: "\u{1D538}",
+  ApplyFunction: "\u2061",
+  Aring: "\xC5",
+  Ascr: "\u{1D49C}",
+  Assign: "\u2254",
+  Atilde: "\xC3",
+  Auml: "\xC4",
+  Backslash: "\u2216",
+  Barv: "\u2AE7",
+  Barwed: "\u2306",
+  Bcy: "\u0411",
+  Because: "\u2235",
+  Bernoullis: "\u212C",
+  Beta: "\u0392",
+  Bfr: "\u{1D505}",
+  Bopf: "\u{1D539}",
+  Breve: "\u02D8",
+  Bscr: "\u212C",
+  Bumpeq: "\u224E",
+  CHcy: "\u0427",
+  COPY: "\xA9",
+  Cacute: "\u0106",
+  Cap: "\u22D2",
+  CapitalDifferentialD: "\u2145",
+  Cayleys: "\u212D",
+  Ccaron: "\u010C",
+  Ccedil: "\xC7",
+  Ccirc: "\u0108",
+  Cconint: "\u2230",
+  Cdot: "\u010A",
+  Cedilla: "\xB8",
+  CenterDot: "\xB7",
+  Cfr: "\u212D",
+  Chi: "\u03A7",
+  CircleDot: "\u2299",
+  CircleMinus: "\u2296",
+  CirclePlus: "\u2295",
+  CircleTimes: "\u2297",
+  ClockwiseContourIntegral: "\u2232",
+  CloseCurlyDoubleQuote: "\u201D",
+  CloseCurlyQuote: "\u2019",
+  Colon: "\u2237",
+  Colone: "\u2A74",
+  Congruent: "\u2261",
+  Conint: "\u222F",
+  ContourIntegral: "\u222E",
+  Copf: "\u2102",
+  Coproduct: "\u2210",
+  CounterClockwiseContourIntegral: "\u2233",
+  Cross: "\u2A2F",
+  Cscr: "\u{1D49E}",
+  Cup: "\u22D3",
+  CupCap: "\u224D",
+  DD: "\u2145",
+  DDotrahd: "\u2911",
+  DJcy: "\u0402",
+  DScy: "\u0405",
+  DZcy: "\u040F",
+  Dagger: "\u2021",
+  Darr: "\u21A1",
+  Dashv: "\u2AE4",
+  Dcaron: "\u010E",
+  Dcy: "\u0414",
+  Del: "\u2207",
+  Delta: "\u0394",
+  Dfr: "\u{1D507}",
+  DiacriticalAcute: "\xB4",
+  DiacriticalDot: "\u02D9",
+  DiacriticalDoubleAcute: "\u02DD",
+  DiacriticalGrave: "`",
+  DiacriticalTilde: "\u02DC",
+  Diamond: "\u22C4",
+  DifferentialD: "\u2146",
+  Dopf: "\u{1D53B}",
+  Dot: "\xA8",
+  DotDot: "\u20DC",
+  DotEqual: "\u2250",
+  DoubleContourIntegral: "\u222F",
+  DoubleDot: "\xA8",
+  DoubleDownArrow: "\u21D3",
+  DoubleLeftArrow: "\u21D0",
+  DoubleLeftRightArrow: "\u21D4",
+  DoubleLeftTee: "\u2AE4",
+  DoubleLongLeftArrow: "\u27F8",
+  DoubleLongLeftRightArrow: "\u27FA",
+  DoubleLongRightArrow: "\u27F9",
+  DoubleRightArrow: "\u21D2",
+  DoubleRightTee: "\u22A8",
+  DoubleUpArrow: "\u21D1",
+  DoubleUpDownArrow: "\u21D5",
+  DoubleVerticalBar: "\u2225",
+  DownArrow: "\u2193",
+  DownArrowBar: "\u2913",
+  DownArrowUpArrow: "\u21F5",
+  DownBreve: "\u0311",
+  DownLeftRightVector: "\u2950",
+  DownLeftTeeVector: "\u295E",
+  DownLeftVector: "\u21BD",
+  DownLeftVectorBar: "\u2956",
+  DownRightTeeVector: "\u295F",
+  DownRightVector: "\u21C1",
+  DownRightVectorBar: "\u2957",
+  DownTee: "\u22A4",
+  DownTeeArrow: "\u21A7",
+  Downarrow: "\u21D3",
+  Dscr: "\u{1D49F}",
+  Dstrok: "\u0110",
+  ENG: "\u014A",
+  ETH: "\xD0",
+  Eacute: "\xC9",
+  Ecaron: "\u011A",
+  Ecirc: "\xCA",
+  Ecy: "\u042D",
+  Edot: "\u0116",
+  Efr: "\u{1D508}",
+  Egrave: "\xC8",
+  Element: "\u2208",
+  Emacr: "\u0112",
+  EmptySmallSquare: "\u25FB",
+  EmptyVerySmallSquare: "\u25AB",
+  Eogon: "\u0118",
+  Eopf: "\u{1D53C}",
+  Epsilon: "\u0395",
+  Equal: "\u2A75",
+  EqualTilde: "\u2242",
+  Equilibrium: "\u21CC",
+  Escr: "\u2130",
+  Esim: "\u2A73",
+  Eta: "\u0397",
+  Euml: "\xCB",
+  Exists: "\u2203",
+  ExponentialE: "\u2147",
+  Fcy: "\u0424",
+  Ffr: "\u{1D509}",
+  FilledSmallSquare: "\u25FC",
+  FilledVerySmallSquare: "\u25AA",
+  Fopf: "\u{1D53D}",
+  ForAll: "\u2200",
+  Fouriertrf: "\u2131",
+  Fscr: "\u2131",
+  GJcy: "\u0403",
+  GT: ">",
+  Gamma: "\u0393",
+  Gammad: "\u03DC",
+  Gbreve: "\u011E",
+  Gcedil: "\u0122",
+  Gcirc: "\u011C",
+  Gcy: "\u0413",
+  Gdot: "\u0120",
+  Gfr: "\u{1D50A}",
+  Gg: "\u22D9",
+  Gopf: "\u{1D53E}",
+  GreaterEqual: "\u2265",
+  GreaterEqualLess: "\u22DB",
+  GreaterFullEqual: "\u2267",
+  GreaterGreater: "\u2AA2",
+  GreaterLess: "\u2277",
+  GreaterSlantEqual: "\u2A7E",
+  GreaterTilde: "\u2273",
+  Gscr: "\u{1D4A2}",
+  Gt: "\u226B",
+  HARDcy: "\u042A",
+  Hacek: "\u02C7",
+  Hat: "^",
+  Hcirc: "\u0124",
+  Hfr: "\u210C",
+  HilbertSpace: "\u210B",
+  Hopf: "\u210D",
+  HorizontalLine: "\u2500",
+  Hscr: "\u210B",
+  Hstrok: "\u0126",
+  HumpDownHump: "\u224E",
+  HumpEqual: "\u224F",
+  IEcy: "\u0415",
+  IJlig: "\u0132",
+  IOcy: "\u0401",
+  Iacute: "\xCD",
+  Icirc: "\xCE",
+  Icy: "\u0418",
+  Idot: "\u0130",
+  Ifr: "\u2111",
+  Igrave: "\xCC",
+  Im: "\u2111",
+  Imacr: "\u012A",
+  ImaginaryI: "\u2148",
+  Implies: "\u21D2",
+  Int: "\u222C",
+  Integral: "\u222B",
+  Intersection: "\u22C2",
+  InvisibleComma: "\u2063",
+  InvisibleTimes: "\u2062",
+  Iogon: "\u012E",
+  Iopf: "\u{1D540}",
+  Iota: "\u0399",
+  Iscr: "\u2110",
+  Itilde: "\u0128",
+  Iukcy: "\u0406",
+  Iuml: "\xCF",
+  Jcirc: "\u0134",
+  Jcy: "\u0419",
+  Jfr: "\u{1D50D}",
+  Jopf: "\u{1D541}",
+  Jscr: "\u{1D4A5}",
+  Jsercy: "\u0408",
+  Jukcy: "\u0404",
+  KHcy: "\u0425",
+  KJcy: "\u040C",
+  Kappa: "\u039A",
+  Kcedil: "\u0136",
+  Kcy: "\u041A",
+  Kfr: "\u{1D50E}",
+  Kopf: "\u{1D542}",
+  Kscr: "\u{1D4A6}",
+  LJcy: "\u0409",
+  LT: "<",
+  Lacute: "\u0139",
+  Lambda: "\u039B",
+  Lang: "\u27EA",
+  Laplacetrf: "\u2112",
+  Larr: "\u219E",
+  Lcaron: "\u013D",
+  Lcedil: "\u013B",
+  Lcy: "\u041B",
+  LeftAngleBracket: "\u27E8",
+  LeftArrow: "\u2190",
+  LeftArrowBar: "\u21E4",
+  LeftArrowRightArrow: "\u21C6",
+  LeftCeiling: "\u2308",
+  LeftDoubleBracket: "\u27E6",
+  LeftDownTeeVector: "\u2961",
+  LeftDownVector: "\u21C3",
+  LeftDownVectorBar: "\u2959",
+  LeftFloor: "\u230A",
+  LeftRightArrow: "\u2194",
+  LeftRightVector: "\u294E",
+  LeftTee: "\u22A3",
+  LeftTeeArrow: "\u21A4",
+  LeftTeeVector: "\u295A",
+  LeftTriangle: "\u22B2",
+  LeftTriangleBar: "\u29CF",
+  LeftTriangleEqual: "\u22B4",
+  LeftUpDownVector: "\u2951",
+  LeftUpTeeVector: "\u2960",
+  LeftUpVector: "\u21BF",
+  LeftUpVectorBar: "\u2958",
+  LeftVector: "\u21BC",
+  LeftVectorBar: "\u2952",
+  Leftarrow: "\u21D0",
+  Leftrightarrow: "\u21D4",
+  LessEqualGreater: "\u22DA",
+  LessFullEqual: "\u2266",
+  LessGreater: "\u2276",
+  LessLess: "\u2AA1",
+  LessSlantEqual: "\u2A7D",
+  LessTilde: "\u2272",
+  Lfr: "\u{1D50F}",
+  Ll: "\u22D8",
+  Lleftarrow: "\u21DA",
+  Lmidot: "\u013F",
+  LongLeftArrow: "\u27F5",
+  LongLeftRightArrow: "\u27F7",
+  LongRightArrow: "\u27F6",
+  Longleftarrow: "\u27F8",
+  Longleftrightarrow: "\u27FA",
+  Longrightarrow: "\u27F9",
+  Lopf: "\u{1D543}",
+  LowerLeftArrow: "\u2199",
+  LowerRightArrow: "\u2198",
+  Lscr: "\u2112",
+  Lsh: "\u21B0",
+  Lstrok: "\u0141",
+  Lt: "\u226A",
+  Map: "\u2905",
+  Mcy: "\u041C",
+  MediumSpace: "\u205F",
+  Mellintrf: "\u2133",
+  Mfr: "\u{1D510}",
+  MinusPlus: "\u2213",
+  Mopf: "\u{1D544}",
+  Mscr: "\u2133",
+  Mu: "\u039C",
+  NJcy: "\u040A",
+  Nacute: "\u0143",
+  Ncaron: "\u0147",
+  Ncedil: "\u0145",
+  Ncy: "\u041D",
+  NegativeMediumSpace: "\u200B",
+  NegativeThickSpace: "\u200B",
+  NegativeThinSpace: "\u200B",
+  NegativeVeryThinSpace: "\u200B",
+  NestedGreaterGreater: "\u226B",
+  NestedLessLess: "\u226A",
+  NewLine: "\n",
+  Nfr: "\u{1D511}",
+  NoBreak: "\u2060",
+  NonBreakingSpace: "\xA0",
+  Nopf: "\u2115",
+  Not: "\u2AEC",
+  NotCongruent: "\u2262",
+  NotCupCap: "\u226D",
+  NotDoubleVerticalBar: "\u2226",
+  NotElement: "\u2209",
+  NotEqual: "\u2260",
+  NotEqualTilde: "\u2242\u0338",
+  NotExists: "\u2204",
+  NotGreater: "\u226F",
+  NotGreaterEqual: "\u2271",
+  NotGreaterFullEqual: "\u2267\u0338",
+  NotGreaterGreater: "\u226B\u0338",
+  NotGreaterLess: "\u2279",
+  NotGreaterSlantEqual: "\u2A7E\u0338",
+  NotGreaterTilde: "\u2275",
+  NotHumpDownHump: "\u224E\u0338",
+  NotHumpEqual: "\u224F\u0338",
+  NotLeftTriangle: "\u22EA",
+  NotLeftTriangleBar: "\u29CF\u0338",
+  NotLeftTriangleEqual: "\u22EC",
+  NotLess: "\u226E",
+  NotLessEqual: "\u2270",
+  NotLessGreater: "\u2278",
+  NotLessLess: "\u226A\u0338",
+  NotLessSlantEqual: "\u2A7D\u0338",
+  NotLessTilde: "\u2274",
+  NotNestedGreaterGreater: "\u2AA2\u0338",
+  NotNestedLessLess: "\u2AA1\u0338",
+  NotPrecedes: "\u2280",
+  NotPrecedesEqual: "\u2AAF\u0338",
+  NotPrecedesSlantEqual: "\u22E0",
+  NotReverseElement: "\u220C",
+  NotRightTriangle: "\u22EB",
+  NotRightTriangleBar: "\u29D0\u0338",
+  NotRightTriangleEqual: "\u22ED",
+  NotSquareSubset: "\u228F\u0338",
+  NotSquareSubsetEqual: "\u22E2",
+  NotSquareSuperset: "\u2290\u0338",
+  NotSquareSupersetEqual: "\u22E3",
+  NotSubset: "\u2282\u20D2",
+  NotSubsetEqual: "\u2288",
+  NotSucceeds: "\u2281",
+  NotSucceedsEqual: "\u2AB0\u0338",
+  NotSucceedsSlantEqual: "\u22E1",
+  NotSucceedsTilde: "\u227F\u0338",
+  NotSuperset: "\u2283\u20D2",
+  NotSupersetEqual: "\u2289",
+  NotTilde: "\u2241",
+  NotTildeEqual: "\u2244",
+  NotTildeFullEqual: "\u2247",
+  NotTildeTilde: "\u2249",
+  NotVerticalBar: "\u2224",
+  Nscr: "\u{1D4A9}",
+  Ntilde: "\xD1",
+  Nu: "\u039D",
+  OElig: "\u0152",
+  Oacute: "\xD3",
+  Ocirc: "\xD4",
+  Ocy: "\u041E",
+  Odblac: "\u0150",
+  Ofr: "\u{1D512}",
+  Ograve: "\xD2",
+  Omacr: "\u014C",
+  Omega: "\u03A9",
+  Omicron: "\u039F",
+  Oopf: "\u{1D546}",
+  OpenCurlyDoubleQuote: "\u201C",
+  OpenCurlyQuote: "\u2018",
+  Or: "\u2A54",
+  Oscr: "\u{1D4AA}",
+  Oslash: "\xD8",
+  Otilde: "\xD5",
+  Otimes: "\u2A37",
+  Ouml: "\xD6",
+  OverBar: "\u203E",
+  OverBrace: "\u23DE",
+  OverBracket: "\u23B4",
+  OverParenthesis: "\u23DC",
+  PartialD: "\u2202",
+  Pcy: "\u041F",
+  Pfr: "\u{1D513}",
+  Phi: "\u03A6",
+  Pi: "\u03A0",
+  PlusMinus: "\xB1",
+  Poincareplane: "\u210C",
+  Popf: "\u2119",
+  Pr: "\u2ABB",
+  Precedes: "\u227A",
+  PrecedesEqual: "\u2AAF",
+  PrecedesSlantEqual: "\u227C",
+  PrecedesTilde: "\u227E",
+  Prime: "\u2033",
+  Product: "\u220F",
+  Proportion: "\u2237",
+  Proportional: "\u221D",
+  Pscr: "\u{1D4AB}",
+  Psi: "\u03A8",
+  QUOT: '"',
+  Qfr: "\u{1D514}",
+  Qopf: "\u211A",
+  Qscr: "\u{1D4AC}",
+  RBarr: "\u2910",
+  REG: "\xAE",
+  Racute: "\u0154",
+  Rang: "\u27EB",
+  Rarr: "\u21A0",
+  Rarrtl: "\u2916",
+  Rcaron: "\u0158",
+  Rcedil: "\u0156",
+  Rcy: "\u0420",
+  Re: "\u211C",
+  ReverseElement: "\u220B",
+  ReverseEquilibrium: "\u21CB",
+  ReverseUpEquilibrium: "\u296F",
+  Rfr: "\u211C",
+  Rho: "\u03A1",
+  RightAngleBracket: "\u27E9",
+  RightArrow: "\u2192",
+  RightArrowBar: "\u21E5",
+  RightArrowLeftArrow: "\u21C4",
+  RightCeiling: "\u2309",
+  RightDoubleBracket: "\u27E7",
+  RightDownTeeVector: "\u295D",
+  RightDownVector: "\u21C2",
+  RightDownVectorBar: "\u2955",
+  RightFloor: "\u230B",
+  RightTee: "\u22A2",
+  RightTeeArrow: "\u21A6",
+  RightTeeVector: "\u295B",
+  RightTriangle: "\u22B3",
+  RightTriangleBar: "\u29D0",
+  RightTriangleEqual: "\u22B5",
+  RightUpDownVector: "\u294F",
+  RightUpTeeVector: "\u295C",
+  RightUpVector: "\u21BE",
+  RightUpVectorBar: "\u2954",
+  RightVector: "\u21C0",
+  RightVectorBar: "\u2953",
+  Rightarrow: "\u21D2",
+  Ropf: "\u211D",
+  RoundImplies: "\u2970",
+  Rrightarrow: "\u21DB",
+  Rscr: "\u211B",
+  Rsh: "\u21B1",
+  RuleDelayed: "\u29F4",
+  SHCHcy: "\u0429",
+  SHcy: "\u0428",
+  SOFTcy: "\u042C",
+  Sacute: "\u015A",
+  Sc: "\u2ABC",
+  Scaron: "\u0160",
+  Scedil: "\u015E",
+  Scirc: "\u015C",
+  Scy: "\u0421",
+  Sfr: "\u{1D516}",
+  ShortDownArrow: "\u2193",
+  ShortLeftArrow: "\u2190",
+  ShortRightArrow: "\u2192",
+  ShortUpArrow: "\u2191",
+  Sigma: "\u03A3",
+  SmallCircle: "\u2218",
+  Sopf: "\u{1D54A}",
+  Sqrt: "\u221A",
+  Square: "\u25A1",
+  SquareIntersection: "\u2293",
+  SquareSubset: "\u228F",
+  SquareSubsetEqual: "\u2291",
+  SquareSuperset: "\u2290",
+  SquareSupersetEqual: "\u2292",
+  SquareUnion: "\u2294",
+  Sscr: "\u{1D4AE}",
+  Star: "\u22C6",
+  Sub: "\u22D0",
+  Subset: "\u22D0",
+  SubsetEqual: "\u2286",
+  Succeeds: "\u227B",
+  SucceedsEqual: "\u2AB0",
+  SucceedsSlantEqual: "\u227D",
+  SucceedsTilde: "\u227F",
+  SuchThat: "\u220B",
+  Sum: "\u2211",
+  Sup: "\u22D1",
+  Superset: "\u2283",
+  SupersetEqual: "\u2287",
+  Supset: "\u22D1",
+  THORN: "\xDE",
+  TRADE: "\u2122",
+  TSHcy: "\u040B",
+  TScy: "\u0426",
+  Tab: "	",
+  Tau: "\u03A4",
+  Tcaron: "\u0164",
+  Tcedil: "\u0162",
+  Tcy: "\u0422",
+  Tfr: "\u{1D517}",
+  Therefore: "\u2234",
+  Theta: "\u0398",
+  ThickSpace: "\u205F\u200A",
+  ThinSpace: "\u2009",
+  Tilde: "\u223C",
+  TildeEqual: "\u2243",
+  TildeFullEqual: "\u2245",
+  TildeTilde: "\u2248",
+  Topf: "\u{1D54B}",
+  TripleDot: "\u20DB",
+  Tscr: "\u{1D4AF}",
+  Tstrok: "\u0166",
+  Uacute: "\xDA",
+  Uarr: "\u219F",
+  Uarrocir: "\u2949",
+  Ubrcy: "\u040E",
+  Ubreve: "\u016C",
+  Ucirc: "\xDB",
+  Ucy: "\u0423",
+  Udblac: "\u0170",
+  Ufr: "\u{1D518}",
+  Ugrave: "\xD9",
+  Umacr: "\u016A",
+  UnderBar: "_",
+  UnderBrace: "\u23DF",
+  UnderBracket: "\u23B5",
+  UnderParenthesis: "\u23DD",
+  Union: "\u22C3",
+  UnionPlus: "\u228E",
+  Uogon: "\u0172",
+  Uopf: "\u{1D54C}",
+  UpArrow: "\u2191",
+  UpArrowBar: "\u2912",
+  UpArrowDownArrow: "\u21C5",
+  UpDownArrow: "\u2195",
+  UpEquilibrium: "\u296E",
+  UpTee: "\u22A5",
+  UpTeeArrow: "\u21A5",
+  Uparrow: "\u21D1",
+  Updownarrow: "\u21D5",
+  UpperLeftArrow: "\u2196",
+  UpperRightArrow: "\u2197",
+  Upsi: "\u03D2",
+  Upsilon: "\u03A5",
+  Uring: "\u016E",
+  Uscr: "\u{1D4B0}",
+  Utilde: "\u0168",
+  Uuml: "\xDC",
+  VDash: "\u22AB",
+  Vbar: "\u2AEB",
+  Vcy: "\u0412",
+  Vdash: "\u22A9",
+  Vdashl: "\u2AE6",
+  Vee: "\u22C1",
+  Verbar: "\u2016",
+  Vert: "\u2016",
+  VerticalBar: "\u2223",
+  VerticalLine: "|",
+  VerticalSeparator: "\u2758",
+  VerticalTilde: "\u2240",
+  VeryThinSpace: "\u200A",
+  Vfr: "\u{1D519}",
+  Vopf: "\u{1D54D}",
+  Vscr: "\u{1D4B1}",
+  Vvdash: "\u22AA",
+  Wcirc: "\u0174",
+  Wedge: "\u22C0",
+  Wfr: "\u{1D51A}",
+  Wopf: "\u{1D54E}",
+  Wscr: "\u{1D4B2}",
+  Xfr: "\u{1D51B}",
+  Xi: "\u039E",
+  Xopf: "\u{1D54F}",
+  Xscr: "\u{1D4B3}",
+  YAcy: "\u042F",
+  YIcy: "\u0407",
+  YUcy: "\u042E",
+  Yacute: "\xDD",
+  Ycirc: "\u0176",
+  Ycy: "\u042B",
+  Yfr: "\u{1D51C}",
+  Yopf: "\u{1D550}",
+  Yscr: "\u{1D4B4}",
+  Yuml: "\u0178",
+  ZHcy: "\u0416",
+  Zacute: "\u0179",
+  Zcaron: "\u017D",
+  Zcy: "\u0417",
+  Zdot: "\u017B",
+  ZeroWidthSpace: "\u200B",
+  Zeta: "\u0396",
+  Zfr: "\u2128",
+  Zopf: "\u2124",
+  Zscr: "\u{1D4B5}",
+  aacute: "\xE1",
+  abreve: "\u0103",
+  ac: "\u223E",
+  acE: "\u223E\u0333",
+  acd: "\u223F",
+  acirc: "\xE2",
+  acute: "\xB4",
+  acy: "\u0430",
+  aelig: "\xE6",
+  af: "\u2061",
+  afr: "\u{1D51E}",
+  agrave: "\xE0",
+  alefsym: "\u2135",
+  aleph: "\u2135",
+  alpha: "\u03B1",
+  amacr: "\u0101",
+  amalg: "\u2A3F",
+  amp: "&",
+  and: "\u2227",
+  andand: "\u2A55",
+  andd: "\u2A5C",
+  andslope: "\u2A58",
+  andv: "\u2A5A",
+  ang: "\u2220",
+  ange: "\u29A4",
+  angle: "\u2220",
+  angmsd: "\u2221",
+  angmsdaa: "\u29A8",
+  angmsdab: "\u29A9",
+  angmsdac: "\u29AA",
+  angmsdad: "\u29AB",
+  angmsdae: "\u29AC",
+  angmsdaf: "\u29AD",
+  angmsdag: "\u29AE",
+  angmsdah: "\u29AF",
+  angrt: "\u221F",
+  angrtvb: "\u22BE",
+  angrtvbd: "\u299D",
+  angsph: "\u2222",
+  angst: "\xC5",
+  angzarr: "\u237C",
+  aogon: "\u0105",
+  aopf: "\u{1D552}",
+  ap: "\u2248",
+  apE: "\u2A70",
+  apacir: "\u2A6F",
+  ape: "\u224A",
+  apid: "\u224B",
+  apos: "'",
+  approx: "\u2248",
+  approxeq: "\u224A",
+  aring: "\xE5",
+  ascr: "\u{1D4B6}",
+  ast: "*",
+  asymp: "\u2248",
+  asympeq: "\u224D",
+  atilde: "\xE3",
+  auml: "\xE4",
+  awconint: "\u2233",
+  awint: "\u2A11",
+  bNot: "\u2AED",
+  backcong: "\u224C",
+  backepsilon: "\u03F6",
+  backprime: "\u2035",
+  backsim: "\u223D",
+  backsimeq: "\u22CD",
+  barvee: "\u22BD",
+  barwed: "\u2305",
+  barwedge: "\u2305",
+  bbrk: "\u23B5",
+  bbrktbrk: "\u23B6",
+  bcong: "\u224C",
+  bcy: "\u0431",
+  bdquo: "\u201E",
+  becaus: "\u2235",
+  because: "\u2235",
+  bemptyv: "\u29B0",
+  bepsi: "\u03F6",
+  bernou: "\u212C",
+  beta: "\u03B2",
+  beth: "\u2136",
+  between: "\u226C",
+  bfr: "\u{1D51F}",
+  bigcap: "\u22C2",
+  bigcirc: "\u25EF",
+  bigcup: "\u22C3",
+  bigodot: "\u2A00",
+  bigoplus: "\u2A01",
+  bigotimes: "\u2A02",
+  bigsqcup: "\u2A06",
+  bigstar: "\u2605",
+  bigtriangledown: "\u25BD",
+  bigtriangleup: "\u25B3",
+  biguplus: "\u2A04",
+  bigvee: "\u22C1",
+  bigwedge: "\u22C0",
+  bkarow: "\u290D",
+  blacklozenge: "\u29EB",
+  blacksquare: "\u25AA",
+  blacktriangle: "\u25B4",
+  blacktriangledown: "\u25BE",
+  blacktriangleleft: "\u25C2",
+  blacktriangleright: "\u25B8",
+  blank: "\u2423",
+  blk12: "\u2592",
+  blk14: "\u2591",
+  blk34: "\u2593",
+  block: "\u2588",
+  bne: "=\u20E5",
+  bnequiv: "\u2261\u20E5",
+  bnot: "\u2310",
+  bopf: "\u{1D553}",
+  bot: "\u22A5",
+  bottom: "\u22A5",
+  bowtie: "\u22C8",
+  boxDL: "\u2557",
+  boxDR: "\u2554",
+  boxDl: "\u2556",
+  boxDr: "\u2553",
+  boxH: "\u2550",
+  boxHD: "\u2566",
+  boxHU: "\u2569",
+  boxHd: "\u2564",
+  boxHu: "\u2567",
+  boxUL: "\u255D",
+  boxUR: "\u255A",
+  boxUl: "\u255C",
+  boxUr: "\u2559",
+  boxV: "\u2551",
+  boxVH: "\u256C",
+  boxVL: "\u2563",
+  boxVR: "\u2560",
+  boxVh: "\u256B",
+  boxVl: "\u2562",
+  boxVr: "\u255F",
+  boxbox: "\u29C9",
+  boxdL: "\u2555",
+  boxdR: "\u2552",
+  boxdl: "\u2510",
+  boxdr: "\u250C",
+  boxh: "\u2500",
+  boxhD: "\u2565",
+  boxhU: "\u2568",
+  boxhd: "\u252C",
+  boxhu: "\u2534",
+  boxminus: "\u229F",
+  boxplus: "\u229E",
+  boxtimes: "\u22A0",
+  boxuL: "\u255B",
+  boxuR: "\u2558",
+  boxul: "\u2518",
+  boxur: "\u2514",
+  boxv: "\u2502",
+  boxvH: "\u256A",
+  boxvL: "\u2561",
+  boxvR: "\u255E",
+  boxvh: "\u253C",
+  boxvl: "\u2524",
+  boxvr: "\u251C",
+  bprime: "\u2035",
+  breve: "\u02D8",
+  brvbar: "\xA6",
+  bscr: "\u{1D4B7}",
+  bsemi: "\u204F",
+  bsim: "\u223D",
+  bsime: "\u22CD",
+  bsol: "\\",
+  bsolb: "\u29C5",
+  bsolhsub: "\u27C8",
+  bull: "\u2022",
+  bullet: "\u2022",
+  bump: "\u224E",
+  bumpE: "\u2AAE",
+  bumpe: "\u224F",
+  bumpeq: "\u224F",
+  cacute: "\u0107",
+  cap: "\u2229",
+  capand: "\u2A44",
+  capbrcup: "\u2A49",
+  capcap: "\u2A4B",
+  capcup: "\u2A47",
+  capdot: "\u2A40",
+  caps: "\u2229\uFE00",
+  caret: "\u2041",
+  caron: "\u02C7",
+  ccaps: "\u2A4D",
+  ccaron: "\u010D",
+  ccedil: "\xE7",
+  ccirc: "\u0109",
+  ccups: "\u2A4C",
+  ccupssm: "\u2A50",
+  cdot: "\u010B",
+  cedil: "\xB8",
+  cemptyv: "\u29B2",
+  cent: "\xA2",
+  centerdot: "\xB7",
+  cfr: "\u{1D520}",
+  chcy: "\u0447",
+  check: "\u2713",
+  checkmark: "\u2713",
+  chi: "\u03C7",
+  cir: "\u25CB",
+  cirE: "\u29C3",
+  circ: "\u02C6",
+  circeq: "\u2257",
+  circlearrowleft: "\u21BA",
+  circlearrowright: "\u21BB",
+  circledR: "\xAE",
+  circledS: "\u24C8",
+  circledast: "\u229B",
+  circledcirc: "\u229A",
+  circleddash: "\u229D",
+  cire: "\u2257",
+  cirfnint: "\u2A10",
+  cirmid: "\u2AEF",
+  cirscir: "\u29C2",
+  clubs: "\u2663",
+  clubsuit: "\u2663",
+  colon: ":",
+  colone: "\u2254",
+  coloneq: "\u2254",
+  comma: ",",
+  commat: "@",
+  comp: "\u2201",
+  compfn: "\u2218",
+  complement: "\u2201",
+  complexes: "\u2102",
+  cong: "\u2245",
+  congdot: "\u2A6D",
+  conint: "\u222E",
+  copf: "\u{1D554}",
+  coprod: "\u2210",
+  copy: "\xA9",
+  copysr: "\u2117",
+  crarr: "\u21B5",
+  cross: "\u2717",
+  cscr: "\u{1D4B8}",
+  csub: "\u2ACF",
+  csube: "\u2AD1",
+  csup: "\u2AD0",
+  csupe: "\u2AD2",
+  ctdot: "\u22EF",
+  cudarrl: "\u2938",
+  cudarrr: "\u2935",
+  cuepr: "\u22DE",
+  cuesc: "\u22DF",
+  cularr: "\u21B6",
+  cularrp: "\u293D",
+  cup: "\u222A",
+  cupbrcap: "\u2A48",
+  cupcap: "\u2A46",
+  cupcup: "\u2A4A",
+  cupdot: "\u228D",
+  cupor: "\u2A45",
+  cups: "\u222A\uFE00",
+  curarr: "\u21B7",
+  curarrm: "\u293C",
+  curlyeqprec: "\u22DE",
+  curlyeqsucc: "\u22DF",
+  curlyvee: "\u22CE",
+  curlywedge: "\u22CF",
+  curren: "\xA4",
+  curvearrowleft: "\u21B6",
+  curvearrowright: "\u21B7",
+  cuvee: "\u22CE",
+  cuwed: "\u22CF",
+  cwconint: "\u2232",
+  cwint: "\u2231",
+  cylcty: "\u232D",
+  dArr: "\u21D3",
+  dHar: "\u2965",
+  dagger: "\u2020",
+  daleth: "\u2138",
+  darr: "\u2193",
+  dash: "\u2010",
+  dashv: "\u22A3",
+  dbkarow: "\u290F",
+  dblac: "\u02DD",
+  dcaron: "\u010F",
+  dcy: "\u0434",
+  dd: "\u2146",
+  ddagger: "\u2021",
+  ddarr: "\u21CA",
+  ddotseq: "\u2A77",
+  deg: "\xB0",
+  delta: "\u03B4",
+  demptyv: "\u29B1",
+  dfisht: "\u297F",
+  dfr: "\u{1D521}",
+  dharl: "\u21C3",
+  dharr: "\u21C2",
+  diam: "\u22C4",
+  diamond: "\u22C4",
+  diamondsuit: "\u2666",
+  diams: "\u2666",
+  die: "\xA8",
+  digamma: "\u03DD",
+  disin: "\u22F2",
+  div: "\xF7",
+  divide: "\xF7",
+  divideontimes: "\u22C7",
+  divonx: "\u22C7",
+  djcy: "\u0452",
+  dlcorn: "\u231E",
+  dlcrop: "\u230D",
+  dollar: "$",
+  dopf: "\u{1D555}",
+  dot: "\u02D9",
+  doteq: "\u2250",
+  doteqdot: "\u2251",
+  dotminus: "\u2238",
+  dotplus: "\u2214",
+  dotsquare: "\u22A1",
+  doublebarwedge: "\u2306",
+  downarrow: "\u2193",
+  downdownarrows: "\u21CA",
+  downharpoonleft: "\u21C3",
+  downharpoonright: "\u21C2",
+  drbkarow: "\u2910",
+  drcorn: "\u231F",
+  drcrop: "\u230C",
+  dscr: "\u{1D4B9}",
+  dscy: "\u0455",
+  dsol: "\u29F6",
+  dstrok: "\u0111",
+  dtdot: "\u22F1",
+  dtri: "\u25BF",
+  dtrif: "\u25BE",
+  duarr: "\u21F5",
+  duhar: "\u296F",
+  dwangle: "\u29A6",
+  dzcy: "\u045F",
+  dzigrarr: "\u27FF",
+  eDDot: "\u2A77",
+  eDot: "\u2251",
+  eacute: "\xE9",
+  easter: "\u2A6E",
+  ecaron: "\u011B",
+  ecir: "\u2256",
+  ecirc: "\xEA",
+  ecolon: "\u2255",
+  ecy: "\u044D",
+  edot: "\u0117",
+  ee: "\u2147",
+  efDot: "\u2252",
+  efr: "\u{1D522}",
+  eg: "\u2A9A",
+  egrave: "\xE8",
+  egs: "\u2A96",
+  egsdot: "\u2A98",
+  el: "\u2A99",
+  elinters: "\u23E7",
+  ell: "\u2113",
+  els: "\u2A95",
+  elsdot: "\u2A97",
+  emacr: "\u0113",
+  empty: "\u2205",
+  emptyset: "\u2205",
+  emptyv: "\u2205",
+  emsp13: "\u2004",
+  emsp14: "\u2005",
+  emsp: "\u2003",
+  eng: "\u014B",
+  ensp: "\u2002",
+  eogon: "\u0119",
+  eopf: "\u{1D556}",
+  epar: "\u22D5",
+  eparsl: "\u29E3",
+  eplus: "\u2A71",
+  epsi: "\u03B5",
+  epsilon: "\u03B5",
+  epsiv: "\u03F5",
+  eqcirc: "\u2256",
+  eqcolon: "\u2255",
+  eqsim: "\u2242",
+  eqslantgtr: "\u2A96",
+  eqslantless: "\u2A95",
+  equals: "=",
+  equest: "\u225F",
+  equiv: "\u2261",
+  equivDD: "\u2A78",
+  eqvparsl: "\u29E5",
+  erDot: "\u2253",
+  erarr: "\u2971",
+  escr: "\u212F",
+  esdot: "\u2250",
+  esim: "\u2242",
+  eta: "\u03B7",
+  eth: "\xF0",
+  euml: "\xEB",
+  euro: "\u20AC",
+  excl: "!",
+  exist: "\u2203",
+  expectation: "\u2130",
+  exponentiale: "\u2147",
+  fallingdotseq: "\u2252",
+  fcy: "\u0444",
+  female: "\u2640",
+  ffilig: "\uFB03",
+  fflig: "\uFB00",
+  ffllig: "\uFB04",
+  ffr: "\u{1D523}",
+  filig: "\uFB01",
+  fjlig: "fj",
+  flat: "\u266D",
+  fllig: "\uFB02",
+  fltns: "\u25B1",
+  fnof: "\u0192",
+  fopf: "\u{1D557}",
+  forall: "\u2200",
+  fork: "\u22D4",
+  forkv: "\u2AD9",
+  fpartint: "\u2A0D",
+  frac12: "\xBD",
+  frac13: "\u2153",
+  frac14: "\xBC",
+  frac15: "\u2155",
+  frac16: "\u2159",
+  frac18: "\u215B",
+  frac23: "\u2154",
+  frac25: "\u2156",
+  frac34: "\xBE",
+  frac35: "\u2157",
+  frac38: "\u215C",
+  frac45: "\u2158",
+  frac56: "\u215A",
+  frac58: "\u215D",
+  frac78: "\u215E",
+  frasl: "\u2044",
+  frown: "\u2322",
+  fscr: "\u{1D4BB}",
+  gE: "\u2267",
+  gEl: "\u2A8C",
+  gacute: "\u01F5",
+  gamma: "\u03B3",
+  gammad: "\u03DD",
+  gap: "\u2A86",
+  gbreve: "\u011F",
+  gcirc: "\u011D",
+  gcy: "\u0433",
+  gdot: "\u0121",
+  ge: "\u2265",
+  gel: "\u22DB",
+  geq: "\u2265",
+  geqq: "\u2267",
+  geqslant: "\u2A7E",
+  ges: "\u2A7E",
+  gescc: "\u2AA9",
+  gesdot: "\u2A80",
+  gesdoto: "\u2A82",
+  gesdotol: "\u2A84",
+  gesl: "\u22DB\uFE00",
+  gesles: "\u2A94",
+  gfr: "\u{1D524}",
+  gg: "\u226B",
+  ggg: "\u22D9",
+  gimel: "\u2137",
+  gjcy: "\u0453",
+  gl: "\u2277",
+  glE: "\u2A92",
+  gla: "\u2AA5",
+  glj: "\u2AA4",
+  gnE: "\u2269",
+  gnap: "\u2A8A",
+  gnapprox: "\u2A8A",
+  gne: "\u2A88",
+  gneq: "\u2A88",
+  gneqq: "\u2269",
+  gnsim: "\u22E7",
+  gopf: "\u{1D558}",
+  grave: "`",
+  gscr: "\u210A",
+  gsim: "\u2273",
+  gsime: "\u2A8E",
+  gsiml: "\u2A90",
+  gt: ">",
+  gtcc: "\u2AA7",
+  gtcir: "\u2A7A",
+  gtdot: "\u22D7",
+  gtlPar: "\u2995",
+  gtquest: "\u2A7C",
+  gtrapprox: "\u2A86",
+  gtrarr: "\u2978",
+  gtrdot: "\u22D7",
+  gtreqless: "\u22DB",
+  gtreqqless: "\u2A8C",
+  gtrless: "\u2277",
+  gtrsim: "\u2273",
+  gvertneqq: "\u2269\uFE00",
+  gvnE: "\u2269\uFE00",
+  hArr: "\u21D4",
+  hairsp: "\u200A",
+  half: "\xBD",
+  hamilt: "\u210B",
+  hardcy: "\u044A",
+  harr: "\u2194",
+  harrcir: "\u2948",
+  harrw: "\u21AD",
+  hbar: "\u210F",
+  hcirc: "\u0125",
+  hearts: "\u2665",
+  heartsuit: "\u2665",
+  hellip: "\u2026",
+  hercon: "\u22B9",
+  hfr: "\u{1D525}",
+  hksearow: "\u2925",
+  hkswarow: "\u2926",
+  hoarr: "\u21FF",
+  homtht: "\u223B",
+  hookleftarrow: "\u21A9",
+  hookrightarrow: "\u21AA",
+  hopf: "\u{1D559}",
+  horbar: "\u2015",
+  hscr: "\u{1D4BD}",
+  hslash: "\u210F",
+  hstrok: "\u0127",
+  hybull: "\u2043",
+  hyphen: "\u2010",
+  iacute: "\xED",
+  ic: "\u2063",
+  icirc: "\xEE",
+  icy: "\u0438",
+  iecy: "\u0435",
+  iexcl: "\xA1",
+  iff: "\u21D4",
+  ifr: "\u{1D526}",
+  igrave: "\xEC",
+  ii: "\u2148",
+  iiiint: "\u2A0C",
+  iiint: "\u222D",
+  iinfin: "\u29DC",
+  iiota: "\u2129",
+  ijlig: "\u0133",
+  imacr: "\u012B",
+  image: "\u2111",
+  imagline: "\u2110",
+  imagpart: "\u2111",
+  imath: "\u0131",
+  imof: "\u22B7",
+  imped: "\u01B5",
+  in: "\u2208",
+  incare: "\u2105",
+  infin: "\u221E",
+  infintie: "\u29DD",
+  inodot: "\u0131",
+  int: "\u222B",
+  intcal: "\u22BA",
+  integers: "\u2124",
+  intercal: "\u22BA",
+  intlarhk: "\u2A17",
+  intprod: "\u2A3C",
+  iocy: "\u0451",
+  iogon: "\u012F",
+  iopf: "\u{1D55A}",
+  iota: "\u03B9",
+  iprod: "\u2A3C",
+  iquest: "\xBF",
+  iscr: "\u{1D4BE}",
+  isin: "\u2208",
+  isinE: "\u22F9",
+  isindot: "\u22F5",
+  isins: "\u22F4",
+  isinsv: "\u22F3",
+  isinv: "\u2208",
+  it: "\u2062",
+  itilde: "\u0129",
+  iukcy: "\u0456",
+  iuml: "\xEF",
+  jcirc: "\u0135",
+  jcy: "\u0439",
+  jfr: "\u{1D527}",
+  jmath: "\u0237",
+  jopf: "\u{1D55B}",
+  jscr: "\u{1D4BF}",
+  jsercy: "\u0458",
+  jukcy: "\u0454",
+  kappa: "\u03BA",
+  kappav: "\u03F0",
+  kcedil: "\u0137",
+  kcy: "\u043A",
+  kfr: "\u{1D528}",
+  kgreen: "\u0138",
+  khcy: "\u0445",
+  kjcy: "\u045C",
+  kopf: "\u{1D55C}",
+  kscr: "\u{1D4C0}",
+  lAarr: "\u21DA",
+  lArr: "\u21D0",
+  lAtail: "\u291B",
+  lBarr: "\u290E",
+  lE: "\u2266",
+  lEg: "\u2A8B",
+  lHar: "\u2962",
+  lacute: "\u013A",
+  laemptyv: "\u29B4",
+  lagran: "\u2112",
+  lambda: "\u03BB",
+  lang: "\u27E8",
+  langd: "\u2991",
+  langle: "\u27E8",
+  lap: "\u2A85",
+  laquo: "\xAB",
+  larr: "\u2190",
+  larrb: "\u21E4",
+  larrbfs: "\u291F",
+  larrfs: "\u291D",
+  larrhk: "\u21A9",
+  larrlp: "\u21AB",
+  larrpl: "\u2939",
+  larrsim: "\u2973",
+  larrtl: "\u21A2",
+  lat: "\u2AAB",
+  latail: "\u2919",
+  late: "\u2AAD",
+  lates: "\u2AAD\uFE00",
+  lbarr: "\u290C",
+  lbbrk: "\u2772",
+  lbrace: "{",
+  lbrack: "[",
+  lbrke: "\u298B",
+  lbrksld: "\u298F",
+  lbrkslu: "\u298D",
+  lcaron: "\u013E",
+  lcedil: "\u013C",
+  lceil: "\u2308",
+  lcub: "{",
+  lcy: "\u043B",
+  ldca: "\u2936",
+  ldquo: "\u201C",
+  ldquor: "\u201E",
+  ldrdhar: "\u2967",
+  ldrushar: "\u294B",
+  ldsh: "\u21B2",
+  le: "\u2264",
+  leftarrow: "\u2190",
+  leftarrowtail: "\u21A2",
+  leftharpoondown: "\u21BD",
+  leftharpoonup: "\u21BC",
+  leftleftarrows: "\u21C7",
+  leftrightarrow: "\u2194",
+  leftrightarrows: "\u21C6",
+  leftrightharpoons: "\u21CB",
+  leftrightsquigarrow: "\u21AD",
+  leftthreetimes: "\u22CB",
+  leg: "\u22DA",
+  leq: "\u2264",
+  leqq: "\u2266",
+  leqslant: "\u2A7D",
+  les: "\u2A7D",
+  lescc: "\u2AA8",
+  lesdot: "\u2A7F",
+  lesdoto: "\u2A81",
+  lesdotor: "\u2A83",
+  lesg: "\u22DA\uFE00",
+  lesges: "\u2A93",
+  lessapprox: "\u2A85",
+  lessdot: "\u22D6",
+  lesseqgtr: "\u22DA",
+  lesseqqgtr: "\u2A8B",
+  lessgtr: "\u2276",
+  lesssim: "\u2272",
+  lfisht: "\u297C",
+  lfloor: "\u230A",
+  lfr: "\u{1D529}",
+  lg: "\u2276",
+  lgE: "\u2A91",
+  lhard: "\u21BD",
+  lharu: "\u21BC",
+  lharul: "\u296A",
+  lhblk: "\u2584",
+  ljcy: "\u0459",
+  ll: "\u226A",
+  llarr: "\u21C7",
+  llcorner: "\u231E",
+  llhard: "\u296B",
+  lltri: "\u25FA",
+  lmidot: "\u0140",
+  lmoust: "\u23B0",
+  lmoustache: "\u23B0",
+  lnE: "\u2268",
+  lnap: "\u2A89",
+  lnapprox: "\u2A89",
+  lne: "\u2A87",
+  lneq: "\u2A87",
+  lneqq: "\u2268",
+  lnsim: "\u22E6",
+  loang: "\u27EC",
+  loarr: "\u21FD",
+  lobrk: "\u27E6",
+  longleftarrow: "\u27F5",
+  longleftrightarrow: "\u27F7",
+  longmapsto: "\u27FC",
+  longrightarrow: "\u27F6",
+  looparrowleft: "\u21AB",
+  looparrowright: "\u21AC",
+  lopar: "\u2985",
+  lopf: "\u{1D55D}",
+  loplus: "\u2A2D",
+  lotimes: "\u2A34",
+  lowast: "\u2217",
+  lowbar: "_",
+  loz: "\u25CA",
+  lozenge: "\u25CA",
+  lozf: "\u29EB",
+  lpar: "(",
+  lparlt: "\u2993",
+  lrarr: "\u21C6",
+  lrcorner: "\u231F",
+  lrhar: "\u21CB",
+  lrhard: "\u296D",
+  lrm: "\u200E",
+  lrtri: "\u22BF",
+  lsaquo: "\u2039",
+  lscr: "\u{1D4C1}",
+  lsh: "\u21B0",
+  lsim: "\u2272",
+  lsime: "\u2A8D",
+  lsimg: "\u2A8F",
+  lsqb: "[",
+  lsquo: "\u2018",
+  lsquor: "\u201A",
+  lstrok: "\u0142",
+  lt: "<",
+  ltcc: "\u2AA6",
+  ltcir: "\u2A79",
+  ltdot: "\u22D6",
+  lthree: "\u22CB",
+  ltimes: "\u22C9",
+  ltlarr: "\u2976",
+  ltquest: "\u2A7B",
+  ltrPar: "\u2996",
+  ltri: "\u25C3",
+  ltrie: "\u22B4",
+  ltrif: "\u25C2",
+  lurdshar: "\u294A",
+  luruhar: "\u2966",
+  lvertneqq: "\u2268\uFE00",
+  lvnE: "\u2268\uFE00",
+  mDDot: "\u223A",
+  macr: "\xAF",
+  male: "\u2642",
+  malt: "\u2720",
+  maltese: "\u2720",
+  map: "\u21A6",
+  mapsto: "\u21A6",
+  mapstodown: "\u21A7",
+  mapstoleft: "\u21A4",
+  mapstoup: "\u21A5",
+  marker: "\u25AE",
+  mcomma: "\u2A29",
+  mcy: "\u043C",
+  mdash: "\u2014",
+  measuredangle: "\u2221",
+  mfr: "\u{1D52A}",
+  mho: "\u2127",
+  micro: "\xB5",
+  mid: "\u2223",
+  midast: "*",
+  midcir: "\u2AF0",
+  middot: "\xB7",
+  minus: "\u2212",
+  minusb: "\u229F",
+  minusd: "\u2238",
+  minusdu: "\u2A2A",
+  mlcp: "\u2ADB",
+  mldr: "\u2026",
+  mnplus: "\u2213",
+  models: "\u22A7",
+  mopf: "\u{1D55E}",
+  mp: "\u2213",
+  mscr: "\u{1D4C2}",
+  mstpos: "\u223E",
+  mu: "\u03BC",
+  multimap: "\u22B8",
+  mumap: "\u22B8",
+  nGg: "\u22D9\u0338",
+  nGt: "\u226B\u20D2",
+  nGtv: "\u226B\u0338",
+  nLeftarrow: "\u21CD",
+  nLeftrightarrow: "\u21CE",
+  nLl: "\u22D8\u0338",
+  nLt: "\u226A\u20D2",
+  nLtv: "\u226A\u0338",
+  nRightarrow: "\u21CF",
+  nVDash: "\u22AF",
+  nVdash: "\u22AE",
+  nabla: "\u2207",
+  nacute: "\u0144",
+  nang: "\u2220\u20D2",
+  nap: "\u2249",
+  napE: "\u2A70\u0338",
+  napid: "\u224B\u0338",
+  napos: "\u0149",
+  napprox: "\u2249",
+  natur: "\u266E",
+  natural: "\u266E",
+  naturals: "\u2115",
+  nbsp: "\xA0",
+  nbump: "\u224E\u0338",
+  nbumpe: "\u224F\u0338",
+  ncap: "\u2A43",
+  ncaron: "\u0148",
+  ncedil: "\u0146",
+  ncong: "\u2247",
+  ncongdot: "\u2A6D\u0338",
+  ncup: "\u2A42",
+  ncy: "\u043D",
+  ndash: "\u2013",
+  ne: "\u2260",
+  neArr: "\u21D7",
+  nearhk: "\u2924",
+  nearr: "\u2197",
+  nearrow: "\u2197",
+  nedot: "\u2250\u0338",
+  nequiv: "\u2262",
+  nesear: "\u2928",
+  nesim: "\u2242\u0338",
+  nexist: "\u2204",
+  nexists: "\u2204",
+  nfr: "\u{1D52B}",
+  ngE: "\u2267\u0338",
+  nge: "\u2271",
+  ngeq: "\u2271",
+  ngeqq: "\u2267\u0338",
+  ngeqslant: "\u2A7E\u0338",
+  nges: "\u2A7E\u0338",
+  ngsim: "\u2275",
+  ngt: "\u226F",
+  ngtr: "\u226F",
+  nhArr: "\u21CE",
+  nharr: "\u21AE",
+  nhpar: "\u2AF2",
+  ni: "\u220B",
+  nis: "\u22FC",
+  nisd: "\u22FA",
+  niv: "\u220B",
+  njcy: "\u045A",
+  nlArr: "\u21CD",
+  nlE: "\u2266\u0338",
+  nlarr: "\u219A",
+  nldr: "\u2025",
+  nle: "\u2270",
+  nleftarrow: "\u219A",
+  nleftrightarrow: "\u21AE",
+  nleq: "\u2270",
+  nleqq: "\u2266\u0338",
+  nleqslant: "\u2A7D\u0338",
+  nles: "\u2A7D\u0338",
+  nless: "\u226E",
+  nlsim: "\u2274",
+  nlt: "\u226E",
+  nltri: "\u22EA",
+  nltrie: "\u22EC",
+  nmid: "\u2224",
+  nopf: "\u{1D55F}",
+  not: "\xAC",
+  notin: "\u2209",
+  notinE: "\u22F9\u0338",
+  notindot: "\u22F5\u0338",
+  notinva: "\u2209",
+  notinvb: "\u22F7",
+  notinvc: "\u22F6",
+  notni: "\u220C",
+  notniva: "\u220C",
+  notnivb: "\u22FE",
+  notnivc: "\u22FD",
+  npar: "\u2226",
+  nparallel: "\u2226",
+  nparsl: "\u2AFD\u20E5",
+  npart: "\u2202\u0338",
+  npolint: "\u2A14",
+  npr: "\u2280",
+  nprcue: "\u22E0",
+  npre: "\u2AAF\u0338",
+  nprec: "\u2280",
+  npreceq: "\u2AAF\u0338",
+  nrArr: "\u21CF",
+  nrarr: "\u219B",
+  nrarrc: "\u2933\u0338",
+  nrarrw: "\u219D\u0338",
+  nrightarrow: "\u219B",
+  nrtri: "\u22EB",
+  nrtrie: "\u22ED",
+  nsc: "\u2281",
+  nsccue: "\u22E1",
+  nsce: "\u2AB0\u0338",
+  nscr: "\u{1D4C3}",
+  nshortmid: "\u2224",
+  nshortparallel: "\u2226",
+  nsim: "\u2241",
+  nsime: "\u2244",
+  nsimeq: "\u2244",
+  nsmid: "\u2224",
+  nspar: "\u2226",
+  nsqsube: "\u22E2",
+  nsqsupe: "\u22E3",
+  nsub: "\u2284",
+  nsubE: "\u2AC5\u0338",
+  nsube: "\u2288",
+  nsubset: "\u2282\u20D2",
+  nsubseteq: "\u2288",
+  nsubseteqq: "\u2AC5\u0338",
+  nsucc: "\u2281",
+  nsucceq: "\u2AB0\u0338",
+  nsup: "\u2285",
+  nsupE: "\u2AC6\u0338",
+  nsupe: "\u2289",
+  nsupset: "\u2283\u20D2",
+  nsupseteq: "\u2289",
+  nsupseteqq: "\u2AC6\u0338",
+  ntgl: "\u2279",
+  ntilde: "\xF1",
+  ntlg: "\u2278",
+  ntriangleleft: "\u22EA",
+  ntrianglelefteq: "\u22EC",
+  ntriangleright: "\u22EB",
+  ntrianglerighteq: "\u22ED",
+  nu: "\u03BD",
+  num: "#",
+  numero: "\u2116",
+  numsp: "\u2007",
+  nvDash: "\u22AD",
+  nvHarr: "\u2904",
+  nvap: "\u224D\u20D2",
+  nvdash: "\u22AC",
+  nvge: "\u2265\u20D2",
+  nvgt: ">\u20D2",
+  nvinfin: "\u29DE",
+  nvlArr: "\u2902",
+  nvle: "\u2264\u20D2",
+  nvlt: "<\u20D2",
+  nvltrie: "\u22B4\u20D2",
+  nvrArr: "\u2903",
+  nvrtrie: "\u22B5\u20D2",
+  nvsim: "\u223C\u20D2",
+  nwArr: "\u21D6",
+  nwarhk: "\u2923",
+  nwarr: "\u2196",
+  nwarrow: "\u2196",
+  nwnear: "\u2927",
+  oS: "\u24C8",
+  oacute: "\xF3",
+  oast: "\u229B",
+  ocir: "\u229A",
+  ocirc: "\xF4",
+  ocy: "\u043E",
+  odash: "\u229D",
+  odblac: "\u0151",
+  odiv: "\u2A38",
+  odot: "\u2299",
+  odsold: "\u29BC",
+  oelig: "\u0153",
+  ofcir: "\u29BF",
+  ofr: "\u{1D52C}",
+  ogon: "\u02DB",
+  ograve: "\xF2",
+  ogt: "\u29C1",
+  ohbar: "\u29B5",
+  ohm: "\u03A9",
+  oint: "\u222E",
+  olarr: "\u21BA",
+  olcir: "\u29BE",
+  olcross: "\u29BB",
+  oline: "\u203E",
+  olt: "\u29C0",
+  omacr: "\u014D",
+  omega: "\u03C9",
+  omicron: "\u03BF",
+  omid: "\u29B6",
+  ominus: "\u2296",
+  oopf: "\u{1D560}",
+  opar: "\u29B7",
+  operp: "\u29B9",
+  oplus: "\u2295",
+  or: "\u2228",
+  orarr: "\u21BB",
+  ord: "\u2A5D",
+  order: "\u2134",
+  orderof: "\u2134",
+  ordf: "\xAA",
+  ordm: "\xBA",
+  origof: "\u22B6",
+  oror: "\u2A56",
+  orslope: "\u2A57",
+  orv: "\u2A5B",
+  oscr: "\u2134",
+  oslash: "\xF8",
+  osol: "\u2298",
+  otilde: "\xF5",
+  otimes: "\u2297",
+  otimesas: "\u2A36",
+  ouml: "\xF6",
+  ovbar: "\u233D",
+  par: "\u2225",
+  para: "\xB6",
+  parallel: "\u2225",
+  parsim: "\u2AF3",
+  parsl: "\u2AFD",
+  part: "\u2202",
+  pcy: "\u043F",
+  percnt: "%",
+  period: ".",
+  permil: "\u2030",
+  perp: "\u22A5",
+  pertenk: "\u2031",
+  pfr: "\u{1D52D}",
+  phi: "\u03C6",
+  phiv: "\u03D5",
+  phmmat: "\u2133",
+  phone: "\u260E",
+  pi: "\u03C0",
+  pitchfork: "\u22D4",
+  piv: "\u03D6",
+  planck: "\u210F",
+  planckh: "\u210E",
+  plankv: "\u210F",
+  plus: "+",
+  plusacir: "\u2A23",
+  plusb: "\u229E",
+  pluscir: "\u2A22",
+  plusdo: "\u2214",
+  plusdu: "\u2A25",
+  pluse: "\u2A72",
+  plusmn: "\xB1",
+  plussim: "\u2A26",
+  plustwo: "\u2A27",
+  pm: "\xB1",
+  pointint: "\u2A15",
+  popf: "\u{1D561}",
+  pound: "\xA3",
+  pr: "\u227A",
+  prE: "\u2AB3",
+  prap: "\u2AB7",
+  prcue: "\u227C",
+  pre: "\u2AAF",
+  prec: "\u227A",
+  precapprox: "\u2AB7",
+  preccurlyeq: "\u227C",
+  preceq: "\u2AAF",
+  precnapprox: "\u2AB9",
+  precneqq: "\u2AB5",
+  precnsim: "\u22E8",
+  precsim: "\u227E",
+  prime: "\u2032",
+  primes: "\u2119",
+  prnE: "\u2AB5",
+  prnap: "\u2AB9",
+  prnsim: "\u22E8",
+  prod: "\u220F",
+  profalar: "\u232E",
+  profline: "\u2312",
+  profsurf: "\u2313",
+  prop: "\u221D",
+  propto: "\u221D",
+  prsim: "\u227E",
+  prurel: "\u22B0",
+  pscr: "\u{1D4C5}",
+  psi: "\u03C8",
+  puncsp: "\u2008",
+  qfr: "\u{1D52E}",
+  qint: "\u2A0C",
+  qopf: "\u{1D562}",
+  qprime: "\u2057",
+  qscr: "\u{1D4C6}",
+  quaternions: "\u210D",
+  quatint: "\u2A16",
+  quest: "?",
+  questeq: "\u225F",
+  quot: '"',
+  rAarr: "\u21DB",
+  rArr: "\u21D2",
+  rAtail: "\u291C",
+  rBarr: "\u290F",
+  rHar: "\u2964",
+  race: "\u223D\u0331",
+  racute: "\u0155",
+  radic: "\u221A",
+  raemptyv: "\u29B3",
+  rang: "\u27E9",
+  rangd: "\u2992",
+  range: "\u29A5",
+  rangle: "\u27E9",
+  raquo: "\xBB",
+  rarr: "\u2192",
+  rarrap: "\u2975",
+  rarrb: "\u21E5",
+  rarrbfs: "\u2920",
+  rarrc: "\u2933",
+  rarrfs: "\u291E",
+  rarrhk: "\u21AA",
+  rarrlp: "\u21AC",
+  rarrpl: "\u2945",
+  rarrsim: "\u2974",
+  rarrtl: "\u21A3",
+  rarrw: "\u219D",
+  ratail: "\u291A",
+  ratio: "\u2236",
+  rationals: "\u211A",
+  rbarr: "\u290D",
+  rbbrk: "\u2773",
+  rbrace: "}",
+  rbrack: "]",
+  rbrke: "\u298C",
+  rbrksld: "\u298E",
+  rbrkslu: "\u2990",
+  rcaron: "\u0159",
+  rcedil: "\u0157",
+  rceil: "\u2309",
+  rcub: "}",
+  rcy: "\u0440",
+  rdca: "\u2937",
+  rdldhar: "\u2969",
+  rdquo: "\u201D",
+  rdquor: "\u201D",
+  rdsh: "\u21B3",
+  real: "\u211C",
+  realine: "\u211B",
+  realpart: "\u211C",
+  reals: "\u211D",
+  rect: "\u25AD",
+  reg: "\xAE",
+  rfisht: "\u297D",
+  rfloor: "\u230B",
+  rfr: "\u{1D52F}",
+  rhard: "\u21C1",
+  rharu: "\u21C0",
+  rharul: "\u296C",
+  rho: "\u03C1",
+  rhov: "\u03F1",
+  rightarrow: "\u2192",
+  rightarrowtail: "\u21A3",
+  rightharpoondown: "\u21C1",
+  rightharpoonup: "\u21C0",
+  rightleftarrows: "\u21C4",
+  rightleftharpoons: "\u21CC",
+  rightrightarrows: "\u21C9",
+  rightsquigarrow: "\u219D",
+  rightthreetimes: "\u22CC",
+  ring: "\u02DA",
+  risingdotseq: "\u2253",
+  rlarr: "\u21C4",
+  rlhar: "\u21CC",
+  rlm: "\u200F",
+  rmoust: "\u23B1",
+  rmoustache: "\u23B1",
+  rnmid: "\u2AEE",
+  roang: "\u27ED",
+  roarr: "\u21FE",
+  robrk: "\u27E7",
+  ropar: "\u2986",
+  ropf: "\u{1D563}",
+  roplus: "\u2A2E",
+  rotimes: "\u2A35",
+  rpar: ")",
+  rpargt: "\u2994",
+  rppolint: "\u2A12",
+  rrarr: "\u21C9",
+  rsaquo: "\u203A",
+  rscr: "\u{1D4C7}",
+  rsh: "\u21B1",
+  rsqb: "]",
+  rsquo: "\u2019",
+  rsquor: "\u2019",
+  rthree: "\u22CC",
+  rtimes: "\u22CA",
+  rtri: "\u25B9",
+  rtrie: "\u22B5",
+  rtrif: "\u25B8",
+  rtriltri: "\u29CE",
+  ruluhar: "\u2968",
+  rx: "\u211E",
+  sacute: "\u015B",
+  sbquo: "\u201A",
+  sc: "\u227B",
+  scE: "\u2AB4",
+  scap: "\u2AB8",
+  scaron: "\u0161",
+  sccue: "\u227D",
+  sce: "\u2AB0",
+  scedil: "\u015F",
+  scirc: "\u015D",
+  scnE: "\u2AB6",
+  scnap: "\u2ABA",
+  scnsim: "\u22E9",
+  scpolint: "\u2A13",
+  scsim: "\u227F",
+  scy: "\u0441",
+  sdot: "\u22C5",
+  sdotb: "\u22A1",
+  sdote: "\u2A66",
+  seArr: "\u21D8",
+  searhk: "\u2925",
+  searr: "\u2198",
+  searrow: "\u2198",
+  sect: "\xA7",
+  semi: ";",
+  seswar: "\u2929",
+  setminus: "\u2216",
+  setmn: "\u2216",
+  sext: "\u2736",
+  sfr: "\u{1D530}",
+  sfrown: "\u2322",
+  sharp: "\u266F",
+  shchcy: "\u0449",
+  shcy: "\u0448",
+  shortmid: "\u2223",
+  shortparallel: "\u2225",
+  shy: "\xAD",
+  sigma: "\u03C3",
+  sigmaf: "\u03C2",
+  sigmav: "\u03C2",
+  sim: "\u223C",
+  simdot: "\u2A6A",
+  sime: "\u2243",
+  simeq: "\u2243",
+  simg: "\u2A9E",
+  simgE: "\u2AA0",
+  siml: "\u2A9D",
+  simlE: "\u2A9F",
+  simne: "\u2246",
+  simplus: "\u2A24",
+  simrarr: "\u2972",
+  slarr: "\u2190",
+  smallsetminus: "\u2216",
+  smashp: "\u2A33",
+  smeparsl: "\u29E4",
+  smid: "\u2223",
+  smile: "\u2323",
+  smt: "\u2AAA",
+  smte: "\u2AAC",
+  smtes: "\u2AAC\uFE00",
+  softcy: "\u044C",
+  sol: "/",
+  solb: "\u29C4",
+  solbar: "\u233F",
+  sopf: "\u{1D564}",
+  spades: "\u2660",
+  spadesuit: "\u2660",
+  spar: "\u2225",
+  sqcap: "\u2293",
+  sqcaps: "\u2293\uFE00",
+  sqcup: "\u2294",
+  sqcups: "\u2294\uFE00",
+  sqsub: "\u228F",
+  sqsube: "\u2291",
+  sqsubset: "\u228F",
+  sqsubseteq: "\u2291",
+  sqsup: "\u2290",
+  sqsupe: "\u2292",
+  sqsupset: "\u2290",
+  sqsupseteq: "\u2292",
+  squ: "\u25A1",
+  square: "\u25A1",
+  squarf: "\u25AA",
+  squf: "\u25AA",
+  srarr: "\u2192",
+  sscr: "\u{1D4C8}",
+  ssetmn: "\u2216",
+  ssmile: "\u2323",
+  sstarf: "\u22C6",
+  star: "\u2606",
+  starf: "\u2605",
+  straightepsilon: "\u03F5",
+  straightphi: "\u03D5",
+  strns: "\xAF",
+  sub: "\u2282",
+  subE: "\u2AC5",
+  subdot: "\u2ABD",
+  sube: "\u2286",
+  subedot: "\u2AC3",
+  submult: "\u2AC1",
+  subnE: "\u2ACB",
+  subne: "\u228A",
+  subplus: "\u2ABF",
+  subrarr: "\u2979",
+  subset: "\u2282",
+  subseteq: "\u2286",
+  subseteqq: "\u2AC5",
+  subsetneq: "\u228A",
+  subsetneqq: "\u2ACB",
+  subsim: "\u2AC7",
+  subsub: "\u2AD5",
+  subsup: "\u2AD3",
+  succ: "\u227B",
+  succapprox: "\u2AB8",
+  succcurlyeq: "\u227D",
+  succeq: "\u2AB0",
+  succnapprox: "\u2ABA",
+  succneqq: "\u2AB6",
+  succnsim: "\u22E9",
+  succsim: "\u227F",
+  sum: "\u2211",
+  sung: "\u266A",
+  sup1: "\xB9",
+  sup2: "\xB2",
+  sup3: "\xB3",
+  sup: "\u2283",
+  supE: "\u2AC6",
+  supdot: "\u2ABE",
+  supdsub: "\u2AD8",
+  supe: "\u2287",
+  supedot: "\u2AC4",
+  suphsol: "\u27C9",
+  suphsub: "\u2AD7",
+  suplarr: "\u297B",
+  supmult: "\u2AC2",
+  supnE: "\u2ACC",
+  supne: "\u228B",
+  supplus: "\u2AC0",
+  supset: "\u2283",
+  supseteq: "\u2287",
+  supseteqq: "\u2AC6",
+  supsetneq: "\u228B",
+  supsetneqq: "\u2ACC",
+  supsim: "\u2AC8",
+  supsub: "\u2AD4",
+  supsup: "\u2AD6",
+  swArr: "\u21D9",
+  swarhk: "\u2926",
+  swarr: "\u2199",
+  swarrow: "\u2199",
+  swnwar: "\u292A",
+  szlig: "\xDF",
+  target: "\u2316",
+  tau: "\u03C4",
+  tbrk: "\u23B4",
+  tcaron: "\u0165",
+  tcedil: "\u0163",
+  tcy: "\u0442",
+  tdot: "\u20DB",
+  telrec: "\u2315",
+  tfr: "\u{1D531}",
+  there4: "\u2234",
+  therefore: "\u2234",
+  theta: "\u03B8",
+  thetasym: "\u03D1",
+  thetav: "\u03D1",
+  thickapprox: "\u2248",
+  thicksim: "\u223C",
+  thinsp: "\u2009",
+  thkap: "\u2248",
+  thksim: "\u223C",
+  thorn: "\xFE",
+  tilde: "\u02DC",
+  times: "\xD7",
+  timesb: "\u22A0",
+  timesbar: "\u2A31",
+  timesd: "\u2A30",
+  tint: "\u222D",
+  toea: "\u2928",
+  top: "\u22A4",
+  topbot: "\u2336",
+  topcir: "\u2AF1",
+  topf: "\u{1D565}",
+  topfork: "\u2ADA",
+  tosa: "\u2929",
+  tprime: "\u2034",
+  trade: "\u2122",
+  triangle: "\u25B5",
+  triangledown: "\u25BF",
+  triangleleft: "\u25C3",
+  trianglelefteq: "\u22B4",
+  triangleq: "\u225C",
+  triangleright: "\u25B9",
+  trianglerighteq: "\u22B5",
+  tridot: "\u25EC",
+  trie: "\u225C",
+  triminus: "\u2A3A",
+  triplus: "\u2A39",
+  trisb: "\u29CD",
+  tritime: "\u2A3B",
+  trpezium: "\u23E2",
+  tscr: "\u{1D4C9}",
+  tscy: "\u0446",
+  tshcy: "\u045B",
+  tstrok: "\u0167",
+  twixt: "\u226C",
+  twoheadleftarrow: "\u219E",
+  twoheadrightarrow: "\u21A0",
+  uArr: "\u21D1",
+  uHar: "\u2963",
+  uacute: "\xFA",
+  uarr: "\u2191",
+  ubrcy: "\u045E",
+  ubreve: "\u016D",
+  ucirc: "\xFB",
+  ucy: "\u0443",
+  udarr: "\u21C5",
+  udblac: "\u0171",
+  udhar: "\u296E",
+  ufisht: "\u297E",
+  ufr: "\u{1D532}",
+  ugrave: "\xF9",
+  uharl: "\u21BF",
+  uharr: "\u21BE",
+  uhblk: "\u2580",
+  ulcorn: "\u231C",
+  ulcorner: "\u231C",
+  ulcrop: "\u230F",
+  ultri: "\u25F8",
+  umacr: "\u016B",
+  uml: "\xA8",
+  uogon: "\u0173",
+  uopf: "\u{1D566}",
+  uparrow: "\u2191",
+  updownarrow: "\u2195",
+  upharpoonleft: "\u21BF",
+  upharpoonright: "\u21BE",
+  uplus: "\u228E",
+  upsi: "\u03C5",
+  upsih: "\u03D2",
+  upsilon: "\u03C5",
+  upuparrows: "\u21C8",
+  urcorn: "\u231D",
+  urcorner: "\u231D",
+  urcrop: "\u230E",
+  uring: "\u016F",
+  urtri: "\u25F9",
+  uscr: "\u{1D4CA}",
+  utdot: "\u22F0",
+  utilde: "\u0169",
+  utri: "\u25B5",
+  utrif: "\u25B4",
+  uuarr: "\u21C8",
+  uuml: "\xFC",
+  uwangle: "\u29A7",
+  vArr: "\u21D5",
+  vBar: "\u2AE8",
+  vBarv: "\u2AE9",
+  vDash: "\u22A8",
+  vangrt: "\u299C",
+  varepsilon: "\u03F5",
+  varkappa: "\u03F0",
+  varnothing: "\u2205",
+  varphi: "\u03D5",
+  varpi: "\u03D6",
+  varpropto: "\u221D",
+  varr: "\u2195",
+  varrho: "\u03F1",
+  varsigma: "\u03C2",
+  varsubsetneq: "\u228A\uFE00",
+  varsubsetneqq: "\u2ACB\uFE00",
+  varsupsetneq: "\u228B\uFE00",
+  varsupsetneqq: "\u2ACC\uFE00",
+  vartheta: "\u03D1",
+  vartriangleleft: "\u22B2",
+  vartriangleright: "\u22B3",
+  vcy: "\u0432",
+  vdash: "\u22A2",
+  vee: "\u2228",
+  veebar: "\u22BB",
+  veeeq: "\u225A",
+  vellip: "\u22EE",
+  verbar: "|",
+  vert: "|",
+  vfr: "\u{1D533}",
+  vltri: "\u22B2",
+  vnsub: "\u2282\u20D2",
+  vnsup: "\u2283\u20D2",
+  vopf: "\u{1D567}",
+  vprop: "\u221D",
+  vrtri: "\u22B3",
+  vscr: "\u{1D4CB}",
+  vsubnE: "\u2ACB\uFE00",
+  vsubne: "\u228A\uFE00",
+  vsupnE: "\u2ACC\uFE00",
+  vsupne: "\u228B\uFE00",
+  vzigzag: "\u299A",
+  wcirc: "\u0175",
+  wedbar: "\u2A5F",
+  wedge: "\u2227",
+  wedgeq: "\u2259",
+  weierp: "\u2118",
+  wfr: "\u{1D534}",
+  wopf: "\u{1D568}",
+  wp: "\u2118",
+  wr: "\u2240",
+  wreath: "\u2240",
+  wscr: "\u{1D4CC}",
+  xcap: "\u22C2",
+  xcirc: "\u25EF",
+  xcup: "\u22C3",
+  xdtri: "\u25BD",
+  xfr: "\u{1D535}",
+  xhArr: "\u27FA",
+  xharr: "\u27F7",
+  xi: "\u03BE",
+  xlArr: "\u27F8",
+  xlarr: "\u27F5",
+  xmap: "\u27FC",
+  xnis: "\u22FB",
+  xodot: "\u2A00",
+  xopf: "\u{1D569}",
+  xoplus: "\u2A01",
+  xotime: "\u2A02",
+  xrArr: "\u27F9",
+  xrarr: "\u27F6",
+  xscr: "\u{1D4CD}",
+  xsqcup: "\u2A06",
+  xuplus: "\u2A04",
+  xutri: "\u25B3",
+  xvee: "\u22C1",
+  xwedge: "\u22C0",
+  yacute: "\xFD",
+  yacy: "\u044F",
+  ycirc: "\u0177",
+  ycy: "\u044B",
+  yen: "\xA5",
+  yfr: "\u{1D536}",
+  yicy: "\u0457",
+  yopf: "\u{1D56A}",
+  yscr: "\u{1D4CE}",
+  yucy: "\u044E",
+  yuml: "\xFF",
+  zacute: "\u017A",
+  zcaron: "\u017E",
+  zcy: "\u0437",
+  zdot: "\u017C",
+  zeetrf: "\u2128",
+  zeta: "\u03B6",
+  zfr: "\u{1D537}",
+  zhcy: "\u0436",
+  zigrarr: "\u21DD",
+  zopf: "\u{1D56B}",
+  zscr: "\u{1D4CF}",
+  zwj: "\u200D",
+  zwnj: "\u200C"
+};
+
+// node_modules/decode-named-character-reference/index.js
+var own = {}.hasOwnProperty;
+function decodeNamedCharacterReference(value) {
+  return own.call(characterEntities, value) ? characterEntities[value] : false;
+}
+
+// node_modules/mdast-util-mdx-jsx/node_modules/parse-entities/lib/index.js
+var fromCharCode = String.fromCharCode;
+var messages = [
+  "",
+  /* 1: Non terminated (named) */
+  "Named character references must be terminated by a semicolon",
+  /* 2: Non terminated (numeric) */
+  "Numeric character references must be terminated by a semicolon",
+  /* 3: Empty (named) */
+  "Named character references cannot be empty",
+  /* 4: Empty (numeric) */
+  "Numeric character references cannot be empty",
+  /* 5: Unknown (named) */
+  "Named character references must be known",
+  /* 6: Disallowed (numeric) */
+  "Numeric character references cannot be disallowed",
+  /* 7: Prohibited (numeric) */
+  "Numeric character references cannot be outside the permissible Unicode range"
+];
+function parseEntities(value, options = {}) {
+  const additional = typeof options.additional === "string" ? options.additional.charCodeAt(0) : options.additional;
+  const result = [];
+  let index2 = 0;
+  let lines = -1;
+  let queue = "";
+  let point4;
+  let indent2;
+  if (options.position) {
+    if ("start" in options.position || "indent" in options.position) {
+      indent2 = options.position.indent;
+      point4 = options.position.start;
+    } else {
+      point4 = options.position;
+    }
+  }
+  let line = (point4 ? point4.line : 0) || 1;
+  let column = (point4 ? point4.column : 0) || 1;
+  let previous2 = now();
+  let character;
+  index2--;
+  while (++index2 <= value.length) {
+    if (character === 10) {
+      column = (indent2 ? indent2[lines] : 0) || 1;
+    }
+    character = value.charCodeAt(index2);
+    if (character === 38) {
+      const following = value.charCodeAt(index2 + 1);
+      if (following === 9 || following === 10 || following === 12 || following === 32 || following === 38 || following === 60 || Number.isNaN(following) || additional && following === additional) {
+        queue += fromCharCode(character);
+        column++;
+        continue;
+      }
+      const start2 = index2 + 1;
+      let begin = start2;
+      let end = start2;
+      let type;
+      if (following === 35) {
+        end = ++begin;
+        const following2 = value.charCodeAt(end);
+        if (following2 === 88 || following2 === 120) {
+          type = "hexadecimal";
+          end = ++begin;
+        } else {
+          type = "decimal";
+        }
+      } else {
+        type = "named";
+      }
+      let characterReferenceCharacters = "";
+      let characterReference2 = "";
+      let characters = "";
+      const test = type === "named" ? isAlphanumerical : type === "decimal" ? isDecimal : isHexadecimal;
+      end--;
+      while (++end <= value.length) {
+        const following2 = value.charCodeAt(end);
+        if (!test(following2)) {
+          break;
+        }
+        characters += fromCharCode(following2);
+        if (type === "named" && characterEntitiesLegacy.includes(characters)) {
+          characterReferenceCharacters = characters;
+          characterReference2 = decodeNamedCharacterReference(characters);
+        }
+      }
+      let terminated = value.charCodeAt(end) === 59;
+      if (terminated) {
+        end++;
+        const namedReference = type === "named" ? decodeNamedCharacterReference(characters) : false;
+        if (namedReference) {
+          characterReferenceCharacters = characters;
+          characterReference2 = namedReference;
+        }
+      }
+      let diff = 1 + end - start2;
+      let reference = "";
+      if (!terminated && options.nonTerminated === false) {
+      } else if (!characters) {
+        if (type !== "named") {
+          warning(4, diff);
+        }
+      } else if (type === "named") {
+        if (terminated && !characterReference2) {
+          warning(5, 1);
+        } else {
+          if (characterReferenceCharacters !== characters) {
+            end = begin + characterReferenceCharacters.length;
+            diff = 1 + end - begin;
+            terminated = false;
+          }
+          if (!terminated) {
+            const reason = characterReferenceCharacters ? 1 : 3;
+            if (options.attribute) {
+              const following2 = value.charCodeAt(end);
+              if (following2 === 61) {
+                warning(reason, diff);
+                characterReference2 = "";
+              } else if (isAlphanumerical(following2)) {
+                characterReference2 = "";
+              } else {
+                warning(reason, diff);
+              }
+            } else {
+              warning(reason, diff);
+            }
+          }
+        }
+        reference = characterReference2;
+      } else {
+        if (!terminated) {
+          warning(2, diff);
+        }
+        let referenceCode = Number.parseInt(
+          characters,
+          type === "hexadecimal" ? 16 : 10
+        );
+        if (prohibited(referenceCode)) {
+          warning(7, diff);
+          reference = fromCharCode(
+            65533
+            /* `�` */
+          );
+        } else if (referenceCode in characterReferenceInvalid) {
+          warning(6, diff);
+          reference = characterReferenceInvalid[referenceCode];
+        } else {
+          let output = "";
+          if (disallowed(referenceCode)) {
+            warning(6, diff);
+          }
+          if (referenceCode > 65535) {
+            referenceCode -= 65536;
+            output += fromCharCode(referenceCode >>> (10 & 1023) | 55296);
+            referenceCode = 56320 | referenceCode & 1023;
+          }
+          reference = output + fromCharCode(referenceCode);
+        }
+      }
+      if (reference) {
+        flush();
+        previous2 = now();
+        index2 = end - 1;
+        column += end - start2 + 1;
+        result.push(reference);
+        const next = now();
+        next.offset++;
+        if (options.reference) {
+          options.reference.call(
+            options.referenceContext,
+            reference,
+            { start: previous2, end: next },
+            value.slice(start2 - 1, end)
+          );
+        }
+        previous2 = next;
+      } else {
+        characters = value.slice(start2 - 1, end);
+        queue += characters;
+        column += characters.length;
+        index2 = end - 1;
+      }
+    } else {
+      if (character === 10) {
+        line++;
+        lines++;
+        column = 0;
+      }
+      if (Number.isNaN(character)) {
+        flush();
+      } else {
+        queue += fromCharCode(character);
+        column++;
+      }
+    }
+  }
+  return result.join("");
+  function now() {
+    return {
+      line,
+      column,
+      offset: index2 + ((point4 ? point4.offset : 0) || 0)
+    };
+  }
+  function warning(code2, offset2) {
+    let position3;
+    if (options.warning) {
+      position3 = now();
+      position3.column += offset2;
+      position3.offset += offset2;
+      options.warning.call(
+        options.warningContext,
+        messages[code2],
+        position3,
+        code2
+      );
+    }
+  }
+  function flush() {
+    if (queue) {
+      result.push(queue);
+      if (options.text) {
+        options.text.call(options.textContext, queue, {
+          start: previous2,
+          end: now()
+        });
+      }
+      queue = "";
+    }
+  }
+}
+function prohibited(code2) {
+  return code2 >= 55296 && code2 <= 57343 || code2 > 1114111;
+}
+function disallowed(code2) {
+  return code2 >= 1 && code2 <= 8 || code2 === 11 || code2 >= 13 && code2 <= 31 || code2 >= 127 && code2 <= 159 || code2 >= 64976 && code2 <= 65007 || (code2 & 65535) === 65535 || (code2 & 65535) === 65534;
+}
+
+// node_modules/stringify-entities/lib/core.js
+var defaultSubsetRegex = /["&'<>`]/g;
+var surrogatePairsRegex = /[\uD800-\uDBFF][\uDC00-\uDFFF]/g;
+var controlCharactersRegex = (
+  // eslint-disable-next-line no-control-regex, unicorn/no-hex-escape
+  /[\x01-\t\v\f\x0E-\x1F\x7F\x81\x8D\x8F\x90\x9D\xA0-\uFFFF]/g
+);
+var regexEscapeRegex = /[|\\{}()[\]^$+*?.]/g;
+var subsetToRegexCache = /* @__PURE__ */ new WeakMap();
+function core(value, options) {
+  value = value.replace(
+    options.subset ? charactersToExpressionCached(options.subset) : defaultSubsetRegex,
+    basic
+  );
+  if (options.subset || options.escapeOnly) {
+    return value;
+  }
+  return value.replace(surrogatePairsRegex, surrogate).replace(controlCharactersRegex, basic);
+  function surrogate(pair, index2, all3) {
+    return options.format(
+      (pair.charCodeAt(0) - 55296) * 1024 + pair.charCodeAt(1) - 56320 + 65536,
+      all3.charCodeAt(index2 + 2),
+      options
+    );
+  }
+  function basic(character, index2, all3) {
+    return options.format(
+      character.charCodeAt(0),
+      all3.charCodeAt(index2 + 1),
+      options
+    );
+  }
+}
+function charactersToExpressionCached(subset) {
+  let cached = subsetToRegexCache.get(subset);
+  if (!cached) {
+    cached = charactersToExpression(subset);
+    subsetToRegexCache.set(subset, cached);
+  }
+  return cached;
+}
+function charactersToExpression(subset) {
+  const groups = [];
+  let index2 = -1;
+  while (++index2 < subset.length) {
+    groups.push(subset[index2].replace(regexEscapeRegex, "\\$&"));
+  }
+  return new RegExp("(?:" + groups.join("|") + ")", "g");
+}
+
+// node_modules/stringify-entities/lib/util/format-basic.js
+function formatBasic(code2) {
+  return "&#x" + code2.toString(16).toUpperCase() + ";";
+}
+
+// node_modules/stringify-entities/lib/index.js
+function stringifyEntitiesLight(value, options) {
+  return core(value, Object.assign({ format: formatBasic }, options));
+}
+
+// node_modules/mdast-util-mdx-jsx/lib/index.js
+var indent = "  ";
+function mdxJsxFromMarkdown() {
+  return {
+    canContainEols: ["mdxJsxTextElement"],
+    enter: {
+      mdxJsxFlowTag: enterMdxJsxTag,
+      mdxJsxFlowTagClosingMarker: enterMdxJsxTagClosingMarker,
+      mdxJsxFlowTagAttribute: enterMdxJsxTagAttribute,
+      mdxJsxFlowTagExpressionAttribute: enterMdxJsxTagExpressionAttribute,
+      mdxJsxFlowTagAttributeValueLiteral: buffer,
+      mdxJsxFlowTagAttributeValueExpression: buffer,
+      mdxJsxFlowTagSelfClosingMarker: enterMdxJsxTagSelfClosingMarker,
+      mdxJsxTextTag: enterMdxJsxTag,
+      mdxJsxTextTagClosingMarker: enterMdxJsxTagClosingMarker,
+      mdxJsxTextTagAttribute: enterMdxJsxTagAttribute,
+      mdxJsxTextTagExpressionAttribute: enterMdxJsxTagExpressionAttribute,
+      mdxJsxTextTagAttributeValueLiteral: buffer,
+      mdxJsxTextTagAttributeValueExpression: buffer,
+      mdxJsxTextTagSelfClosingMarker: enterMdxJsxTagSelfClosingMarker
+    },
+    exit: {
+      mdxJsxFlowTagClosingMarker: exitMdxJsxTagClosingMarker,
+      mdxJsxFlowTagNamePrimary: exitMdxJsxTagNamePrimary,
+      mdxJsxFlowTagNameMember: exitMdxJsxTagNameMember,
+      mdxJsxFlowTagNameLocal: exitMdxJsxTagNameLocal,
+      mdxJsxFlowTagExpressionAttribute: exitMdxJsxTagExpressionAttribute,
+      mdxJsxFlowTagExpressionAttributeValue: data2,
+      mdxJsxFlowTagAttributeNamePrimary: exitMdxJsxTagAttributeNamePrimary,
+      mdxJsxFlowTagAttributeNameLocal: exitMdxJsxTagAttributeNameLocal,
+      mdxJsxFlowTagAttributeValueLiteral: exitMdxJsxTagAttributeValueLiteral,
+      mdxJsxFlowTagAttributeValueLiteralValue: data2,
+      mdxJsxFlowTagAttributeValueExpression: exitMdxJsxTagAttributeValueExpression,
+      mdxJsxFlowTagAttributeValueExpressionValue: data2,
+      mdxJsxFlowTagSelfClosingMarker: exitMdxJsxTagSelfClosingMarker,
+      mdxJsxFlowTag: exitMdxJsxTag,
+      mdxJsxTextTagClosingMarker: exitMdxJsxTagClosingMarker,
+      mdxJsxTextTagNamePrimary: exitMdxJsxTagNamePrimary,
+      mdxJsxTextTagNameMember: exitMdxJsxTagNameMember,
+      mdxJsxTextTagNameLocal: exitMdxJsxTagNameLocal,
+      mdxJsxTextTagExpressionAttribute: exitMdxJsxTagExpressionAttribute,
+      mdxJsxTextTagExpressionAttributeValue: data2,
+      mdxJsxTextTagAttributeNamePrimary: exitMdxJsxTagAttributeNamePrimary,
+      mdxJsxTextTagAttributeNameLocal: exitMdxJsxTagAttributeNameLocal,
+      mdxJsxTextTagAttributeValueLiteral: exitMdxJsxTagAttributeValueLiteral,
+      mdxJsxTextTagAttributeValueLiteralValue: data2,
+      mdxJsxTextTagAttributeValueExpression: exitMdxJsxTagAttributeValueExpression,
+      mdxJsxTextTagAttributeValueExpressionValue: data2,
+      mdxJsxTextTagSelfClosingMarker: exitMdxJsxTagSelfClosingMarker,
+      mdxJsxTextTag: exitMdxJsxTag
+    }
+  };
+  function buffer() {
+    this.buffer();
+  }
+  function point4(d) {
+    return { line: d.line, column: d.column, offset: d.offset };
+  }
+  function data2(token) {
+    this.config.enter.data.call(this, token);
+    this.config.exit.data.call(this, token);
+  }
+  function enterMdxJsxTag(token) {
+    const tag = {
+      name: void 0,
+      attributes: [],
+      close: false,
+      selfClosing: false,
+      start: token.start,
+      end: token.end
+    };
+    if (!this.data.mdxJsxTagStack) this.data.mdxJsxTagStack = [];
+    this.data.mdxJsxTag = tag;
+    this.buffer();
+  }
+  function enterMdxJsxTagClosingMarker(token) {
+    const stack = this.data.mdxJsxTagStack;
+    ok(stack, "expected `mdxJsxTagStack`");
+    if (stack.length === 0) {
+      throw new VFileMessage(
+        "Unexpected closing slash `/` in tag, expected an open tag first",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-closing-slash"
+      );
+    }
+  }
+  function enterMdxJsxTagAnyAttribute(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    if (tag.close) {
+      throw new VFileMessage(
+        "Unexpected attribute in closing tag, expected the end of the tag",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-attribute"
+      );
+    }
+  }
+  function enterMdxJsxTagSelfClosingMarker(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    if (tag.close) {
+      throw new VFileMessage(
+        "Unexpected self-closing slash `/` in closing tag, expected the end of the tag",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:unexpected-self-closing-slash"
+      );
+    }
+  }
+  function exitMdxJsxTagClosingMarker() {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    tag.close = true;
+  }
+  function exitMdxJsxTagNamePrimary(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    tag.name = this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagNameMember(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    tag.name += "." + this.sliceSerialize(token);
+  }
+  function exitMdxJsxTagNameLocal(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    tag.name += ":" + this.sliceSerialize(token);
+  }
+  function enterMdxJsxTagAttribute(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    enterMdxJsxTagAnyAttribute.call(this, token);
+    tag.attributes.push({
+      type: "mdxJsxAttribute",
+      name: "",
+      value: null,
+      position: {
+        start: point4(token.start),
+        // @ts-expect-error: `end` will be patched later.
+        end: void 0
+      }
+    });
+  }
+  function enterMdxJsxTagExpressionAttribute(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    enterMdxJsxTagAnyAttribute.call(this, token);
+    tag.attributes.push({ type: "mdxJsxExpressionAttribute", value: "" });
+    this.buffer();
+  }
+  function exitMdxJsxTagExpressionAttribute(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    const tail = tag.attributes[tag.attributes.length - 1];
+    ok(tail.type === "mdxJsxExpressionAttribute");
+    const estree = token.estree;
+    tail.value = this.resume();
+    if (estree) {
+      tail.data = { estree };
+    }
+  }
+  function exitMdxJsxTagAttributeNamePrimary(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    const node2 = tag.attributes[tag.attributes.length - 1];
+    ok(node2.type === "mdxJsxAttribute");
+    node2.name = this.sliceSerialize(token);
+    ok(node2.position !== void 0);
+    node2.position.end = point4(token.end);
+  }
+  function exitMdxJsxTagAttributeNameLocal(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    const node2 = tag.attributes[tag.attributes.length - 1];
+    ok(node2.type === "mdxJsxAttribute");
+    node2.name += ":" + this.sliceSerialize(token);
+    ok(node2.position !== void 0);
+    node2.position.end = point4(token.end);
+  }
+  function exitMdxJsxTagAttributeValueLiteral(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    const node2 = tag.attributes[tag.attributes.length - 1];
+    node2.value = parseEntities(this.resume(), { nonTerminated: false });
+    ok(node2.position !== void 0);
+    node2.position.end = point4(token.end);
+  }
+  function exitMdxJsxTagAttributeValueExpression(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    const tail = tag.attributes[tag.attributes.length - 1];
+    ok(tail.type === "mdxJsxAttribute");
+    const node2 = { type: "mdxJsxAttributeValueExpression", value: this.resume() };
+    const estree = token.estree;
+    if (estree) {
+      node2.data = { estree };
+    }
+    tail.value = node2;
+    ok(tail.position !== void 0);
+    tail.position.end = point4(token.end);
+  }
+  function exitMdxJsxTagSelfClosingMarker() {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    tag.selfClosing = true;
+  }
+  function exitMdxJsxTag(token) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    const stack = this.data.mdxJsxTagStack;
+    ok(stack, "expected `mdxJsxTagStack`");
+    const tail = stack[stack.length - 1];
+    if (tag.close && tail.name !== tag.name) {
+      throw new VFileMessage(
+        "Unexpected closing tag `" + serializeAbbreviatedTag(tag) + "`, expected corresponding closing tag for `" + serializeAbbreviatedTag(tail) + "` (" + stringifyPosition(tail) + ")",
+        { start: token.start, end: token.end },
+        "mdast-util-mdx-jsx:end-tag-mismatch"
+      );
+    }
+    this.resume();
+    if (tag.close) {
+      stack.pop();
+    } else {
+      this.enter(
+        {
+          type: token.type === "mdxJsxTextTag" ? "mdxJsxTextElement" : "mdxJsxFlowElement",
+          name: tag.name || null,
+          attributes: tag.attributes,
+          children: []
+        },
+        token,
+        onErrorRightIsTag
+      );
+    }
+    if (tag.selfClosing || tag.close) {
+      this.exit(token, onErrorLeftIsTag);
+    } else {
+      stack.push(tag);
+    }
+  }
+  function onErrorRightIsTag(closing, open) {
+    const stack = this.data.mdxJsxTagStack;
+    ok(stack, "expected `mdxJsxTagStack`");
+    const tag = stack[stack.length - 1];
+    ok(tag, "expected `mdxJsxTag`");
+    const place = closing ? " before the end of `" + closing.type + "`" : "";
+    const position3 = closing ? { start: closing.start, end: closing.end } : void 0;
+    throw new VFileMessage(
+      "Expected a closing tag for `" + serializeAbbreviatedTag(tag) + "` (" + stringifyPosition({ start: open.start, end: open.end }) + ")" + place,
+      position3,
+      "mdast-util-mdx-jsx:end-tag-mismatch"
+    );
+  }
+  function onErrorLeftIsTag(a, b) {
+    const tag = this.data.mdxJsxTag;
+    ok(tag, "expected `mdxJsxTag`");
+    throw new VFileMessage(
+      "Expected the closing tag `" + serializeAbbreviatedTag(tag) + "` either after the end of `" + b.type + "` (" + stringifyPosition(b.end) + ") or another opening tag after the start of `" + b.type + "` (" + stringifyPosition(b.start) + ")",
+      { start: a.start, end: a.end },
+      "mdast-util-mdx-jsx:end-tag-mismatch"
+    );
+  }
+  function serializeAbbreviatedTag(tag) {
+    return "<" + (tag.close ? "/" : "") + (tag.name || "") + ">";
+  }
+}
+function mdxJsxToMarkdown(options) {
+  const options_ = options || {};
+  const quote = options_.quote || '"';
+  const quoteSmart = options_.quoteSmart || false;
+  const tightSelfClosing = options_.tightSelfClosing || false;
+  const printWidth = options_.printWidth || Number.POSITIVE_INFINITY;
+  const alternative = quote === '"' ? "'" : '"';
+  if (quote !== '"' && quote !== "'") {
+    throw new Error(
+      "Cannot serialize attribute values with `" + quote + "` for `options.quote`, expected `\"`, or `'`"
+    );
+  }
+  mdxElement.peek = peekElement;
+  return {
+    handlers: {
+      mdxJsxFlowElement: mdxElement,
+      mdxJsxTextElement: mdxElement
+    },
+    unsafe: [
+      { character: "<", inConstruct: ["phrasing"] },
+      { atBreak: true, character: "<" }
+    ],
+    // Always generate fenced code (never indented code).
+    fences: true,
+    // Always generate links with resources (never autolinks).
+    resourceLink: true
+  };
+  function mdxElement(node2, _, state, info) {
+    const flow3 = node2.type === "mdxJsxFlowElement";
+    const selfClosing = node2.name ? !node2.children || node2.children.length === 0 : false;
+    const depth = inferDepth(state);
+    const currentIndent = createIndent(depth);
+    const trackerOneLine = state.createTracker(info);
+    const trackerMultiLine = state.createTracker(info);
+    const serializedAttributes = [];
+    const prefix = (flow3 ? currentIndent : "") + "<" + (node2.name || "");
+    const exit2 = state.enter(node2.type);
+    trackerOneLine.move(prefix);
+    trackerMultiLine.move(prefix);
+    if (node2.attributes && node2.attributes.length > 0) {
+      if (!node2.name) {
+        throw new Error("Cannot serialize fragment w/ attributes");
+      }
+      let index2 = -1;
+      while (++index2 < node2.attributes.length) {
+        const attribute = node2.attributes[index2];
+        let result;
+        if (attribute.type === "mdxJsxExpressionAttribute") {
+          result = "{" + (attribute.value || "") + "}";
+        } else {
+          if (!attribute.name) {
+            throw new Error("Cannot serialize attribute w/o name");
+          }
+          const value2 = attribute.value;
+          const left = attribute.name;
+          let right = "";
+          if (value2 === null || value2 === void 0) {
+          } else if (typeof value2 === "object") {
+            right = "{" + (value2.value || "") + "}";
+          } else {
+            const appliedQuote = quoteSmart && ccount(value2, quote) > ccount(value2, alternative) ? alternative : quote;
+            right = appliedQuote + stringifyEntitiesLight(value2, { subset: [appliedQuote] }) + appliedQuote;
+          }
+          result = left + (right ? "=" : "") + right;
+        }
+        serializedAttributes.push(result);
+      }
+    }
+    let attributesOnTheirOwnLine = false;
+    const attributesOnOneLine = serializedAttributes.join(" ");
+    if (
+      // Block:
+      flow3 && // Including a line ending (expressions).
+      (/\r?\n|\r/.test(attributesOnOneLine) || // Current position (including `<tag`).
+      trackerOneLine.current().now.column + // -1 because columns, +1 for ` ` before attributes.
+      // Attributes joined by spaces.
+      attributesOnOneLine.length + // ` />`.
+      (selfClosing ? tightSelfClosing ? 2 : 3 : 1) > printWidth)
+    ) {
+      attributesOnTheirOwnLine = true;
+    }
+    let tracker = trackerOneLine;
+    let value = prefix;
+    if (attributesOnTheirOwnLine) {
+      tracker = trackerMultiLine;
+      let index2 = -1;
+      while (++index2 < serializedAttributes.length) {
+        serializedAttributes[index2] = currentIndent + indent + serializedAttributes[index2];
+      }
+      value += tracker.move(
+        "\n" + serializedAttributes.join("\n") + "\n" + currentIndent
+      );
+    } else if (attributesOnOneLine) {
+      value += tracker.move(" " + attributesOnOneLine);
+    }
+    if (selfClosing) {
+      value += tracker.move(
+        (tightSelfClosing || attributesOnTheirOwnLine ? "" : " ") + "/"
+      );
+    }
+    value += tracker.move(">");
+    if (node2.children && node2.children.length > 0) {
+      if (node2.type === "mdxJsxTextElement") {
+        value += tracker.move(
+          // @ts-expect-error: `containerPhrasing` is typed correctly, but TS
+          // generates *hardcoded* types, which means that our dynamically added
+          // directives are not present.
+          // At some point, TS should fix that, and `from-markdown` should be fine.
+          state.containerPhrasing(node2, {
+            ...tracker.current(),
+            before: ">",
+            after: "<"
+          })
+        );
+      } else {
+        tracker.shift(2);
+        value += tracker.move("\n");
+        value += tracker.move(containerFlow(node2, state, tracker.current()));
+        value += tracker.move("\n");
+      }
+    }
+    if (!selfClosing) {
+      value += tracker.move(
+        (flow3 ? currentIndent : "") + "</" + (node2.name || "") + ">"
+      );
+    }
+    exit2();
+    return value;
+  }
+}
+function containerFlow(parent, state, info) {
+  const indexStack = state.indexStack;
+  const children = parent.children;
+  const tracker = state.createTracker(info);
+  const currentIndent = createIndent(inferDepth(state));
+  const results = [];
+  let index2 = -1;
+  indexStack.push(-1);
+  while (++index2 < children.length) {
+    const child = children[index2];
+    indexStack[indexStack.length - 1] = index2;
+    const childInfo = { before: "\n", after: "\n", ...tracker.current() };
+    const result = state.handle(child, parent, state, childInfo);
+    const serializedChild = child.type === "mdxJsxFlowElement" ? result : state.indentLines(result, function(line, _, blank) {
+      return (blank ? "" : currentIndent) + line;
+    });
+    results.push(tracker.move(serializedChild));
+    if (child.type !== "list") {
+      state.bulletLastUsed = void 0;
+    }
+    if (index2 < children.length - 1) {
+      results.push(tracker.move("\n\n"));
+    }
+  }
+  indexStack.pop();
+  return results.join("");
+}
+function inferDepth(state) {
+  let depth = 0;
+  let index2 = state.stack.length;
+  while (--index2 > -1) {
+    const name2 = state.stack[index2];
+    if (name2 === "blockquote" || name2 === "listItem") break;
+    if (name2 === "mdxJsxFlowElement") depth++;
+  }
+  return depth;
+}
+function createIndent(depth) {
+  return indent.repeat(depth);
+}
+function peekElement() {
+  return "<";
+}
+
+// node_modules/mdast-util-mdxjs-esm/lib/index.js
+function mdxjsEsmFromMarkdown() {
+  return {
+    enter: { mdxjsEsm: enterMdxjsEsm },
+    exit: { mdxjsEsm: exitMdxjsEsm, mdxjsEsmData: exitMdxjsEsmData }
+  };
+}
+function mdxjsEsmToMarkdown() {
+  return { handlers: { mdxjsEsm: handleMdxjsEsm } };
+}
+function enterMdxjsEsm(token) {
+  this.enter({ type: "mdxjsEsm", value: "" }, token);
+  this.buffer();
+}
+function exitMdxjsEsm(token) {
+  const value = this.resume();
+  const node2 = this.stack[this.stack.length - 1];
+  ok(node2.type === "mdxjsEsm");
+  this.exit(token);
+  const estree = token.estree;
+  node2.value = value;
+  if (estree) {
+    node2.data = { estree };
+  }
+}
+function exitMdxjsEsmData(token) {
+  this.config.enter.data.call(this, token);
+  this.config.exit.data.call(this, token);
+}
+function handleMdxjsEsm(node2) {
+  return node2.value || "";
+}
+
+// node_modules/mdast-util-mdx/lib/index.js
+function mdxFromMarkdown() {
+  return [
+    mdxExpressionFromMarkdown(),
+    mdxJsxFromMarkdown(),
+    mdxjsEsmFromMarkdown()
+  ];
+}
+function mdxToMarkdown(options) {
+  return {
+    extensions: [
+      mdxExpressionToMarkdown(),
+      mdxJsxToMarkdown(options),
+      mdxjsEsmToMarkdown()
+    ]
+  };
+}
+
+// node_modules/micromark-extension-mdxjs/node_modules/acorn/dist/acorn.mjs
+var astralIdentifierCodes = [509, 0, 227, 0, 150, 4, 294, 9, 1368, 2, 2, 1, 6, 3, 41, 2, 5, 0, 166, 1, 574, 3, 9, 9, 370, 1, 81, 2, 71, 10, 50, 3, 123, 2, 54, 14, 32, 10, 3, 1, 11, 3, 46, 10, 8, 0, 46, 9, 7, 2, 37, 13, 2, 9, 6, 1, 45, 0, 13, 2, 49, 13, 9, 3, 2, 11, 83, 11, 7, 0, 3, 0, 158, 11, 6, 9, 7, 3, 56, 1, 2, 6, 3, 1, 3, 2, 10, 0, 11, 1, 3, 6, 4, 4, 193, 17, 10, 9, 5, 0, 82, 19, 13, 9, 214, 6, 3, 8, 28, 1, 83, 16, 16, 9, 82, 12, 9, 9, 84, 14, 5, 9, 243, 14, 166, 9, 71, 5, 2, 1, 3, 3, 2, 0, 2, 1, 13, 9, 120, 6, 3, 6, 4, 0, 29, 9, 41, 6, 2, 3, 9, 0, 10, 10, 47, 15, 406, 7, 2, 7, 17, 9, 57, 21, 2, 13, 123, 5, 4, 0, 2, 1, 2, 6, 2, 0, 9, 9, 49, 4, 2, 1, 2, 4, 9, 9, 330, 3, 10, 1, 2, 0, 49, 6, 4, 4, 14, 9, 5351, 0, 7, 14, 13835, 9, 87, 9, 39, 4, 60, 6, 26, 9, 1014, 0, 2, 54, 8, 3, 82, 0, 12, 1, 19628, 1, 4706, 45, 3, 22, 543, 4, 4, 5, 9, 7, 3, 6, 31, 3, 149, 2, 1418, 49, 513, 54, 5, 49, 9, 0, 15, 0, 23, 4, 2, 14, 1361, 6, 2, 16, 3, 6, 2, 1, 2, 4, 101, 0, 161, 6, 10, 9, 357, 0, 62, 13, 499, 13, 983, 6, 110, 6, 6, 9, 4759, 9, 787719, 239];
+var astralIdentifierStartCodes = [0, 11, 2, 25, 2, 18, 2, 1, 2, 14, 3, 13, 35, 122, 70, 52, 268, 28, 4, 48, 48, 31, 14, 29, 6, 37, 11, 29, 3, 35, 5, 7, 2, 4, 43, 157, 19, 35, 5, 35, 5, 39, 9, 51, 13, 10, 2, 14, 2, 6, 2, 1, 2, 10, 2, 14, 2, 6, 2, 1, 68, 310, 10, 21, 11, 7, 25, 5, 2, 41, 2, 8, 70, 5, 3, 0, 2, 43, 2, 1, 4, 0, 3, 22, 11, 22, 10, 30, 66, 18, 2, 1, 11, 21, 11, 25, 71, 55, 7, 1, 65, 0, 16, 3, 2, 2, 2, 28, 43, 28, 4, 28, 36, 7, 2, 27, 28, 53, 11, 21, 11, 18, 14, 17, 111, 72, 56, 50, 14, 50, 14, 35, 349, 41, 7, 1, 79, 28, 11, 0, 9, 21, 43, 17, 47, 20, 28, 22, 13, 52, 58, 1, 3, 0, 14, 44, 33, 24, 27, 35, 30, 0, 3, 0, 9, 34, 4, 0, 13, 47, 15, 3, 22, 0, 2, 0, 36, 17, 2, 24, 20, 1, 64, 6, 2, 0, 2, 3, 2, 14, 2, 9, 8, 46, 39, 7, 3, 1, 3, 21, 2, 6, 2, 1, 2, 4, 4, 0, 19, 0, 13, 4, 159, 52, 19, 3, 21, 2, 31, 47, 21, 1, 2, 0, 185, 46, 42, 3, 37, 47, 21, 0, 60, 42, 14, 0, 72, 26, 38, 6, 186, 43, 117, 63, 32, 7, 3, 0, 3, 7, 2, 1, 2, 23, 16, 0, 2, 0, 95, 7, 3, 38, 17, 0, 2, 0, 29, 0, 11, 39, 8, 0, 22, 0, 12, 45, 20, 0, 19, 72, 264, 8, 2, 36, 18, 0, 50, 29, 113, 6, 2, 1, 2, 37, 22, 0, 26, 5, 2, 1, 2, 31, 15, 0, 328, 18, 16, 0, 2, 12, 2, 33, 125, 0, 80, 921, 103, 110, 18, 195, 2637, 96, 16, 1071, 18, 5, 4026, 582, 8634, 568, 8, 30, 18, 78, 18, 29, 19, 47, 17, 3, 32, 20, 6, 18, 689, 63, 129, 74, 6, 0, 67, 12, 65, 1, 2, 0, 29, 6135, 9, 1237, 43, 8, 8936, 3, 2, 6, 2, 1, 2, 290, 16, 0, 30, 2, 3, 0, 15, 3, 9, 395, 2309, 106, 6, 12, 4, 8, 8, 9, 5991, 84, 2, 70, 2, 1, 3, 0, 3, 1, 3, 3, 2, 11, 2, 0, 2, 6, 2, 64, 2, 3, 3, 7, 2, 6, 2, 27, 2, 3, 2, 4, 2, 0, 4, 6, 2, 339, 3, 24, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 30, 2, 24, 2, 7, 1845, 30, 7, 5, 262, 61, 147, 44, 11, 6, 17, 0, 322, 29, 19, 43, 485, 27, 757, 6, 2, 3, 2, 1, 2, 14, 2, 196, 60, 67, 8, 0, 1205, 3, 2, 26, 2, 1, 2, 0, 3, 0, 2, 9, 2, 3, 2, 0, 2, 0, 7, 0, 5, 0, 2, 0, 2, 0, 2, 2, 2, 1, 2, 0, 3, 0, 2, 0, 2, 0, 2, 0, 2, 0, 2, 1, 2, 0, 3, 3, 2, 6, 2, 3, 2, 3, 2, 0, 2, 9, 2, 16, 6, 2, 2, 4, 2, 16, 4421, 42719, 33, 4153, 7, 221, 3, 5761, 15, 7472, 16, 621, 2467, 541, 1507, 4938, 6, 4191];
+var nonASCIIidentifierChars = "\u200C\u200D\xB7\u0300-\u036F\u0387\u0483-\u0487\u0591-\u05BD\u05BF\u05C1\u05C2\u05C4\u05C5\u05C7\u0610-\u061A\u064B-\u0669\u0670\u06D6-\u06DC\u06DF-\u06E4\u06E7\u06E8\u06EA-\u06ED\u06F0-\u06F9\u0711\u0730-\u074A\u07A6-\u07B0\u07C0-\u07C9\u07EB-\u07F3\u07FD\u0816-\u0819\u081B-\u0823\u0825-\u0827\u0829-\u082D\u0859-\u085B\u0898-\u089F\u08CA-\u08E1\u08E3-\u0903\u093A-\u093C\u093E-\u094F\u0951-\u0957\u0962\u0963\u0966-\u096F\u0981-\u0983\u09BC\u09BE-\u09C4\u09C7\u09C8\u09CB-\u09CD\u09D7\u09E2\u09E3\u09E6-\u09EF\u09FE\u0A01-\u0A03\u0A3C\u0A3E-\u0A42\u0A47\u0A48\u0A4B-\u0A4D\u0A51\u0A66-\u0A71\u0A75\u0A81-\u0A83\u0ABC\u0ABE-\u0AC5\u0AC7-\u0AC9\u0ACB-\u0ACD\u0AE2\u0AE3\u0AE6-\u0AEF\u0AFA-\u0AFF\u0B01-\u0B03\u0B3C\u0B3E-\u0B44\u0B47\u0B48\u0B4B-\u0B4D\u0B55-\u0B57\u0B62\u0B63\u0B66-\u0B6F\u0B82\u0BBE-\u0BC2\u0BC6-\u0BC8\u0BCA-\u0BCD\u0BD7\u0BE6-\u0BEF\u0C00-\u0C04\u0C3C\u0C3E-\u0C44\u0C46-\u0C48\u0C4A-\u0C4D\u0C55\u0C56\u0C62\u0C63\u0C66-\u0C6F\u0C81-\u0C83\u0CBC\u0CBE-\u0CC4\u0CC6-\u0CC8\u0CCA-\u0CCD\u0CD5\u0CD6\u0CE2\u0CE3\u0CE6-\u0CEF\u0CF3\u0D00-\u0D03\u0D3B\u0D3C\u0D3E-\u0D44\u0D46-\u0D48\u0D4A-\u0D4D\u0D57\u0D62\u0D63\u0D66-\u0D6F\u0D81-\u0D83\u0DCA\u0DCF-\u0DD4\u0DD6\u0DD8-\u0DDF\u0DE6-\u0DEF\u0DF2\u0DF3\u0E31\u0E34-\u0E3A\u0E47-\u0E4E\u0E50-\u0E59\u0EB1\u0EB4-\u0EBC\u0EC8-\u0ECE\u0ED0-\u0ED9\u0F18\u0F19\u0F20-\u0F29\u0F35\u0F37\u0F39\u0F3E\u0F3F\u0F71-\u0F84\u0F86\u0F87\u0F8D-\u0F97\u0F99-\u0FBC\u0FC6\u102B-\u103E\u1040-\u1049\u1056-\u1059\u105E-\u1060\u1062-\u1064\u1067-\u106D\u1071-\u1074\u1082-\u108D\u108F-\u109D\u135D-\u135F\u1369-\u1371\u1712-\u1715\u1732-\u1734\u1752\u1753\u1772\u1773\u17B4-\u17D3\u17DD\u17E0-\u17E9\u180B-\u180D\u180F-\u1819\u18A9\u1920-\u192B\u1930-\u193B\u1946-\u194F\u19D0-\u19DA\u1A17-\u1A1B\u1A55-\u1A5E\u1A60-\u1A7C\u1A7F-\u1A89\u1A90-\u1A99\u1AB0-\u1ABD\u1ABF-\u1ACE\u1B00-\u1B04\u1B34-\u1B44\u1B50-\u1B59\u1B6B-\u1B73\u1B80-\u1B82\u1BA1-\u1BAD\u1BB0-\u1BB9\u1BE6-\u1BF3\u1C24-\u1C37\u1C40-\u1C49\u1C50-\u1C59\u1CD0-\u1CD2\u1CD4-\u1CE8\u1CED\u1CF4\u1CF7-\u1CF9\u1DC0-\u1DFF\u200C\u200D\u203F\u2040\u2054\u20D0-\u20DC\u20E1\u20E5-\u20F0\u2CEF-\u2CF1\u2D7F\u2DE0-\u2DFF\u302A-\u302F\u3099\u309A\u30FB\uA620-\uA629\uA66F\uA674-\uA67D\uA69E\uA69F\uA6F0\uA6F1\uA802\uA806\uA80B\uA823-\uA827\uA82C\uA880\uA881\uA8B4-\uA8C5\uA8D0-\uA8D9\uA8E0-\uA8F1\uA8FF-\uA909\uA926-\uA92D\uA947-\uA953\uA980-\uA983\uA9B3-\uA9C0\uA9D0-\uA9D9\uA9E5\uA9F0-\uA9F9\uAA29-\uAA36\uAA43\uAA4C\uAA4D\uAA50-\uAA59\uAA7B-\uAA7D\uAAB0\uAAB2-\uAAB4\uAAB7\uAAB8\uAABE\uAABF\uAAC1\uAAEB-\uAAEF\uAAF5\uAAF6\uABE3-\uABEA\uABEC\uABED\uABF0-\uABF9\uFB1E\uFE00-\uFE0F\uFE20-\uFE2F\uFE33\uFE34\uFE4D-\uFE4F\uFF10-\uFF19\uFF3F\uFF65";
+var nonASCIIidentifierStartChars = "\xAA\xB5\xBA\xC0-\xD6\xD8-\xF6\xF8-\u02C1\u02C6-\u02D1\u02E0-\u02E4\u02EC\u02EE\u0370-\u0374\u0376\u0377\u037A-\u037D\u037F\u0386\u0388-\u038A\u038C\u038E-\u03A1\u03A3-\u03F5\u03F7-\u0481\u048A-\u052F\u0531-\u0556\u0559\u0560-\u0588\u05D0-\u05EA\u05EF-\u05F2\u0620-\u064A\u066E\u066F\u0671-\u06D3\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u06FC\u06FF\u0710\u0712-\u072F\u074D-\u07A5\u07B1\u07CA-\u07EA\u07F4\u07F5\u07FA\u0800-\u0815\u081A\u0824\u0828\u0840-\u0858\u0860-\u086A\u0870-\u0887\u0889-\u088E\u08A0-\u08C9\u0904-\u0939\u093D\u0950\u0958-\u0961\u0971-\u0980\u0985-\u098C\u098F\u0990\u0993-\u09A8\u09AA-\u09B0\u09B2\u09B6-\u09B9\u09BD\u09CE\u09DC\u09DD\u09DF-\u09E1\u09F0\u09F1\u09FC\u0A05-\u0A0A\u0A0F\u0A10\u0A13-\u0A28\u0A2A-\u0A30\u0A32\u0A33\u0A35\u0A36\u0A38\u0A39\u0A59-\u0A5C\u0A5E\u0A72-\u0A74\u0A85-\u0A8D\u0A8F-\u0A91\u0A93-\u0AA8\u0AAA-\u0AB0\u0AB2\u0AB3\u0AB5-\u0AB9\u0ABD\u0AD0\u0AE0\u0AE1\u0AF9\u0B05-\u0B0C\u0B0F\u0B10\u0B13-\u0B28\u0B2A-\u0B30\u0B32\u0B33\u0B35-\u0B39\u0B3D\u0B5C\u0B5D\u0B5F-\u0B61\u0B71\u0B83\u0B85-\u0B8A\u0B8E-\u0B90\u0B92-\u0B95\u0B99\u0B9A\u0B9C\u0B9E\u0B9F\u0BA3\u0BA4\u0BA8-\u0BAA\u0BAE-\u0BB9\u0BD0\u0C05-\u0C0C\u0C0E-\u0C10\u0C12-\u0C28\u0C2A-\u0C39\u0C3D\u0C58-\u0C5A\u0C5D\u0C60\u0C61\u0C80\u0C85-\u0C8C\u0C8E-\u0C90\u0C92-\u0CA8\u0CAA-\u0CB3\u0CB5-\u0CB9\u0CBD\u0CDD\u0CDE\u0CE0\u0CE1\u0CF1\u0CF2\u0D04-\u0D0C\u0D0E-\u0D10\u0D12-\u0D3A\u0D3D\u0D4E\u0D54-\u0D56\u0D5F-\u0D61\u0D7A-\u0D7F\u0D85-\u0D96\u0D9A-\u0DB1\u0DB3-\u0DBB\u0DBD\u0DC0-\u0DC6\u0E01-\u0E30\u0E32\u0E33\u0E40-\u0E46\u0E81\u0E82\u0E84\u0E86-\u0E8A\u0E8C-\u0EA3\u0EA5\u0EA7-\u0EB0\u0EB2\u0EB3\u0EBD\u0EC0-\u0EC4\u0EC6\u0EDC-\u0EDF\u0F00\u0F40-\u0F47\u0F49-\u0F6C\u0F88-\u0F8C\u1000-\u102A\u103F\u1050-\u1055\u105A-\u105D\u1061\u1065\u1066\u106E-\u1070\u1075-\u1081\u108E\u10A0-\u10C5\u10C7\u10CD\u10D0-\u10FA\u10FC-\u1248\u124A-\u124D\u1250-\u1256\u1258\u125A-\u125D\u1260-\u1288\u128A-\u128D\u1290-\u12B0\u12B2-\u12B5\u12B8-\u12BE\u12C0\u12C2-\u12C5\u12C8-\u12D6\u12D8-\u1310\u1312-\u1315\u1318-\u135A\u1380-\u138F\u13A0-\u13F5\u13F8-\u13FD\u1401-\u166C\u166F-\u167F\u1681-\u169A\u16A0-\u16EA\u16EE-\u16F8\u1700-\u1711\u171F-\u1731\u1740-\u1751\u1760-\u176C\u176E-\u1770\u1780-\u17B3\u17D7\u17DC\u1820-\u1878\u1880-\u18A8\u18AA\u18B0-\u18F5\u1900-\u191E\u1950-\u196D\u1970-\u1974\u1980-\u19AB\u19B0-\u19C9\u1A00-\u1A16\u1A20-\u1A54\u1AA7\u1B05-\u1B33\u1B45-\u1B4C\u1B83-\u1BA0\u1BAE\u1BAF\u1BBA-\u1BE5\u1C00-\u1C23\u1C4D-\u1C4F\u1C5A-\u1C7D\u1C80-\u1C88\u1C90-\u1CBA\u1CBD-\u1CBF\u1CE9-\u1CEC\u1CEE-\u1CF3\u1CF5\u1CF6\u1CFA\u1D00-\u1DBF\u1E00-\u1F15\u1F18-\u1F1D\u1F20-\u1F45\u1F48-\u1F4D\u1F50-\u1F57\u1F59\u1F5B\u1F5D\u1F5F-\u1F7D\u1F80-\u1FB4\u1FB6-\u1FBC\u1FBE\u1FC2-\u1FC4\u1FC6-\u1FCC\u1FD0-\u1FD3\u1FD6-\u1FDB\u1FE0-\u1FEC\u1FF2-\u1FF4\u1FF6-\u1FFC\u2071\u207F\u2090-\u209C\u2102\u2107\u210A-\u2113\u2115\u2118-\u211D\u2124\u2126\u2128\u212A-\u2139\u213C-\u213F\u2145-\u2149\u214E\u2160-\u2188\u2C00-\u2CE4\u2CEB-\u2CEE\u2CF2\u2CF3\u2D00-\u2D25\u2D27\u2D2D\u2D30-\u2D67\u2D6F\u2D80-\u2D96\u2DA0-\u2DA6\u2DA8-\u2DAE\u2DB0-\u2DB6\u2DB8-\u2DBE\u2DC0-\u2DC6\u2DC8-\u2DCE\u2DD0-\u2DD6\u2DD8-\u2DDE\u3005-\u3007\u3021-\u3029\u3031-\u3035\u3038-\u303C\u3041-\u3096\u309B-\u309F\u30A1-\u30FA\u30FC-\u30FF\u3105-\u312F\u3131-\u318E\u31A0-\u31BF\u31F0-\u31FF\u3400-\u4DBF\u4E00-\uA48C\uA4D0-\uA4FD\uA500-\uA60C\uA610-\uA61F\uA62A\uA62B\uA640-\uA66E\uA67F-\uA69D\uA6A0-\uA6EF\uA717-\uA71F\uA722-\uA788\uA78B-\uA7CA\uA7D0\uA7D1\uA7D3\uA7D5-\uA7D9\uA7F2-\uA801\uA803-\uA805\uA807-\uA80A\uA80C-\uA822\uA840-\uA873\uA882-\uA8B3\uA8F2-\uA8F7\uA8FB\uA8FD\uA8FE\uA90A-\uA925\uA930-\uA946\uA960-\uA97C\uA984-\uA9B2\uA9CF\uA9E0-\uA9E4\uA9E6-\uA9EF\uA9FA-\uA9FE\uAA00-\uAA28\uAA40-\uAA42\uAA44-\uAA4B\uAA60-\uAA76\uAA7A\uAA7E-\uAAAF\uAAB1\uAAB5\uAAB6\uAAB9-\uAABD\uAAC0\uAAC2\uAADB-\uAADD\uAAE0-\uAAEA\uAAF2-\uAAF4\uAB01-\uAB06\uAB09-\uAB0E\uAB11-\uAB16\uAB20-\uAB26\uAB28-\uAB2E\uAB30-\uAB5A\uAB5C-\uAB69\uAB70-\uABE2\uAC00-\uD7A3\uD7B0-\uD7C6\uD7CB-\uD7FB\uF900-\uFA6D\uFA70-\uFAD9\uFB00-\uFB06\uFB13-\uFB17\uFB1D\uFB1F-\uFB28\uFB2A-\uFB36\uFB38-\uFB3C\uFB3E\uFB40\uFB41\uFB43\uFB44\uFB46-\uFBB1\uFBD3-\uFD3D\uFD50-\uFD8F\uFD92-\uFDC7\uFDF0-\uFDFB\uFE70-\uFE74\uFE76-\uFEFC\uFF21-\uFF3A\uFF41-\uFF5A\uFF66-\uFFBE\uFFC2-\uFFC7\uFFCA-\uFFCF\uFFD2-\uFFD7\uFFDA-\uFFDC";
+var reservedWords = {
+  3: "abstract boolean byte char class double enum export extends final float goto implements import int interface long native package private protected public short static super synchronized throws transient volatile",
+  5: "class enum extends super const export import",
+  6: "enum",
+  strict: "implements interface let package private protected public static yield",
+  strictBind: "eval arguments"
+};
+var ecma5AndLessKeywords = "break case catch continue debugger default do else finally for function if return switch throw try var while with null true false instanceof typeof void delete new in this";
+var keywords$1 = {
+  5: ecma5AndLessKeywords,
+  "5module": ecma5AndLessKeywords + " export import",
+  6: ecma5AndLessKeywords + " const class extends export import super"
+};
+var keywordRelationalOperator = /^in(stanceof)?$/;
+var nonASCIIidentifierStart = new RegExp("[" + nonASCIIidentifierStartChars + "]");
+var nonASCIIidentifier = new RegExp("[" + nonASCIIidentifierStartChars + nonASCIIidentifierChars + "]");
+function isInAstralSet(code2, set) {
+  var pos = 65536;
+  for (var i = 0; i < set.length; i += 2) {
+    pos += set[i];
+    if (pos > code2) {
+      return false;
+    }
+    pos += set[i + 1];
+    if (pos >= code2) {
+      return true;
+    }
+  }
+  return false;
+}
+function isIdentifierStart(code2, astral) {
+  if (code2 < 65) {
+    return code2 === 36;
+  }
+  if (code2 < 91) {
+    return true;
+  }
+  if (code2 < 97) {
+    return code2 === 95;
+  }
+  if (code2 < 123) {
+    return true;
+  }
+  if (code2 <= 65535) {
+    return code2 >= 170 && nonASCIIidentifierStart.test(String.fromCharCode(code2));
+  }
+  if (astral === false) {
+    return false;
+  }
+  return isInAstralSet(code2, astralIdentifierStartCodes);
+}
+function isIdentifierChar(code2, astral) {
+  if (code2 < 48) {
+    return code2 === 36;
+  }
+  if (code2 < 58) {
+    return true;
+  }
+  if (code2 < 65) {
+    return false;
+  }
+  if (code2 < 91) {
+    return true;
+  }
+  if (code2 < 97) {
+    return code2 === 95;
+  }
+  if (code2 < 123) {
+    return true;
+  }
+  if (code2 <= 65535) {
+    return code2 >= 170 && nonASCIIidentifier.test(String.fromCharCode(code2));
+  }
+  if (astral === false) {
+    return false;
+  }
+  return isInAstralSet(code2, astralIdentifierStartCodes) || isInAstralSet(code2, astralIdentifierCodes);
+}
+var TokenType = function TokenType2(label, conf) {
+  if (conf === void 0) conf = {};
+  this.label = label;
+  this.keyword = conf.keyword;
+  this.beforeExpr = !!conf.beforeExpr;
+  this.startsExpr = !!conf.startsExpr;
+  this.isLoop = !!conf.isLoop;
+  this.isAssign = !!conf.isAssign;
+  this.prefix = !!conf.prefix;
+  this.postfix = !!conf.postfix;
+  this.binop = conf.binop || null;
+  this.updateContext = null;
+};
+function binop(name2, prec) {
+  return new TokenType(name2, { beforeExpr: true, binop: prec });
+}
+var beforeExpr = { beforeExpr: true };
+var startsExpr = { startsExpr: true };
+var keywords = {};
+function kw(name2, options) {
+  if (options === void 0) options = {};
+  options.keyword = name2;
+  return keywords[name2] = new TokenType(name2, options);
+}
+var types$1 = {
+  num: new TokenType("num", startsExpr),
+  regexp: new TokenType("regexp", startsExpr),
+  string: new TokenType("string", startsExpr),
+  name: new TokenType("name", startsExpr),
+  privateId: new TokenType("privateId", startsExpr),
+  eof: new TokenType("eof"),
+  // Punctuation token types.
+  bracketL: new TokenType("[", { beforeExpr: true, startsExpr: true }),
+  bracketR: new TokenType("]"),
+  braceL: new TokenType("{", { beforeExpr: true, startsExpr: true }),
+  braceR: new TokenType("}"),
+  parenL: new TokenType("(", { beforeExpr: true, startsExpr: true }),
+  parenR: new TokenType(")"),
+  comma: new TokenType(",", beforeExpr),
+  semi: new TokenType(";", beforeExpr),
+  colon: new TokenType(":", beforeExpr),
+  dot: new TokenType("."),
+  question: new TokenType("?", beforeExpr),
+  questionDot: new TokenType("?."),
+  arrow: new TokenType("=>", beforeExpr),
+  template: new TokenType("template"),
+  invalidTemplate: new TokenType("invalidTemplate"),
+  ellipsis: new TokenType("...", beforeExpr),
+  backQuote: new TokenType("`", startsExpr),
+  dollarBraceL: new TokenType("${", { beforeExpr: true, startsExpr: true }),
+  // Operators. These carry several kinds of properties to help the
+  // parser use them properly (the presence of these properties is
+  // what categorizes them as operators).
+  //
+  // `binop`, when present, specifies that this operator is a binary
+  // operator, and will refer to its precedence.
+  //
+  // `prefix` and `postfix` mark the operator as a prefix or postfix
+  // unary operator.
+  //
+  // `isAssign` marks all of `=`, `+=`, `-=` etcetera, which act as
+  // binary operators with a very low precedence, that should result
+  // in AssignmentExpression nodes.
+  eq: new TokenType("=", { beforeExpr: true, isAssign: true }),
+  assign: new TokenType("_=", { beforeExpr: true, isAssign: true }),
+  incDec: new TokenType("++/--", { prefix: true, postfix: true, startsExpr: true }),
+  prefix: new TokenType("!/~", { beforeExpr: true, prefix: true, startsExpr: true }),
+  logicalOR: binop("||", 1),
+  logicalAND: binop("&&", 2),
+  bitwiseOR: binop("|", 3),
+  bitwiseXOR: binop("^", 4),
+  bitwiseAND: binop("&", 5),
+  equality: binop("==/!=/===/!==", 6),
+  relational: binop("</>/<=/>=", 7),
+  bitShift: binop("<</>>/>>>", 8),
+  plusMin: new TokenType("+/-", { beforeExpr: true, binop: 9, prefix: true, startsExpr: true }),
+  modulo: binop("%", 10),
+  star: binop("*", 10),
+  slash: binop("/", 10),
+  starstar: new TokenType("**", { beforeExpr: true }),
+  coalesce: binop("??", 1),
+  // Keyword token types.
+  _break: kw("break"),
+  _case: kw("case", beforeExpr),
+  _catch: kw("catch"),
+  _continue: kw("continue"),
+  _debugger: kw("debugger"),
+  _default: kw("default", beforeExpr),
+  _do: kw("do", { isLoop: true, beforeExpr: true }),
+  _else: kw("else", beforeExpr),
+  _finally: kw("finally"),
+  _for: kw("for", { isLoop: true }),
+  _function: kw("function", startsExpr),
+  _if: kw("if"),
+  _return: kw("return", beforeExpr),
+  _switch: kw("switch"),
+  _throw: kw("throw", beforeExpr),
+  _try: kw("try"),
+  _var: kw("var"),
+  _const: kw("const"),
+  _while: kw("while", { isLoop: true }),
+  _with: kw("with"),
+  _new: kw("new", { beforeExpr: true, startsExpr: true }),
+  _this: kw("this", startsExpr),
+  _super: kw("super", startsExpr),
+  _class: kw("class", startsExpr),
+  _extends: kw("extends", beforeExpr),
+  _export: kw("export"),
+  _import: kw("import", startsExpr),
+  _null: kw("null", startsExpr),
+  _true: kw("true", startsExpr),
+  _false: kw("false", startsExpr),
+  _in: kw("in", { beforeExpr: true, binop: 7 }),
+  _instanceof: kw("instanceof", { beforeExpr: true, binop: 7 }),
+  _typeof: kw("typeof", { beforeExpr: true, prefix: true, startsExpr: true }),
+  _void: kw("void", { beforeExpr: true, prefix: true, startsExpr: true }),
+  _delete: kw("delete", { beforeExpr: true, prefix: true, startsExpr: true })
+};
+var lineBreak = /\r\n?|\n|\u2028|\u2029/;
+var lineBreakG = new RegExp(lineBreak.source, "g");
+function isNewLine(code2) {
+  return code2 === 10 || code2 === 13 || code2 === 8232 || code2 === 8233;
+}
+function nextLineBreak(code2, from, end) {
+  if (end === void 0) end = code2.length;
+  for (var i = from; i < end; i++) {
+    var next = code2.charCodeAt(i);
+    if (isNewLine(next)) {
+      return i < end - 1 && next === 13 && code2.charCodeAt(i + 1) === 10 ? i + 2 : i + 1;
+    }
+  }
+  return -1;
+}
+var nonASCIIwhitespace = /[\u1680\u2000-\u200a\u202f\u205f\u3000\ufeff]/;
+var skipWhiteSpace = /(?:\s|\/\/.*|\/\*[^]*?\*\/)*/g;
+var ref = Object.prototype;
+var hasOwnProperty = ref.hasOwnProperty;
+var toString = ref.toString;
+var hasOwn = Object.hasOwn || function(obj, propName) {
+  return hasOwnProperty.call(obj, propName);
+};
+var isArray = Array.isArray || function(obj) {
+  return toString.call(obj) === "[object Array]";
+};
+var regexpCache = /* @__PURE__ */ Object.create(null);
+function wordsRegexp(words) {
+  return regexpCache[words] || (regexpCache[words] = new RegExp("^(?:" + words.replace(/ /g, "|") + ")$"));
+}
+function codePointToString(code2) {
+  if (code2 <= 65535) {
+    return String.fromCharCode(code2);
+  }
+  code2 -= 65536;
+  return String.fromCharCode((code2 >> 10) + 55296, (code2 & 1023) + 56320);
+}
+var loneSurrogate = /(?:[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF])/;
+var Position = function Position2(line, col) {
+  this.line = line;
+  this.column = col;
+};
+Position.prototype.offset = function offset(n) {
+  return new Position(this.line, this.column + n);
+};
+var SourceLocation = function SourceLocation2(p, start2, end) {
+  this.start = start2;
+  this.end = end;
+  if (p.sourceFile !== null) {
+    this.source = p.sourceFile;
+  }
+};
+function getLineInfo(input, offset2) {
+  for (var line = 1, cur = 0; ; ) {
+    var nextBreak = nextLineBreak(input, cur, offset2);
+    if (nextBreak < 0) {
+      return new Position(line, offset2 - cur);
+    }
+    ++line;
+    cur = nextBreak;
+  }
+}
+var defaultOptions = {
+  // `ecmaVersion` indicates the ECMAScript version to parse. Must be
+  // either 3, 5, 6 (or 2015), 7 (2016), 8 (2017), 9 (2018), 10
+  // (2019), 11 (2020), 12 (2021), 13 (2022), 14 (2023), or `"latest"`
+  // (the latest version the library supports). This influences
+  // support for strict mode, the set of reserved words, and support
+  // for new syntax features.
+  ecmaVersion: null,
+  // `sourceType` indicates the mode the code should be parsed in.
+  // Can be either `"script"` or `"module"`. This influences global
+  // strict mode and parsing of `import` and `export` declarations.
+  sourceType: "script",
+  // `onInsertedSemicolon` can be a callback that will be called when
+  // a semicolon is automatically inserted. It will be passed the
+  // position of the inserted semicolon as an offset, and if
+  // `locations` is enabled, it is given the location as a `{line,
+  // column}` object as second argument.
+  onInsertedSemicolon: null,
+  // `onTrailingComma` is similar to `onInsertedSemicolon`, but for
+  // trailing commas.
+  onTrailingComma: null,
+  // By default, reserved words are only enforced if ecmaVersion >= 5.
+  // Set `allowReserved` to a boolean value to explicitly turn this on
+  // an off. When this option has the value "never", reserved words
+  // and keywords can also not be used as property names.
+  allowReserved: null,
+  // When enabled, a return at the top level is not considered an
+  // error.
+  allowReturnOutsideFunction: false,
+  // When enabled, import/export statements are not constrained to
+  // appearing at the top of the program, and an import.meta expression
+  // in a script isn't considered an error.
+  allowImportExportEverywhere: false,
+  // By default, await identifiers are allowed to appear at the top-level scope only if ecmaVersion >= 2022.
+  // When enabled, await identifiers are allowed to appear at the top-level scope,
+  // but they are still not allowed in non-async functions.
+  allowAwaitOutsideFunction: null,
+  // When enabled, super identifiers are not constrained to
+  // appearing in methods and do not raise an error when they appear elsewhere.
+  allowSuperOutsideMethod: null,
+  // When enabled, hashbang directive in the beginning of file is
+  // allowed and treated as a line comment. Enabled by default when
+  // `ecmaVersion` >= 2023.
+  allowHashBang: false,
+  // By default, the parser will verify that private properties are
+  // only used in places where they are valid and have been declared.
+  // Set this to false to turn such checks off.
+  checkPrivateFields: true,
+  // When `locations` is on, `loc` properties holding objects with
+  // `start` and `end` properties in `{line, column}` form (with
+  // line being 1-based and column 0-based) will be attached to the
+  // nodes.
+  locations: false,
+  // A function can be passed as `onToken` option, which will
+  // cause Acorn to call that function with object in the same
+  // format as tokens returned from `tokenizer().getToken()`. Note
+  // that you are not allowed to call the parser from the
+  // callback—that will corrupt its internal state.
+  onToken: null,
+  // A function can be passed as `onComment` option, which will
+  // cause Acorn to call that function with `(block, text, start,
+  // end)` parameters whenever a comment is skipped. `block` is a
+  // boolean indicating whether this is a block (`/* */`) comment,
+  // `text` is the content of the comment, and `start` and `end` are
+  // character offsets that denote the start and end of the comment.
+  // When the `locations` option is on, two more parameters are
+  // passed, the full `{line, column}` locations of the start and
+  // end of the comments. Note that you are not allowed to call the
+  // parser from the callback—that will corrupt its internal state.
+  // When this option has an array as value, objects representing the
+  // comments are pushed to it.
+  onComment: null,
+  // Nodes have their start and end characters offsets recorded in
+  // `start` and `end` properties (directly on the node, rather than
+  // the `loc` object, which holds line/column data. To also add a
+  // [semi-standardized][range] `range` property holding a `[start,
+  // end]` array with the same numbers, set the `ranges` option to
+  // `true`.
+  //
+  // [range]: https://bugzilla.mozilla.org/show_bug.cgi?id=745678
+  ranges: false,
+  // It is possible to parse multiple files into a single AST by
+  // passing the tree produced by parsing the first file as
+  // `program` option in subsequent parses. This will add the
+  // toplevel forms of the parsed file to the `Program` (top) node
+  // of an existing parse tree.
+  program: null,
+  // When `locations` is on, you can pass this to record the source
+  // file in every node's `loc` object.
+  sourceFile: null,
+  // This value, if given, is stored in every node, whether
+  // `locations` is on or off.
+  directSourceFile: null,
+  // When enabled, parenthesized expressions are represented by
+  // (non-standard) ParenthesizedExpression nodes
+  preserveParens: false
+};
+var warnedAboutEcmaVersion = false;
+function getOptions(opts) {
+  var options = {};
+  for (var opt in defaultOptions) {
+    options[opt] = opts && hasOwn(opts, opt) ? opts[opt] : defaultOptions[opt];
+  }
+  if (options.ecmaVersion === "latest") {
+    options.ecmaVersion = 1e8;
+  } else if (options.ecmaVersion == null) {
+    if (!warnedAboutEcmaVersion && typeof console === "object" && console.warn) {
+      warnedAboutEcmaVersion = true;
+      console.warn("Since Acorn 8.0.0, options.ecmaVersion is required.\nDefaulting to 2020, but this will stop working in the future.");
+    }
+    options.ecmaVersion = 11;
+  } else if (options.ecmaVersion >= 2015) {
+    options.ecmaVersion -= 2009;
+  }
+  if (options.allowReserved == null) {
+    options.allowReserved = options.ecmaVersion < 5;
+  }
+  if (!opts || opts.allowHashBang == null) {
+    options.allowHashBang = options.ecmaVersion >= 14;
+  }
+  if (isArray(options.onToken)) {
+    var tokens = options.onToken;
+    options.onToken = function(token) {
+      return tokens.push(token);
+    };
+  }
+  if (isArray(options.onComment)) {
+    options.onComment = pushComment(options, options.onComment);
+  }
+  return options;
+}
+function pushComment(options, array) {
+  return function(block, text5, start2, end, startLoc, endLoc) {
+    var comment2 = {
+      type: block ? "Block" : "Line",
+      value: text5,
+      start: start2,
+      end
+    };
+    if (options.locations) {
+      comment2.loc = new SourceLocation(this, startLoc, endLoc);
+    }
+    if (options.ranges) {
+      comment2.range = [start2, end];
+    }
+    array.push(comment2);
+  };
+}
+var SCOPE_TOP = 1;
+var SCOPE_FUNCTION = 2;
+var SCOPE_ASYNC = 4;
+var SCOPE_GENERATOR = 8;
+var SCOPE_ARROW = 16;
+var SCOPE_SIMPLE_CATCH = 32;
+var SCOPE_SUPER = 64;
+var SCOPE_DIRECT_SUPER = 128;
+var SCOPE_CLASS_STATIC_BLOCK = 256;
+var SCOPE_VAR = SCOPE_TOP | SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK;
+function functionFlags(async, generator) {
+  return SCOPE_FUNCTION | (async ? SCOPE_ASYNC : 0) | (generator ? SCOPE_GENERATOR : 0);
+}
+var BIND_NONE = 0;
+var BIND_VAR = 1;
+var BIND_LEXICAL = 2;
+var BIND_FUNCTION = 3;
+var BIND_SIMPLE_CATCH = 4;
+var BIND_OUTSIDE = 5;
+var Parser = function Parser2(options, input, startPos) {
+  this.options = options = getOptions(options);
+  this.sourceFile = options.sourceFile;
+  this.keywords = wordsRegexp(keywords$1[options.ecmaVersion >= 6 ? 6 : options.sourceType === "module" ? "5module" : 5]);
+  var reserved = "";
+  if (options.allowReserved !== true) {
+    reserved = reservedWords[options.ecmaVersion >= 6 ? 6 : options.ecmaVersion === 5 ? 5 : 3];
+    if (options.sourceType === "module") {
+      reserved += " await";
+    }
+  }
+  this.reservedWords = wordsRegexp(reserved);
+  var reservedStrict = (reserved ? reserved + " " : "") + reservedWords.strict;
+  this.reservedWordsStrict = wordsRegexp(reservedStrict);
+  this.reservedWordsStrictBind = wordsRegexp(reservedStrict + " " + reservedWords.strictBind);
+  this.input = String(input);
+  this.containsEsc = false;
+  if (startPos) {
+    this.pos = startPos;
+    this.lineStart = this.input.lastIndexOf("\n", startPos - 1) + 1;
+    this.curLine = this.input.slice(0, this.lineStart).split(lineBreak).length;
+  } else {
+    this.pos = this.lineStart = 0;
+    this.curLine = 1;
+  }
+  this.type = types$1.eof;
+  this.value = null;
+  this.start = this.end = this.pos;
+  this.startLoc = this.endLoc = this.curPosition();
+  this.lastTokEndLoc = this.lastTokStartLoc = null;
+  this.lastTokStart = this.lastTokEnd = this.pos;
+  this.context = this.initialContext();
+  this.exprAllowed = true;
+  this.inModule = options.sourceType === "module";
+  this.strict = this.inModule || this.strictDirective(this.pos);
+  this.potentialArrowAt = -1;
+  this.potentialArrowInForAwait = false;
+  this.yieldPos = this.awaitPos = this.awaitIdentPos = 0;
+  this.labels = [];
+  this.undefinedExports = /* @__PURE__ */ Object.create(null);
+  if (this.pos === 0 && options.allowHashBang && this.input.slice(0, 2) === "#!") {
+    this.skipLineComment(2);
+  }
+  this.scopeStack = [];
+  this.enterScope(SCOPE_TOP);
+  this.regexpState = null;
+  this.privateNameStack = [];
+};
+var prototypeAccessors = { inFunction: { configurable: true }, inGenerator: { configurable: true }, inAsync: { configurable: true }, canAwait: { configurable: true }, allowSuper: { configurable: true }, allowDirectSuper: { configurable: true }, treatFunctionsAsVar: { configurable: true }, allowNewDotTarget: { configurable: true }, inClassStaticBlock: { configurable: true } };
+Parser.prototype.parse = function parse() {
+  var node2 = this.options.program || this.startNode();
+  this.nextToken();
+  return this.parseTopLevel(node2);
+};
+prototypeAccessors.inFunction.get = function() {
+  return (this.currentVarScope().flags & SCOPE_FUNCTION) > 0;
+};
+prototypeAccessors.inGenerator.get = function() {
+  return (this.currentVarScope().flags & SCOPE_GENERATOR) > 0 && !this.currentVarScope().inClassFieldInit;
+};
+prototypeAccessors.inAsync.get = function() {
+  return (this.currentVarScope().flags & SCOPE_ASYNC) > 0 && !this.currentVarScope().inClassFieldInit;
+};
+prototypeAccessors.canAwait.get = function() {
+  for (var i = this.scopeStack.length - 1; i >= 0; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.inClassFieldInit || scope.flags & SCOPE_CLASS_STATIC_BLOCK) {
+      return false;
+    }
+    if (scope.flags & SCOPE_FUNCTION) {
+      return (scope.flags & SCOPE_ASYNC) > 0;
+    }
+  }
+  return this.inModule && this.options.ecmaVersion >= 13 || this.options.allowAwaitOutsideFunction;
+};
+prototypeAccessors.allowSuper.get = function() {
+  var ref2 = this.currentThisScope();
+  var flags = ref2.flags;
+  var inClassFieldInit = ref2.inClassFieldInit;
+  return (flags & SCOPE_SUPER) > 0 || inClassFieldInit || this.options.allowSuperOutsideMethod;
+};
+prototypeAccessors.allowDirectSuper.get = function() {
+  return (this.currentThisScope().flags & SCOPE_DIRECT_SUPER) > 0;
+};
+prototypeAccessors.treatFunctionsAsVar.get = function() {
+  return this.treatFunctionsAsVarInScope(this.currentScope());
+};
+prototypeAccessors.allowNewDotTarget.get = function() {
+  var ref2 = this.currentThisScope();
+  var flags = ref2.flags;
+  var inClassFieldInit = ref2.inClassFieldInit;
+  return (flags & (SCOPE_FUNCTION | SCOPE_CLASS_STATIC_BLOCK)) > 0 || inClassFieldInit;
+};
+prototypeAccessors.inClassStaticBlock.get = function() {
+  return (this.currentVarScope().flags & SCOPE_CLASS_STATIC_BLOCK) > 0;
+};
+Parser.extend = function extend() {
+  var plugins = [], len = arguments.length;
+  while (len--) plugins[len] = arguments[len];
+  var cls = this;
+  for (var i = 0; i < plugins.length; i++) {
+    cls = plugins[i](cls);
+  }
+  return cls;
+};
+Parser.parse = function parse2(input, options) {
+  return new this(options, input).parse();
+};
+Parser.parseExpressionAt = function parseExpressionAt(input, pos, options) {
+  var parser = new this(options, input, pos);
+  parser.nextToken();
+  return parser.parseExpression();
+};
+Parser.tokenizer = function tokenizer(input, options) {
+  return new this(options, input);
+};
+Object.defineProperties(Parser.prototype, prototypeAccessors);
+var pp$9 = Parser.prototype;
+var literal = /^(?:'((?:\\[^]|[^'\\])*?)'|"((?:\\[^]|[^"\\])*?)")/;
+pp$9.strictDirective = function(start2) {
+  if (this.options.ecmaVersion < 5) {
+    return false;
+  }
+  for (; ; ) {
+    skipWhiteSpace.lastIndex = start2;
+    start2 += skipWhiteSpace.exec(this.input)[0].length;
+    var match = literal.exec(this.input.slice(start2));
+    if (!match) {
+      return false;
+    }
+    if ((match[1] || match[2]) === "use strict") {
+      skipWhiteSpace.lastIndex = start2 + match[0].length;
+      var spaceAfter = skipWhiteSpace.exec(this.input), end = spaceAfter.index + spaceAfter[0].length;
+      var next = this.input.charAt(end);
+      return next === ";" || next === "}" || lineBreak.test(spaceAfter[0]) && !(/[(`.[+\-/*%<>=,?^&]/.test(next) || next === "!" && this.input.charAt(end + 1) === "=");
+    }
+    start2 += match[0].length;
+    skipWhiteSpace.lastIndex = start2;
+    start2 += skipWhiteSpace.exec(this.input)[0].length;
+    if (this.input[start2] === ";") {
+      start2++;
+    }
+  }
+};
+pp$9.eat = function(type) {
+  if (this.type === type) {
+    this.next();
+    return true;
+  } else {
+    return false;
+  }
+};
+pp$9.isContextual = function(name2) {
+  return this.type === types$1.name && this.value === name2 && !this.containsEsc;
+};
+pp$9.eatContextual = function(name2) {
+  if (!this.isContextual(name2)) {
+    return false;
+  }
+  this.next();
+  return true;
+};
+pp$9.expectContextual = function(name2) {
+  if (!this.eatContextual(name2)) {
+    this.unexpected();
+  }
+};
+pp$9.canInsertSemicolon = function() {
+  return this.type === types$1.eof || this.type === types$1.braceR || lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+pp$9.insertSemicolon = function() {
+  if (this.canInsertSemicolon()) {
+    if (this.options.onInsertedSemicolon) {
+      this.options.onInsertedSemicolon(this.lastTokEnd, this.lastTokEndLoc);
+    }
+    return true;
+  }
+};
+pp$9.semicolon = function() {
+  if (!this.eat(types$1.semi) && !this.insertSemicolon()) {
+    this.unexpected();
+  }
+};
+pp$9.afterTrailingComma = function(tokType, notNext) {
+  if (this.type === tokType) {
+    if (this.options.onTrailingComma) {
+      this.options.onTrailingComma(this.lastTokStart, this.lastTokStartLoc);
+    }
+    if (!notNext) {
+      this.next();
+    }
+    return true;
+  }
+};
+pp$9.expect = function(type) {
+  this.eat(type) || this.unexpected();
+};
+pp$9.unexpected = function(pos) {
+  this.raise(pos != null ? pos : this.start, "Unexpected token");
+};
+var DestructuringErrors = function DestructuringErrors2() {
+  this.shorthandAssign = this.trailingComma = this.parenthesizedAssign = this.parenthesizedBind = this.doubleProto = -1;
+};
+pp$9.checkPatternErrors = function(refDestructuringErrors, isAssign) {
+  if (!refDestructuringErrors) {
+    return;
+  }
+  if (refDestructuringErrors.trailingComma > -1) {
+    this.raiseRecoverable(refDestructuringErrors.trailingComma, "Comma is not permitted after the rest element");
+  }
+  var parens = isAssign ? refDestructuringErrors.parenthesizedAssign : refDestructuringErrors.parenthesizedBind;
+  if (parens > -1) {
+    this.raiseRecoverable(parens, isAssign ? "Assigning to rvalue" : "Parenthesized pattern");
+  }
+};
+pp$9.checkExpressionErrors = function(refDestructuringErrors, andThrow) {
+  if (!refDestructuringErrors) {
+    return false;
+  }
+  var shorthandAssign = refDestructuringErrors.shorthandAssign;
+  var doubleProto = refDestructuringErrors.doubleProto;
+  if (!andThrow) {
+    return shorthandAssign >= 0 || doubleProto >= 0;
+  }
+  if (shorthandAssign >= 0) {
+    this.raise(shorthandAssign, "Shorthand property assignments are valid only in destructuring patterns");
+  }
+  if (doubleProto >= 0) {
+    this.raiseRecoverable(doubleProto, "Redefinition of __proto__ property");
+  }
+};
+pp$9.checkYieldAwaitInDefaultParams = function() {
+  if (this.yieldPos && (!this.awaitPos || this.yieldPos < this.awaitPos)) {
+    this.raise(this.yieldPos, "Yield expression cannot be a default value");
+  }
+  if (this.awaitPos) {
+    this.raise(this.awaitPos, "Await expression cannot be a default value");
+  }
+};
+pp$9.isSimpleAssignTarget = function(expr) {
+  if (expr.type === "ParenthesizedExpression") {
+    return this.isSimpleAssignTarget(expr.expression);
+  }
+  return expr.type === "Identifier" || expr.type === "MemberExpression";
+};
+var pp$8 = Parser.prototype;
+pp$8.parseTopLevel = function(node2) {
+  var exports2 = /* @__PURE__ */ Object.create(null);
+  if (!node2.body) {
+    node2.body = [];
+  }
+  while (this.type !== types$1.eof) {
+    var stmt = this.parseStatement(null, true, exports2);
+    node2.body.push(stmt);
+  }
+  if (this.inModule) {
+    for (var i = 0, list3 = Object.keys(this.undefinedExports); i < list3.length; i += 1) {
+      var name2 = list3[i];
+      this.raiseRecoverable(this.undefinedExports[name2].start, "Export '" + name2 + "' is not defined");
+    }
+  }
+  this.adaptDirectivePrologue(node2.body);
+  this.next();
+  node2.sourceType = this.options.sourceType;
+  return this.finishNode(node2, "Program");
+};
+var loopLabel = { kind: "loop" };
+var switchLabel = { kind: "switch" };
+pp$8.isLet = function(context) {
+  if (this.options.ecmaVersion < 6 || !this.isContextual("let")) {
+    return false;
+  }
+  skipWhiteSpace.lastIndex = this.pos;
+  var skip = skipWhiteSpace.exec(this.input);
+  var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+  if (nextCh === 91 || nextCh === 92) {
+    return true;
+  }
+  if (context) {
+    return false;
+  }
+  if (nextCh === 123 || nextCh > 55295 && nextCh < 56320) {
+    return true;
+  }
+  if (isIdentifierStart(nextCh, true)) {
+    var pos = next + 1;
+    while (isIdentifierChar(nextCh = this.input.charCodeAt(pos), true)) {
+      ++pos;
+    }
+    if (nextCh === 92 || nextCh > 55295 && nextCh < 56320) {
+      return true;
+    }
+    var ident = this.input.slice(next, pos);
+    if (!keywordRelationalOperator.test(ident)) {
+      return true;
+    }
+  }
+  return false;
+};
+pp$8.isAsyncFunction = function() {
+  if (this.options.ecmaVersion < 8 || !this.isContextual("async")) {
+    return false;
+  }
+  skipWhiteSpace.lastIndex = this.pos;
+  var skip = skipWhiteSpace.exec(this.input);
+  var next = this.pos + skip[0].length, after;
+  return !lineBreak.test(this.input.slice(this.pos, next)) && this.input.slice(next, next + 8) === "function" && (next + 8 === this.input.length || !(isIdentifierChar(after = this.input.charCodeAt(next + 8)) || after > 55295 && after < 56320));
+};
+pp$8.parseStatement = function(context, topLevel, exports2) {
+  var starttype = this.type, node2 = this.startNode(), kind;
+  if (this.isLet(context)) {
+    starttype = types$1._var;
+    kind = "let";
+  }
+  switch (starttype) {
+    case types$1._break:
+    case types$1._continue:
+      return this.parseBreakContinueStatement(node2, starttype.keyword);
+    case types$1._debugger:
+      return this.parseDebuggerStatement(node2);
+    case types$1._do:
+      return this.parseDoStatement(node2);
+    case types$1._for:
+      return this.parseForStatement(node2);
+    case types$1._function:
+      if (context && (this.strict || context !== "if" && context !== "label") && this.options.ecmaVersion >= 6) {
+        this.unexpected();
+      }
+      return this.parseFunctionStatement(node2, false, !context);
+    case types$1._class:
+      if (context) {
+        this.unexpected();
+      }
+      return this.parseClass(node2, true);
+    case types$1._if:
+      return this.parseIfStatement(node2);
+    case types$1._return:
+      return this.parseReturnStatement(node2);
+    case types$1._switch:
+      return this.parseSwitchStatement(node2);
+    case types$1._throw:
+      return this.parseThrowStatement(node2);
+    case types$1._try:
+      return this.parseTryStatement(node2);
+    case types$1._const:
+    case types$1._var:
+      kind = kind || this.value;
+      if (context && kind !== "var") {
+        this.unexpected();
+      }
+      return this.parseVarStatement(node2, kind);
+    case types$1._while:
+      return this.parseWhileStatement(node2);
+    case types$1._with:
+      return this.parseWithStatement(node2);
+    case types$1.braceL:
+      return this.parseBlock(true, node2);
+    case types$1.semi:
+      return this.parseEmptyStatement(node2);
+    case types$1._export:
+    case types$1._import:
+      if (this.options.ecmaVersion > 10 && starttype === types$1._import) {
+        skipWhiteSpace.lastIndex = this.pos;
+        var skip = skipWhiteSpace.exec(this.input);
+        var next = this.pos + skip[0].length, nextCh = this.input.charCodeAt(next);
+        if (nextCh === 40 || nextCh === 46) {
+          return this.parseExpressionStatement(node2, this.parseExpression());
+        }
+      }
+      if (!this.options.allowImportExportEverywhere) {
+        if (!topLevel) {
+          this.raise(this.start, "'import' and 'export' may only appear at the top level");
+        }
+        if (!this.inModule) {
+          this.raise(this.start, "'import' and 'export' may appear only with 'sourceType: module'");
+        }
+      }
+      return starttype === types$1._import ? this.parseImport(node2) : this.parseExport(node2, exports2);
+    default:
+      if (this.isAsyncFunction()) {
+        if (context) {
+          this.unexpected();
+        }
+        this.next();
+        return this.parseFunctionStatement(node2, true, !context);
+      }
+      var maybeName = this.value, expr = this.parseExpression();
+      if (starttype === types$1.name && expr.type === "Identifier" && this.eat(types$1.colon)) {
+        return this.parseLabeledStatement(node2, maybeName, expr, context);
+      } else {
+        return this.parseExpressionStatement(node2, expr);
+      }
+  }
+};
+pp$8.parseBreakContinueStatement = function(node2, keyword) {
+  var isBreak = keyword === "break";
+  this.next();
+  if (this.eat(types$1.semi) || this.insertSemicolon()) {
+    node2.label = null;
+  } else if (this.type !== types$1.name) {
+    this.unexpected();
+  } else {
+    node2.label = this.parseIdent();
+    this.semicolon();
+  }
+  var i = 0;
+  for (; i < this.labels.length; ++i) {
+    var lab = this.labels[i];
+    if (node2.label == null || lab.name === node2.label.name) {
+      if (lab.kind != null && (isBreak || lab.kind === "loop")) {
+        break;
+      }
+      if (node2.label && isBreak) {
+        break;
+      }
+    }
+  }
+  if (i === this.labels.length) {
+    this.raise(node2.start, "Unsyntactic " + keyword);
+  }
+  return this.finishNode(node2, isBreak ? "BreakStatement" : "ContinueStatement");
+};
+pp$8.parseDebuggerStatement = function(node2) {
+  this.next();
+  this.semicolon();
+  return this.finishNode(node2, "DebuggerStatement");
+};
+pp$8.parseDoStatement = function(node2) {
+  this.next();
+  this.labels.push(loopLabel);
+  node2.body = this.parseStatement("do");
+  this.labels.pop();
+  this.expect(types$1._while);
+  node2.test = this.parseParenExpression();
+  if (this.options.ecmaVersion >= 6) {
+    this.eat(types$1.semi);
+  } else {
+    this.semicolon();
+  }
+  return this.finishNode(node2, "DoWhileStatement");
+};
+pp$8.parseForStatement = function(node2) {
+  this.next();
+  var awaitAt = this.options.ecmaVersion >= 9 && this.canAwait && this.eatContextual("await") ? this.lastTokStart : -1;
+  this.labels.push(loopLabel);
+  this.enterScope(0);
+  this.expect(types$1.parenL);
+  if (this.type === types$1.semi) {
+    if (awaitAt > -1) {
+      this.unexpected(awaitAt);
+    }
+    return this.parseFor(node2, null);
+  }
+  var isLet = this.isLet();
+  if (this.type === types$1._var || this.type === types$1._const || isLet) {
+    var init$1 = this.startNode(), kind = isLet ? "let" : this.value;
+    this.next();
+    this.parseVar(init$1, true, kind);
+    this.finishNode(init$1, "VariableDeclaration");
+    if ((this.type === types$1._in || this.options.ecmaVersion >= 6 && this.isContextual("of")) && init$1.declarations.length === 1) {
+      if (this.options.ecmaVersion >= 9) {
+        if (this.type === types$1._in) {
+          if (awaitAt > -1) {
+            this.unexpected(awaitAt);
+          }
+        } else {
+          node2.await = awaitAt > -1;
+        }
+      }
+      return this.parseForIn(node2, init$1);
+    }
+    if (awaitAt > -1) {
+      this.unexpected(awaitAt);
+    }
+    return this.parseFor(node2, init$1);
+  }
+  var startsWithLet = this.isContextual("let"), isForOf = false;
+  var containsEsc = this.containsEsc;
+  var refDestructuringErrors = new DestructuringErrors();
+  var initPos = this.start;
+  var init = awaitAt > -1 ? this.parseExprSubscripts(refDestructuringErrors, "await") : this.parseExpression(true, refDestructuringErrors);
+  if (this.type === types$1._in || (isForOf = this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+    if (awaitAt > -1) {
+      if (this.type === types$1._in) {
+        this.unexpected(awaitAt);
+      }
+      node2.await = true;
+    } else if (isForOf && this.options.ecmaVersion >= 8) {
+      if (init.start === initPos && !containsEsc && init.type === "Identifier" && init.name === "async") {
+        this.unexpected();
+      } else if (this.options.ecmaVersion >= 9) {
+        node2.await = false;
+      }
+    }
+    if (startsWithLet && isForOf) {
+      this.raise(init.start, "The left-hand side of a for-of loop may not start with 'let'.");
+    }
+    this.toAssignable(init, false, refDestructuringErrors);
+    this.checkLValPattern(init);
+    return this.parseForIn(node2, init);
+  } else {
+    this.checkExpressionErrors(refDestructuringErrors, true);
+  }
+  if (awaitAt > -1) {
+    this.unexpected(awaitAt);
+  }
+  return this.parseFor(node2, init);
+};
+pp$8.parseFunctionStatement = function(node2, isAsync, declarationPosition) {
+  this.next();
+  return this.parseFunction(node2, FUNC_STATEMENT | (declarationPosition ? 0 : FUNC_HANGING_STATEMENT), false, isAsync);
+};
+pp$8.parseIfStatement = function(node2) {
+  this.next();
+  node2.test = this.parseParenExpression();
+  node2.consequent = this.parseStatement("if");
+  node2.alternate = this.eat(types$1._else) ? this.parseStatement("if") : null;
+  return this.finishNode(node2, "IfStatement");
+};
+pp$8.parseReturnStatement = function(node2) {
+  if (!this.inFunction && !this.options.allowReturnOutsideFunction) {
+    this.raise(this.start, "'return' outside of function");
+  }
+  this.next();
+  if (this.eat(types$1.semi) || this.insertSemicolon()) {
+    node2.argument = null;
+  } else {
+    node2.argument = this.parseExpression();
+    this.semicolon();
+  }
+  return this.finishNode(node2, "ReturnStatement");
+};
+pp$8.parseSwitchStatement = function(node2) {
+  this.next();
+  node2.discriminant = this.parseParenExpression();
+  node2.cases = [];
+  this.expect(types$1.braceL);
+  this.labels.push(switchLabel);
+  this.enterScope(0);
+  var cur;
+  for (var sawDefault = false; this.type !== types$1.braceR; ) {
+    if (this.type === types$1._case || this.type === types$1._default) {
+      var isCase = this.type === types$1._case;
+      if (cur) {
+        this.finishNode(cur, "SwitchCase");
+      }
+      node2.cases.push(cur = this.startNode());
+      cur.consequent = [];
+      this.next();
+      if (isCase) {
+        cur.test = this.parseExpression();
+      } else {
+        if (sawDefault) {
+          this.raiseRecoverable(this.lastTokStart, "Multiple default clauses");
+        }
+        sawDefault = true;
+        cur.test = null;
+      }
+      this.expect(types$1.colon);
+    } else {
+      if (!cur) {
+        this.unexpected();
+      }
+      cur.consequent.push(this.parseStatement(null));
+    }
+  }
+  this.exitScope();
+  if (cur) {
+    this.finishNode(cur, "SwitchCase");
+  }
+  this.next();
+  this.labels.pop();
+  return this.finishNode(node2, "SwitchStatement");
+};
+pp$8.parseThrowStatement = function(node2) {
+  this.next();
+  if (lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) {
+    this.raise(this.lastTokEnd, "Illegal newline after throw");
+  }
+  node2.argument = this.parseExpression();
+  this.semicolon();
+  return this.finishNode(node2, "ThrowStatement");
+};
+var empty$1 = [];
+pp$8.parseCatchClauseParam = function() {
+  var param = this.parseBindingAtom();
+  var simple = param.type === "Identifier";
+  this.enterScope(simple ? SCOPE_SIMPLE_CATCH : 0);
+  this.checkLValPattern(param, simple ? BIND_SIMPLE_CATCH : BIND_LEXICAL);
+  this.expect(types$1.parenR);
+  return param;
+};
+pp$8.parseTryStatement = function(node2) {
+  this.next();
+  node2.block = this.parseBlock();
+  node2.handler = null;
+  if (this.type === types$1._catch) {
+    var clause = this.startNode();
+    this.next();
+    if (this.eat(types$1.parenL)) {
+      clause.param = this.parseCatchClauseParam();
+    } else {
+      if (this.options.ecmaVersion < 10) {
+        this.unexpected();
+      }
+      clause.param = null;
+      this.enterScope(0);
+    }
+    clause.body = this.parseBlock(false);
+    this.exitScope();
+    node2.handler = this.finishNode(clause, "CatchClause");
+  }
+  node2.finalizer = this.eat(types$1._finally) ? this.parseBlock() : null;
+  if (!node2.handler && !node2.finalizer) {
+    this.raise(node2.start, "Missing catch or finally clause");
+  }
+  return this.finishNode(node2, "TryStatement");
+};
+pp$8.parseVarStatement = function(node2, kind, allowMissingInitializer) {
+  this.next();
+  this.parseVar(node2, false, kind, allowMissingInitializer);
+  this.semicolon();
+  return this.finishNode(node2, "VariableDeclaration");
+};
+pp$8.parseWhileStatement = function(node2) {
+  this.next();
+  node2.test = this.parseParenExpression();
+  this.labels.push(loopLabel);
+  node2.body = this.parseStatement("while");
+  this.labels.pop();
+  return this.finishNode(node2, "WhileStatement");
+};
+pp$8.parseWithStatement = function(node2) {
+  if (this.strict) {
+    this.raise(this.start, "'with' in strict mode");
+  }
+  this.next();
+  node2.object = this.parseParenExpression();
+  node2.body = this.parseStatement("with");
+  return this.finishNode(node2, "WithStatement");
+};
+pp$8.parseEmptyStatement = function(node2) {
+  this.next();
+  return this.finishNode(node2, "EmptyStatement");
+};
+pp$8.parseLabeledStatement = function(node2, maybeName, expr, context) {
+  for (var i$1 = 0, list3 = this.labels; i$1 < list3.length; i$1 += 1) {
+    var label = list3[i$1];
+    if (label.name === maybeName) {
+      this.raise(expr.start, "Label '" + maybeName + "' is already declared");
+    }
+  }
+  var kind = this.type.isLoop ? "loop" : this.type === types$1._switch ? "switch" : null;
+  for (var i = this.labels.length - 1; i >= 0; i--) {
+    var label$1 = this.labels[i];
+    if (label$1.statementStart === node2.start) {
+      label$1.statementStart = this.start;
+      label$1.kind = kind;
+    } else {
+      break;
+    }
+  }
+  this.labels.push({ name: maybeName, kind, statementStart: this.start });
+  node2.body = this.parseStatement(context ? context.indexOf("label") === -1 ? context + "label" : context : "label");
+  this.labels.pop();
+  node2.label = expr;
+  return this.finishNode(node2, "LabeledStatement");
+};
+pp$8.parseExpressionStatement = function(node2, expr) {
+  node2.expression = expr;
+  this.semicolon();
+  return this.finishNode(node2, "ExpressionStatement");
+};
+pp$8.parseBlock = function(createNewLexicalScope, node2, exitStrict) {
+  if (createNewLexicalScope === void 0) createNewLexicalScope = true;
+  if (node2 === void 0) node2 = this.startNode();
+  node2.body = [];
+  this.expect(types$1.braceL);
+  if (createNewLexicalScope) {
+    this.enterScope(0);
+  }
+  while (this.type !== types$1.braceR) {
+    var stmt = this.parseStatement(null);
+    node2.body.push(stmt);
+  }
+  if (exitStrict) {
+    this.strict = false;
+  }
+  this.next();
+  if (createNewLexicalScope) {
+    this.exitScope();
+  }
+  return this.finishNode(node2, "BlockStatement");
+};
+pp$8.parseFor = function(node2, init) {
+  node2.init = init;
+  this.expect(types$1.semi);
+  node2.test = this.type === types$1.semi ? null : this.parseExpression();
+  this.expect(types$1.semi);
+  node2.update = this.type === types$1.parenR ? null : this.parseExpression();
+  this.expect(types$1.parenR);
+  node2.body = this.parseStatement("for");
+  this.exitScope();
+  this.labels.pop();
+  return this.finishNode(node2, "ForStatement");
+};
+pp$8.parseForIn = function(node2, init) {
+  var isForIn = this.type === types$1._in;
+  this.next();
+  if (init.type === "VariableDeclaration" && init.declarations[0].init != null && (!isForIn || this.options.ecmaVersion < 8 || this.strict || init.kind !== "var" || init.declarations[0].id.type !== "Identifier")) {
+    this.raise(
+      init.start,
+      (isForIn ? "for-in" : "for-of") + " loop variable declaration may not have an initializer"
+    );
+  }
+  node2.left = init;
+  node2.right = isForIn ? this.parseExpression() : this.parseMaybeAssign();
+  this.expect(types$1.parenR);
+  node2.body = this.parseStatement("for");
+  this.exitScope();
+  this.labels.pop();
+  return this.finishNode(node2, isForIn ? "ForInStatement" : "ForOfStatement");
+};
+pp$8.parseVar = function(node2, isFor, kind, allowMissingInitializer) {
+  node2.declarations = [];
+  node2.kind = kind;
+  for (; ; ) {
+    var decl = this.startNode();
+    this.parseVarId(decl, kind);
+    if (this.eat(types$1.eq)) {
+      decl.init = this.parseMaybeAssign(isFor);
+    } else if (!allowMissingInitializer && kind === "const" && !(this.type === types$1._in || this.options.ecmaVersion >= 6 && this.isContextual("of"))) {
+      this.unexpected();
+    } else if (!allowMissingInitializer && decl.id.type !== "Identifier" && !(isFor && (this.type === types$1._in || this.isContextual("of")))) {
+      this.raise(this.lastTokEnd, "Complex binding patterns require an initialization value");
+    } else {
+      decl.init = null;
+    }
+    node2.declarations.push(this.finishNode(decl, "VariableDeclarator"));
+    if (!this.eat(types$1.comma)) {
+      break;
+    }
+  }
+  return node2;
+};
+pp$8.parseVarId = function(decl, kind) {
+  decl.id = this.parseBindingAtom();
+  this.checkLValPattern(decl.id, kind === "var" ? BIND_VAR : BIND_LEXICAL, false);
+};
+var FUNC_STATEMENT = 1;
+var FUNC_HANGING_STATEMENT = 2;
+var FUNC_NULLABLE_ID = 4;
+pp$8.parseFunction = function(node2, statement, allowExpressionBody, isAsync, forInit) {
+  this.initFunction(node2);
+  if (this.options.ecmaVersion >= 9 || this.options.ecmaVersion >= 6 && !isAsync) {
+    if (this.type === types$1.star && statement & FUNC_HANGING_STATEMENT) {
+      this.unexpected();
+    }
+    node2.generator = this.eat(types$1.star);
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node2.async = !!isAsync;
+  }
+  if (statement & FUNC_STATEMENT) {
+    node2.id = statement & FUNC_NULLABLE_ID && this.type !== types$1.name ? null : this.parseIdent();
+    if (node2.id && !(statement & FUNC_HANGING_STATEMENT)) {
+      this.checkLValSimple(node2.id, this.strict || node2.generator || node2.async ? this.treatFunctionsAsVar ? BIND_VAR : BIND_LEXICAL : BIND_FUNCTION);
+    }
+  }
+  var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  this.enterScope(functionFlags(node2.async, node2.generator));
+  if (!(statement & FUNC_STATEMENT)) {
+    node2.id = this.type === types$1.name ? this.parseIdent() : null;
+  }
+  this.parseFunctionParams(node2);
+  this.parseFunctionBody(node2, allowExpressionBody, false, forInit);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node2, statement & FUNC_STATEMENT ? "FunctionDeclaration" : "FunctionExpression");
+};
+pp$8.parseFunctionParams = function(node2) {
+  this.expect(types$1.parenL);
+  node2.params = this.parseBindingList(types$1.parenR, false, this.options.ecmaVersion >= 8);
+  this.checkYieldAwaitInDefaultParams();
+};
+pp$8.parseClass = function(node2, isStatement) {
+  this.next();
+  var oldStrict = this.strict;
+  this.strict = true;
+  this.parseClassId(node2, isStatement);
+  this.parseClassSuper(node2);
+  var privateNameMap = this.enterClassBody();
+  var classBody = this.startNode();
+  var hadConstructor = false;
+  classBody.body = [];
+  this.expect(types$1.braceL);
+  while (this.type !== types$1.braceR) {
+    var element2 = this.parseClassElement(node2.superClass !== null);
+    if (element2) {
+      classBody.body.push(element2);
+      if (element2.type === "MethodDefinition" && element2.kind === "constructor") {
+        if (hadConstructor) {
+          this.raiseRecoverable(element2.start, "Duplicate constructor in the same class");
+        }
+        hadConstructor = true;
+      } else if (element2.key && element2.key.type === "PrivateIdentifier" && isPrivateNameConflicted(privateNameMap, element2)) {
+        this.raiseRecoverable(element2.key.start, "Identifier '#" + element2.key.name + "' has already been declared");
+      }
+    }
+  }
+  this.strict = oldStrict;
+  this.next();
+  node2.body = this.finishNode(classBody, "ClassBody");
+  this.exitClassBody();
+  return this.finishNode(node2, isStatement ? "ClassDeclaration" : "ClassExpression");
+};
+pp$8.parseClassElement = function(constructorAllowsSuper) {
+  if (this.eat(types$1.semi)) {
+    return null;
+  }
+  var ecmaVersion = this.options.ecmaVersion;
+  var node2 = this.startNode();
+  var keyName = "";
+  var isGenerator = false;
+  var isAsync = false;
+  var kind = "method";
+  var isStatic = false;
+  if (this.eatContextual("static")) {
+    if (ecmaVersion >= 13 && this.eat(types$1.braceL)) {
+      this.parseClassStaticBlock(node2);
+      return node2;
+    }
+    if (this.isClassElementNameStart() || this.type === types$1.star) {
+      isStatic = true;
+    } else {
+      keyName = "static";
+    }
+  }
+  node2.static = isStatic;
+  if (!keyName && ecmaVersion >= 8 && this.eatContextual("async")) {
+    if ((this.isClassElementNameStart() || this.type === types$1.star) && !this.canInsertSemicolon()) {
+      isAsync = true;
+    } else {
+      keyName = "async";
+    }
+  }
+  if (!keyName && (ecmaVersion >= 9 || !isAsync) && this.eat(types$1.star)) {
+    isGenerator = true;
+  }
+  if (!keyName && !isAsync && !isGenerator) {
+    var lastValue = this.value;
+    if (this.eatContextual("get") || this.eatContextual("set")) {
+      if (this.isClassElementNameStart()) {
+        kind = lastValue;
+      } else {
+        keyName = lastValue;
+      }
+    }
+  }
+  if (keyName) {
+    node2.computed = false;
+    node2.key = this.startNodeAt(this.lastTokStart, this.lastTokStartLoc);
+    node2.key.name = keyName;
+    this.finishNode(node2.key, "Identifier");
+  } else {
+    this.parseClassElementName(node2);
+  }
+  if (ecmaVersion < 13 || this.type === types$1.parenL || kind !== "method" || isGenerator || isAsync) {
+    var isConstructor = !node2.static && checkKeyName(node2, "constructor");
+    var allowsDirectSuper = isConstructor && constructorAllowsSuper;
+    if (isConstructor && kind !== "method") {
+      this.raise(node2.key.start, "Constructor can't have get/set modifier");
+    }
+    node2.kind = isConstructor ? "constructor" : kind;
+    this.parseClassMethod(node2, isGenerator, isAsync, allowsDirectSuper);
+  } else {
+    this.parseClassField(node2);
+  }
+  return node2;
+};
+pp$8.isClassElementNameStart = function() {
+  return this.type === types$1.name || this.type === types$1.privateId || this.type === types$1.num || this.type === types$1.string || this.type === types$1.bracketL || this.type.keyword;
+};
+pp$8.parseClassElementName = function(element2) {
+  if (this.type === types$1.privateId) {
+    if (this.value === "constructor") {
+      this.raise(this.start, "Classes can't have an element named '#constructor'");
+    }
+    element2.computed = false;
+    element2.key = this.parsePrivateIdent();
+  } else {
+    this.parsePropertyName(element2);
+  }
+};
+pp$8.parseClassMethod = function(method, isGenerator, isAsync, allowsDirectSuper) {
+  var key = method.key;
+  if (method.kind === "constructor") {
+    if (isGenerator) {
+      this.raise(key.start, "Constructor can't be a generator");
+    }
+    if (isAsync) {
+      this.raise(key.start, "Constructor can't be an async method");
+    }
+  } else if (method.static && checkKeyName(method, "prototype")) {
+    this.raise(key.start, "Classes may not have a static property named prototype");
+  }
+  var value = method.value = this.parseMethod(isGenerator, isAsync, allowsDirectSuper);
+  if (method.kind === "get" && value.params.length !== 0) {
+    this.raiseRecoverable(value.start, "getter should have no params");
+  }
+  if (method.kind === "set" && value.params.length !== 1) {
+    this.raiseRecoverable(value.start, "setter should have exactly one param");
+  }
+  if (method.kind === "set" && value.params[0].type === "RestElement") {
+    this.raiseRecoverable(value.params[0].start, "Setter cannot use rest params");
+  }
+  return this.finishNode(method, "MethodDefinition");
+};
+pp$8.parseClassField = function(field) {
+  if (checkKeyName(field, "constructor")) {
+    this.raise(field.key.start, "Classes can't have a field named 'constructor'");
+  } else if (field.static && checkKeyName(field, "prototype")) {
+    this.raise(field.key.start, "Classes can't have a static field named 'prototype'");
+  }
+  if (this.eat(types$1.eq)) {
+    var scope = this.currentThisScope();
+    var inClassFieldInit = scope.inClassFieldInit;
+    scope.inClassFieldInit = true;
+    field.value = this.parseMaybeAssign();
+    scope.inClassFieldInit = inClassFieldInit;
+  } else {
+    field.value = null;
+  }
+  this.semicolon();
+  return this.finishNode(field, "PropertyDefinition");
+};
+pp$8.parseClassStaticBlock = function(node2) {
+  node2.body = [];
+  var oldLabels = this.labels;
+  this.labels = [];
+  this.enterScope(SCOPE_CLASS_STATIC_BLOCK | SCOPE_SUPER);
+  while (this.type !== types$1.braceR) {
+    var stmt = this.parseStatement(null);
+    node2.body.push(stmt);
+  }
+  this.next();
+  this.exitScope();
+  this.labels = oldLabels;
+  return this.finishNode(node2, "StaticBlock");
+};
+pp$8.parseClassId = function(node2, isStatement) {
+  if (this.type === types$1.name) {
+    node2.id = this.parseIdent();
+    if (isStatement) {
+      this.checkLValSimple(node2.id, BIND_LEXICAL, false);
+    }
+  } else {
+    if (isStatement === true) {
+      this.unexpected();
+    }
+    node2.id = null;
+  }
+};
+pp$8.parseClassSuper = function(node2) {
+  node2.superClass = this.eat(types$1._extends) ? this.parseExprSubscripts(null, false) : null;
+};
+pp$8.enterClassBody = function() {
+  var element2 = { declared: /* @__PURE__ */ Object.create(null), used: [] };
+  this.privateNameStack.push(element2);
+  return element2.declared;
+};
+pp$8.exitClassBody = function() {
+  var ref2 = this.privateNameStack.pop();
+  var declared = ref2.declared;
+  var used = ref2.used;
+  if (!this.options.checkPrivateFields) {
+    return;
+  }
+  var len = this.privateNameStack.length;
+  var parent = len === 0 ? null : this.privateNameStack[len - 1];
+  for (var i = 0; i < used.length; ++i) {
+    var id = used[i];
+    if (!hasOwn(declared, id.name)) {
+      if (parent) {
+        parent.used.push(id);
+      } else {
+        this.raiseRecoverable(id.start, "Private field '#" + id.name + "' must be declared in an enclosing class");
+      }
+    }
+  }
+};
+function isPrivateNameConflicted(privateNameMap, element2) {
+  var name2 = element2.key.name;
+  var curr = privateNameMap[name2];
+  var next = "true";
+  if (element2.type === "MethodDefinition" && (element2.kind === "get" || element2.kind === "set")) {
+    next = (element2.static ? "s" : "i") + element2.kind;
+  }
+  if (curr === "iget" && next === "iset" || curr === "iset" && next === "iget" || curr === "sget" && next === "sset" || curr === "sset" && next === "sget") {
+    privateNameMap[name2] = "true";
+    return false;
+  } else if (!curr) {
+    privateNameMap[name2] = next;
+    return false;
+  } else {
+    return true;
+  }
+}
+function checkKeyName(node2, name2) {
+  var computed = node2.computed;
+  var key = node2.key;
+  return !computed && (key.type === "Identifier" && key.name === name2 || key.type === "Literal" && key.value === name2);
+}
+pp$8.parseExportAllDeclaration = function(node2, exports2) {
+  if (this.options.ecmaVersion >= 11) {
+    if (this.eatContextual("as")) {
+      node2.exported = this.parseModuleExportName();
+      this.checkExport(exports2, node2.exported, this.lastTokStart);
+    } else {
+      node2.exported = null;
+    }
+  }
+  this.expectContextual("from");
+  if (this.type !== types$1.string) {
+    this.unexpected();
+  }
+  node2.source = this.parseExprAtom();
+  this.semicolon();
+  return this.finishNode(node2, "ExportAllDeclaration");
+};
+pp$8.parseExport = function(node2, exports2) {
+  this.next();
+  if (this.eat(types$1.star)) {
+    return this.parseExportAllDeclaration(node2, exports2);
+  }
+  if (this.eat(types$1._default)) {
+    this.checkExport(exports2, "default", this.lastTokStart);
+    node2.declaration = this.parseExportDefaultDeclaration();
+    return this.finishNode(node2, "ExportDefaultDeclaration");
+  }
+  if (this.shouldParseExportStatement()) {
+    node2.declaration = this.parseExportDeclaration(node2);
+    if (node2.declaration.type === "VariableDeclaration") {
+      this.checkVariableExport(exports2, node2.declaration.declarations);
+    } else {
+      this.checkExport(exports2, node2.declaration.id, node2.declaration.id.start);
+    }
+    node2.specifiers = [];
+    node2.source = null;
+  } else {
+    node2.declaration = null;
+    node2.specifiers = this.parseExportSpecifiers(exports2);
+    if (this.eatContextual("from")) {
+      if (this.type !== types$1.string) {
+        this.unexpected();
+      }
+      node2.source = this.parseExprAtom();
+    } else {
+      for (var i = 0, list3 = node2.specifiers; i < list3.length; i += 1) {
+        var spec = list3[i];
+        this.checkUnreserved(spec.local);
+        this.checkLocalExport(spec.local);
+        if (spec.local.type === "Literal") {
+          this.raise(spec.local.start, "A string literal cannot be used as an exported binding without `from`.");
+        }
+      }
+      node2.source = null;
+    }
+    this.semicolon();
+  }
+  return this.finishNode(node2, "ExportNamedDeclaration");
+};
+pp$8.parseExportDeclaration = function(node2) {
+  return this.parseStatement(null);
+};
+pp$8.parseExportDefaultDeclaration = function() {
+  var isAsync;
+  if (this.type === types$1._function || (isAsync = this.isAsyncFunction())) {
+    var fNode = this.startNode();
+    this.next();
+    if (isAsync) {
+      this.next();
+    }
+    return this.parseFunction(fNode, FUNC_STATEMENT | FUNC_NULLABLE_ID, false, isAsync);
+  } else if (this.type === types$1._class) {
+    var cNode = this.startNode();
+    return this.parseClass(cNode, "nullableID");
+  } else {
+    var declaration = this.parseMaybeAssign();
+    this.semicolon();
+    return declaration;
+  }
+};
+pp$8.checkExport = function(exports2, name2, pos) {
+  if (!exports2) {
+    return;
+  }
+  if (typeof name2 !== "string") {
+    name2 = name2.type === "Identifier" ? name2.name : name2.value;
+  }
+  if (hasOwn(exports2, name2)) {
+    this.raiseRecoverable(pos, "Duplicate export '" + name2 + "'");
+  }
+  exports2[name2] = true;
+};
+pp$8.checkPatternExport = function(exports2, pat) {
+  var type = pat.type;
+  if (type === "Identifier") {
+    this.checkExport(exports2, pat, pat.start);
+  } else if (type === "ObjectPattern") {
+    for (var i = 0, list3 = pat.properties; i < list3.length; i += 1) {
+      var prop = list3[i];
+      this.checkPatternExport(exports2, prop);
+    }
+  } else if (type === "ArrayPattern") {
+    for (var i$1 = 0, list$1 = pat.elements; i$1 < list$1.length; i$1 += 1) {
+      var elt = list$1[i$1];
+      if (elt) {
+        this.checkPatternExport(exports2, elt);
+      }
+    }
+  } else if (type === "Property") {
+    this.checkPatternExport(exports2, pat.value);
+  } else if (type === "AssignmentPattern") {
+    this.checkPatternExport(exports2, pat.left);
+  } else if (type === "RestElement") {
+    this.checkPatternExport(exports2, pat.argument);
+  }
+};
+pp$8.checkVariableExport = function(exports2, decls) {
+  if (!exports2) {
+    return;
+  }
+  for (var i = 0, list3 = decls; i < list3.length; i += 1) {
+    var decl = list3[i];
+    this.checkPatternExport(exports2, decl.id);
+  }
+};
+pp$8.shouldParseExportStatement = function() {
+  return this.type.keyword === "var" || this.type.keyword === "const" || this.type.keyword === "class" || this.type.keyword === "function" || this.isLet() || this.isAsyncFunction();
+};
+pp$8.parseExportSpecifier = function(exports2) {
+  var node2 = this.startNode();
+  node2.local = this.parseModuleExportName();
+  node2.exported = this.eatContextual("as") ? this.parseModuleExportName() : node2.local;
+  this.checkExport(
+    exports2,
+    node2.exported,
+    node2.exported.start
+  );
+  return this.finishNode(node2, "ExportSpecifier");
+};
+pp$8.parseExportSpecifiers = function(exports2) {
+  var nodes = [], first = true;
+  this.expect(types$1.braceL);
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    nodes.push(this.parseExportSpecifier(exports2));
+  }
+  return nodes;
+};
+pp$8.parseImport = function(node2) {
+  this.next();
+  if (this.type === types$1.string) {
+    node2.specifiers = empty$1;
+    node2.source = this.parseExprAtom();
+  } else {
+    node2.specifiers = this.parseImportSpecifiers();
+    this.expectContextual("from");
+    node2.source = this.type === types$1.string ? this.parseExprAtom() : this.unexpected();
+  }
+  this.semicolon();
+  return this.finishNode(node2, "ImportDeclaration");
+};
+pp$8.parseImportSpecifier = function() {
+  var node2 = this.startNode();
+  node2.imported = this.parseModuleExportName();
+  if (this.eatContextual("as")) {
+    node2.local = this.parseIdent();
+  } else {
+    this.checkUnreserved(node2.imported);
+    node2.local = node2.imported;
+  }
+  this.checkLValSimple(node2.local, BIND_LEXICAL);
+  return this.finishNode(node2, "ImportSpecifier");
+};
+pp$8.parseImportDefaultSpecifier = function() {
+  var node2 = this.startNode();
+  node2.local = this.parseIdent();
+  this.checkLValSimple(node2.local, BIND_LEXICAL);
+  return this.finishNode(node2, "ImportDefaultSpecifier");
+};
+pp$8.parseImportNamespaceSpecifier = function() {
+  var node2 = this.startNode();
+  this.next();
+  this.expectContextual("as");
+  node2.local = this.parseIdent();
+  this.checkLValSimple(node2.local, BIND_LEXICAL);
+  return this.finishNode(node2, "ImportNamespaceSpecifier");
+};
+pp$8.parseImportSpecifiers = function() {
+  var nodes = [], first = true;
+  if (this.type === types$1.name) {
+    nodes.push(this.parseImportDefaultSpecifier());
+    if (!this.eat(types$1.comma)) {
+      return nodes;
+    }
+  }
+  if (this.type === types$1.star) {
+    nodes.push(this.parseImportNamespaceSpecifier());
+    return nodes;
+  }
+  this.expect(types$1.braceL);
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    nodes.push(this.parseImportSpecifier());
+  }
+  return nodes;
+};
+pp$8.parseModuleExportName = function() {
+  if (this.options.ecmaVersion >= 13 && this.type === types$1.string) {
+    var stringLiteral = this.parseLiteral(this.value);
+    if (loneSurrogate.test(stringLiteral.value)) {
+      this.raise(stringLiteral.start, "An export name cannot include a lone surrogate.");
+    }
+    return stringLiteral;
+  }
+  return this.parseIdent(true);
+};
+pp$8.adaptDirectivePrologue = function(statements) {
+  for (var i = 0; i < statements.length && this.isDirectiveCandidate(statements[i]); ++i) {
+    statements[i].directive = statements[i].expression.raw.slice(1, -1);
+  }
+};
+pp$8.isDirectiveCandidate = function(statement) {
+  return this.options.ecmaVersion >= 5 && statement.type === "ExpressionStatement" && statement.expression.type === "Literal" && typeof statement.expression.value === "string" && // Reject parenthesized strings.
+  (this.input[statement.start] === '"' || this.input[statement.start] === "'");
+};
+var pp$7 = Parser.prototype;
+pp$7.toAssignable = function(node2, isBinding, refDestructuringErrors) {
+  if (this.options.ecmaVersion >= 6 && node2) {
+    switch (node2.type) {
+      case "Identifier":
+        if (this.inAsync && node2.name === "await") {
+          this.raise(node2.start, "Cannot use 'await' as identifier inside an async function");
+        }
+        break;
+      case "ObjectPattern":
+      case "ArrayPattern":
+      case "AssignmentPattern":
+      case "RestElement":
+        break;
+      case "ObjectExpression":
+        node2.type = "ObjectPattern";
+        if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        for (var i = 0, list3 = node2.properties; i < list3.length; i += 1) {
+          var prop = list3[i];
+          this.toAssignable(prop, isBinding);
+          if (prop.type === "RestElement" && (prop.argument.type === "ArrayPattern" || prop.argument.type === "ObjectPattern")) {
+            this.raise(prop.argument.start, "Unexpected token");
+          }
+        }
+        break;
+      case "Property":
+        if (node2.kind !== "init") {
+          this.raise(node2.key.start, "Object pattern can't contain getter or setter");
+        }
+        this.toAssignable(node2.value, isBinding);
+        break;
+      case "ArrayExpression":
+        node2.type = "ArrayPattern";
+        if (refDestructuringErrors) {
+          this.checkPatternErrors(refDestructuringErrors, true);
+        }
+        this.toAssignableList(node2.elements, isBinding);
+        break;
+      case "SpreadElement":
+        node2.type = "RestElement";
+        this.toAssignable(node2.argument, isBinding);
+        if (node2.argument.type === "AssignmentPattern") {
+          this.raise(node2.argument.start, "Rest elements cannot have a default value");
+        }
+        break;
+      case "AssignmentExpression":
+        if (node2.operator !== "=") {
+          this.raise(node2.left.end, "Only '=' operator can be used for specifying default value.");
+        }
+        node2.type = "AssignmentPattern";
+        delete node2.operator;
+        this.toAssignable(node2.left, isBinding);
+        break;
+      case "ParenthesizedExpression":
+        this.toAssignable(node2.expression, isBinding, refDestructuringErrors);
+        break;
+      case "ChainExpression":
+        this.raiseRecoverable(node2.start, "Optional chaining cannot appear in left-hand side");
+        break;
+      case "MemberExpression":
+        if (!isBinding) {
+          break;
+        }
+      default:
+        this.raise(node2.start, "Assigning to rvalue");
+    }
+  } else if (refDestructuringErrors) {
+    this.checkPatternErrors(refDestructuringErrors, true);
+  }
+  return node2;
+};
+pp$7.toAssignableList = function(exprList, isBinding) {
+  var end = exprList.length;
+  for (var i = 0; i < end; i++) {
+    var elt = exprList[i];
+    if (elt) {
+      this.toAssignable(elt, isBinding);
+    }
+  }
+  if (end) {
+    var last = exprList[end - 1];
+    if (this.options.ecmaVersion === 6 && isBinding && last && last.type === "RestElement" && last.argument.type !== "Identifier") {
+      this.unexpected(last.argument.start);
+    }
+  }
+  return exprList;
+};
+pp$7.parseSpread = function(refDestructuringErrors) {
+  var node2 = this.startNode();
+  this.next();
+  node2.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+  return this.finishNode(node2, "SpreadElement");
+};
+pp$7.parseRestBinding = function() {
+  var node2 = this.startNode();
+  this.next();
+  if (this.options.ecmaVersion === 6 && this.type !== types$1.name) {
+    this.unexpected();
+  }
+  node2.argument = this.parseBindingAtom();
+  return this.finishNode(node2, "RestElement");
+};
+pp$7.parseBindingAtom = function() {
+  if (this.options.ecmaVersion >= 6) {
+    switch (this.type) {
+      case types$1.bracketL:
+        var node2 = this.startNode();
+        this.next();
+        node2.elements = this.parseBindingList(types$1.bracketR, true, true);
+        return this.finishNode(node2, "ArrayPattern");
+      case types$1.braceL:
+        return this.parseObj(true);
+    }
+  }
+  return this.parseIdent();
+};
+pp$7.parseBindingList = function(close, allowEmpty, allowTrailingComma, allowModifiers) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (first) {
+      first = false;
+    } else {
+      this.expect(types$1.comma);
+    }
+    if (allowEmpty && this.type === types$1.comma) {
+      elts.push(null);
+    } else if (allowTrailingComma && this.afterTrailingComma(close)) {
+      break;
+    } else if (this.type === types$1.ellipsis) {
+      var rest = this.parseRestBinding();
+      this.parseBindingListItem(rest);
+      elts.push(rest);
+      if (this.type === types$1.comma) {
+        this.raiseRecoverable(this.start, "Comma is not permitted after the rest element");
+      }
+      this.expect(close);
+      break;
+    } else {
+      elts.push(this.parseAssignableListItem(allowModifiers));
+    }
+  }
+  return elts;
+};
+pp$7.parseAssignableListItem = function(allowModifiers) {
+  var elem = this.parseMaybeDefault(this.start, this.startLoc);
+  this.parseBindingListItem(elem);
+  return elem;
+};
+pp$7.parseBindingListItem = function(param) {
+  return param;
+};
+pp$7.parseMaybeDefault = function(startPos, startLoc, left) {
+  left = left || this.parseBindingAtom();
+  if (this.options.ecmaVersion < 6 || !this.eat(types$1.eq)) {
+    return left;
+  }
+  var node2 = this.startNodeAt(startPos, startLoc);
+  node2.left = left;
+  node2.right = this.parseMaybeAssign();
+  return this.finishNode(node2, "AssignmentPattern");
+};
+pp$7.checkLValSimple = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0) bindingType = BIND_NONE;
+  var isBind = bindingType !== BIND_NONE;
+  switch (expr.type) {
+    case "Identifier":
+      if (this.strict && this.reservedWordsStrictBind.test(expr.name)) {
+        this.raiseRecoverable(expr.start, (isBind ? "Binding " : "Assigning to ") + expr.name + " in strict mode");
+      }
+      if (isBind) {
+        if (bindingType === BIND_LEXICAL && expr.name === "let") {
+          this.raiseRecoverable(expr.start, "let is disallowed as a lexically bound name");
+        }
+        if (checkClashes) {
+          if (hasOwn(checkClashes, expr.name)) {
+            this.raiseRecoverable(expr.start, "Argument name clash");
+          }
+          checkClashes[expr.name] = true;
+        }
+        if (bindingType !== BIND_OUTSIDE) {
+          this.declareName(expr.name, bindingType, expr.start);
+        }
+      }
+      break;
+    case "ChainExpression":
+      this.raiseRecoverable(expr.start, "Optional chaining cannot appear in left-hand side");
+      break;
+    case "MemberExpression":
+      if (isBind) {
+        this.raiseRecoverable(expr.start, "Binding member expression");
+      }
+      break;
+    case "ParenthesizedExpression":
+      if (isBind) {
+        this.raiseRecoverable(expr.start, "Binding parenthesized expression");
+      }
+      return this.checkLValSimple(expr.expression, bindingType, checkClashes);
+    default:
+      this.raise(expr.start, (isBind ? "Binding" : "Assigning to") + " rvalue");
+  }
+};
+pp$7.checkLValPattern = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0) bindingType = BIND_NONE;
+  switch (expr.type) {
+    case "ObjectPattern":
+      for (var i = 0, list3 = expr.properties; i < list3.length; i += 1) {
+        var prop = list3[i];
+        this.checkLValInnerPattern(prop, bindingType, checkClashes);
+      }
+      break;
+    case "ArrayPattern":
+      for (var i$1 = 0, list$1 = expr.elements; i$1 < list$1.length; i$1 += 1) {
+        var elem = list$1[i$1];
+        if (elem) {
+          this.checkLValInnerPattern(elem, bindingType, checkClashes);
+        }
+      }
+      break;
+    default:
+      this.checkLValSimple(expr, bindingType, checkClashes);
+  }
+};
+pp$7.checkLValInnerPattern = function(expr, bindingType, checkClashes) {
+  if (bindingType === void 0) bindingType = BIND_NONE;
+  switch (expr.type) {
+    case "Property":
+      this.checkLValInnerPattern(expr.value, bindingType, checkClashes);
+      break;
+    case "AssignmentPattern":
+      this.checkLValPattern(expr.left, bindingType, checkClashes);
+      break;
+    case "RestElement":
+      this.checkLValPattern(expr.argument, bindingType, checkClashes);
+      break;
+    default:
+      this.checkLValPattern(expr, bindingType, checkClashes);
+  }
+};
+var TokContext = function TokContext2(token, isExpr, preserveSpace, override, generator) {
+  this.token = token;
+  this.isExpr = !!isExpr;
+  this.preserveSpace = !!preserveSpace;
+  this.override = override;
+  this.generator = !!generator;
+};
+var types = {
+  b_stat: new TokContext("{", false),
+  b_expr: new TokContext("{", true),
+  b_tmpl: new TokContext("${", false),
+  p_stat: new TokContext("(", false),
+  p_expr: new TokContext("(", true),
+  q_tmpl: new TokContext("`", true, true, function(p) {
+    return p.tryReadTemplateToken();
+  }),
+  f_stat: new TokContext("function", false),
+  f_expr: new TokContext("function", true),
+  f_expr_gen: new TokContext("function", true, false, null, true),
+  f_gen: new TokContext("function", false, false, null, true)
+};
+var pp$6 = Parser.prototype;
+pp$6.initialContext = function() {
+  return [types.b_stat];
+};
+pp$6.curContext = function() {
+  return this.context[this.context.length - 1];
+};
+pp$6.braceIsBlock = function(prevType) {
+  var parent = this.curContext();
+  if (parent === types.f_expr || parent === types.f_stat) {
+    return true;
+  }
+  if (prevType === types$1.colon && (parent === types.b_stat || parent === types.b_expr)) {
+    return !parent.isExpr;
+  }
+  if (prevType === types$1._return || prevType === types$1.name && this.exprAllowed) {
+    return lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+  }
+  if (prevType === types$1._else || prevType === types$1.semi || prevType === types$1.eof || prevType === types$1.parenR || prevType === types$1.arrow) {
+    return true;
+  }
+  if (prevType === types$1.braceL) {
+    return parent === types.b_stat;
+  }
+  if (prevType === types$1._var || prevType === types$1._const || prevType === types$1.name) {
+    return false;
+  }
+  return !this.exprAllowed;
+};
+pp$6.inGeneratorContext = function() {
+  for (var i = this.context.length - 1; i >= 1; i--) {
+    var context = this.context[i];
+    if (context.token === "function") {
+      return context.generator;
+    }
+  }
+  return false;
+};
+pp$6.updateContext = function(prevType) {
+  var update, type = this.type;
+  if (type.keyword && prevType === types$1.dot) {
+    this.exprAllowed = false;
+  } else if (update = type.updateContext) {
+    update.call(this, prevType);
+  } else {
+    this.exprAllowed = type.beforeExpr;
+  }
+};
+pp$6.overrideContext = function(tokenCtx) {
+  if (this.curContext() !== tokenCtx) {
+    this.context[this.context.length - 1] = tokenCtx;
+  }
+};
+types$1.parenR.updateContext = types$1.braceR.updateContext = function() {
+  if (this.context.length === 1) {
+    this.exprAllowed = true;
+    return;
+  }
+  var out = this.context.pop();
+  if (out === types.b_stat && this.curContext().token === "function") {
+    out = this.context.pop();
+  }
+  this.exprAllowed = !out.isExpr;
+};
+types$1.braceL.updateContext = function(prevType) {
+  this.context.push(this.braceIsBlock(prevType) ? types.b_stat : types.b_expr);
+  this.exprAllowed = true;
+};
+types$1.dollarBraceL.updateContext = function() {
+  this.context.push(types.b_tmpl);
+  this.exprAllowed = true;
+};
+types$1.parenL.updateContext = function(prevType) {
+  var statementParens = prevType === types$1._if || prevType === types$1._for || prevType === types$1._with || prevType === types$1._while;
+  this.context.push(statementParens ? types.p_stat : types.p_expr);
+  this.exprAllowed = true;
+};
+types$1.incDec.updateContext = function() {
+};
+types$1._function.updateContext = types$1._class.updateContext = function(prevType) {
+  if (prevType.beforeExpr && prevType !== types$1._else && !(prevType === types$1.semi && this.curContext() !== types.p_stat) && !(prevType === types$1._return && lineBreak.test(this.input.slice(this.lastTokEnd, this.start))) && !((prevType === types$1.colon || prevType === types$1.braceL) && this.curContext() === types.b_stat)) {
+    this.context.push(types.f_expr);
+  } else {
+    this.context.push(types.f_stat);
+  }
+  this.exprAllowed = false;
+};
+types$1.colon.updateContext = function() {
+  if (this.curContext().token === "function") {
+    this.context.pop();
+  }
+  this.exprAllowed = true;
+};
+types$1.backQuote.updateContext = function() {
+  if (this.curContext() === types.q_tmpl) {
+    this.context.pop();
+  } else {
+    this.context.push(types.q_tmpl);
+  }
+  this.exprAllowed = false;
+};
+types$1.star.updateContext = function(prevType) {
+  if (prevType === types$1._function) {
+    var index2 = this.context.length - 1;
+    if (this.context[index2] === types.f_expr) {
+      this.context[index2] = types.f_expr_gen;
+    } else {
+      this.context[index2] = types.f_gen;
+    }
+  }
+  this.exprAllowed = true;
+};
+types$1.name.updateContext = function(prevType) {
+  var allowed = false;
+  if (this.options.ecmaVersion >= 6 && prevType !== types$1.dot) {
+    if (this.value === "of" && !this.exprAllowed || this.value === "yield" && this.inGeneratorContext()) {
+      allowed = true;
+    }
+  }
+  this.exprAllowed = allowed;
+};
+var pp$5 = Parser.prototype;
+pp$5.checkPropClash = function(prop, propHash, refDestructuringErrors) {
+  if (this.options.ecmaVersion >= 9 && prop.type === "SpreadElement") {
+    return;
+  }
+  if (this.options.ecmaVersion >= 6 && (prop.computed || prop.method || prop.shorthand)) {
+    return;
+  }
+  var key = prop.key;
+  var name2;
+  switch (key.type) {
+    case "Identifier":
+      name2 = key.name;
+      break;
+    case "Literal":
+      name2 = String(key.value);
+      break;
+    default:
+      return;
+  }
+  var kind = prop.kind;
+  if (this.options.ecmaVersion >= 6) {
+    if (name2 === "__proto__" && kind === "init") {
+      if (propHash.proto) {
+        if (refDestructuringErrors) {
+          if (refDestructuringErrors.doubleProto < 0) {
+            refDestructuringErrors.doubleProto = key.start;
+          }
+        } else {
+          this.raiseRecoverable(key.start, "Redefinition of __proto__ property");
+        }
+      }
+      propHash.proto = true;
+    }
+    return;
+  }
+  name2 = "$" + name2;
+  var other = propHash[name2];
+  if (other) {
+    var redefinition;
+    if (kind === "init") {
+      redefinition = this.strict && other.init || other.get || other.set;
+    } else {
+      redefinition = other.init || other[kind];
+    }
+    if (redefinition) {
+      this.raiseRecoverable(key.start, "Redefinition of property");
+    }
+  } else {
+    other = propHash[name2] = {
+      init: false,
+      get: false,
+      set: false
+    };
+  }
+  other[kind] = true;
+};
+pp$5.parseExpression = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseMaybeAssign(forInit, refDestructuringErrors);
+  if (this.type === types$1.comma) {
+    var node2 = this.startNodeAt(startPos, startLoc);
+    node2.expressions = [expr];
+    while (this.eat(types$1.comma)) {
+      node2.expressions.push(this.parseMaybeAssign(forInit, refDestructuringErrors));
+    }
+    return this.finishNode(node2, "SequenceExpression");
+  }
+  return expr;
+};
+pp$5.parseMaybeAssign = function(forInit, refDestructuringErrors, afterLeftParse) {
+  if (this.isContextual("yield")) {
+    if (this.inGenerator) {
+      return this.parseYield(forInit);
+    } else {
+      this.exprAllowed = false;
+    }
+  }
+  var ownDestructuringErrors = false, oldParenAssign = -1, oldTrailingComma = -1, oldDoubleProto = -1;
+  if (refDestructuringErrors) {
+    oldParenAssign = refDestructuringErrors.parenthesizedAssign;
+    oldTrailingComma = refDestructuringErrors.trailingComma;
+    oldDoubleProto = refDestructuringErrors.doubleProto;
+    refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = -1;
+  } else {
+    refDestructuringErrors = new DestructuringErrors();
+    ownDestructuringErrors = true;
+  }
+  var startPos = this.start, startLoc = this.startLoc;
+  if (this.type === types$1.parenL || this.type === types$1.name) {
+    this.potentialArrowAt = this.start;
+    this.potentialArrowInForAwait = forInit === "await";
+  }
+  var left = this.parseMaybeConditional(forInit, refDestructuringErrors);
+  if (afterLeftParse) {
+    left = afterLeftParse.call(this, left, startPos, startLoc);
+  }
+  if (this.type.isAssign) {
+    var node2 = this.startNodeAt(startPos, startLoc);
+    node2.operator = this.value;
+    if (this.type === types$1.eq) {
+      left = this.toAssignable(left, false, refDestructuringErrors);
+    }
+    if (!ownDestructuringErrors) {
+      refDestructuringErrors.parenthesizedAssign = refDestructuringErrors.trailingComma = refDestructuringErrors.doubleProto = -1;
+    }
+    if (refDestructuringErrors.shorthandAssign >= left.start) {
+      refDestructuringErrors.shorthandAssign = -1;
+    }
+    if (this.type === types$1.eq) {
+      this.checkLValPattern(left);
+    } else {
+      this.checkLValSimple(left);
+    }
+    node2.left = left;
+    this.next();
+    node2.right = this.parseMaybeAssign(forInit);
+    if (oldDoubleProto > -1) {
+      refDestructuringErrors.doubleProto = oldDoubleProto;
+    }
+    return this.finishNode(node2, "AssignmentExpression");
+  } else {
+    if (ownDestructuringErrors) {
+      this.checkExpressionErrors(refDestructuringErrors, true);
+    }
+  }
+  if (oldParenAssign > -1) {
+    refDestructuringErrors.parenthesizedAssign = oldParenAssign;
+  }
+  if (oldTrailingComma > -1) {
+    refDestructuringErrors.trailingComma = oldTrailingComma;
+  }
+  return left;
+};
+pp$5.parseMaybeConditional = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseExprOps(forInit, refDestructuringErrors);
+  if (this.checkExpressionErrors(refDestructuringErrors)) {
+    return expr;
+  }
+  if (this.eat(types$1.question)) {
+    var node2 = this.startNodeAt(startPos, startLoc);
+    node2.test = expr;
+    node2.consequent = this.parseMaybeAssign();
+    this.expect(types$1.colon);
+    node2.alternate = this.parseMaybeAssign(forInit);
+    return this.finishNode(node2, "ConditionalExpression");
+  }
+  return expr;
+};
+pp$5.parseExprOps = function(forInit, refDestructuringErrors) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseMaybeUnary(refDestructuringErrors, false, false, forInit);
+  if (this.checkExpressionErrors(refDestructuringErrors)) {
+    return expr;
+  }
+  return expr.start === startPos && expr.type === "ArrowFunctionExpression" ? expr : this.parseExprOp(expr, startPos, startLoc, -1, forInit);
+};
+pp$5.parseExprOp = function(left, leftStartPos, leftStartLoc, minPrec, forInit) {
+  var prec = this.type.binop;
+  if (prec != null && (!forInit || this.type !== types$1._in)) {
+    if (prec > minPrec) {
+      var logical = this.type === types$1.logicalOR || this.type === types$1.logicalAND;
+      var coalesce = this.type === types$1.coalesce;
+      if (coalesce) {
+        prec = types$1.logicalAND.binop;
+      }
+      var op = this.value;
+      this.next();
+      var startPos = this.start, startLoc = this.startLoc;
+      var right = this.parseExprOp(this.parseMaybeUnary(null, false, false, forInit), startPos, startLoc, prec, forInit);
+      var node2 = this.buildBinary(leftStartPos, leftStartLoc, left, right, op, logical || coalesce);
+      if (logical && this.type === types$1.coalesce || coalesce && (this.type === types$1.logicalOR || this.type === types$1.logicalAND)) {
+        this.raiseRecoverable(this.start, "Logical expressions and coalesce expressions cannot be mixed. Wrap either by parentheses");
+      }
+      return this.parseExprOp(node2, leftStartPos, leftStartLoc, minPrec, forInit);
+    }
+  }
+  return left;
+};
+pp$5.buildBinary = function(startPos, startLoc, left, right, op, logical) {
+  if (right.type === "PrivateIdentifier") {
+    this.raise(right.start, "Private identifier can only be left side of binary expression");
+  }
+  var node2 = this.startNodeAt(startPos, startLoc);
+  node2.left = left;
+  node2.operator = op;
+  node2.right = right;
+  return this.finishNode(node2, logical ? "LogicalExpression" : "BinaryExpression");
+};
+pp$5.parseMaybeUnary = function(refDestructuringErrors, sawUnary, incDec, forInit) {
+  var startPos = this.start, startLoc = this.startLoc, expr;
+  if (this.isContextual("await") && this.canAwait) {
+    expr = this.parseAwait(forInit);
+    sawUnary = true;
+  } else if (this.type.prefix) {
+    var node2 = this.startNode(), update = this.type === types$1.incDec;
+    node2.operator = this.value;
+    node2.prefix = true;
+    this.next();
+    node2.argument = this.parseMaybeUnary(null, true, update, forInit);
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    if (update) {
+      this.checkLValSimple(node2.argument);
+    } else if (this.strict && node2.operator === "delete" && isLocalVariableAccess(node2.argument)) {
+      this.raiseRecoverable(node2.start, "Deleting local variable in strict mode");
+    } else if (node2.operator === "delete" && isPrivateFieldAccess(node2.argument)) {
+      this.raiseRecoverable(node2.start, "Private fields can not be deleted");
+    } else {
+      sawUnary = true;
+    }
+    expr = this.finishNode(node2, update ? "UpdateExpression" : "UnaryExpression");
+  } else if (!sawUnary && this.type === types$1.privateId) {
+    if ((forInit || this.privateNameStack.length === 0) && this.options.checkPrivateFields) {
+      this.unexpected();
+    }
+    expr = this.parsePrivateIdent();
+    if (this.type !== types$1._in) {
+      this.unexpected();
+    }
+  } else {
+    expr = this.parseExprSubscripts(refDestructuringErrors, forInit);
+    if (this.checkExpressionErrors(refDestructuringErrors)) {
+      return expr;
+    }
+    while (this.type.postfix && !this.canInsertSemicolon()) {
+      var node$1 = this.startNodeAt(startPos, startLoc);
+      node$1.operator = this.value;
+      node$1.prefix = false;
+      node$1.argument = expr;
+      this.checkLValSimple(expr);
+      this.next();
+      expr = this.finishNode(node$1, "UpdateExpression");
+    }
+  }
+  if (!incDec && this.eat(types$1.starstar)) {
+    if (sawUnary) {
+      this.unexpected(this.lastTokStart);
+    } else {
+      return this.buildBinary(startPos, startLoc, expr, this.parseMaybeUnary(null, false, false, forInit), "**", false);
+    }
+  } else {
+    return expr;
+  }
+};
+function isLocalVariableAccess(node2) {
+  return node2.type === "Identifier" || node2.type === "ParenthesizedExpression" && isLocalVariableAccess(node2.expression);
+}
+function isPrivateFieldAccess(node2) {
+  return node2.type === "MemberExpression" && node2.property.type === "PrivateIdentifier" || node2.type === "ChainExpression" && isPrivateFieldAccess(node2.expression) || node2.type === "ParenthesizedExpression" && isPrivateFieldAccess(node2.expression);
+}
+pp$5.parseExprSubscripts = function(refDestructuringErrors, forInit) {
+  var startPos = this.start, startLoc = this.startLoc;
+  var expr = this.parseExprAtom(refDestructuringErrors, forInit);
+  if (expr.type === "ArrowFunctionExpression" && this.input.slice(this.lastTokStart, this.lastTokEnd) !== ")") {
+    return expr;
+  }
+  var result = this.parseSubscripts(expr, startPos, startLoc, false, forInit);
+  if (refDestructuringErrors && result.type === "MemberExpression") {
+    if (refDestructuringErrors.parenthesizedAssign >= result.start) {
+      refDestructuringErrors.parenthesizedAssign = -1;
+    }
+    if (refDestructuringErrors.parenthesizedBind >= result.start) {
+      refDestructuringErrors.parenthesizedBind = -1;
+    }
+    if (refDestructuringErrors.trailingComma >= result.start) {
+      refDestructuringErrors.trailingComma = -1;
+    }
+  }
+  return result;
+};
+pp$5.parseSubscripts = function(base, startPos, startLoc, noCalls, forInit) {
+  var maybeAsyncArrow = this.options.ecmaVersion >= 8 && base.type === "Identifier" && base.name === "async" && this.lastTokEnd === base.end && !this.canInsertSemicolon() && base.end - base.start === 5 && this.potentialArrowAt === base.start;
+  var optionalChained = false;
+  while (true) {
+    var element2 = this.parseSubscript(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit);
+    if (element2.optional) {
+      optionalChained = true;
+    }
+    if (element2 === base || element2.type === "ArrowFunctionExpression") {
+      if (optionalChained) {
+        var chainNode = this.startNodeAt(startPos, startLoc);
+        chainNode.expression = element2;
+        element2 = this.finishNode(chainNode, "ChainExpression");
+      }
+      return element2;
+    }
+    base = element2;
+  }
+};
+pp$5.shouldParseAsyncArrow = function() {
+  return !this.canInsertSemicolon() && this.eat(types$1.arrow);
+};
+pp$5.parseSubscriptAsyncArrow = function(startPos, startLoc, exprList, forInit) {
+  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, true, forInit);
+};
+pp$5.parseSubscript = function(base, startPos, startLoc, noCalls, maybeAsyncArrow, optionalChained, forInit) {
+  var optionalSupported = this.options.ecmaVersion >= 11;
+  var optional = optionalSupported && this.eat(types$1.questionDot);
+  if (noCalls && optional) {
+    this.raise(this.lastTokStart, "Optional chaining cannot appear in the callee of new expressions");
+  }
+  var computed = this.eat(types$1.bracketL);
+  if (computed || optional && this.type !== types$1.parenL && this.type !== types$1.backQuote || this.eat(types$1.dot)) {
+    var node2 = this.startNodeAt(startPos, startLoc);
+    node2.object = base;
+    if (computed) {
+      node2.property = this.parseExpression();
+      this.expect(types$1.bracketR);
+    } else if (this.type === types$1.privateId && base.type !== "Super") {
+      node2.property = this.parsePrivateIdent();
+    } else {
+      node2.property = this.parseIdent(this.options.allowReserved !== "never");
+    }
+    node2.computed = !!computed;
+    if (optionalSupported) {
+      node2.optional = optional;
+    }
+    base = this.finishNode(node2, "MemberExpression");
+  } else if (!noCalls && this.eat(types$1.parenL)) {
+    var refDestructuringErrors = new DestructuringErrors(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+    this.yieldPos = 0;
+    this.awaitPos = 0;
+    this.awaitIdentPos = 0;
+    var exprList = this.parseExprList(types$1.parenR, this.options.ecmaVersion >= 8, false, refDestructuringErrors);
+    if (maybeAsyncArrow && !optional && this.shouldParseAsyncArrow()) {
+      this.checkPatternErrors(refDestructuringErrors, false);
+      this.checkYieldAwaitInDefaultParams();
+      if (this.awaitIdentPos > 0) {
+        this.raise(this.awaitIdentPos, "Cannot use 'await' as identifier inside an async function");
+      }
+      this.yieldPos = oldYieldPos;
+      this.awaitPos = oldAwaitPos;
+      this.awaitIdentPos = oldAwaitIdentPos;
+      return this.parseSubscriptAsyncArrow(startPos, startLoc, exprList, forInit);
+    }
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    this.yieldPos = oldYieldPos || this.yieldPos;
+    this.awaitPos = oldAwaitPos || this.awaitPos;
+    this.awaitIdentPos = oldAwaitIdentPos || this.awaitIdentPos;
+    var node$1 = this.startNodeAt(startPos, startLoc);
+    node$1.callee = base;
+    node$1.arguments = exprList;
+    if (optionalSupported) {
+      node$1.optional = optional;
+    }
+    base = this.finishNode(node$1, "CallExpression");
+  } else if (this.type === types$1.backQuote) {
+    if (optional || optionalChained) {
+      this.raise(this.start, "Optional chaining cannot appear in the tag of tagged template expressions");
+    }
+    var node$2 = this.startNodeAt(startPos, startLoc);
+    node$2.tag = base;
+    node$2.quasi = this.parseTemplate({ isTagged: true });
+    base = this.finishNode(node$2, "TaggedTemplateExpression");
+  }
+  return base;
+};
+pp$5.parseExprAtom = function(refDestructuringErrors, forInit, forNew) {
+  if (this.type === types$1.slash) {
+    this.readRegexp();
+  }
+  var node2, canBeArrow = this.potentialArrowAt === this.start;
+  switch (this.type) {
+    case types$1._super:
+      if (!this.allowSuper) {
+        this.raise(this.start, "'super' keyword outside a method");
+      }
+      node2 = this.startNode();
+      this.next();
+      if (this.type === types$1.parenL && !this.allowDirectSuper) {
+        this.raise(node2.start, "super() call outside constructor of a subclass");
+      }
+      if (this.type !== types$1.dot && this.type !== types$1.bracketL && this.type !== types$1.parenL) {
+        this.unexpected();
+      }
+      return this.finishNode(node2, "Super");
+    case types$1._this:
+      node2 = this.startNode();
+      this.next();
+      return this.finishNode(node2, "ThisExpression");
+    case types$1.name:
+      var startPos = this.start, startLoc = this.startLoc, containsEsc = this.containsEsc;
+      var id = this.parseIdent(false);
+      if (this.options.ecmaVersion >= 8 && !containsEsc && id.name === "async" && !this.canInsertSemicolon() && this.eat(types$1._function)) {
+        this.overrideContext(types.f_expr);
+        return this.parseFunction(this.startNodeAt(startPos, startLoc), 0, false, true, forInit);
+      }
+      if (canBeArrow && !this.canInsertSemicolon()) {
+        if (this.eat(types$1.arrow)) {
+          return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], false, forInit);
+        }
+        if (this.options.ecmaVersion >= 8 && id.name === "async" && this.type === types$1.name && !containsEsc && (!this.potentialArrowInForAwait || this.value !== "of" || this.containsEsc)) {
+          id = this.parseIdent(false);
+          if (this.canInsertSemicolon() || !this.eat(types$1.arrow)) {
+            this.unexpected();
+          }
+          return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), [id], true, forInit);
+        }
+      }
+      return id;
+    case types$1.regexp:
+      var value = this.value;
+      node2 = this.parseLiteral(value.value);
+      node2.regex = { pattern: value.pattern, flags: value.flags };
+      return node2;
+    case types$1.num:
+    case types$1.string:
+      return this.parseLiteral(this.value);
+    case types$1._null:
+    case types$1._true:
+    case types$1._false:
+      node2 = this.startNode();
+      node2.value = this.type === types$1._null ? null : this.type === types$1._true;
+      node2.raw = this.type.keyword;
+      this.next();
+      return this.finishNode(node2, "Literal");
+    case types$1.parenL:
+      var start2 = this.start, expr = this.parseParenAndDistinguishExpression(canBeArrow, forInit);
+      if (refDestructuringErrors) {
+        if (refDestructuringErrors.parenthesizedAssign < 0 && !this.isSimpleAssignTarget(expr)) {
+          refDestructuringErrors.parenthesizedAssign = start2;
+        }
+        if (refDestructuringErrors.parenthesizedBind < 0) {
+          refDestructuringErrors.parenthesizedBind = start2;
+        }
+      }
+      return expr;
+    case types$1.bracketL:
+      node2 = this.startNode();
+      this.next();
+      node2.elements = this.parseExprList(types$1.bracketR, true, true, refDestructuringErrors);
+      return this.finishNode(node2, "ArrayExpression");
+    case types$1.braceL:
+      this.overrideContext(types.b_expr);
+      return this.parseObj(false, refDestructuringErrors);
+    case types$1._function:
+      node2 = this.startNode();
+      this.next();
+      return this.parseFunction(node2, 0);
+    case types$1._class:
+      return this.parseClass(this.startNode(), false);
+    case types$1._new:
+      return this.parseNew();
+    case types$1.backQuote:
+      return this.parseTemplate();
+    case types$1._import:
+      if (this.options.ecmaVersion >= 11) {
+        return this.parseExprImport(forNew);
+      } else {
+        return this.unexpected();
+      }
+    default:
+      return this.parseExprAtomDefault();
+  }
+};
+pp$5.parseExprAtomDefault = function() {
+  this.unexpected();
+};
+pp$5.parseExprImport = function(forNew) {
+  var node2 = this.startNode();
+  if (this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword import");
+  }
+  this.next();
+  if (this.type === types$1.parenL && !forNew) {
+    return this.parseDynamicImport(node2);
+  } else if (this.type === types$1.dot) {
+    var meta = this.startNodeAt(node2.start, node2.loc && node2.loc.start);
+    meta.name = "import";
+    node2.meta = this.finishNode(meta, "Identifier");
+    return this.parseImportMeta(node2);
+  } else {
+    this.unexpected();
+  }
+};
+pp$5.parseDynamicImport = function(node2) {
+  this.next();
+  node2.source = this.parseMaybeAssign();
+  if (!this.eat(types$1.parenR)) {
+    var errorPos = this.start;
+    if (this.eat(types$1.comma) && this.eat(types$1.parenR)) {
+      this.raiseRecoverable(errorPos, "Trailing comma is not allowed in import()");
+    } else {
+      this.unexpected(errorPos);
+    }
+  }
+  return this.finishNode(node2, "ImportExpression");
+};
+pp$5.parseImportMeta = function(node2) {
+  this.next();
+  var containsEsc = this.containsEsc;
+  node2.property = this.parseIdent(true);
+  if (node2.property.name !== "meta") {
+    this.raiseRecoverable(node2.property.start, "The only valid meta property for import is 'import.meta'");
+  }
+  if (containsEsc) {
+    this.raiseRecoverable(node2.start, "'import.meta' must not contain escaped characters");
+  }
+  if (this.options.sourceType !== "module" && !this.options.allowImportExportEverywhere) {
+    this.raiseRecoverable(node2.start, "Cannot use 'import.meta' outside a module");
+  }
+  return this.finishNode(node2, "MetaProperty");
+};
+pp$5.parseLiteral = function(value) {
+  var node2 = this.startNode();
+  node2.value = value;
+  node2.raw = this.input.slice(this.start, this.end);
+  if (node2.raw.charCodeAt(node2.raw.length - 1) === 110) {
+    node2.bigint = node2.raw.slice(0, -1).replace(/_/g, "");
+  }
+  this.next();
+  return this.finishNode(node2, "Literal");
+};
+pp$5.parseParenExpression = function() {
+  this.expect(types$1.parenL);
+  var val = this.parseExpression();
+  this.expect(types$1.parenR);
+  return val;
+};
+pp$5.shouldParseArrow = function(exprList) {
+  return !this.canInsertSemicolon();
+};
+pp$5.parseParenAndDistinguishExpression = function(canBeArrow, forInit) {
+  var startPos = this.start, startLoc = this.startLoc, val, allowTrailingComma = this.options.ecmaVersion >= 8;
+  if (this.options.ecmaVersion >= 6) {
+    this.next();
+    var innerStartPos = this.start, innerStartLoc = this.startLoc;
+    var exprList = [], first = true, lastIsComma = false;
+    var refDestructuringErrors = new DestructuringErrors(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, spreadStart;
+    this.yieldPos = 0;
+    this.awaitPos = 0;
+    while (this.type !== types$1.parenR) {
+      first ? first = false : this.expect(types$1.comma);
+      if (allowTrailingComma && this.afterTrailingComma(types$1.parenR, true)) {
+        lastIsComma = true;
+        break;
+      } else if (this.type === types$1.ellipsis) {
+        spreadStart = this.start;
+        exprList.push(this.parseParenItem(this.parseRestBinding()));
+        if (this.type === types$1.comma) {
+          this.raiseRecoverable(
+            this.start,
+            "Comma is not permitted after the rest element"
+          );
+        }
+        break;
+      } else {
+        exprList.push(this.parseMaybeAssign(false, refDestructuringErrors, this.parseParenItem));
+      }
+    }
+    var innerEndPos = this.lastTokEnd, innerEndLoc = this.lastTokEndLoc;
+    this.expect(types$1.parenR);
+    if (canBeArrow && this.shouldParseArrow(exprList) && this.eat(types$1.arrow)) {
+      this.checkPatternErrors(refDestructuringErrors, false);
+      this.checkYieldAwaitInDefaultParams();
+      this.yieldPos = oldYieldPos;
+      this.awaitPos = oldAwaitPos;
+      return this.parseParenArrowList(startPos, startLoc, exprList, forInit);
+    }
+    if (!exprList.length || lastIsComma) {
+      this.unexpected(this.lastTokStart);
+    }
+    if (spreadStart) {
+      this.unexpected(spreadStart);
+    }
+    this.checkExpressionErrors(refDestructuringErrors, true);
+    this.yieldPos = oldYieldPos || this.yieldPos;
+    this.awaitPos = oldAwaitPos || this.awaitPos;
+    if (exprList.length > 1) {
+      val = this.startNodeAt(innerStartPos, innerStartLoc);
+      val.expressions = exprList;
+      this.finishNodeAt(val, "SequenceExpression", innerEndPos, innerEndLoc);
+    } else {
+      val = exprList[0];
+    }
+  } else {
+    val = this.parseParenExpression();
+  }
+  if (this.options.preserveParens) {
+    var par = this.startNodeAt(startPos, startLoc);
+    par.expression = val;
+    return this.finishNode(par, "ParenthesizedExpression");
+  } else {
+    return val;
+  }
+};
+pp$5.parseParenItem = function(item) {
+  return item;
+};
+pp$5.parseParenArrowList = function(startPos, startLoc, exprList, forInit) {
+  return this.parseArrowExpression(this.startNodeAt(startPos, startLoc), exprList, false, forInit);
+};
+var empty = [];
+pp$5.parseNew = function() {
+  if (this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword new");
+  }
+  var node2 = this.startNode();
+  this.next();
+  if (this.options.ecmaVersion >= 6 && this.type === types$1.dot) {
+    var meta = this.startNodeAt(node2.start, node2.loc && node2.loc.start);
+    meta.name = "new";
+    node2.meta = this.finishNode(meta, "Identifier");
+    this.next();
+    var containsEsc = this.containsEsc;
+    node2.property = this.parseIdent(true);
+    if (node2.property.name !== "target") {
+      this.raiseRecoverable(node2.property.start, "The only valid meta property for new is 'new.target'");
+    }
+    if (containsEsc) {
+      this.raiseRecoverable(node2.start, "'new.target' must not contain escaped characters");
+    }
+    if (!this.allowNewDotTarget) {
+      this.raiseRecoverable(node2.start, "'new.target' can only be used in functions and class static block");
+    }
+    return this.finishNode(node2, "MetaProperty");
+  }
+  var startPos = this.start, startLoc = this.startLoc;
+  node2.callee = this.parseSubscripts(this.parseExprAtom(null, false, true), startPos, startLoc, true, false);
+  if (this.eat(types$1.parenL)) {
+    node2.arguments = this.parseExprList(types$1.parenR, this.options.ecmaVersion >= 8, false);
+  } else {
+    node2.arguments = empty;
+  }
+  return this.finishNode(node2, "NewExpression");
+};
+pp$5.parseTemplateElement = function(ref2) {
+  var isTagged = ref2.isTagged;
+  var elem = this.startNode();
+  if (this.type === types$1.invalidTemplate) {
+    if (!isTagged) {
+      this.raiseRecoverable(this.start, "Bad escape sequence in untagged template literal");
+    }
+    elem.value = {
+      raw: this.value.replace(/\r\n?/g, "\n"),
+      cooked: null
+    };
+  } else {
+    elem.value = {
+      raw: this.input.slice(this.start, this.end).replace(/\r\n?/g, "\n"),
+      cooked: this.value
+    };
+  }
+  this.next();
+  elem.tail = this.type === types$1.backQuote;
+  return this.finishNode(elem, "TemplateElement");
+};
+pp$5.parseTemplate = function(ref2) {
+  if (ref2 === void 0) ref2 = {};
+  var isTagged = ref2.isTagged;
+  if (isTagged === void 0) isTagged = false;
+  var node2 = this.startNode();
+  this.next();
+  node2.expressions = [];
+  var curElt = this.parseTemplateElement({ isTagged });
+  node2.quasis = [curElt];
+  while (!curElt.tail) {
+    if (this.type === types$1.eof) {
+      this.raise(this.pos, "Unterminated template literal");
+    }
+    this.expect(types$1.dollarBraceL);
+    node2.expressions.push(this.parseExpression());
+    this.expect(types$1.braceR);
+    node2.quasis.push(curElt = this.parseTemplateElement({ isTagged }));
+  }
+  this.next();
+  return this.finishNode(node2, "TemplateLiteral");
+};
+pp$5.isAsyncProp = function(prop) {
+  return !prop.computed && prop.key.type === "Identifier" && prop.key.name === "async" && (this.type === types$1.name || this.type === types$1.num || this.type === types$1.string || this.type === types$1.bracketL || this.type.keyword || this.options.ecmaVersion >= 9 && this.type === types$1.star) && !lineBreak.test(this.input.slice(this.lastTokEnd, this.start));
+};
+pp$5.parseObj = function(isPattern, refDestructuringErrors) {
+  var node2 = this.startNode(), first = true, propHash = {};
+  node2.properties = [];
+  this.next();
+  while (!this.eat(types$1.braceR)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (this.options.ecmaVersion >= 5 && this.afterTrailingComma(types$1.braceR)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var prop = this.parseProperty(isPattern, refDestructuringErrors);
+    if (!isPattern) {
+      this.checkPropClash(prop, propHash, refDestructuringErrors);
+    }
+    node2.properties.push(prop);
+  }
+  return this.finishNode(node2, isPattern ? "ObjectPattern" : "ObjectExpression");
+};
+pp$5.parseProperty = function(isPattern, refDestructuringErrors) {
+  var prop = this.startNode(), isGenerator, isAsync, startPos, startLoc;
+  if (this.options.ecmaVersion >= 9 && this.eat(types$1.ellipsis)) {
+    if (isPattern) {
+      prop.argument = this.parseIdent(false);
+      if (this.type === types$1.comma) {
+        this.raiseRecoverable(this.start, "Comma is not permitted after the rest element");
+      }
+      return this.finishNode(prop, "RestElement");
+    }
+    prop.argument = this.parseMaybeAssign(false, refDestructuringErrors);
+    if (this.type === types$1.comma && refDestructuringErrors && refDestructuringErrors.trailingComma < 0) {
+      refDestructuringErrors.trailingComma = this.start;
+    }
+    return this.finishNode(prop, "SpreadElement");
+  }
+  if (this.options.ecmaVersion >= 6) {
+    prop.method = false;
+    prop.shorthand = false;
+    if (isPattern || refDestructuringErrors) {
+      startPos = this.start;
+      startLoc = this.startLoc;
+    }
+    if (!isPattern) {
+      isGenerator = this.eat(types$1.star);
+    }
+  }
+  var containsEsc = this.containsEsc;
+  this.parsePropertyName(prop);
+  if (!isPattern && !containsEsc && this.options.ecmaVersion >= 8 && !isGenerator && this.isAsyncProp(prop)) {
+    isAsync = true;
+    isGenerator = this.options.ecmaVersion >= 9 && this.eat(types$1.star);
+    this.parsePropertyName(prop);
+  } else {
+    isAsync = false;
+  }
+  this.parsePropertyValue(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc);
+  return this.finishNode(prop, "Property");
+};
+pp$5.parseGetterSetter = function(prop) {
+  prop.kind = prop.key.name;
+  this.parsePropertyName(prop);
+  prop.value = this.parseMethod(false);
+  var paramCount = prop.kind === "get" ? 0 : 1;
+  if (prop.value.params.length !== paramCount) {
+    var start2 = prop.value.start;
+    if (prop.kind === "get") {
+      this.raiseRecoverable(start2, "getter should have no params");
+    } else {
+      this.raiseRecoverable(start2, "setter should have exactly one param");
+    }
+  } else {
+    if (prop.kind === "set" && prop.value.params[0].type === "RestElement") {
+      this.raiseRecoverable(prop.value.params[0].start, "Setter cannot use rest params");
+    }
+  }
+};
+pp$5.parsePropertyValue = function(prop, isPattern, isGenerator, isAsync, startPos, startLoc, refDestructuringErrors, containsEsc) {
+  if ((isGenerator || isAsync) && this.type === types$1.colon) {
+    this.unexpected();
+  }
+  if (this.eat(types$1.colon)) {
+    prop.value = isPattern ? this.parseMaybeDefault(this.start, this.startLoc) : this.parseMaybeAssign(false, refDestructuringErrors);
+    prop.kind = "init";
+  } else if (this.options.ecmaVersion >= 6 && this.type === types$1.parenL) {
+    if (isPattern) {
+      this.unexpected();
+    }
+    prop.kind = "init";
+    prop.method = true;
+    prop.value = this.parseMethod(isGenerator, isAsync);
+  } else if (!isPattern && !containsEsc && this.options.ecmaVersion >= 5 && !prop.computed && prop.key.type === "Identifier" && (prop.key.name === "get" || prop.key.name === "set") && (this.type !== types$1.comma && this.type !== types$1.braceR && this.type !== types$1.eq)) {
+    if (isGenerator || isAsync) {
+      this.unexpected();
+    }
+    this.parseGetterSetter(prop);
+  } else if (this.options.ecmaVersion >= 6 && !prop.computed && prop.key.type === "Identifier") {
+    if (isGenerator || isAsync) {
+      this.unexpected();
+    }
+    this.checkUnreserved(prop.key);
+    if (prop.key.name === "await" && !this.awaitIdentPos) {
+      this.awaitIdentPos = startPos;
+    }
+    prop.kind = "init";
+    if (isPattern) {
+      prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+    } else if (this.type === types$1.eq && refDestructuringErrors) {
+      if (refDestructuringErrors.shorthandAssign < 0) {
+        refDestructuringErrors.shorthandAssign = this.start;
+      }
+      prop.value = this.parseMaybeDefault(startPos, startLoc, this.copyNode(prop.key));
+    } else {
+      prop.value = this.copyNode(prop.key);
+    }
+    prop.shorthand = true;
+  } else {
+    this.unexpected();
+  }
+};
+pp$5.parsePropertyName = function(prop) {
+  if (this.options.ecmaVersion >= 6) {
+    if (this.eat(types$1.bracketL)) {
+      prop.computed = true;
+      prop.key = this.parseMaybeAssign();
+      this.expect(types$1.bracketR);
+      return prop.key;
+    } else {
+      prop.computed = false;
+    }
+  }
+  return prop.key = this.type === types$1.num || this.type === types$1.string ? this.parseExprAtom() : this.parseIdent(this.options.allowReserved !== "never");
+};
+pp$5.initFunction = function(node2) {
+  node2.id = null;
+  if (this.options.ecmaVersion >= 6) {
+    node2.generator = node2.expression = false;
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node2.async = false;
+  }
+};
+pp$5.parseMethod = function(isGenerator, isAsync, allowDirectSuper) {
+  var node2 = this.startNode(), oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.initFunction(node2);
+  if (this.options.ecmaVersion >= 6) {
+    node2.generator = isGenerator;
+  }
+  if (this.options.ecmaVersion >= 8) {
+    node2.async = !!isAsync;
+  }
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  this.enterScope(functionFlags(isAsync, node2.generator) | SCOPE_SUPER | (allowDirectSuper ? SCOPE_DIRECT_SUPER : 0));
+  this.expect(types$1.parenL);
+  node2.params = this.parseBindingList(types$1.parenR, false, this.options.ecmaVersion >= 8);
+  this.checkYieldAwaitInDefaultParams();
+  this.parseFunctionBody(node2, false, true, false);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node2, "FunctionExpression");
+};
+pp$5.parseArrowExpression = function(node2, params, isAsync, forInit) {
+  var oldYieldPos = this.yieldPos, oldAwaitPos = this.awaitPos, oldAwaitIdentPos = this.awaitIdentPos;
+  this.enterScope(functionFlags(isAsync, false) | SCOPE_ARROW);
+  this.initFunction(node2);
+  if (this.options.ecmaVersion >= 8) {
+    node2.async = !!isAsync;
+  }
+  this.yieldPos = 0;
+  this.awaitPos = 0;
+  this.awaitIdentPos = 0;
+  node2.params = this.toAssignableList(params, true);
+  this.parseFunctionBody(node2, true, false, forInit);
+  this.yieldPos = oldYieldPos;
+  this.awaitPos = oldAwaitPos;
+  this.awaitIdentPos = oldAwaitIdentPos;
+  return this.finishNode(node2, "ArrowFunctionExpression");
+};
+pp$5.parseFunctionBody = function(node2, isArrowFunction, isMethod, forInit) {
+  var isExpression = isArrowFunction && this.type !== types$1.braceL;
+  var oldStrict = this.strict, useStrict = false;
+  if (isExpression) {
+    node2.body = this.parseMaybeAssign(forInit);
+    node2.expression = true;
+    this.checkParams(node2, false);
+  } else {
+    var nonSimple = this.options.ecmaVersion >= 7 && !this.isSimpleParamList(node2.params);
+    if (!oldStrict || nonSimple) {
+      useStrict = this.strictDirective(this.end);
+      if (useStrict && nonSimple) {
+        this.raiseRecoverable(node2.start, "Illegal 'use strict' directive in function with non-simple parameter list");
+      }
+    }
+    var oldLabels = this.labels;
+    this.labels = [];
+    if (useStrict) {
+      this.strict = true;
+    }
+    this.checkParams(node2, !oldStrict && !useStrict && !isArrowFunction && !isMethod && this.isSimpleParamList(node2.params));
+    if (this.strict && node2.id) {
+      this.checkLValSimple(node2.id, BIND_OUTSIDE);
+    }
+    node2.body = this.parseBlock(false, void 0, useStrict && !oldStrict);
+    node2.expression = false;
+    this.adaptDirectivePrologue(node2.body.body);
+    this.labels = oldLabels;
+  }
+  this.exitScope();
+};
+pp$5.isSimpleParamList = function(params) {
+  for (var i = 0, list3 = params; i < list3.length; i += 1) {
+    var param = list3[i];
+    if (param.type !== "Identifier") {
+      return false;
+    }
+  }
+  return true;
+};
+pp$5.checkParams = function(node2, allowDuplicates) {
+  var nameHash = /* @__PURE__ */ Object.create(null);
+  for (var i = 0, list3 = node2.params; i < list3.length; i += 1) {
+    var param = list3[i];
+    this.checkLValInnerPattern(param, BIND_VAR, allowDuplicates ? null : nameHash);
+  }
+};
+pp$5.parseExprList = function(close, allowTrailingComma, allowEmpty, refDestructuringErrors) {
+  var elts = [], first = true;
+  while (!this.eat(close)) {
+    if (!first) {
+      this.expect(types$1.comma);
+      if (allowTrailingComma && this.afterTrailingComma(close)) {
+        break;
+      }
+    } else {
+      first = false;
+    }
+    var elt = void 0;
+    if (allowEmpty && this.type === types$1.comma) {
+      elt = null;
+    } else if (this.type === types$1.ellipsis) {
+      elt = this.parseSpread(refDestructuringErrors);
+      if (refDestructuringErrors && this.type === types$1.comma && refDestructuringErrors.trailingComma < 0) {
+        refDestructuringErrors.trailingComma = this.start;
+      }
+    } else {
+      elt = this.parseMaybeAssign(false, refDestructuringErrors);
+    }
+    elts.push(elt);
+  }
+  return elts;
+};
+pp$5.checkUnreserved = function(ref2) {
+  var start2 = ref2.start;
+  var end = ref2.end;
+  var name2 = ref2.name;
+  if (this.inGenerator && name2 === "yield") {
+    this.raiseRecoverable(start2, "Cannot use 'yield' as identifier inside a generator");
+  }
+  if (this.inAsync && name2 === "await") {
+    this.raiseRecoverable(start2, "Cannot use 'await' as identifier inside an async function");
+  }
+  if (this.currentThisScope().inClassFieldInit && name2 === "arguments") {
+    this.raiseRecoverable(start2, "Cannot use 'arguments' in class field initializer");
+  }
+  if (this.inClassStaticBlock && (name2 === "arguments" || name2 === "await")) {
+    this.raise(start2, "Cannot use " + name2 + " in class static initialization block");
+  }
+  if (this.keywords.test(name2)) {
+    this.raise(start2, "Unexpected keyword '" + name2 + "'");
+  }
+  if (this.options.ecmaVersion < 6 && this.input.slice(start2, end).indexOf("\\") !== -1) {
+    return;
+  }
+  var re2 = this.strict ? this.reservedWordsStrict : this.reservedWords;
+  if (re2.test(name2)) {
+    if (!this.inAsync && name2 === "await") {
+      this.raiseRecoverable(start2, "Cannot use keyword 'await' outside an async function");
+    }
+    this.raiseRecoverable(start2, "The keyword '" + name2 + "' is reserved");
+  }
+};
+pp$5.parseIdent = function(liberal) {
+  var node2 = this.parseIdentNode();
+  this.next(!!liberal);
+  this.finishNode(node2, "Identifier");
+  if (!liberal) {
+    this.checkUnreserved(node2);
+    if (node2.name === "await" && !this.awaitIdentPos) {
+      this.awaitIdentPos = node2.start;
+    }
+  }
+  return node2;
+};
+pp$5.parseIdentNode = function() {
+  var node2 = this.startNode();
+  if (this.type === types$1.name) {
+    node2.name = this.value;
+  } else if (this.type.keyword) {
+    node2.name = this.type.keyword;
+    if ((node2.name === "class" || node2.name === "function") && (this.lastTokEnd !== this.lastTokStart + 1 || this.input.charCodeAt(this.lastTokStart) !== 46)) {
+      this.context.pop();
+    }
+    this.type = types$1.name;
+  } else {
+    this.unexpected();
+  }
+  return node2;
+};
+pp$5.parsePrivateIdent = function() {
+  var node2 = this.startNode();
+  if (this.type === types$1.privateId) {
+    node2.name = this.value;
+  } else {
+    this.unexpected();
+  }
+  this.next();
+  this.finishNode(node2, "PrivateIdentifier");
+  if (this.options.checkPrivateFields) {
+    if (this.privateNameStack.length === 0) {
+      this.raise(node2.start, "Private field '#" + node2.name + "' must be declared in an enclosing class");
+    } else {
+      this.privateNameStack[this.privateNameStack.length - 1].used.push(node2);
+    }
+  }
+  return node2;
+};
+pp$5.parseYield = function(forInit) {
+  if (!this.yieldPos) {
+    this.yieldPos = this.start;
+  }
+  var node2 = this.startNode();
+  this.next();
+  if (this.type === types$1.semi || this.canInsertSemicolon() || this.type !== types$1.star && !this.type.startsExpr) {
+    node2.delegate = false;
+    node2.argument = null;
+  } else {
+    node2.delegate = this.eat(types$1.star);
+    node2.argument = this.parseMaybeAssign(forInit);
+  }
+  return this.finishNode(node2, "YieldExpression");
+};
+pp$5.parseAwait = function(forInit) {
+  if (!this.awaitPos) {
+    this.awaitPos = this.start;
+  }
+  var node2 = this.startNode();
+  this.next();
+  node2.argument = this.parseMaybeUnary(null, true, false, forInit);
+  return this.finishNode(node2, "AwaitExpression");
+};
+var pp$4 = Parser.prototype;
+pp$4.raise = function(pos, message) {
+  var loc = getLineInfo(this.input, pos);
+  message += " (" + loc.line + ":" + loc.column + ")";
+  var err = new SyntaxError(message);
+  err.pos = pos;
+  err.loc = loc;
+  err.raisedAt = this.pos;
+  throw err;
+};
+pp$4.raiseRecoverable = pp$4.raise;
+pp$4.curPosition = function() {
+  if (this.options.locations) {
+    return new Position(this.curLine, this.pos - this.lineStart);
+  }
+};
+var pp$3 = Parser.prototype;
+var Scope = function Scope2(flags) {
+  this.flags = flags;
+  this.var = [];
+  this.lexical = [];
+  this.functions = [];
+  this.inClassFieldInit = false;
+};
+pp$3.enterScope = function(flags) {
+  this.scopeStack.push(new Scope(flags));
+};
+pp$3.exitScope = function() {
+  this.scopeStack.pop();
+};
+pp$3.treatFunctionsAsVarInScope = function(scope) {
+  return scope.flags & SCOPE_FUNCTION || !this.inModule && scope.flags & SCOPE_TOP;
+};
+pp$3.declareName = function(name2, bindingType, pos) {
+  var redeclared = false;
+  if (bindingType === BIND_LEXICAL) {
+    var scope = this.currentScope();
+    redeclared = scope.lexical.indexOf(name2) > -1 || scope.functions.indexOf(name2) > -1 || scope.var.indexOf(name2) > -1;
+    scope.lexical.push(name2);
+    if (this.inModule && scope.flags & SCOPE_TOP) {
+      delete this.undefinedExports[name2];
+    }
+  } else if (bindingType === BIND_SIMPLE_CATCH) {
+    var scope$1 = this.currentScope();
+    scope$1.lexical.push(name2);
+  } else if (bindingType === BIND_FUNCTION) {
+    var scope$2 = this.currentScope();
+    if (this.treatFunctionsAsVar) {
+      redeclared = scope$2.lexical.indexOf(name2) > -1;
+    } else {
+      redeclared = scope$2.lexical.indexOf(name2) > -1 || scope$2.var.indexOf(name2) > -1;
+    }
+    scope$2.functions.push(name2);
+  } else {
+    for (var i = this.scopeStack.length - 1; i >= 0; --i) {
+      var scope$3 = this.scopeStack[i];
+      if (scope$3.lexical.indexOf(name2) > -1 && !(scope$3.flags & SCOPE_SIMPLE_CATCH && scope$3.lexical[0] === name2) || !this.treatFunctionsAsVarInScope(scope$3) && scope$3.functions.indexOf(name2) > -1) {
+        redeclared = true;
+        break;
+      }
+      scope$3.var.push(name2);
+      if (this.inModule && scope$3.flags & SCOPE_TOP) {
+        delete this.undefinedExports[name2];
+      }
+      if (scope$3.flags & SCOPE_VAR) {
+        break;
+      }
+    }
+  }
+  if (redeclared) {
+    this.raiseRecoverable(pos, "Identifier '" + name2 + "' has already been declared");
+  }
+};
+pp$3.checkLocalExport = function(id) {
+  if (this.scopeStack[0].lexical.indexOf(id.name) === -1 && this.scopeStack[0].var.indexOf(id.name) === -1) {
+    this.undefinedExports[id.name] = id;
+  }
+};
+pp$3.currentScope = function() {
+  return this.scopeStack[this.scopeStack.length - 1];
+};
+pp$3.currentVarScope = function() {
+  for (var i = this.scopeStack.length - 1; ; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.flags & SCOPE_VAR) {
+      return scope;
+    }
+  }
+};
+pp$3.currentThisScope = function() {
+  for (var i = this.scopeStack.length - 1; ; i--) {
+    var scope = this.scopeStack[i];
+    if (scope.flags & SCOPE_VAR && !(scope.flags & SCOPE_ARROW)) {
+      return scope;
+    }
+  }
+};
+var Node = function Node2(parser, pos, loc) {
+  this.type = "";
+  this.start = pos;
+  this.end = 0;
+  if (parser.options.locations) {
+    this.loc = new SourceLocation(parser, loc);
+  }
+  if (parser.options.directSourceFile) {
+    this.sourceFile = parser.options.directSourceFile;
+  }
+  if (parser.options.ranges) {
+    this.range = [pos, 0];
+  }
+};
+var pp$2 = Parser.prototype;
+pp$2.startNode = function() {
+  return new Node(this, this.start, this.startLoc);
+};
+pp$2.startNodeAt = function(pos, loc) {
+  return new Node(this, pos, loc);
+};
+function finishNodeAt(node2, type, pos, loc) {
+  node2.type = type;
+  node2.end = pos;
+  if (this.options.locations) {
+    node2.loc.end = loc;
+  }
+  if (this.options.ranges) {
+    node2.range[1] = pos;
+  }
+  return node2;
+}
+pp$2.finishNode = function(node2, type) {
+  return finishNodeAt.call(this, node2, type, this.lastTokEnd, this.lastTokEndLoc);
+};
+pp$2.finishNodeAt = function(node2, type, pos, loc) {
+  return finishNodeAt.call(this, node2, type, pos, loc);
+};
+pp$2.copyNode = function(node2) {
+  var newNode = new Node(this, node2.start, this.startLoc);
+  for (var prop in node2) {
+    newNode[prop] = node2[prop];
+  }
+  return newNode;
+};
+var ecma9BinaryProperties = "ASCII ASCII_Hex_Digit AHex Alphabetic Alpha Any Assigned Bidi_Control Bidi_C Bidi_Mirrored Bidi_M Case_Ignorable CI Cased Changes_When_Casefolded CWCF Changes_When_Casemapped CWCM Changes_When_Lowercased CWL Changes_When_NFKC_Casefolded CWKCF Changes_When_Titlecased CWT Changes_When_Uppercased CWU Dash Default_Ignorable_Code_Point DI Deprecated Dep Diacritic Dia Emoji Emoji_Component Emoji_Modifier Emoji_Modifier_Base Emoji_Presentation Extender Ext Grapheme_Base Gr_Base Grapheme_Extend Gr_Ext Hex_Digit Hex IDS_Binary_Operator IDSB IDS_Trinary_Operator IDST ID_Continue IDC ID_Start IDS Ideographic Ideo Join_Control Join_C Logical_Order_Exception LOE Lowercase Lower Math Noncharacter_Code_Point NChar Pattern_Syntax Pat_Syn Pattern_White_Space Pat_WS Quotation_Mark QMark Radical Regional_Indicator RI Sentence_Terminal STerm Soft_Dotted SD Terminal_Punctuation Term Unified_Ideograph UIdeo Uppercase Upper Variation_Selector VS White_Space space XID_Continue XIDC XID_Start XIDS";
+var ecma10BinaryProperties = ecma9BinaryProperties + " Extended_Pictographic";
+var ecma11BinaryProperties = ecma10BinaryProperties;
+var ecma12BinaryProperties = ecma11BinaryProperties + " EBase EComp EMod EPres ExtPict";
+var ecma13BinaryProperties = ecma12BinaryProperties;
+var ecma14BinaryProperties = ecma13BinaryProperties;
+var unicodeBinaryProperties = {
+  9: ecma9BinaryProperties,
+  10: ecma10BinaryProperties,
+  11: ecma11BinaryProperties,
+  12: ecma12BinaryProperties,
+  13: ecma13BinaryProperties,
+  14: ecma14BinaryProperties
+};
+var ecma14BinaryPropertiesOfStrings = "Basic_Emoji Emoji_Keycap_Sequence RGI_Emoji_Modifier_Sequence RGI_Emoji_Flag_Sequence RGI_Emoji_Tag_Sequence RGI_Emoji_ZWJ_Sequence RGI_Emoji";
+var unicodeBinaryPropertiesOfStrings = {
+  9: "",
+  10: "",
+  11: "",
+  12: "",
+  13: "",
+  14: ecma14BinaryPropertiesOfStrings
+};
+var unicodeGeneralCategoryValues = "Cased_Letter LC Close_Punctuation Pe Connector_Punctuation Pc Control Cc cntrl Currency_Symbol Sc Dash_Punctuation Pd Decimal_Number Nd digit Enclosing_Mark Me Final_Punctuation Pf Format Cf Initial_Punctuation Pi Letter L Letter_Number Nl Line_Separator Zl Lowercase_Letter Ll Mark M Combining_Mark Math_Symbol Sm Modifier_Letter Lm Modifier_Symbol Sk Nonspacing_Mark Mn Number N Open_Punctuation Ps Other C Other_Letter Lo Other_Number No Other_Punctuation Po Other_Symbol So Paragraph_Separator Zp Private_Use Co Punctuation P punct Separator Z Space_Separator Zs Spacing_Mark Mc Surrogate Cs Symbol S Titlecase_Letter Lt Unassigned Cn Uppercase_Letter Lu";
+var ecma9ScriptValues = "Adlam Adlm Ahom Anatolian_Hieroglyphs Hluw Arabic Arab Armenian Armn Avestan Avst Balinese Bali Bamum Bamu Bassa_Vah Bass Batak Batk Bengali Beng Bhaiksuki Bhks Bopomofo Bopo Brahmi Brah Braille Brai Buginese Bugi Buhid Buhd Canadian_Aboriginal Cans Carian Cari Caucasian_Albanian Aghb Chakma Cakm Cham Cham Cherokee Cher Common Zyyy Coptic Copt Qaac Cuneiform Xsux Cypriot Cprt Cyrillic Cyrl Deseret Dsrt Devanagari Deva Duployan Dupl Egyptian_Hieroglyphs Egyp Elbasan Elba Ethiopic Ethi Georgian Geor Glagolitic Glag Gothic Goth Grantha Gran Greek Grek Gujarati Gujr Gurmukhi Guru Han Hani Hangul Hang Hanunoo Hano Hatran Hatr Hebrew Hebr Hiragana Hira Imperial_Aramaic Armi Inherited Zinh Qaai Inscriptional_Pahlavi Phli Inscriptional_Parthian Prti Javanese Java Kaithi Kthi Kannada Knda Katakana Kana Kayah_Li Kali Kharoshthi Khar Khmer Khmr Khojki Khoj Khudawadi Sind Lao Laoo Latin Latn Lepcha Lepc Limbu Limb Linear_A Lina Linear_B Linb Lisu Lisu Lycian Lyci Lydian Lydi Mahajani Mahj Malayalam Mlym Mandaic Mand Manichaean Mani Marchen Marc Masaram_Gondi Gonm Meetei_Mayek Mtei Mende_Kikakui Mend Meroitic_Cursive Merc Meroitic_Hieroglyphs Mero Miao Plrd Modi Mongolian Mong Mro Mroo Multani Mult Myanmar Mymr Nabataean Nbat New_Tai_Lue Talu Newa Newa Nko Nkoo Nushu Nshu Ogham Ogam Ol_Chiki Olck Old_Hungarian Hung Old_Italic Ital Old_North_Arabian Narb Old_Permic Perm Old_Persian Xpeo Old_South_Arabian Sarb Old_Turkic Orkh Oriya Orya Osage Osge Osmanya Osma Pahawh_Hmong Hmng Palmyrene Palm Pau_Cin_Hau Pauc Phags_Pa Phag Phoenician Phnx Psalter_Pahlavi Phlp Rejang Rjng Runic Runr Samaritan Samr Saurashtra Saur Sharada Shrd Shavian Shaw Siddham Sidd SignWriting Sgnw Sinhala Sinh Sora_Sompeng Sora Soyombo Soyo Sundanese Sund Syloti_Nagri Sylo Syriac Syrc Tagalog Tglg Tagbanwa Tagb Tai_Le Tale Tai_Tham Lana Tai_Viet Tavt Takri Takr Tamil Taml Tangut Tang Telugu Telu Thaana Thaa Thai Thai Tibetan Tibt Tifinagh Tfng Tirhuta Tirh Ugaritic Ugar Vai Vaii Warang_Citi Wara Yi Yiii Zanabazar_Square Zanb";
+var ecma10ScriptValues = ecma9ScriptValues + " Dogra Dogr Gunjala_Gondi Gong Hanifi_Rohingya Rohg Makasar Maka Medefaidrin Medf Old_Sogdian Sogo Sogdian Sogd";
+var ecma11ScriptValues = ecma10ScriptValues + " Elymaic Elym Nandinagari Nand Nyiakeng_Puachue_Hmong Hmnp Wancho Wcho";
+var ecma12ScriptValues = ecma11ScriptValues + " Chorasmian Chrs Diak Dives_Akuru Khitan_Small_Script Kits Yezi Yezidi";
+var ecma13ScriptValues = ecma12ScriptValues + " Cypro_Minoan Cpmn Old_Uyghur Ougr Tangsa Tnsa Toto Vithkuqi Vith";
+var ecma14ScriptValues = ecma13ScriptValues + " Hrkt Katakana_Or_Hiragana Kawi Nag_Mundari Nagm Unknown Zzzz";
+var unicodeScriptValues = {
+  9: ecma9ScriptValues,
+  10: ecma10ScriptValues,
+  11: ecma11ScriptValues,
+  12: ecma12ScriptValues,
+  13: ecma13ScriptValues,
+  14: ecma14ScriptValues
+};
+var data = {};
+function buildUnicodeData(ecmaVersion) {
+  var d = data[ecmaVersion] = {
+    binary: wordsRegexp(unicodeBinaryProperties[ecmaVersion] + " " + unicodeGeneralCategoryValues),
+    binaryOfStrings: wordsRegexp(unicodeBinaryPropertiesOfStrings[ecmaVersion]),
+    nonBinary: {
+      General_Category: wordsRegexp(unicodeGeneralCategoryValues),
+      Script: wordsRegexp(unicodeScriptValues[ecmaVersion])
+    }
+  };
+  d.nonBinary.Script_Extensions = d.nonBinary.Script;
+  d.nonBinary.gc = d.nonBinary.General_Category;
+  d.nonBinary.sc = d.nonBinary.Script;
+  d.nonBinary.scx = d.nonBinary.Script_Extensions;
+}
+for (i = 0, list3 = [9, 10, 11, 12, 13, 14]; i < list3.length; i += 1) {
+  ecmaVersion = list3[i];
+  buildUnicodeData(ecmaVersion);
+}
+var ecmaVersion;
+var i;
+var list3;
+var pp$1 = Parser.prototype;
+var BranchID = function BranchID2(parent, base) {
+  this.parent = parent;
+  this.base = base || this;
+};
+BranchID.prototype.separatedFrom = function separatedFrom(alt) {
+  for (var self2 = this; self2; self2 = self2.parent) {
+    for (var other = alt; other; other = other.parent) {
+      if (self2.base === other.base && self2 !== other) {
+        return true;
+      }
+    }
+  }
+  return false;
+};
+BranchID.prototype.sibling = function sibling() {
+  return new BranchID(this.parent, this.base);
+};
+var RegExpValidationState = function RegExpValidationState2(parser) {
+  this.parser = parser;
+  this.validFlags = "gim" + (parser.options.ecmaVersion >= 6 ? "uy" : "") + (parser.options.ecmaVersion >= 9 ? "s" : "") + (parser.options.ecmaVersion >= 13 ? "d" : "") + (parser.options.ecmaVersion >= 15 ? "v" : "");
+  this.unicodeProperties = data[parser.options.ecmaVersion >= 14 ? 14 : parser.options.ecmaVersion];
+  this.source = "";
+  this.flags = "";
+  this.start = 0;
+  this.switchU = false;
+  this.switchV = false;
+  this.switchN = false;
+  this.pos = 0;
+  this.lastIntValue = 0;
+  this.lastStringValue = "";
+  this.lastAssertionIsQuantifiable = false;
+  this.numCapturingParens = 0;
+  this.maxBackReference = 0;
+  this.groupNames = /* @__PURE__ */ Object.create(null);
+  this.backReferenceNames = [];
+  this.branchID = null;
+};
+RegExpValidationState.prototype.reset = function reset(start2, pattern, flags) {
+  var unicodeSets = flags.indexOf("v") !== -1;
+  var unicode = flags.indexOf("u") !== -1;
+  this.start = start2 | 0;
+  this.source = pattern + "";
+  this.flags = flags;
+  if (unicodeSets && this.parser.options.ecmaVersion >= 15) {
+    this.switchU = true;
+    this.switchV = true;
+    this.switchN = true;
+  } else {
+    this.switchU = unicode && this.parser.options.ecmaVersion >= 6;
+    this.switchV = false;
+    this.switchN = unicode && this.parser.options.ecmaVersion >= 9;
+  }
+};
+RegExpValidationState.prototype.raise = function raise(message) {
+  this.parser.raiseRecoverable(this.start, "Invalid regular expression: /" + this.source + "/: " + message);
+};
+RegExpValidationState.prototype.at = function at(i, forceU) {
+  if (forceU === void 0) forceU = false;
+  var s = this.source;
+  var l = s.length;
+  if (i >= l) {
+    return -1;
+  }
+  var c = s.charCodeAt(i);
+  if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l) {
+    return c;
+  }
+  var next = s.charCodeAt(i + 1);
+  return next >= 56320 && next <= 57343 ? (c << 10) + next - 56613888 : c;
+};
+RegExpValidationState.prototype.nextIndex = function nextIndex(i, forceU) {
+  if (forceU === void 0) forceU = false;
+  var s = this.source;
+  var l = s.length;
+  if (i >= l) {
+    return l;
+  }
+  var c = s.charCodeAt(i), next;
+  if (!(forceU || this.switchU) || c <= 55295 || c >= 57344 || i + 1 >= l || (next = s.charCodeAt(i + 1)) < 56320 || next > 57343) {
+    return i + 1;
+  }
+  return i + 2;
+};
+RegExpValidationState.prototype.current = function current(forceU) {
+  if (forceU === void 0) forceU = false;
+  return this.at(this.pos, forceU);
+};
+RegExpValidationState.prototype.lookahead = function lookahead(forceU) {
+  if (forceU === void 0) forceU = false;
+  return this.at(this.nextIndex(this.pos, forceU), forceU);
+};
+RegExpValidationState.prototype.advance = function advance(forceU) {
+  if (forceU === void 0) forceU = false;
+  this.pos = this.nextIndex(this.pos, forceU);
+};
+RegExpValidationState.prototype.eat = function eat(ch, forceU) {
+  if (forceU === void 0) forceU = false;
+  if (this.current(forceU) === ch) {
+    this.advance(forceU);
+    return true;
+  }
+  return false;
+};
+RegExpValidationState.prototype.eatChars = function eatChars(chs, forceU) {
+  if (forceU === void 0) forceU = false;
+  var pos = this.pos;
+  for (var i = 0, list3 = chs; i < list3.length; i += 1) {
+    var ch = list3[i];
+    var current2 = this.at(pos, forceU);
+    if (current2 === -1 || current2 !== ch) {
+      return false;
+    }
+    pos = this.nextIndex(pos, forceU);
+  }
+  this.pos = pos;
+  return true;
+};
+pp$1.validateRegExpFlags = function(state) {
+  var validFlags = state.validFlags;
+  var flags = state.flags;
+  var u = false;
+  var v = false;
+  for (var i = 0; i < flags.length; i++) {
+    var flag = flags.charAt(i);
+    if (validFlags.indexOf(flag) === -1) {
+      this.raise(state.start, "Invalid regular expression flag");
+    }
+    if (flags.indexOf(flag, i + 1) > -1) {
+      this.raise(state.start, "Duplicate regular expression flag");
+    }
+    if (flag === "u") {
+      u = true;
+    }
+    if (flag === "v") {
+      v = true;
+    }
+  }
+  if (this.options.ecmaVersion >= 15 && u && v) {
+    this.raise(state.start, "Invalid regular expression flag");
+  }
+};
+function hasProp(obj) {
+  for (var _ in obj) {
+    return true;
+  }
+  return false;
+}
+pp$1.validateRegExpPattern = function(state) {
+  this.regexp_pattern(state);
+  if (!state.switchN && this.options.ecmaVersion >= 9 && hasProp(state.groupNames)) {
+    state.switchN = true;
+    this.regexp_pattern(state);
+  }
+};
+pp$1.regexp_pattern = function(state) {
+  state.pos = 0;
+  state.lastIntValue = 0;
+  state.lastStringValue = "";
+  state.lastAssertionIsQuantifiable = false;
+  state.numCapturingParens = 0;
+  state.maxBackReference = 0;
+  state.groupNames = /* @__PURE__ */ Object.create(null);
+  state.backReferenceNames.length = 0;
+  state.branchID = null;
+  this.regexp_disjunction(state);
+  if (state.pos !== state.source.length) {
+    if (state.eat(
+      41
+      /* ) */
+    )) {
+      state.raise("Unmatched ')'");
+    }
+    if (state.eat(
+      93
+      /* ] */
+    ) || state.eat(
+      125
+      /* } */
+    )) {
+      state.raise("Lone quantifier brackets");
+    }
+  }
+  if (state.maxBackReference > state.numCapturingParens) {
+    state.raise("Invalid escape");
+  }
+  for (var i = 0, list3 = state.backReferenceNames; i < list3.length; i += 1) {
+    var name2 = list3[i];
+    if (!state.groupNames[name2]) {
+      state.raise("Invalid named capture referenced");
+    }
+  }
+};
+pp$1.regexp_disjunction = function(state) {
+  var trackDisjunction = this.options.ecmaVersion >= 16;
+  if (trackDisjunction) {
+    state.branchID = new BranchID(state.branchID, null);
+  }
+  this.regexp_alternative(state);
+  while (state.eat(
+    124
+    /* | */
+  )) {
+    if (trackDisjunction) {
+      state.branchID = state.branchID.sibling();
+    }
+    this.regexp_alternative(state);
+  }
+  if (trackDisjunction) {
+    state.branchID = state.branchID.parent;
+  }
+  if (this.regexp_eatQuantifier(state, true)) {
+    state.raise("Nothing to repeat");
+  }
+  if (state.eat(
+    123
+    /* { */
+  )) {
+    state.raise("Lone quantifier brackets");
+  }
+};
+pp$1.regexp_alternative = function(state) {
+  while (state.pos < state.source.length && this.regexp_eatTerm(state)) {
+  }
+};
+pp$1.regexp_eatTerm = function(state) {
+  if (this.regexp_eatAssertion(state)) {
+    if (state.lastAssertionIsQuantifiable && this.regexp_eatQuantifier(state)) {
+      if (state.switchU) {
+        state.raise("Invalid quantifier");
+      }
+    }
+    return true;
+  }
+  if (state.switchU ? this.regexp_eatAtom(state) : this.regexp_eatExtendedAtom(state)) {
+    this.regexp_eatQuantifier(state);
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatAssertion = function(state) {
+  var start2 = state.pos;
+  state.lastAssertionIsQuantifiable = false;
+  if (state.eat(
+    94
+    /* ^ */
+  ) || state.eat(
+    36
+    /* $ */
+  )) {
+    return true;
+  }
+  if (state.eat(
+    92
+    /* \ */
+  )) {
+    if (state.eat(
+      66
+      /* B */
+    ) || state.eat(
+      98
+      /* b */
+    )) {
+      return true;
+    }
+    state.pos = start2;
+  }
+  if (state.eat(
+    40
+    /* ( */
+  ) && state.eat(
+    63
+    /* ? */
+  )) {
+    var lookbehind = false;
+    if (this.options.ecmaVersion >= 9) {
+      lookbehind = state.eat(
+        60
+        /* < */
+      );
+    }
+    if (state.eat(
+      61
+      /* = */
+    ) || state.eat(
+      33
+      /* ! */
+    )) {
+      this.regexp_disjunction(state);
+      if (!state.eat(
+        41
+        /* ) */
+      )) {
+        state.raise("Unterminated group");
+      }
+      state.lastAssertionIsQuantifiable = !lookbehind;
+      return true;
+    }
+  }
+  state.pos = start2;
+  return false;
+};
+pp$1.regexp_eatQuantifier = function(state, noError) {
+  if (noError === void 0) noError = false;
+  if (this.regexp_eatQuantifierPrefix(state, noError)) {
+    state.eat(
+      63
+      /* ? */
+    );
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatQuantifierPrefix = function(state, noError) {
+  return state.eat(
+    42
+    /* * */
+  ) || state.eat(
+    43
+    /* + */
+  ) || state.eat(
+    63
+    /* ? */
+  ) || this.regexp_eatBracedQuantifier(state, noError);
+};
+pp$1.regexp_eatBracedQuantifier = function(state, noError) {
+  var start2 = state.pos;
+  if (state.eat(
+    123
+    /* { */
+  )) {
+    var min = 0, max = -1;
+    if (this.regexp_eatDecimalDigits(state)) {
+      min = state.lastIntValue;
+      if (state.eat(
+        44
+        /* , */
+      ) && this.regexp_eatDecimalDigits(state)) {
+        max = state.lastIntValue;
+      }
+      if (state.eat(
+        125
+        /* } */
+      )) {
+        if (max !== -1 && max < min && !noError) {
+          state.raise("numbers out of order in {} quantifier");
+        }
+        return true;
+      }
+    }
+    if (state.switchU && !noError) {
+      state.raise("Incomplete quantifier");
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatAtom = function(state) {
+  return this.regexp_eatPatternCharacters(state) || state.eat(
+    46
+    /* . */
+  ) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state);
+};
+pp$1.regexp_eatReverseSolidusAtomEscape = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    92
+    /* \ */
+  )) {
+    if (this.regexp_eatAtomEscape(state)) {
+      return true;
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatUncapturingGroup = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    40
+    /* ( */
+  )) {
+    if (state.eat(
+      63
+      /* ? */
+    ) && state.eat(
+      58
+      /* : */
+    )) {
+      this.regexp_disjunction(state);
+      if (state.eat(
+        41
+        /* ) */
+      )) {
+        return true;
+      }
+      state.raise("Unterminated group");
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatCapturingGroup = function(state) {
+  if (state.eat(
+    40
+    /* ( */
+  )) {
+    if (this.options.ecmaVersion >= 9) {
+      this.regexp_groupSpecifier(state);
+    } else if (state.current() === 63) {
+      state.raise("Invalid group");
+    }
+    this.regexp_disjunction(state);
+    if (state.eat(
+      41
+      /* ) */
+    )) {
+      state.numCapturingParens += 1;
+      return true;
+    }
+    state.raise("Unterminated group");
+  }
+  return false;
+};
+pp$1.regexp_eatExtendedAtom = function(state) {
+  return state.eat(
+    46
+    /* . */
+  ) || this.regexp_eatReverseSolidusAtomEscape(state) || this.regexp_eatCharacterClass(state) || this.regexp_eatUncapturingGroup(state) || this.regexp_eatCapturingGroup(state) || this.regexp_eatInvalidBracedQuantifier(state) || this.regexp_eatExtendedPatternCharacter(state);
+};
+pp$1.regexp_eatInvalidBracedQuantifier = function(state) {
+  if (this.regexp_eatBracedQuantifier(state, true)) {
+    state.raise("Nothing to repeat");
+  }
+  return false;
+};
+pp$1.regexp_eatSyntaxCharacter = function(state) {
+  var ch = state.current();
+  if (isSyntaxCharacter(ch)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isSyntaxCharacter(ch) {
+  return ch === 36 || ch >= 40 && ch <= 43 || ch === 46 || ch === 63 || ch >= 91 && ch <= 94 || ch >= 123 && ch <= 125;
+}
+pp$1.regexp_eatPatternCharacters = function(state) {
+  var start2 = state.pos;
+  var ch = 0;
+  while ((ch = state.current()) !== -1 && !isSyntaxCharacter(ch)) {
+    state.advance();
+  }
+  return state.pos !== start2;
+};
+pp$1.regexp_eatExtendedPatternCharacter = function(state) {
+  var ch = state.current();
+  if (ch !== -1 && ch !== 36 && !(ch >= 40 && ch <= 43) && ch !== 46 && ch !== 63 && ch !== 91 && ch !== 94 && ch !== 124) {
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_groupSpecifier = function(state) {
+  if (state.eat(
+    63
+    /* ? */
+  )) {
+    if (!this.regexp_eatGroupName(state)) {
+      state.raise("Invalid group");
+    }
+    var trackDisjunction = this.options.ecmaVersion >= 16;
+    var known = state.groupNames[state.lastStringValue];
+    if (known) {
+      if (trackDisjunction) {
+        for (var i = 0, list3 = known; i < list3.length; i += 1) {
+          var altID = list3[i];
+          if (!altID.separatedFrom(state.branchID)) {
+            state.raise("Duplicate capture group name");
+          }
+        }
+      } else {
+        state.raise("Duplicate capture group name");
+      }
+    }
+    if (trackDisjunction) {
+      (known || (state.groupNames[state.lastStringValue] = [])).push(state.branchID);
+    } else {
+      state.groupNames[state.lastStringValue] = true;
+    }
+  }
+};
+pp$1.regexp_eatGroupName = function(state) {
+  state.lastStringValue = "";
+  if (state.eat(
+    60
+    /* < */
+  )) {
+    if (this.regexp_eatRegExpIdentifierName(state) && state.eat(
+      62
+      /* > */
+    )) {
+      return true;
+    }
+    state.raise("Invalid capture group name");
+  }
+  return false;
+};
+pp$1.regexp_eatRegExpIdentifierName = function(state) {
+  state.lastStringValue = "";
+  if (this.regexp_eatRegExpIdentifierStart(state)) {
+    state.lastStringValue += codePointToString(state.lastIntValue);
+    while (this.regexp_eatRegExpIdentifierPart(state)) {
+      state.lastStringValue += codePointToString(state.lastIntValue);
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatRegExpIdentifierStart = function(state) {
+  var start2 = state.pos;
+  var forceU = this.options.ecmaVersion >= 11;
+  var ch = state.current(forceU);
+  state.advance(forceU);
+  if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+    ch = state.lastIntValue;
+  }
+  if (isRegExpIdentifierStart(ch)) {
+    state.lastIntValue = ch;
+    return true;
+  }
+  state.pos = start2;
+  return false;
+};
+function isRegExpIdentifierStart(ch) {
+  return isIdentifierStart(ch, true) || ch === 36 || ch === 95;
+}
+pp$1.regexp_eatRegExpIdentifierPart = function(state) {
+  var start2 = state.pos;
+  var forceU = this.options.ecmaVersion >= 11;
+  var ch = state.current(forceU);
+  state.advance(forceU);
+  if (ch === 92 && this.regexp_eatRegExpUnicodeEscapeSequence(state, forceU)) {
+    ch = state.lastIntValue;
+  }
+  if (isRegExpIdentifierPart(ch)) {
+    state.lastIntValue = ch;
+    return true;
+  }
+  state.pos = start2;
+  return false;
+};
+function isRegExpIdentifierPart(ch) {
+  return isIdentifierChar(ch, true) || ch === 36 || ch === 95 || ch === 8204 || ch === 8205;
+}
+pp$1.regexp_eatAtomEscape = function(state) {
+  if (this.regexp_eatBackReference(state) || this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state) || state.switchN && this.regexp_eatKGroupName(state)) {
+    return true;
+  }
+  if (state.switchU) {
+    if (state.current() === 99) {
+      state.raise("Invalid unicode escape");
+    }
+    state.raise("Invalid escape");
+  }
+  return false;
+};
+pp$1.regexp_eatBackReference = function(state) {
+  var start2 = state.pos;
+  if (this.regexp_eatDecimalEscape(state)) {
+    var n = state.lastIntValue;
+    if (state.switchU) {
+      if (n > state.maxBackReference) {
+        state.maxBackReference = n;
+      }
+      return true;
+    }
+    if (n <= state.numCapturingParens) {
+      return true;
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatKGroupName = function(state) {
+  if (state.eat(
+    107
+    /* k */
+  )) {
+    if (this.regexp_eatGroupName(state)) {
+      state.backReferenceNames.push(state.lastStringValue);
+      return true;
+    }
+    state.raise("Invalid named reference");
+  }
+  return false;
+};
+pp$1.regexp_eatCharacterEscape = function(state) {
+  return this.regexp_eatControlEscape(state) || this.regexp_eatCControlLetter(state) || this.regexp_eatZero(state) || this.regexp_eatHexEscapeSequence(state) || this.regexp_eatRegExpUnicodeEscapeSequence(state, false) || !state.switchU && this.regexp_eatLegacyOctalEscapeSequence(state) || this.regexp_eatIdentityEscape(state);
+};
+pp$1.regexp_eatCControlLetter = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    99
+    /* c */
+  )) {
+    if (this.regexp_eatControlLetter(state)) {
+      return true;
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatZero = function(state) {
+  if (state.current() === 48 && !isDecimalDigit(state.lookahead())) {
+    state.lastIntValue = 0;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatControlEscape = function(state) {
+  var ch = state.current();
+  if (ch === 116) {
+    state.lastIntValue = 9;
+    state.advance();
+    return true;
+  }
+  if (ch === 110) {
+    state.lastIntValue = 10;
+    state.advance();
+    return true;
+  }
+  if (ch === 118) {
+    state.lastIntValue = 11;
+    state.advance();
+    return true;
+  }
+  if (ch === 102) {
+    state.lastIntValue = 12;
+    state.advance();
+    return true;
+  }
+  if (ch === 114) {
+    state.lastIntValue = 13;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatControlLetter = function(state) {
+  var ch = state.current();
+  if (isControlLetter(ch)) {
+    state.lastIntValue = ch % 32;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isControlLetter(ch) {
+  return ch >= 65 && ch <= 90 || ch >= 97 && ch <= 122;
+}
+pp$1.regexp_eatRegExpUnicodeEscapeSequence = function(state, forceU) {
+  if (forceU === void 0) forceU = false;
+  var start2 = state.pos;
+  var switchU = forceU || state.switchU;
+  if (state.eat(
+    117
+    /* u */
+  )) {
+    if (this.regexp_eatFixedHexDigits(state, 4)) {
+      var lead = state.lastIntValue;
+      if (switchU && lead >= 55296 && lead <= 56319) {
+        var leadSurrogateEnd = state.pos;
+        if (state.eat(
+          92
+          /* \ */
+        ) && state.eat(
+          117
+          /* u */
+        ) && this.regexp_eatFixedHexDigits(state, 4)) {
+          var trail = state.lastIntValue;
+          if (trail >= 56320 && trail <= 57343) {
+            state.lastIntValue = (lead - 55296) * 1024 + (trail - 56320) + 65536;
+            return true;
+          }
+        }
+        state.pos = leadSurrogateEnd;
+        state.lastIntValue = lead;
+      }
+      return true;
+    }
+    if (switchU && state.eat(
+      123
+      /* { */
+    ) && this.regexp_eatHexDigits(state) && state.eat(
+      125
+      /* } */
+    ) && isValidUnicode(state.lastIntValue)) {
+      return true;
+    }
+    if (switchU) {
+      state.raise("Invalid unicode escape");
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+function isValidUnicode(ch) {
+  return ch >= 0 && ch <= 1114111;
+}
+pp$1.regexp_eatIdentityEscape = function(state) {
+  if (state.switchU) {
+    if (this.regexp_eatSyntaxCharacter(state)) {
+      return true;
+    }
+    if (state.eat(
+      47
+      /* / */
+    )) {
+      state.lastIntValue = 47;
+      return true;
+    }
+    return false;
+  }
+  var ch = state.current();
+  if (ch !== 99 && (!state.switchN || ch !== 107)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatDecimalEscape = function(state) {
+  state.lastIntValue = 0;
+  var ch = state.current();
+  if (ch >= 49 && ch <= 57) {
+    do {
+      state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+      state.advance();
+    } while ((ch = state.current()) >= 48 && ch <= 57);
+    return true;
+  }
+  return false;
+};
+var CharSetNone = 0;
+var CharSetOk = 1;
+var CharSetString = 2;
+pp$1.regexp_eatCharacterClassEscape = function(state) {
+  var ch = state.current();
+  if (isCharacterClassEscape(ch)) {
+    state.lastIntValue = -1;
+    state.advance();
+    return CharSetOk;
+  }
+  var negate = false;
+  if (state.switchU && this.options.ecmaVersion >= 9 && ((negate = ch === 80) || ch === 112)) {
+    state.lastIntValue = -1;
+    state.advance();
+    var result;
+    if (state.eat(
+      123
+      /* { */
+    ) && (result = this.regexp_eatUnicodePropertyValueExpression(state)) && state.eat(
+      125
+      /* } */
+    )) {
+      if (negate && result === CharSetString) {
+        state.raise("Invalid property name");
+      }
+      return result;
+    }
+    state.raise("Invalid property name");
+  }
+  return CharSetNone;
+};
+function isCharacterClassEscape(ch) {
+  return ch === 100 || ch === 68 || ch === 115 || ch === 83 || ch === 119 || ch === 87;
+}
+pp$1.regexp_eatUnicodePropertyValueExpression = function(state) {
+  var start2 = state.pos;
+  if (this.regexp_eatUnicodePropertyName(state) && state.eat(
+    61
+    /* = */
+  )) {
+    var name2 = state.lastStringValue;
+    if (this.regexp_eatUnicodePropertyValue(state)) {
+      var value = state.lastStringValue;
+      this.regexp_validateUnicodePropertyNameAndValue(state, name2, value);
+      return CharSetOk;
+    }
+  }
+  state.pos = start2;
+  if (this.regexp_eatLoneUnicodePropertyNameOrValue(state)) {
+    var nameOrValue = state.lastStringValue;
+    return this.regexp_validateUnicodePropertyNameOrValue(state, nameOrValue);
+  }
+  return CharSetNone;
+};
+pp$1.regexp_validateUnicodePropertyNameAndValue = function(state, name2, value) {
+  if (!hasOwn(state.unicodeProperties.nonBinary, name2)) {
+    state.raise("Invalid property name");
+  }
+  if (!state.unicodeProperties.nonBinary[name2].test(value)) {
+    state.raise("Invalid property value");
+  }
+};
+pp$1.regexp_validateUnicodePropertyNameOrValue = function(state, nameOrValue) {
+  if (state.unicodeProperties.binary.test(nameOrValue)) {
+    return CharSetOk;
+  }
+  if (state.switchV && state.unicodeProperties.binaryOfStrings.test(nameOrValue)) {
+    return CharSetString;
+  }
+  state.raise("Invalid property name");
+};
+pp$1.regexp_eatUnicodePropertyName = function(state) {
+  var ch = 0;
+  state.lastStringValue = "";
+  while (isUnicodePropertyNameCharacter(ch = state.current())) {
+    state.lastStringValue += codePointToString(ch);
+    state.advance();
+  }
+  return state.lastStringValue !== "";
+};
+function isUnicodePropertyNameCharacter(ch) {
+  return isControlLetter(ch) || ch === 95;
+}
+pp$1.regexp_eatUnicodePropertyValue = function(state) {
+  var ch = 0;
+  state.lastStringValue = "";
+  while (isUnicodePropertyValueCharacter(ch = state.current())) {
+    state.lastStringValue += codePointToString(ch);
+    state.advance();
+  }
+  return state.lastStringValue !== "";
+};
+function isUnicodePropertyValueCharacter(ch) {
+  return isUnicodePropertyNameCharacter(ch) || isDecimalDigit(ch);
+}
+pp$1.regexp_eatLoneUnicodePropertyNameOrValue = function(state) {
+  return this.regexp_eatUnicodePropertyValue(state);
+};
+pp$1.regexp_eatCharacterClass = function(state) {
+  if (state.eat(
+    91
+    /* [ */
+  )) {
+    var negate = state.eat(
+      94
+      /* ^ */
+    );
+    var result = this.regexp_classContents(state);
+    if (!state.eat(
+      93
+      /* ] */
+    )) {
+      state.raise("Unterminated character class");
+    }
+    if (negate && result === CharSetString) {
+      state.raise("Negated character class may contain strings");
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_classContents = function(state) {
+  if (state.current() === 93) {
+    return CharSetOk;
+  }
+  if (state.switchV) {
+    return this.regexp_classSetExpression(state);
+  }
+  this.regexp_nonEmptyClassRanges(state);
+  return CharSetOk;
+};
+pp$1.regexp_nonEmptyClassRanges = function(state) {
+  while (this.regexp_eatClassAtom(state)) {
+    var left = state.lastIntValue;
+    if (state.eat(
+      45
+      /* - */
+    ) && this.regexp_eatClassAtom(state)) {
+      var right = state.lastIntValue;
+      if (state.switchU && (left === -1 || right === -1)) {
+        state.raise("Invalid character class");
+      }
+      if (left !== -1 && right !== -1 && left > right) {
+        state.raise("Range out of order in character class");
+      }
+    }
+  }
+};
+pp$1.regexp_eatClassAtom = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    92
+    /* \ */
+  )) {
+    if (this.regexp_eatClassEscape(state)) {
+      return true;
+    }
+    if (state.switchU) {
+      var ch$1 = state.current();
+      if (ch$1 === 99 || isOctalDigit(ch$1)) {
+        state.raise("Invalid class escape");
+      }
+      state.raise("Invalid escape");
+    }
+    state.pos = start2;
+  }
+  var ch = state.current();
+  if (ch !== 93) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatClassEscape = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    98
+    /* b */
+  )) {
+    state.lastIntValue = 8;
+    return true;
+  }
+  if (state.switchU && state.eat(
+    45
+    /* - */
+  )) {
+    state.lastIntValue = 45;
+    return true;
+  }
+  if (!state.switchU && state.eat(
+    99
+    /* c */
+  )) {
+    if (this.regexp_eatClassControlLetter(state)) {
+      return true;
+    }
+    state.pos = start2;
+  }
+  return this.regexp_eatCharacterClassEscape(state) || this.regexp_eatCharacterEscape(state);
+};
+pp$1.regexp_classSetExpression = function(state) {
+  var result = CharSetOk, subResult;
+  if (this.regexp_eatClassSetRange(state)) ;
+  else if (subResult = this.regexp_eatClassSetOperand(state)) {
+    if (subResult === CharSetString) {
+      result = CharSetString;
+    }
+    var start2 = state.pos;
+    while (state.eatChars(
+      [38, 38]
+      /* && */
+    )) {
+      if (state.current() !== 38 && (subResult = this.regexp_eatClassSetOperand(state))) {
+        if (subResult !== CharSetString) {
+          result = CharSetOk;
+        }
+        continue;
+      }
+      state.raise("Invalid character in character class");
+    }
+    if (start2 !== state.pos) {
+      return result;
+    }
+    while (state.eatChars(
+      [45, 45]
+      /* -- */
+    )) {
+      if (this.regexp_eatClassSetOperand(state)) {
+        continue;
+      }
+      state.raise("Invalid character in character class");
+    }
+    if (start2 !== state.pos) {
+      return result;
+    }
+  } else {
+    state.raise("Invalid character in character class");
+  }
+  for (; ; ) {
+    if (this.regexp_eatClassSetRange(state)) {
+      continue;
+    }
+    subResult = this.regexp_eatClassSetOperand(state);
+    if (!subResult) {
+      return result;
+    }
+    if (subResult === CharSetString) {
+      result = CharSetString;
+    }
+  }
+};
+pp$1.regexp_eatClassSetRange = function(state) {
+  var start2 = state.pos;
+  if (this.regexp_eatClassSetCharacter(state)) {
+    var left = state.lastIntValue;
+    if (state.eat(
+      45
+      /* - */
+    ) && this.regexp_eatClassSetCharacter(state)) {
+      var right = state.lastIntValue;
+      if (left !== -1 && right !== -1 && left > right) {
+        state.raise("Range out of order in character class");
+      }
+      return true;
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatClassSetOperand = function(state) {
+  if (this.regexp_eatClassSetCharacter(state)) {
+    return CharSetOk;
+  }
+  return this.regexp_eatClassStringDisjunction(state) || this.regexp_eatNestedClass(state);
+};
+pp$1.regexp_eatNestedClass = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    91
+    /* [ */
+  )) {
+    var negate = state.eat(
+      94
+      /* ^ */
+    );
+    var result = this.regexp_classContents(state);
+    if (state.eat(
+      93
+      /* ] */
+    )) {
+      if (negate && result === CharSetString) {
+        state.raise("Negated character class may contain strings");
+      }
+      return result;
+    }
+    state.pos = start2;
+  }
+  if (state.eat(
+    92
+    /* \ */
+  )) {
+    var result$1 = this.regexp_eatCharacterClassEscape(state);
+    if (result$1) {
+      return result$1;
+    }
+    state.pos = start2;
+  }
+  return null;
+};
+pp$1.regexp_eatClassStringDisjunction = function(state) {
+  var start2 = state.pos;
+  if (state.eatChars(
+    [92, 113]
+    /* \q */
+  )) {
+    if (state.eat(
+      123
+      /* { */
+    )) {
+      var result = this.regexp_classStringDisjunctionContents(state);
+      if (state.eat(
+        125
+        /* } */
+      )) {
+        return result;
+      }
+    } else {
+      state.raise("Invalid escape");
+    }
+    state.pos = start2;
+  }
+  return null;
+};
+pp$1.regexp_classStringDisjunctionContents = function(state) {
+  var result = this.regexp_classString(state);
+  while (state.eat(
+    124
+    /* | */
+  )) {
+    if (this.regexp_classString(state) === CharSetString) {
+      result = CharSetString;
+    }
+  }
+  return result;
+};
+pp$1.regexp_classString = function(state) {
+  var count = 0;
+  while (this.regexp_eatClassSetCharacter(state)) {
+    count++;
+  }
+  return count === 1 ? CharSetOk : CharSetString;
+};
+pp$1.regexp_eatClassSetCharacter = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    92
+    /* \ */
+  )) {
+    if (this.regexp_eatCharacterEscape(state) || this.regexp_eatClassSetReservedPunctuator(state)) {
+      return true;
+    }
+    if (state.eat(
+      98
+      /* b */
+    )) {
+      state.lastIntValue = 8;
+      return true;
+    }
+    state.pos = start2;
+    return false;
+  }
+  var ch = state.current();
+  if (ch < 0 || ch === state.lookahead() && isClassSetReservedDoublePunctuatorCharacter(ch)) {
+    return false;
+  }
+  if (isClassSetSyntaxCharacter(ch)) {
+    return false;
+  }
+  state.advance();
+  state.lastIntValue = ch;
+  return true;
+};
+function isClassSetReservedDoublePunctuatorCharacter(ch) {
+  return ch === 33 || ch >= 35 && ch <= 38 || ch >= 42 && ch <= 44 || ch === 46 || ch >= 58 && ch <= 64 || ch === 94 || ch === 96 || ch === 126;
+}
+function isClassSetSyntaxCharacter(ch) {
+  return ch === 40 || ch === 41 || ch === 45 || ch === 47 || ch >= 91 && ch <= 93 || ch >= 123 && ch <= 125;
+}
+pp$1.regexp_eatClassSetReservedPunctuator = function(state) {
+  var ch = state.current();
+  if (isClassSetReservedPunctuator(ch)) {
+    state.lastIntValue = ch;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+function isClassSetReservedPunctuator(ch) {
+  return ch === 33 || ch === 35 || ch === 37 || ch === 38 || ch === 44 || ch === 45 || ch >= 58 && ch <= 62 || ch === 64 || ch === 96 || ch === 126;
+}
+pp$1.regexp_eatClassControlLetter = function(state) {
+  var ch = state.current();
+  if (isDecimalDigit(ch) || ch === 95) {
+    state.lastIntValue = ch % 32;
+    state.advance();
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatHexEscapeSequence = function(state) {
+  var start2 = state.pos;
+  if (state.eat(
+    120
+    /* x */
+  )) {
+    if (this.regexp_eatFixedHexDigits(state, 2)) {
+      return true;
+    }
+    if (state.switchU) {
+      state.raise("Invalid escape");
+    }
+    state.pos = start2;
+  }
+  return false;
+};
+pp$1.regexp_eatDecimalDigits = function(state) {
+  var start2 = state.pos;
+  var ch = 0;
+  state.lastIntValue = 0;
+  while (isDecimalDigit(ch = state.current())) {
+    state.lastIntValue = 10 * state.lastIntValue + (ch - 48);
+    state.advance();
+  }
+  return state.pos !== start2;
+};
+function isDecimalDigit(ch) {
+  return ch >= 48 && ch <= 57;
+}
+pp$1.regexp_eatHexDigits = function(state) {
+  var start2 = state.pos;
+  var ch = 0;
+  state.lastIntValue = 0;
+  while (isHexDigit(ch = state.current())) {
+    state.lastIntValue = 16 * state.lastIntValue + hexToInt(ch);
+    state.advance();
+  }
+  return state.pos !== start2;
+};
+function isHexDigit(ch) {
+  return ch >= 48 && ch <= 57 || ch >= 65 && ch <= 70 || ch >= 97 && ch <= 102;
+}
+function hexToInt(ch) {
+  if (ch >= 65 && ch <= 70) {
+    return 10 + (ch - 65);
+  }
+  if (ch >= 97 && ch <= 102) {
+    return 10 + (ch - 97);
+  }
+  return ch - 48;
+}
+pp$1.regexp_eatLegacyOctalEscapeSequence = function(state) {
+  if (this.regexp_eatOctalDigit(state)) {
+    var n1 = state.lastIntValue;
+    if (this.regexp_eatOctalDigit(state)) {
+      var n2 = state.lastIntValue;
+      if (n1 <= 3 && this.regexp_eatOctalDigit(state)) {
+        state.lastIntValue = n1 * 64 + n2 * 8 + state.lastIntValue;
+      } else {
+        state.lastIntValue = n1 * 8 + n2;
+      }
+    } else {
+      state.lastIntValue = n1;
+    }
+    return true;
+  }
+  return false;
+};
+pp$1.regexp_eatOctalDigit = function(state) {
+  var ch = state.current();
+  if (isOctalDigit(ch)) {
+    state.lastIntValue = ch - 48;
+    state.advance();
+    return true;
+  }
+  state.lastIntValue = 0;
+  return false;
+};
+function isOctalDigit(ch) {
+  return ch >= 48 && ch <= 55;
+}
+pp$1.regexp_eatFixedHexDigits = function(state, length) {
+  var start2 = state.pos;
+  state.lastIntValue = 0;
+  for (var i = 0; i < length; ++i) {
+    var ch = state.current();
+    if (!isHexDigit(ch)) {
+      state.pos = start2;
+      return false;
+    }
+    state.lastIntValue = 16 * state.lastIntValue + hexToInt(ch);
+    state.advance();
+  }
+  return true;
+};
+var Token = function Token2(p) {
+  this.type = p.type;
+  this.value = p.value;
+  this.start = p.start;
+  this.end = p.end;
+  if (p.options.locations) {
+    this.loc = new SourceLocation(p, p.startLoc, p.endLoc);
+  }
+  if (p.options.ranges) {
+    this.range = [p.start, p.end];
+  }
+};
+var pp = Parser.prototype;
+pp.next = function(ignoreEscapeSequenceInKeyword) {
+  if (!ignoreEscapeSequenceInKeyword && this.type.keyword && this.containsEsc) {
+    this.raiseRecoverable(this.start, "Escape sequence in keyword " + this.type.keyword);
+  }
+  if (this.options.onToken) {
+    this.options.onToken(new Token(this));
+  }
+  this.lastTokEnd = this.end;
+  this.lastTokStart = this.start;
+  this.lastTokEndLoc = this.endLoc;
+  this.lastTokStartLoc = this.startLoc;
+  this.nextToken();
+};
+pp.getToken = function() {
+  this.next();
+  return new Token(this);
+};
+if (typeof Symbol !== "undefined") {
+  pp[Symbol.iterator] = function() {
+    var this$1$1 = this;
+    return {
+      next: function() {
+        var token = this$1$1.getToken();
+        return {
+          done: token.type === types$1.eof,
+          value: token
+        };
+      }
+    };
+  };
+}
+pp.nextToken = function() {
+  var curContext = this.curContext();
+  if (!curContext || !curContext.preserveSpace) {
+    this.skipSpace();
+  }
+  this.start = this.pos;
+  if (this.options.locations) {
+    this.startLoc = this.curPosition();
+  }
+  if (this.pos >= this.input.length) {
+    return this.finishToken(types$1.eof);
+  }
+  if (curContext.override) {
+    return curContext.override(this);
+  } else {
+    this.readToken(this.fullCharCodeAtPos());
+  }
+};
+pp.readToken = function(code2) {
+  if (isIdentifierStart(code2, this.options.ecmaVersion >= 6) || code2 === 92) {
+    return this.readWord();
+  }
+  return this.getTokenFromCode(code2);
+};
+pp.fullCharCodeAtPos = function() {
+  var code2 = this.input.charCodeAt(this.pos);
+  if (code2 <= 55295 || code2 >= 56320) {
+    return code2;
+  }
+  var next = this.input.charCodeAt(this.pos + 1);
+  return next <= 56319 || next >= 57344 ? code2 : (code2 << 10) + next - 56613888;
+};
+pp.skipBlockComment = function() {
+  var startLoc = this.options.onComment && this.curPosition();
+  var start2 = this.pos, end = this.input.indexOf("*/", this.pos += 2);
+  if (end === -1) {
+    this.raise(this.pos - 2, "Unterminated comment");
+  }
+  this.pos = end + 2;
+  if (this.options.locations) {
+    for (var nextBreak = void 0, pos = start2; (nextBreak = nextLineBreak(this.input, pos, this.pos)) > -1; ) {
+      ++this.curLine;
+      pos = this.lineStart = nextBreak;
+    }
+  }
+  if (this.options.onComment) {
+    this.options.onComment(
+      true,
+      this.input.slice(start2 + 2, end),
+      start2,
+      this.pos,
+      startLoc,
+      this.curPosition()
+    );
+  }
+};
+pp.skipLineComment = function(startSkip) {
+  var start2 = this.pos;
+  var startLoc = this.options.onComment && this.curPosition();
+  var ch = this.input.charCodeAt(this.pos += startSkip);
+  while (this.pos < this.input.length && !isNewLine(ch)) {
+    ch = this.input.charCodeAt(++this.pos);
+  }
+  if (this.options.onComment) {
+    this.options.onComment(
+      false,
+      this.input.slice(start2 + startSkip, this.pos),
+      start2,
+      this.pos,
+      startLoc,
+      this.curPosition()
+    );
+  }
+};
+pp.skipSpace = function() {
+  loop: while (this.pos < this.input.length) {
+    var ch = this.input.charCodeAt(this.pos);
+    switch (ch) {
+      case 32:
+      case 160:
+        ++this.pos;
+        break;
+      case 13:
+        if (this.input.charCodeAt(this.pos + 1) === 10) {
+          ++this.pos;
+        }
+      case 10:
+      case 8232:
+      case 8233:
+        ++this.pos;
+        if (this.options.locations) {
+          ++this.curLine;
+          this.lineStart = this.pos;
+        }
+        break;
+      case 47:
+        switch (this.input.charCodeAt(this.pos + 1)) {
+          case 42:
+            this.skipBlockComment();
+            break;
+          case 47:
+            this.skipLineComment(2);
+            break;
+          default:
+            break loop;
+        }
+        break;
+      default:
+        if (ch > 8 && ch < 14 || ch >= 5760 && nonASCIIwhitespace.test(String.fromCharCode(ch))) {
+          ++this.pos;
+        } else {
+          break loop;
+        }
+    }
+  }
+};
+pp.finishToken = function(type, val) {
+  this.end = this.pos;
+  if (this.options.locations) {
+    this.endLoc = this.curPosition();
+  }
+  var prevType = this.type;
+  this.type = type;
+  this.value = val;
+  this.updateContext(prevType);
+};
+pp.readToken_dot = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next >= 48 && next <= 57) {
+    return this.readNumber(true);
+  }
+  var next2 = this.input.charCodeAt(this.pos + 2);
+  if (this.options.ecmaVersion >= 6 && next === 46 && next2 === 46) {
+    this.pos += 3;
+    return this.finishToken(types$1.ellipsis);
+  } else {
+    ++this.pos;
+    return this.finishToken(types$1.dot);
+  }
+};
+pp.readToken_slash = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (this.exprAllowed) {
+    ++this.pos;
+    return this.readRegexp();
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.slash, 1);
+};
+pp.readToken_mult_modulo_exp = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  var tokentype = code2 === 42 ? types$1.star : types$1.modulo;
+  if (this.options.ecmaVersion >= 7 && code2 === 42 && next === 42) {
+    ++size;
+    tokentype = types$1.starstar;
+    next = this.input.charCodeAt(this.pos + 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, size + 1);
+  }
+  return this.finishOp(tokentype, size);
+};
+pp.readToken_pipe_amp = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code2) {
+    if (this.options.ecmaVersion >= 12) {
+      var next2 = this.input.charCodeAt(this.pos + 2);
+      if (next2 === 61) {
+        return this.finishOp(types$1.assign, 3);
+      }
+    }
+    return this.finishOp(code2 === 124 ? types$1.logicalOR : types$1.logicalAND, 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(code2 === 124 ? types$1.bitwiseOR : types$1.bitwiseAND, 1);
+};
+pp.readToken_caret = function() {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.bitwiseXOR, 1);
+};
+pp.readToken_plus_min = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === code2) {
+    if (next === 45 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 62 && (this.lastTokEnd === 0 || lineBreak.test(this.input.slice(this.lastTokEnd, this.pos)))) {
+      this.skipLineComment(3);
+      this.skipSpace();
+      return this.nextToken();
+    }
+    return this.finishOp(types$1.incDec, 2);
+  }
+  if (next === 61) {
+    return this.finishOp(types$1.assign, 2);
+  }
+  return this.finishOp(types$1.plusMin, 1);
+};
+pp.readToken_lt_gt = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  var size = 1;
+  if (next === code2) {
+    size = code2 === 62 && this.input.charCodeAt(this.pos + 2) === 62 ? 3 : 2;
+    if (this.input.charCodeAt(this.pos + size) === 61) {
+      return this.finishOp(types$1.assign, size + 1);
+    }
+    return this.finishOp(types$1.bitShift, size);
+  }
+  if (next === 33 && code2 === 60 && !this.inModule && this.input.charCodeAt(this.pos + 2) === 45 && this.input.charCodeAt(this.pos + 3) === 45) {
+    this.skipLineComment(4);
+    this.skipSpace();
+    return this.nextToken();
+  }
+  if (next === 61) {
+    size = 2;
+  }
+  return this.finishOp(types$1.relational, size);
+};
+pp.readToken_eq_excl = function(code2) {
+  var next = this.input.charCodeAt(this.pos + 1);
+  if (next === 61) {
+    return this.finishOp(types$1.equality, this.input.charCodeAt(this.pos + 2) === 61 ? 3 : 2);
+  }
+  if (code2 === 61 && next === 62 && this.options.ecmaVersion >= 6) {
+    this.pos += 2;
+    return this.finishToken(types$1.arrow);
+  }
+  return this.finishOp(code2 === 61 ? types$1.eq : types$1.prefix, 1);
+};
+pp.readToken_question = function() {
+  var ecmaVersion = this.options.ecmaVersion;
+  if (ecmaVersion >= 11) {
+    var next = this.input.charCodeAt(this.pos + 1);
+    if (next === 46) {
+      var next2 = this.input.charCodeAt(this.pos + 2);
+      if (next2 < 48 || next2 > 57) {
+        return this.finishOp(types$1.questionDot, 2);
+      }
+    }
+    if (next === 63) {
+      if (ecmaVersion >= 12) {
+        var next2$1 = this.input.charCodeAt(this.pos + 2);
+        if (next2$1 === 61) {
+          return this.finishOp(types$1.assign, 3);
+        }
+      }
+      return this.finishOp(types$1.coalesce, 2);
+    }
+  }
+  return this.finishOp(types$1.question, 1);
+};
+pp.readToken_numberSign = function() {
+  var ecmaVersion = this.options.ecmaVersion;
+  var code2 = 35;
+  if (ecmaVersion >= 13) {
+    ++this.pos;
+    code2 = this.fullCharCodeAtPos();
+    if (isIdentifierStart(code2, true) || code2 === 92) {
+      return this.finishToken(types$1.privateId, this.readWord1());
+    }
+  }
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code2) + "'");
+};
+pp.getTokenFromCode = function(code2) {
+  switch (code2) {
+    case 46:
+      return this.readToken_dot();
+    case 40:
+      ++this.pos;
+      return this.finishToken(types$1.parenL);
+    case 41:
+      ++this.pos;
+      return this.finishToken(types$1.parenR);
+    case 59:
+      ++this.pos;
+      return this.finishToken(types$1.semi);
+    case 44:
+      ++this.pos;
+      return this.finishToken(types$1.comma);
+    case 91:
+      ++this.pos;
+      return this.finishToken(types$1.bracketL);
+    case 93:
+      ++this.pos;
+      return this.finishToken(types$1.bracketR);
+    case 123:
+      ++this.pos;
+      return this.finishToken(types$1.braceL);
+    case 125:
+      ++this.pos;
+      return this.finishToken(types$1.braceR);
+    case 58:
+      ++this.pos;
+      return this.finishToken(types$1.colon);
+    case 96:
+      if (this.options.ecmaVersion < 6) {
+        break;
+      }
+      ++this.pos;
+      return this.finishToken(types$1.backQuote);
+    case 48:
+      var next = this.input.charCodeAt(this.pos + 1);
+      if (next === 120 || next === 88) {
+        return this.readRadixNumber(16);
+      }
+      if (this.options.ecmaVersion >= 6) {
+        if (next === 111 || next === 79) {
+          return this.readRadixNumber(8);
+        }
+        if (next === 98 || next === 66) {
+          return this.readRadixNumber(2);
+        }
+      }
+    case 49:
+    case 50:
+    case 51:
+    case 52:
+    case 53:
+    case 54:
+    case 55:
+    case 56:
+    case 57:
+      return this.readNumber(false);
+    case 34:
+    case 39:
+      return this.readString(code2);
+    case 47:
+      return this.readToken_slash();
+    case 37:
+    case 42:
+      return this.readToken_mult_modulo_exp(code2);
+    case 124:
+    case 38:
+      return this.readToken_pipe_amp(code2);
+    case 94:
+      return this.readToken_caret();
+    case 43:
+    case 45:
+      return this.readToken_plus_min(code2);
+    case 60:
+    case 62:
+      return this.readToken_lt_gt(code2);
+    case 61:
+    case 33:
+      return this.readToken_eq_excl(code2);
+    case 63:
+      return this.readToken_question();
+    case 126:
+      return this.finishOp(types$1.prefix, 1);
+    case 35:
+      return this.readToken_numberSign();
+  }
+  this.raise(this.pos, "Unexpected character '" + codePointToString(code2) + "'");
+};
+pp.finishOp = function(type, size) {
+  var str = this.input.slice(this.pos, this.pos + size);
+  this.pos += size;
+  return this.finishToken(type, str);
+};
+pp.readRegexp = function() {
+  var escaped, inClass, start2 = this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(start2, "Unterminated regular expression");
+    }
+    var ch = this.input.charAt(this.pos);
+    if (lineBreak.test(ch)) {
+      this.raise(start2, "Unterminated regular expression");
+    }
+    if (!escaped) {
+      if (ch === "[") {
+        inClass = true;
+      } else if (ch === "]" && inClass) {
+        inClass = false;
+      } else if (ch === "/" && !inClass) {
+        break;
+      }
+      escaped = ch === "\\";
+    } else {
+      escaped = false;
+    }
+    ++this.pos;
+  }
+  var pattern = this.input.slice(start2, this.pos);
+  ++this.pos;
+  var flagsStart = this.pos;
+  var flags = this.readWord1();
+  if (this.containsEsc) {
+    this.unexpected(flagsStart);
+  }
+  var state = this.regexpState || (this.regexpState = new RegExpValidationState(this));
+  state.reset(start2, pattern, flags);
+  this.validateRegExpFlags(state);
+  this.validateRegExpPattern(state);
+  var value = null;
+  try {
+    value = new RegExp(pattern, flags);
+  } catch (e) {
+  }
+  return this.finishToken(types$1.regexp, { pattern, flags, value });
+};
+pp.readInt = function(radix, len, maybeLegacyOctalNumericLiteral) {
+  var allowSeparators = this.options.ecmaVersion >= 12 && len === void 0;
+  var isLegacyOctalNumericLiteral = maybeLegacyOctalNumericLiteral && this.input.charCodeAt(this.pos) === 48;
+  var start2 = this.pos, total = 0, lastCode = 0;
+  for (var i = 0, e = len == null ? Infinity : len; i < e; ++i, ++this.pos) {
+    var code2 = this.input.charCodeAt(this.pos), val = void 0;
+    if (allowSeparators && code2 === 95) {
+      if (isLegacyOctalNumericLiteral) {
+        this.raiseRecoverable(this.pos, "Numeric separator is not allowed in legacy octal numeric literals");
+      }
+      if (lastCode === 95) {
+        this.raiseRecoverable(this.pos, "Numeric separator must be exactly one underscore");
+      }
+      if (i === 0) {
+        this.raiseRecoverable(this.pos, "Numeric separator is not allowed at the first of digits");
+      }
+      lastCode = code2;
+      continue;
+    }
+    if (code2 >= 97) {
+      val = code2 - 97 + 10;
+    } else if (code2 >= 65) {
+      val = code2 - 65 + 10;
+    } else if (code2 >= 48 && code2 <= 57) {
+      val = code2 - 48;
+    } else {
+      val = Infinity;
+    }
+    if (val >= radix) {
+      break;
+    }
+    lastCode = code2;
+    total = total * radix + val;
+  }
+  if (allowSeparators && lastCode === 95) {
+    this.raiseRecoverable(this.pos - 1, "Numeric separator is not allowed at the last of digits");
+  }
+  if (this.pos === start2 || len != null && this.pos - start2 !== len) {
+    return null;
+  }
+  return total;
+};
+function stringToNumber(str, isLegacyOctalNumericLiteral) {
+  if (isLegacyOctalNumericLiteral) {
+    return parseInt(str, 8);
+  }
+  return parseFloat(str.replace(/_/g, ""));
+}
+function stringToBigInt(str) {
+  if (typeof BigInt !== "function") {
+    return null;
+  }
+  return BigInt(str.replace(/_/g, ""));
+}
+pp.readRadixNumber = function(radix) {
+  var start2 = this.pos;
+  this.pos += 2;
+  var val = this.readInt(radix);
+  if (val == null) {
+    this.raise(this.start + 2, "Expected number in radix " + radix);
+  }
+  if (this.options.ecmaVersion >= 11 && this.input.charCodeAt(this.pos) === 110) {
+    val = stringToBigInt(this.input.slice(start2, this.pos));
+    ++this.pos;
+  } else if (isIdentifierStart(this.fullCharCodeAtPos())) {
+    this.raise(this.pos, "Identifier directly after number");
+  }
+  return this.finishToken(types$1.num, val);
+};
+pp.readNumber = function(startsWithDot) {
+  var start2 = this.pos;
+  if (!startsWithDot && this.readInt(10, void 0, true) === null) {
+    this.raise(start2, "Invalid number");
+  }
+  var octal = this.pos - start2 >= 2 && this.input.charCodeAt(start2) === 48;
+  if (octal && this.strict) {
+    this.raise(start2, "Invalid number");
+  }
+  var next = this.input.charCodeAt(this.pos);
+  if (!octal && !startsWithDot && this.options.ecmaVersion >= 11 && next === 110) {
+    var val$1 = stringToBigInt(this.input.slice(start2, this.pos));
+    ++this.pos;
+    if (isIdentifierStart(this.fullCharCodeAtPos())) {
+      this.raise(this.pos, "Identifier directly after number");
+    }
+    return this.finishToken(types$1.num, val$1);
+  }
+  if (octal && /[89]/.test(this.input.slice(start2, this.pos))) {
+    octal = false;
+  }
+  if (next === 46 && !octal) {
+    ++this.pos;
+    this.readInt(10);
+    next = this.input.charCodeAt(this.pos);
+  }
+  if ((next === 69 || next === 101) && !octal) {
+    next = this.input.charCodeAt(++this.pos);
+    if (next === 43 || next === 45) {
+      ++this.pos;
+    }
+    if (this.readInt(10) === null) {
+      this.raise(start2, "Invalid number");
+    }
+  }
+  if (isIdentifierStart(this.fullCharCodeAtPos())) {
+    this.raise(this.pos, "Identifier directly after number");
+  }
+  var val = stringToNumber(this.input.slice(start2, this.pos), octal);
+  return this.finishToken(types$1.num, val);
+};
+pp.readCodePoint = function() {
+  var ch = this.input.charCodeAt(this.pos), code2;
+  if (ch === 123) {
+    if (this.options.ecmaVersion < 6) {
+      this.unexpected();
+    }
+    var codePos = ++this.pos;
+    code2 = this.readHexChar(this.input.indexOf("}", this.pos) - this.pos);
+    ++this.pos;
+    if (code2 > 1114111) {
+      this.invalidStringToken(codePos, "Code point out of bounds");
+    }
+  } else {
+    code2 = this.readHexChar(4);
+  }
+  return code2;
+};
+pp.readString = function(quote) {
+  var out = "", chunkStart = ++this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(this.start, "Unterminated string constant");
+    }
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === quote) {
+      break;
+    }
+    if (ch === 92) {
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar(false);
+      chunkStart = this.pos;
+    } else if (ch === 8232 || ch === 8233) {
+      if (this.options.ecmaVersion < 10) {
+        this.raise(this.start, "Unterminated string constant");
+      }
+      ++this.pos;
+      if (this.options.locations) {
+        this.curLine++;
+        this.lineStart = this.pos;
+      }
+    } else {
+      if (isNewLine(ch)) {
+        this.raise(this.start, "Unterminated string constant");
+      }
+      ++this.pos;
+    }
+  }
+  out += this.input.slice(chunkStart, this.pos++);
+  return this.finishToken(types$1.string, out);
+};
+var INVALID_TEMPLATE_ESCAPE_ERROR = {};
+pp.tryReadTemplateToken = function() {
+  this.inTemplateElement = true;
+  try {
+    this.readTmplToken();
+  } catch (err) {
+    if (err === INVALID_TEMPLATE_ESCAPE_ERROR) {
+      this.readInvalidTemplateToken();
+    } else {
+      throw err;
+    }
+  }
+  this.inTemplateElement = false;
+};
+pp.invalidStringToken = function(position3, message) {
+  if (this.inTemplateElement && this.options.ecmaVersion >= 9) {
+    throw INVALID_TEMPLATE_ESCAPE_ERROR;
+  } else {
+    this.raise(position3, message);
+  }
+};
+pp.readTmplToken = function() {
+  var out = "", chunkStart = this.pos;
+  for (; ; ) {
+    if (this.pos >= this.input.length) {
+      this.raise(this.start, "Unterminated template");
+    }
+    var ch = this.input.charCodeAt(this.pos);
+    if (ch === 96 || ch === 36 && this.input.charCodeAt(this.pos + 1) === 123) {
+      if (this.pos === this.start && (this.type === types$1.template || this.type === types$1.invalidTemplate)) {
+        if (ch === 36) {
+          this.pos += 2;
+          return this.finishToken(types$1.dollarBraceL);
+        } else {
+          ++this.pos;
+          return this.finishToken(types$1.backQuote);
+        }
+      }
+      out += this.input.slice(chunkStart, this.pos);
+      return this.finishToken(types$1.template, out);
+    }
+    if (ch === 92) {
+      out += this.input.slice(chunkStart, this.pos);
+      out += this.readEscapedChar(true);
+      chunkStart = this.pos;
+    } else if (isNewLine(ch)) {
+      out += this.input.slice(chunkStart, this.pos);
+      ++this.pos;
+      switch (ch) {
+        case 13:
+          if (this.input.charCodeAt(this.pos) === 10) {
+            ++this.pos;
+          }
+        case 10:
+          out += "\n";
+          break;
+        default:
+          out += String.fromCharCode(ch);
+          break;
+      }
+      if (this.options.locations) {
+        ++this.curLine;
+        this.lineStart = this.pos;
+      }
+      chunkStart = this.pos;
+    } else {
+      ++this.pos;
+    }
+  }
+};
+pp.readInvalidTemplateToken = function() {
+  for (; this.pos < this.input.length; this.pos++) {
+    switch (this.input[this.pos]) {
+      case "\\":
+        ++this.pos;
+        break;
+      case "$":
+        if (this.input[this.pos + 1] !== "{") {
+          break;
+        }
+      case "`":
+        return this.finishToken(types$1.invalidTemplate, this.input.slice(this.start, this.pos));
+      case "\r":
+        if (this.input[this.pos + 1] === "\n") {
+          ++this.pos;
+        }
+      case "\n":
+      case "\u2028":
+      case "\u2029":
+        ++this.curLine;
+        this.lineStart = this.pos + 1;
+        break;
+    }
+  }
+  this.raise(this.start, "Unterminated template");
+};
+pp.readEscapedChar = function(inTemplate) {
+  var ch = this.input.charCodeAt(++this.pos);
+  ++this.pos;
+  switch (ch) {
+    case 110:
+      return "\n";
+    case 114:
+      return "\r";
+    case 120:
+      return String.fromCharCode(this.readHexChar(2));
+    case 117:
+      return codePointToString(this.readCodePoint());
+    case 116:
+      return "	";
+    case 98:
+      return "\b";
+    case 118:
+      return "\v";
+    case 102:
+      return "\f";
+    case 13:
+      if (this.input.charCodeAt(this.pos) === 10) {
+        ++this.pos;
+      }
+    case 10:
+      if (this.options.locations) {
+        this.lineStart = this.pos;
+        ++this.curLine;
+      }
+      return "";
+    case 56:
+    case 57:
+      if (this.strict) {
+        this.invalidStringToken(
+          this.pos - 1,
+          "Invalid escape sequence"
+        );
+      }
+      if (inTemplate) {
+        var codePos = this.pos - 1;
+        this.invalidStringToken(
+          codePos,
+          "Invalid escape sequence in template string"
+        );
+      }
+    default:
+      if (ch >= 48 && ch <= 55) {
+        var octalStr = this.input.substr(this.pos - 1, 3).match(/^[0-7]+/)[0];
+        var octal = parseInt(octalStr, 8);
+        if (octal > 255) {
+          octalStr = octalStr.slice(0, -1);
+          octal = parseInt(octalStr, 8);
+        }
+        this.pos += octalStr.length - 1;
+        ch = this.input.charCodeAt(this.pos);
+        if ((octalStr !== "0" || ch === 56 || ch === 57) && (this.strict || inTemplate)) {
+          this.invalidStringToken(
+            this.pos - 1 - octalStr.length,
+            inTemplate ? "Octal literal in template string" : "Octal literal in strict mode"
+          );
+        }
+        return String.fromCharCode(octal);
+      }
+      if (isNewLine(ch)) {
+        if (this.options.locations) {
+          this.lineStart = this.pos;
+          ++this.curLine;
+        }
+        return "";
+      }
+      return String.fromCharCode(ch);
+  }
+};
+pp.readHexChar = function(len) {
+  var codePos = this.pos;
+  var n = this.readInt(16, len);
+  if (n === null) {
+    this.invalidStringToken(codePos, "Bad character escape sequence");
+  }
+  return n;
+};
+pp.readWord1 = function() {
+  this.containsEsc = false;
+  var word = "", first = true, chunkStart = this.pos;
+  var astral = this.options.ecmaVersion >= 6;
+  while (this.pos < this.input.length) {
+    var ch = this.fullCharCodeAtPos();
+    if (isIdentifierChar(ch, astral)) {
+      this.pos += ch <= 65535 ? 1 : 2;
+    } else if (ch === 92) {
+      this.containsEsc = true;
+      word += this.input.slice(chunkStart, this.pos);
+      var escStart = this.pos;
+      if (this.input.charCodeAt(++this.pos) !== 117) {
+        this.invalidStringToken(this.pos, "Expecting Unicode escape sequence \\uXXXX");
+      }
+      ++this.pos;
+      var esc = this.readCodePoint();
+      if (!(first ? isIdentifierStart : isIdentifierChar)(esc, astral)) {
+        this.invalidStringToken(escStart, "Invalid Unicode escape");
+      }
+      word += codePointToString(esc);
+      chunkStart = this.pos;
+    } else {
+      break;
+    }
+    first = false;
+  }
+  return word + this.input.slice(chunkStart, this.pos);
+};
+pp.readWord = function() {
+  var word = this.readWord1();
+  var type = types$1.name;
+  if (this.keywords.test(word)) {
+    type = keywords[word];
+  }
+  return this.finishToken(type, word);
+};
+var version = "8.12.1";
+Parser.acorn = {
+  Parser,
+  version,
+  defaultOptions,
+  Position,
+  SourceLocation,
+  getLineInfo,
+  Node,
+  TokenType,
+  tokTypes: types$1,
+  keywordTypes: keywords,
+  TokContext,
+  tokContexts: types,
+  isIdentifierChar,
+  isIdentifierStart,
+  Token,
+  isNewLine,
+  lineBreak,
+  lineBreakG,
+  nonASCIIwhitespace
+};
+
+// node_modules/micromark-extension-mdxjs/index.js
+var import_acorn_jsx = __toESM(require_acorn_jsx(), 1);
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function asciiControl(code2) {
+  return (
+    // Special whitespace codes (which have negative values), C0 and Control
+    // character DEL
+    code2 !== null && (code2 < 32 || code2 === 127)
+  );
+}
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+function markdownLineEnding(code2) {
+  return code2 !== null && code2 < -2;
+}
+function markdownLineEndingOrSpace(code2) {
+  return code2 !== null && (code2 < 0 || code2 === 32);
+}
+function markdownSpace(code2) {
+  return code2 === -2 || code2 === -1 || code2 === 32;
+}
+var unicodePunctuation = regexCheck(/\p{P}|\p{S}/u);
+var unicodeWhitespace = regexCheck(/\s/);
+function regexCheck(regex2) {
+  return check;
+  function check(code2) {
+    return code2 !== null && code2 > -1 && regex2.test(String.fromCharCode(code2));
+  }
+}
+
+// node_modules/estree-util-visit/lib/color.node.js
+function color(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/estree-util-visit/lib/index.js
+var own2 = {}.hasOwnProperty;
+var CONTINUE = Symbol("continue");
+var EXIT = Symbol("exit");
+var SKIP = Symbol("skip");
+function visit(tree, visitor) {
+  let enter;
+  let leave;
+  if (typeof visitor === "function") {
+    enter = visitor;
+  } else if (visitor && typeof visitor === "object") {
+    if (visitor.enter) enter = visitor.enter;
+    if (visitor.leave) leave = visitor.leave;
+  }
+  build(tree, void 0, void 0, [])();
+  function build(node2, key, index2, parents) {
+    if (nodelike(node2)) {
+      visit4.displayName = "node (" + color(node2.type) + ")";
+    }
+    return visit4;
+    function visit4() {
+      const result = enter ? toResult(enter(node2, key, index2, parents)) : [];
+      if (result[0] === EXIT) {
+        return result;
+      }
+      if (result[0] !== SKIP) {
+        let cKey;
+        for (cKey in node2) {
+          if (own2.call(node2, cKey) && node2[cKey] && typeof node2[cKey] === "object" && // @ts-expect-error: custom esast extension.
+          cKey !== "data" && // @ts-expect-error: custom esast extension.
+          cKey !== "position") {
+            const grandparents = parents.concat(node2);
+            const value = node2[cKey];
+            if (Array.isArray(value)) {
+              const nodes = (
+                /** @type {Array<unknown>} */
+                value
+              );
+              let cIndex = 0;
+              while (cIndex > -1 && cIndex < nodes.length) {
+                const subvalue = nodes[cIndex];
+                if (nodelike(subvalue)) {
+                  const subresult = build(
+                    subvalue,
+                    cKey,
+                    cIndex,
+                    grandparents
+                  )();
+                  if (subresult[0] === EXIT) return subresult;
+                  cIndex = typeof subresult[1] === "number" ? subresult[1] : cIndex + 1;
+                } else {
+                  cIndex++;
+                }
+              }
+            } else if (nodelike(value)) {
+              const subresult = build(value, cKey, void 0, grandparents)();
+              if (subresult[0] === EXIT) return subresult;
+            }
+          }
+        }
+      }
+      return leave ? toResult(leave(node2, key, index2, parents)) : result;
+    }
+  }
+}
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return [value];
+}
+function nodelike(value) {
+  return Boolean(
+    value && typeof value === "object" && "type" in value && typeof value.type === "string" && value.type.length > 0
+  );
+}
+
+// node_modules/micromark-util-events-to-acorn/index.js
+function eventsToAcorn(events, options) {
+  const prefix = options.prefix || "";
+  const suffix = options.suffix || "";
+  const acornOptions = Object.assign({}, options.acornOptions);
+  const comments = [];
+  const tokens = [];
+  const onComment = acornOptions.onComment;
+  const onToken = acornOptions.onToken;
+  let swallow = false;
+  let estree;
+  let exception;
+  const acornConfig = Object.assign({}, acornOptions, {
+    onComment: comments,
+    preserveParens: true
+  });
+  if (onToken) {
+    acornConfig.onToken = tokens;
+  }
+  const collection = collect(events, options.tokenTypes);
+  const source = collection.value;
+  const value = prefix + source + suffix;
+  const isEmptyExpression = options.expression && empty2(source);
+  if (isEmptyExpression && !options.allowEmpty) {
+    throw new VFileMessage("Unexpected empty expression", {
+      place: parseOffsetToUnistPoint(0),
+      ruleId: "unexpected-empty-expression",
+      source: "micromark-extension-mdx-expression"
+    });
+  }
+  try {
+    estree = options.expression && !isEmptyExpression ? options.acorn.parseExpressionAt(value, 0, acornConfig) : options.acorn.parse(value, acornConfig);
+  } catch (error_) {
+    const error = (
+      /** @type {AcornError} */
+      error_
+    );
+    const point4 = parseOffsetToUnistPoint(error.pos);
+    error.message = String(error.message).replace(/ \(\d+:\d+\)$/, "");
+    error.pos = point4.offset;
+    error.loc = {
+      line: point4.line,
+      column: point4.column - 1
+    };
+    exception = error;
+    swallow = error.raisedAt >= prefix.length + source.length || // Broken comments are raised at their start, not their end.
+    error.message === "Unterminated comment";
+  }
+  if (estree && options.expression && !isEmptyExpression) {
+    if (empty2(value.slice(estree.end, value.length - suffix.length))) {
+      estree = {
+        type: "Program",
+        start: 0,
+        end: prefix.length + source.length,
+        // @ts-expect-error: It’s good.
+        body: [{
+          type: "ExpressionStatement",
+          expression: estree,
+          start: 0,
+          end: prefix.length + source.length
+        }],
+        sourceType: "module",
+        comments: []
+      };
+    } else {
+      const point4 = parseOffsetToUnistPoint(estree.end);
+      const error = (
+        /** @type {AcornError} */
+        new Error("Unexpected content after expression")
+      );
+      error.pos = point4.offset;
+      error.loc = {
+        line: point4.line,
+        column: point4.column - 1
+      };
+      exception = error;
+      estree = void 0;
+    }
+  }
+  if (estree) {
+    estree.comments = comments;
+    visit(estree, function(esnode, field, index2, parents) {
+      let context = (
+        /** @type {AcornNode | Array<AcornNode>} */
+        parents[parents.length - 1]
+      );
+      let prop = field;
+      if (esnode.type === "ParenthesizedExpression" && context && prop) {
+        if (typeof index2 === "number") {
+          context = context[prop];
+          prop = index2;
+        }
+        context[prop] = esnode.expression;
+      }
+      fixPosition(esnode);
+    });
+    if (Array.isArray(onComment)) {
+      onComment.push(...comments);
+    } else if (typeof onComment === "function") {
+      for (const comment2 of comments) {
+        onComment(comment2.type === "Block", comment2.value, comment2.start, comment2.end, comment2.loc.start, comment2.loc.end);
+      }
+    }
+    for (const token of tokens) {
+      if (token.end <= prefix.length || token.start - prefix.length >= source.length) {
+        continue;
+      }
+      fixPosition(token);
+      if (Array.isArray(onToken)) {
+        onToken.push(token);
+      } else {
+        onToken(token);
+      }
+    }
+  }
+  return {
+    estree,
+    error: exception,
+    swallow
+  };
+  function fixPosition(nodeOrToken) {
+    const pointStart2 = parseOffsetToUnistPoint(nodeOrToken.start);
+    const pointEnd2 = parseOffsetToUnistPoint(nodeOrToken.end);
+    nodeOrToken.start = pointStart2.offset;
+    nodeOrToken.end = pointEnd2.offset;
+    nodeOrToken.loc = {
+      start: {
+        line: pointStart2.line,
+        column: pointStart2.column - 1,
+        offset: pointStart2.offset
+      },
+      end: {
+        line: pointEnd2.line,
+        column: pointEnd2.column - 1,
+        offset: pointEnd2.offset
+      }
+    };
+    nodeOrToken.range = [nodeOrToken.start, nodeOrToken.end];
+  }
+  function parseOffsetToUnistPoint(acornOffset) {
+    let sourceOffset = acornOffset - prefix.length;
+    if (sourceOffset < 0) {
+      sourceOffset = 0;
+    } else if (sourceOffset > source.length) {
+      sourceOffset = source.length;
+    }
+    let point4 = relativeToPoint(collection.stops, sourceOffset);
+    if (!point4) {
+      point4 = {
+        line: options.start.line,
+        column: options.start.column,
+        offset: options.start.offset
+      };
+    }
+    return point4;
+  }
+}
+function empty2(value) {
+  return /^\s*$/.test(value.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/[^\r\n]*(\r\n|\n|\r)/g, ""));
+}
+function collect(events, tokenTypes) {
+  const result = {
+    value: "",
+    stops: []
+  };
+  let index2 = -1;
+  while (++index2 < events.length) {
+    const event = events[index2];
+    if (event[0] === "enter") {
+      const type = event[1].type;
+      if (type === "lineEnding" || tokenTypes.includes(type)) {
+        const chunks = event[2].sliceStream(event[1]);
+        while (chunks.length > 0 && chunks[0] === -1) {
+          chunks.shift();
+        }
+        const value = serializeChunks(chunks);
+        result.stops.push([result.value.length, event[1].start]);
+        result.value += value;
+        result.stops.push([result.value.length, event[1].end]);
+      }
+    }
+  }
+  return result;
+}
+function relativeToPoint(stops, relative) {
+  let index2 = 0;
+  while (index2 < stops.length && stops[index2][0] <= relative) {
+    index2 += 1;
+  }
+  if (index2 === 0) {
+    return void 0;
+  }
+  const [stopRelative, stopAbsolute] = stops[index2 - 1];
+  const rest = relative - stopRelative;
+  return {
+    line: stopAbsolute.line,
+    column: stopAbsolute.column + rest,
+    offset: stopAbsolute.offset + rest
+  };
+}
+function serializeChunks(chunks) {
+  let index2 = -1;
+  const result = [];
+  let atTab;
+  while (++index2 < chunks.length) {
+    const chunk = chunks[index2];
+    let value;
+    if (typeof chunk === "string") {
+      value = chunk;
+    } else switch (chunk) {
+      case -5: {
+        value = "\r";
+        break;
+      }
+      case -4: {
+        value = "\n";
+        break;
+      }
+      case -3: {
+        value = "\r\n";
+        break;
+      }
+      case -2: {
+        value = "	";
+        break;
+      }
+      case -1: {
+        if (atTab) continue;
+        value = " ";
+        break;
+      }
+      default: {
+        value = String.fromCharCode(chunk);
+      }
+    }
+    atTab = chunk === -2;
+    result.push(value);
+  }
+  return result.join("");
+}
+
+// node_modules/unist-util-position-from-estree/lib/index.js
+function positionFromEstree(node2) {
+  const nodeLike = node2 || {};
+  const loc = nodeLike.loc || {};
+  const range = nodeLike.range || [void 0, void 0];
+  const start2 = pointOrUndefined(loc.start, range[0] || nodeLike.start);
+  const end = pointOrUndefined(loc.end, range[1] || nodeLike.end);
+  if (start2 && end) {
+    return { start: start2, end };
+  }
+}
+function pointOrUndefined(estreePoint, estreeOffset) {
+  if (estreePoint && typeof estreePoint === "object") {
+    const line = "line" in estreePoint ? numberOrUndefined(estreePoint.line) : void 0;
+    const column = "column" in estreePoint ? numberOrUndefined(estreePoint.column) : void 0;
+    if (line && column !== void 0) {
+      return {
+        line,
+        column: column + 1,
+        offset: numberOrUndefined(estreeOffset)
+      };
+    }
+  }
+}
+function numberOrUndefined(value) {
+  return typeof value === "number" && value > -1 ? value : void 0;
+}
+
+// node_modules/micromark-factory-mdx-expression/index.js
+var trouble = "https://github.com/micromark/micromark-extension-mdx-expression/tree/main/packages/micromark-extension-mdx-expression";
+var unexpectedEofHash = "#unexpected-end-of-file-in-expression-expected-a-corresponding-closing-brace-for-";
+var unexpectedLazyHash = "#unexpected-lazy-line-in-expression-in-container-expected-line-to-be-prefixed";
+var nonSpreadHash = "#unexpected-type-in-code-expected-an-object-spread-spread";
+var spreadExtraHash = "#unexpected-extra-content-in-spread-only-a-single-spread-is-supported";
+var acornHash = "#could-not-parse-expression-with-acorn";
+function factoryMdxExpression(effects, ok4, type, markerType, chunkType, acorn, acornOptions, addResult, spread, allowEmpty, allowLazy) {
+  const self2 = this;
+  const eventStart = this.events.length + 3;
+  let size = 0;
+  let pointStart2;
+  let lastCrash;
+  return start2;
+  function start2(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    pointStart2 = self2.now();
+    return before;
+  }
+  function before(code2) {
+    if (code2 === null) {
+      if (lastCrash) throw lastCrash;
+      const error = new VFileMessage(
+        "Unexpected end of file in expression, expected a corresponding closing brace for `{`",
+        {
+          place: self2.now(),
+          ruleId: "unexpected-eof",
+          source: "micromark-extension-mdx-expression"
+        }
+      );
+      error.url = trouble + unexpectedEofHash;
+      throw error;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return eolAfter;
+    }
+    if (code2 === 125 && size === 0) {
+      const next = acorn ? mdxExpressionParse.call(
+        self2,
+        acorn,
+        acornOptions,
+        chunkType,
+        eventStart,
+        pointStart2,
+        allowEmpty || false,
+        spread || false
+      ) : {
+        type: "ok",
+        estree: void 0
+      };
+      if (next.type === "ok") {
+        effects.enter(markerType);
+        effects.consume(code2);
+        effects.exit(markerType);
+        const token = effects.exit(type);
+        if (addResult && next.estree) {
+          Object.assign(token, {
+            estree: next.estree
+          });
+        }
+        return ok4;
+      }
+      lastCrash = next.message;
+      effects.enter(chunkType);
+      effects.consume(code2);
+      return inside;
+    }
+    effects.enter(chunkType);
+    return inside(code2);
+  }
+  function inside(code2) {
+    if (code2 === 125 && size === 0 || code2 === null || markdownLineEnding(code2)) {
+      effects.exit(chunkType);
+      return before(code2);
+    }
+    if (code2 === 123 && !acorn) {
+      size += 1;
+    } else if (code2 === 125) {
+      size -= 1;
+    }
+    effects.consume(code2);
+    return inside;
+  }
+  function eolAfter(code2) {
+    const now = self2.now();
+    if (now.line !== pointStart2.line && !allowLazy && self2.parser.lazy[now.line]) {
+      const error = new VFileMessage(
+        "Unexpected lazy line in expression in container, expected line to be prefixed with `>` when in a block quote, whitespace when in a list, etc",
+        {
+          place: self2.now(),
+          ruleId: "unexpected-lazy",
+          source: "micromark-extension-mdx-expression"
+        }
+      );
+      error.url = trouble + unexpectedLazyHash;
+      throw error;
+    }
+    return before(code2);
+  }
+}
+function mdxExpressionParse(acorn, acornOptions, chunkType, eventStart, pointStart2, allowEmpty, spread) {
+  const result = eventsToAcorn(this.events.slice(eventStart), {
+    acorn,
+    tokenTypes: [chunkType],
+    acornOptions,
+    start: pointStart2,
+    expression: true,
+    allowEmpty,
+    prefix: spread ? "({" : "",
+    suffix: spread ? "})" : ""
+  });
+  const estree = result.estree;
+  if (spread && estree) {
+    const head = estree.body[0];
+    if (head.type !== "ExpressionStatement" || head.expression.type !== "ObjectExpression") {
+      const place = positionFromEstree(head);
+      const error = new VFileMessage(
+        "Unexpected `" + head.type + "` in code: expected an object spread (`{...spread}`)",
+        {
+          place: place.start,
+          ruleId: "non-spread",
+          source: "micromark-extension-mdx-expression"
+        }
+      );
+      error.url = trouble + nonSpreadHash;
+      throw error;
+    }
+    if (head.expression.properties[1]) {
+      const place = positionFromEstree(head.expression.properties[1]);
+      const error = new VFileMessage(
+        "Unexpected extra content in spread: only a single spread is supported",
+        {
+          place: place.start,
+          ruleId: "spread-extra",
+          source: "micromark-extension-mdx-expression"
+        }
+      );
+      error.url = trouble + spreadExtraHash;
+      throw error;
+    }
+    if (head.expression.properties[0] && head.expression.properties[0].type !== "SpreadElement") {
+      const place = positionFromEstree(head.expression.properties[0]);
+      const error = new VFileMessage(
+        "Unexpected `" + head.expression.properties[0].type + "` in code: only spread elements are supported",
+        {
+          place: place.start,
+          ruleId: "non-spread",
+          source: "micromark-extension-mdx-expression"
+        }
+      );
+      error.url = trouble + nonSpreadHash;
+      throw error;
+    }
+  }
+  if (result.error) {
+    const error = new VFileMessage("Could not parse expression with acorn", {
+      cause: result.error,
+      place: {
+        line: result.error.loc.line,
+        column: result.error.loc.column + 1,
+        offset: result.error.pos
+      },
+      ruleId: "acorn",
+      source: "micromark-extension-mdx-expression"
+    });
+    error.url = trouble + acornHash;
+    return {
+      type: "nok",
+      message: error
+    };
+  }
+  return {
+    type: "ok",
+    estree
+  };
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok4, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start2;
+  function start2(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter(type);
+      return prefix(code2);
+    }
+    return ok4(code2);
+  }
+  function prefix(code2) {
+    if (markdownSpace(code2) && size++ < limit) {
+      effects.consume(code2);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok4(code2);
+  }
+}
+
+// node_modules/micromark-extension-mdx-expression/lib/syntax.js
+function mdxExpression(options) {
+  const options_ = options || {};
+  const addResult = options_.addResult;
+  const acorn = options_.acorn;
+  const spread = options_.spread;
+  let allowEmpty = options_.allowEmpty;
+  let acornOptions;
+  if (allowEmpty === null || allowEmpty === void 0) {
+    allowEmpty = true;
+  }
+  if (acorn) {
+    if (!acorn.parseExpressionAt) {
+      throw new Error("Expected a proper `acorn` instance passed in as `options.acorn`");
+    }
+    acornOptions = Object.assign({
+      ecmaVersion: 2024,
+      sourceType: "module"
+    }, options_.acornOptions);
+  } else if (options_.acornOptions || options_.addResult) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  return {
+    flow: {
+      [123]: {
+        name: "mdxFlowExpression",
+        tokenize: tokenizeFlowExpression,
+        concrete: true
+      }
+    },
+    text: {
+      [123]: {
+        name: "mdxTextExpression",
+        tokenize: tokenizeTextExpression
+      }
+    }
+  };
+  function tokenizeFlowExpression(effects, ok4, nok) {
+    const self2 = this;
+    return start2;
+    function start2(code2) {
+      return before(code2);
+    }
+    function before(code2) {
+      return factoryMdxExpression.call(self2, effects, after, "mdxFlowExpression", "mdxFlowExpressionMarker", "mdxFlowExpressionChunk", acorn, acornOptions, addResult, spread, allowEmpty)(code2);
+    }
+    function after(code2) {
+      return markdownSpace(code2) ? factorySpace(effects, end, "whitespace")(code2) : end(code2);
+    }
+    function end(code2) {
+      const lessThanValue = self2.parser.constructs.flow[60];
+      const constructs2 = Array.isArray(lessThanValue) ? lessThanValue : (
+        /* c8 ignore next 3 -- always a list when normalized. */
+        lessThanValue ? [lessThanValue] : []
+      );
+      const jsxTag = constructs2.find(function(d) {
+        return d.name === "mdxJsxFlowTag";
+      });
+      if (code2 === 60 && jsxTag) {
+        return effects.attempt(jsxTag, end, nok)(code2);
+      }
+      return code2 === null || markdownLineEnding(code2) ? ok4(code2) : nok(code2);
+    }
+  }
+  function tokenizeTextExpression(effects, ok4) {
+    const self2 = this;
+    return start2;
+    function start2(code2) {
+      return factoryMdxExpression.call(self2, effects, ok4, "mdxTextExpression", "mdxTextExpressionMarker", "mdxTextExpressionChunk", acorn, acornOptions, addResult, spread, allowEmpty, true)(code2);
+    }
+  }
+}
+
+// node_modules/estree-util-is-identifier-name/lib/index.js
+var startRe = /[$_\p{ID_Start}]/u;
+var contRe = /[$_\u{200C}\u{200D}\p{ID_Continue}]/u;
+var contReJsx = /[-$_\u{200C}\u{200D}\p{ID_Continue}]/u;
+var nameRe = /^[$_\p{ID_Start}][$_\u{200C}\u{200D}\p{ID_Continue}]*$/u;
+var nameReJsx = /^[$_\p{ID_Start}][-$_\u{200C}\u{200D}\p{ID_Continue}]*$/u;
+var emptyOptions = {};
+function start(code2) {
+  return code2 ? startRe.test(String.fromCodePoint(code2)) : false;
+}
+function cont(code2, options) {
+  const settings = options || emptyOptions;
+  const re2 = settings.jsx ? contReJsx : contRe;
+  return code2 ? re2.test(String.fromCodePoint(code2)) : false;
+}
+function name(name2, options) {
+  const settings = options || emptyOptions;
+  const re2 = settings.jsx ? nameReJsx : nameRe;
+  return re2.test(name2);
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/factory-tag.js
+var trouble2 = "https://github.com/micromark/micromark-extension-mdx-jsx";
+function factoryTag(effects, ok4, nok, acorn, acornOptions, addResult, allowLazy, tagType, tagMarkerType, tagClosingMarkerType, tagSelfClosingMarker, tagNameType, tagNamePrimaryType, tagNameMemberMarkerType, tagNameMemberType, tagNamePrefixMarkerType, tagNameLocalType, tagExpressionAttributeType, tagExpressionAttributeMarkerType, tagExpressionAttributeValueType, tagAttributeType, tagAttributeNameType, tagAttributeNamePrimaryType, tagAttributeNamePrefixMarkerType, tagAttributeNameLocalType, tagAttributeInitializerMarkerType, tagAttributeValueLiteralType, tagAttributeValueLiteralMarkerType, tagAttributeValueLiteralValueType, tagAttributeValueExpressionType, tagAttributeValueExpressionMarkerType, tagAttributeValueExpressionValueType) {
+  const self2 = this;
+  let returnState;
+  let marker;
+  return start2;
+  function start2(code2) {
+    effects.enter(tagType);
+    effects.enter(tagMarkerType);
+    effects.consume(code2);
+    effects.exit(tagMarkerType);
+    return startAfter;
+  }
+  function startAfter(code2) {
+    if (markdownLineEndingOrSpace(code2)) {
+      return nok(code2);
+    }
+    returnState = nameBefore;
+    return esWhitespaceStart(code2);
+  }
+  function nameBefore(code2) {
+    if (code2 === 47) {
+      effects.enter(tagClosingMarkerType);
+      effects.consume(code2);
+      effects.exit(tagClosingMarkerType);
+      returnState = closingTagNameBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    if (code2 !== null && code2 >= 0 && start(code2)) {
+      effects.enter(tagNameType);
+      effects.enter(tagNamePrimaryType);
+      effects.consume(code2);
+      return primaryName;
+    }
+    crash(code2, "before name", "a character that can start a name, such as a letter, `$`, or `_`" + (code2 === 33 ? " (note: to create a comment in MDX, use `{/* text */}`)" : ""));
+  }
+  function closingTagNameBefore(code2) {
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    if (code2 !== null && code2 >= 0 && start(code2)) {
+      effects.enter(tagNameType);
+      effects.enter(tagNamePrimaryType);
+      effects.consume(code2);
+      return primaryName;
+    }
+    crash(code2, "before name", "a character that can start a name, such as a letter, `$`, or `_`" + (code2 === 42 || code2 === 47 ? " (note: JS comments in JSX tags are not supported in MDX)" : ""));
+  }
+  function primaryName(code2) {
+    if (code2 !== null && code2 >= 0 && cont(code2, {
+      jsx: true
+    })) {
+      effects.consume(code2);
+      return primaryName;
+    }
+    if (code2 === 46 || code2 === 47 || code2 === 58 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagNamePrimaryType);
+      returnState = primaryNameAfter;
+      return esWhitespaceStart(code2);
+    }
+    crash(code2, "in name", "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag" + (code2 === 64 ? " (note: to create a link in MDX, use `[text](url)`)" : ""));
+  }
+  function primaryNameAfter(code2) {
+    if (code2 === 46) {
+      effects.enter(tagNameMemberMarkerType);
+      effects.consume(code2);
+      effects.exit(tagNameMemberMarkerType);
+      returnState = memberNameBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 58) {
+      effects.enter(tagNamePrefixMarkerType);
+      effects.consume(code2);
+      effects.exit(tagNamePrefixMarkerType);
+      returnState = localNameBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && code2 >= 0 && start(code2)) {
+      effects.exit(tagNameType);
+      return attributeBefore(code2);
+    }
+    crash(code2, "after name", "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag");
+  }
+  function memberNameBefore(code2) {
+    if (code2 !== null && code2 >= 0 && start(code2)) {
+      effects.enter(tagNameMemberType);
+      effects.consume(code2);
+      return memberName;
+    }
+    crash(code2, "before member name", "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag");
+  }
+  function memberName(code2) {
+    if (code2 !== null && code2 >= 0 && cont(code2, {
+      jsx: true
+    })) {
+      effects.consume(code2);
+      return memberName;
+    }
+    if (code2 === 46 || code2 === 47 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagNameMemberType);
+      returnState = memberNameAfter;
+      return esWhitespaceStart(code2);
+    }
+    crash(code2, "in member name", "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag" + (code2 === 64 ? " (note: to create a link in MDX, use `[text](url)`)" : ""));
+  }
+  function memberNameAfter(code2) {
+    if (code2 === 46) {
+      effects.enter(tagNameMemberMarkerType);
+      effects.consume(code2);
+      effects.exit(tagNameMemberMarkerType);
+      returnState = memberNameBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && code2 >= 0 && start(code2)) {
+      effects.exit(tagNameType);
+      return attributeBefore(code2);
+    }
+    crash(code2, "after member name", "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag");
+  }
+  function localNameBefore(code2) {
+    if (code2 !== null && code2 >= 0 && start(code2)) {
+      effects.enter(tagNameLocalType);
+      effects.consume(code2);
+      return localName;
+    }
+    crash(code2, "before local name", "a character that can start a name, such as a letter, `$`, or `_`" + (code2 === 43 || code2 !== null && code2 > 46 && code2 < 58 ? " (note: to create a link in MDX, use `[text](url)`)" : ""));
+  }
+  function localName(code2) {
+    if (code2 !== null && code2 >= 0 && cont(code2, {
+      jsx: true
+    })) {
+      effects.consume(code2);
+      return localName;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagNameLocalType);
+      returnState = localNameAfter;
+      return esWhitespaceStart(code2);
+    }
+    crash(code2, "in local name", "a name character such as letters, digits, `$`, or `_`; whitespace before attributes; or the end of the tag");
+  }
+  function localNameAfter(code2) {
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && code2 >= 0 && start(code2)) {
+      effects.exit(tagNameType);
+      return attributeBefore(code2);
+    }
+    crash(code2, "after local name", "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag");
+  }
+  function attributeBefore(code2) {
+    if (code2 === 47) {
+      effects.enter(tagSelfClosingMarker);
+      effects.consume(code2);
+      effects.exit(tagSelfClosingMarker);
+      returnState = selfClosing;
+      return esWhitespaceStart;
+    }
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    if (code2 === 123) {
+      return factoryMdxExpression.call(self2, effects, attributeExpressionAfter, tagExpressionAttributeType, tagExpressionAttributeMarkerType, tagExpressionAttributeValueType, acorn, acornOptions, addResult, true, false, allowLazy)(code2);
+    }
+    if (code2 !== null && code2 >= 0 && start(code2)) {
+      effects.enter(tagAttributeType);
+      effects.enter(tagAttributeNameType);
+      effects.enter(tagAttributeNamePrimaryType);
+      effects.consume(code2);
+      return attributePrimaryName;
+    }
+    crash(code2, "before attribute name", "a character that can start an attribute name, such as a letter, `$`, or `_`; whitespace before attributes; or the end of the tag");
+  }
+  function attributeExpressionAfter(code2) {
+    returnState = attributeBefore;
+    return esWhitespaceStart(code2);
+  }
+  function attributePrimaryName(code2) {
+    if (code2 !== null && code2 >= 0 && cont(code2, {
+      jsx: true
+    })) {
+      effects.consume(code2);
+      return attributePrimaryName;
+    }
+    if (code2 === 47 || code2 === 58 || code2 === 61 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagAttributeNamePrimaryType);
+      returnState = attributePrimaryNameAfter;
+      return esWhitespaceStart(code2);
+    }
+    crash(code2, "in attribute name", "an attribute name character such as letters, digits, `$`, or `_`; `=` to initialize a value; whitespace before attributes; or the end of the tag");
+  }
+  function attributePrimaryNameAfter(code2) {
+    if (code2 === 58) {
+      effects.enter(tagAttributeNamePrefixMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeNamePrefixMarkerType);
+      returnState = attributeLocalNameBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 61) {
+      effects.exit(tagAttributeNameType);
+      effects.enter(tagAttributeInitializerMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeInitializerMarkerType);
+      returnState = attributeValueBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2) || code2 !== null && code2 >= 0 && start(code2)) {
+      effects.exit(tagAttributeNameType);
+      effects.exit(tagAttributeType);
+      returnState = attributeBefore;
+      return esWhitespaceStart(code2);
+    }
+    crash(code2, "after attribute name", "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag");
+  }
+  function attributeLocalNameBefore(code2) {
+    if (code2 !== null && code2 >= 0 && start(code2)) {
+      effects.enter(tagAttributeNameLocalType);
+      effects.consume(code2);
+      return attributeLocalName;
+    }
+    crash(code2, "before local attribute name", "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag");
+  }
+  function attributeLocalName(code2) {
+    if (code2 !== null && code2 >= 0 && cont(code2, {
+      jsx: true
+    })) {
+      effects.consume(code2);
+      return attributeLocalName;
+    }
+    if (code2 === 47 || code2 === 61 || code2 === 62 || code2 === 123 || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+      effects.exit(tagAttributeNameLocalType);
+      effects.exit(tagAttributeNameType);
+      returnState = attributeLocalNameAfter;
+      return esWhitespaceStart(code2);
+    }
+    crash(code2, "in local attribute name", "an attribute name character such as letters, digits, `$`, or `_`; `=` to initialize a value; whitespace before attributes; or the end of the tag");
+  }
+  function attributeLocalNameAfter(code2) {
+    if (code2 === 61) {
+      effects.enter(tagAttributeInitializerMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeInitializerMarkerType);
+      returnState = attributeValueBefore;
+      return esWhitespaceStart;
+    }
+    if (code2 === 47 || code2 === 62 || code2 === 123 || code2 !== null && code2 >= 0 && start(code2)) {
+      effects.exit(tagAttributeType);
+      return attributeBefore(code2);
+    }
+    crash(code2, "after local attribute name", "a character that can start an attribute name, such as a letter, `$`, or `_`; `=` to initialize a value; or the end of the tag");
+  }
+  function attributeValueBefore(code2) {
+    if (code2 === 34 || code2 === 39) {
+      effects.enter(tagAttributeValueLiteralType);
+      effects.enter(tagAttributeValueLiteralMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeValueLiteralMarkerType);
+      marker = code2;
+      return attributeValueQuotedStart;
+    }
+    if (code2 === 123) {
+      return factoryMdxExpression.call(self2, effects, attributeValueExpressionAfter, tagAttributeValueExpressionType, tagAttributeValueExpressionMarkerType, tagAttributeValueExpressionValueType, acorn, acornOptions, addResult, false, false, allowLazy)(code2);
+    }
+    crash(code2, "before attribute value", "a character that can start an attribute value, such as `\"`, `'`, or `{`" + (code2 === 60 ? " (note: to use an element or fragment as a prop value in MDX, use `{<element />}`)" : ""));
+  }
+  function attributeValueExpressionAfter(code2) {
+    effects.exit(tagAttributeType);
+    returnState = attributeBefore;
+    return esWhitespaceStart(code2);
+  }
+  function attributeValueQuotedStart(code2) {
+    if (code2 === null) {
+      crash(code2, "in attribute value", "a corresponding closing quote `" + String.fromCodePoint(marker) + "`");
+    }
+    if (code2 === marker) {
+      effects.enter(tagAttributeValueLiteralMarkerType);
+      effects.consume(code2);
+      effects.exit(tagAttributeValueLiteralMarkerType);
+      effects.exit(tagAttributeValueLiteralType);
+      effects.exit(tagAttributeType);
+      marker = void 0;
+      returnState = attributeBefore;
+      return esWhitespaceStart;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = attributeValueQuotedStart;
+      return esWhitespaceStart(code2);
+    }
+    effects.enter(tagAttributeValueLiteralValueType);
+    return attributeValueQuoted(code2);
+  }
+  function attributeValueQuoted(code2) {
+    if (code2 === null || code2 === marker || markdownLineEnding(code2)) {
+      effects.exit(tagAttributeValueLiteralValueType);
+      return attributeValueQuotedStart(code2);
+    }
+    effects.consume(code2);
+    return attributeValueQuoted;
+  }
+  function selfClosing(code2) {
+    if (code2 === 62) {
+      return tagEnd(code2);
+    }
+    crash(code2, "after self-closing slash", "`>` to end the tag" + (code2 === 42 || code2 === 47 ? " (note: JS comments in JSX tags are not supported in MDX)" : ""));
+  }
+  function tagEnd(code2) {
+    effects.enter(tagMarkerType);
+    effects.consume(code2);
+    effects.exit(tagMarkerType);
+    effects.exit(tagType);
+    return ok4;
+  }
+  function esWhitespaceStart(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return esWhitespaceEolAfter;
+    }
+    if (markdownSpace(code2) || unicodeWhitespace(code2)) {
+      effects.enter("esWhitespace");
+      return esWhitespaceInside(code2);
+    }
+    return returnState(code2);
+  }
+  function esWhitespaceInside(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.exit("esWhitespace");
+      return esWhitespaceStart(code2);
+    }
+    if (markdownSpace(code2) || unicodeWhitespace(code2)) {
+      effects.consume(code2);
+      return esWhitespaceInside;
+    }
+    effects.exit("esWhitespace");
+    return returnState(code2);
+  }
+  function esWhitespaceEolAfter(code2) {
+    if (!allowLazy && self2.parser.lazy[self2.now().line]) {
+      const error = new VFileMessage("Unexpected lazy line in container, expected line to be prefixed with `>` when in a block quote, whitespace when in a list, etc", self2.now(), "micromark-extension-mdx-jsx:unexpected-lazy");
+      error.url = trouble2 + "#unexpected-lazy-line-in-container-expected-line-to-be";
+      throw error;
+    }
+    return esWhitespaceStart(code2);
+  }
+  function crash(code2, at2, expect) {
+    const error = new VFileMessage("Unexpected " + (code2 === null ? "end of file" : "character `" + (code2 === 96 ? "` ` `" : String.fromCodePoint(code2)) + "` (" + serializeCharCode(code2) + ")") + " " + at2 + ", expected " + expect, self2.now(), "micromark-extension-mdx-jsx:unexpected-" + (code2 === null ? "eof" : "character"));
+    error.url = trouble2 + (code2 === null ? "#unexpected-end-of-file-at-expected-expect" : "#unexpected-character-at-expected-expect");
+    throw error;
+  }
+}
+function serializeCharCode(code2) {
+  return "U+" + code2.toString(16).toUpperCase().padStart(4, "0");
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/jsx-text.js
+function jsxText(acorn, options) {
+  return {
+    name: "mdxJsxTextTag",
+    tokenize: tokenizeJsxText
+  };
+  function tokenizeJsxText(effects, ok4, nok) {
+    return factoryTag.call(this, effects, ok4, nok, acorn, options.acornOptions, options.addResult, true, "mdxJsxTextTag", "mdxJsxTextTagMarker", "mdxJsxTextTagClosingMarker", "mdxJsxTextTagSelfClosingMarker", "mdxJsxTextTagName", "mdxJsxTextTagNamePrimary", "mdxJsxTextTagNameMemberMarker", "mdxJsxTextTagNameMember", "mdxJsxTextTagNamePrefixMarker", "mdxJsxTextTagNameLocal", "mdxJsxTextTagExpressionAttribute", "mdxJsxTextTagExpressionAttributeMarker", "mdxJsxTextTagExpressionAttributeValue", "mdxJsxTextTagAttribute", "mdxJsxTextTagAttributeName", "mdxJsxTextTagAttributeNamePrimary", "mdxJsxTextTagAttributeNamePrefixMarker", "mdxJsxTextTagAttributeNameLocal", "mdxJsxTextTagAttributeInitializerMarker", "mdxJsxTextTagAttributeValueLiteral", "mdxJsxTextTagAttributeValueLiteralMarker", "mdxJsxTextTagAttributeValueLiteralValue", "mdxJsxTextTagAttributeValueExpression", "mdxJsxTextTagAttributeValueExpressionMarker", "mdxJsxTextTagAttributeValueExpressionValue");
+  }
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/jsx-flow.js
+function jsxFlow(acorn, options) {
+  return {
+    name: "mdxJsxFlowTag",
+    tokenize: tokenizeJsxFlow,
+    concrete: true
+  };
+  function tokenizeJsxFlow(effects, ok4, nok) {
+    const self2 = this;
+    return start2;
+    function start2(code2) {
+      return before(code2);
+    }
+    function before(code2) {
+      return factoryTag.call(self2, effects, after, nok, acorn, options.acornOptions, options.addResult, false, "mdxJsxFlowTag", "mdxJsxFlowTagMarker", "mdxJsxFlowTagClosingMarker", "mdxJsxFlowTagSelfClosingMarker", "mdxJsxFlowTagName", "mdxJsxFlowTagNamePrimary", "mdxJsxFlowTagNameMemberMarker", "mdxJsxFlowTagNameMember", "mdxJsxFlowTagNamePrefixMarker", "mdxJsxFlowTagNameLocal", "mdxJsxFlowTagExpressionAttribute", "mdxJsxFlowTagExpressionAttributeMarker", "mdxJsxFlowTagExpressionAttributeValue", "mdxJsxFlowTagAttribute", "mdxJsxFlowTagAttributeName", "mdxJsxFlowTagAttributeNamePrimary", "mdxJsxFlowTagAttributeNamePrefixMarker", "mdxJsxFlowTagAttributeNameLocal", "mdxJsxFlowTagAttributeInitializerMarker", "mdxJsxFlowTagAttributeValueLiteral", "mdxJsxFlowTagAttributeValueLiteralMarker", "mdxJsxFlowTagAttributeValueLiteralValue", "mdxJsxFlowTagAttributeValueExpression", "mdxJsxFlowTagAttributeValueExpressionMarker", "mdxJsxFlowTagAttributeValueExpressionValue")(code2);
+    }
+    function after(code2) {
+      return markdownSpace(code2) ? factorySpace(effects, end, "whitespace")(code2) : end(code2);
+    }
+    function end(code2) {
+      const leftBraceValue = self2.parser.constructs.flow[123];
+      const constructs2 = Array.isArray(leftBraceValue) ? leftBraceValue : leftBraceValue ? [leftBraceValue] : [];
+      const expression = constructs2.find((d) => d.name === "mdxFlowExpression");
+      return code2 === 60 ? (
+        // We can’t just say: fine. Lines of blocks have to be parsed until an eol/eof.
+        start2(code2)
+      ) : code2 === 123 && expression ? effects.attempt(expression, end, nok)(code2) : code2 === null || markdownLineEnding(code2) ? ok4(code2) : nok(code2);
+    }
+  }
+}
+
+// node_modules/micromark-extension-mdx-jsx/lib/syntax.js
+function mdxJsx(options) {
+  const settings = options || {};
+  const acorn = settings.acorn;
+  let acornOptions;
+  if (acorn) {
+    if (!acorn.parse || !acorn.parseExpressionAt) {
+      throw new Error("Expected a proper `acorn` instance passed in as `options.acorn`");
+    }
+    acornOptions = Object.assign({
+      ecmaVersion: 2024,
+      sourceType: "module"
+    }, settings.acornOptions, {
+      locations: true
+    });
+  } else if (settings.acornOptions || settings.addResult) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  return {
+    flow: {
+      [60]: jsxFlow(acorn || void 0, {
+        acornOptions,
+        addResult: settings.addResult || void 0
+      })
+    },
+    text: {
+      [60]: jsxText(acorn || void 0, {
+        acornOptions,
+        addResult: settings.addResult || void 0
+      })
+    }
+  };
+}
+
+// node_modules/micromark-extension-mdx-md/index.js
+function mdxMd() {
+  return {
+    disable: { null: ["autolink", "codeIndented", "htmlFlow", "htmlText"] }
+  };
+}
+
+// node_modules/micromark-util-chunked/index.js
+function splice(list3, start2, remove, items) {
+  const end = list3.length;
+  let chunkStart = 0;
+  let parameters;
+  if (start2 < 0) {
+    start2 = -start2 > end ? 0 : end + start2;
+  } else {
+    start2 = start2 > end ? end : start2;
+  }
+  remove = remove > 0 ? remove : 0;
+  if (items.length < 1e4) {
+    parameters = Array.from(items);
+    parameters.unshift(start2, remove);
+    list3.splice(...parameters);
+  } else {
+    if (remove) list3.splice(start2, remove);
+    while (chunkStart < items.length) {
+      parameters = items.slice(chunkStart, chunkStart + 1e4);
+      parameters.unshift(start2, 0);
+      list3.splice(...parameters);
+      chunkStart += 1e4;
+      start2 += 1e4;
+    }
+  }
+}
+function push(list3, items) {
+  if (list3.length > 0) {
+    splice(list3, list3.length, 0, items);
+    return list3;
+  }
+  return items;
+}
+
+// node_modules/micromark-util-classify-character/index.js
+function classifyCharacter(code2) {
+  if (code2 === null || markdownLineEndingOrSpace(code2) || unicodeWhitespace(code2)) {
+    return 1;
+  }
+  if (unicodePunctuation(code2)) {
+    return 2;
+  }
+}
+
+// node_modules/micromark-util-resolve-all/index.js
+function resolveAll(constructs2, events, context) {
+  const called = [];
+  let index2 = -1;
+  while (++index2 < constructs2.length) {
+    const resolve = constructs2[index2].resolveAll;
+    if (resolve && !called.includes(resolve)) {
+      events = resolve(events, context);
+      called.push(resolve);
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark-core-commonmark/lib/attention.js
+var attention = {
+  name: "attention",
+  tokenize: tokenizeAttention,
+  resolveAll: resolveAllAttention
+};
+function resolveAllAttention(events, context) {
+  let index2 = -1;
+  let open;
+  let group;
+  let text5;
+  let openingSequence;
+  let closingSequence;
+  let use;
+  let nextEvents;
+  let offset2;
+  while (++index2 < events.length) {
+    if (events[index2][0] === "enter" && events[index2][1].type === "attentionSequence" && events[index2][1]._close) {
+      open = index2;
+      while (open--) {
+        if (events[open][0] === "exit" && events[open][1].type === "attentionSequence" && events[open][1]._open && // If the markers are the same:
+        context.sliceSerialize(events[open][1]).charCodeAt(0) === context.sliceSerialize(events[index2][1]).charCodeAt(0)) {
+          if ((events[open][1]._close || events[index2][1]._open) && (events[index2][1].end.offset - events[index2][1].start.offset) % 3 && !((events[open][1].end.offset - events[open][1].start.offset + events[index2][1].end.offset - events[index2][1].start.offset) % 3)) {
+            continue;
+          }
+          use = events[open][1].end.offset - events[open][1].start.offset > 1 && events[index2][1].end.offset - events[index2][1].start.offset > 1 ? 2 : 1;
+          const start2 = Object.assign({}, events[open][1].end);
+          const end = Object.assign({}, events[index2][1].start);
+          movePoint(start2, -use);
+          movePoint(end, use);
+          openingSequence = {
+            type: use > 1 ? "strongSequence" : "emphasisSequence",
+            start: start2,
+            end: Object.assign({}, events[open][1].end)
+          };
+          closingSequence = {
+            type: use > 1 ? "strongSequence" : "emphasisSequence",
+            start: Object.assign({}, events[index2][1].start),
+            end
+          };
+          text5 = {
+            type: use > 1 ? "strongText" : "emphasisText",
+            start: Object.assign({}, events[open][1].end),
+            end: Object.assign({}, events[index2][1].start)
+          };
+          group = {
+            type: use > 1 ? "strong" : "emphasis",
+            start: Object.assign({}, openingSequence.start),
+            end: Object.assign({}, closingSequence.end)
+          };
+          events[open][1].end = Object.assign({}, openingSequence.start);
+          events[index2][1].start = Object.assign({}, closingSequence.end);
+          nextEvents = [];
+          if (events[open][1].end.offset - events[open][1].start.offset) {
+            nextEvents = push(nextEvents, [["enter", events[open][1], context], ["exit", events[open][1], context]]);
+          }
+          nextEvents = push(nextEvents, [["enter", group, context], ["enter", openingSequence, context], ["exit", openingSequence, context], ["enter", text5, context]]);
+          nextEvents = push(nextEvents, resolveAll(context.parser.constructs.insideSpan.null, events.slice(open + 1, index2), context));
+          nextEvents = push(nextEvents, [["exit", text5, context], ["enter", closingSequence, context], ["exit", closingSequence, context], ["exit", group, context]]);
+          if (events[index2][1].end.offset - events[index2][1].start.offset) {
+            offset2 = 2;
+            nextEvents = push(nextEvents, [["enter", events[index2][1], context], ["exit", events[index2][1], context]]);
+          } else {
+            offset2 = 0;
+          }
+          splice(events, open - 1, index2 - open + 3, nextEvents);
+          index2 = open + nextEvents.length - offset2 - 2;
+          break;
+        }
+      }
+    }
+  }
+  index2 = -1;
+  while (++index2 < events.length) {
+    if (events[index2][1].type === "attentionSequence") {
+      events[index2][1].type = "data";
+    }
+  }
+  return events;
+}
+function tokenizeAttention(effects, ok4) {
+  const attentionMarkers2 = this.parser.constructs.attentionMarkers.null;
+  const previous2 = this.previous;
+  const before = classifyCharacter(previous2);
+  let marker;
+  return start2;
+  function start2(code2) {
+    marker = code2;
+    effects.enter("attentionSequence");
+    return inside(code2);
+  }
+  function inside(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return inside;
+    }
+    const token = effects.exit("attentionSequence");
+    const after = classifyCharacter(code2);
+    const open = !after || after === 2 && before || attentionMarkers2.includes(code2);
+    const close = !before || before === 2 && after || attentionMarkers2.includes(previous2);
+    token._open = Boolean(marker === 42 ? open : open && (before || !close));
+    token._close = Boolean(marker === 42 ? close : close && (after || !open));
+    return ok4(code2);
+  }
+}
+function movePoint(point4, offset2) {
+  point4.column += offset2;
+  point4.offset += offset2;
+  point4._bufferIndex += offset2;
+}
+
+// node_modules/micromark-core-commonmark/lib/autolink.js
+var autolink = {
+  name: "autolink",
+  tokenize: tokenizeAutolink
+};
+function tokenizeAutolink(effects, ok4, nok) {
+  let size = 0;
+  return start2;
+  function start2(code2) {
+    effects.enter("autolink");
+    effects.enter("autolinkMarker");
+    effects.consume(code2);
+    effects.exit("autolinkMarker");
+    effects.enter("autolinkProtocol");
+    return open;
+  }
+  function open(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return schemeOrEmailAtext;
+    }
+    if (code2 === 64) {
+      return nok(code2);
+    }
+    return emailAtext(code2);
+  }
+  function schemeOrEmailAtext(code2) {
+    if (code2 === 43 || code2 === 45 || code2 === 46 || asciiAlphanumeric(code2)) {
+      size = 1;
+      return schemeInsideOrEmailAtext(code2);
+    }
+    return emailAtext(code2);
+  }
+  function schemeInsideOrEmailAtext(code2) {
+    if (code2 === 58) {
+      effects.consume(code2);
+      size = 0;
+      return urlInside;
+    }
+    if ((code2 === 43 || code2 === 45 || code2 === 46 || asciiAlphanumeric(code2)) && size++ < 32) {
+      effects.consume(code2);
+      return schemeInsideOrEmailAtext;
+    }
+    size = 0;
+    return emailAtext(code2);
+  }
+  function urlInside(code2) {
+    if (code2 === 62) {
+      effects.exit("autolinkProtocol");
+      effects.enter("autolinkMarker");
+      effects.consume(code2);
+      effects.exit("autolinkMarker");
+      effects.exit("autolink");
+      return ok4;
+    }
+    if (code2 === null || code2 === 32 || code2 === 60 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return urlInside;
+  }
+  function emailAtext(code2) {
+    if (code2 === 64) {
+      effects.consume(code2);
+      return emailAtSignOrDot;
+    }
+    if (asciiAtext(code2)) {
+      effects.consume(code2);
+      return emailAtext;
+    }
+    return nok(code2);
+  }
+  function emailAtSignOrDot(code2) {
+    return asciiAlphanumeric(code2) ? emailLabel(code2) : nok(code2);
+  }
+  function emailLabel(code2) {
+    if (code2 === 46) {
+      effects.consume(code2);
+      size = 0;
+      return emailAtSignOrDot;
+    }
+    if (code2 === 62) {
+      effects.exit("autolinkProtocol").type = "autolinkEmail";
+      effects.enter("autolinkMarker");
+      effects.consume(code2);
+      effects.exit("autolinkMarker");
+      effects.exit("autolink");
+      return ok4;
+    }
+    return emailValue(code2);
+  }
+  function emailValue(code2) {
+    if ((code2 === 45 || asciiAlphanumeric(code2)) && size++ < 63) {
+      const next = code2 === 45 ? emailValue : emailLabel;
+      effects.consume(code2);
+      return next;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/blank-line.js
+var blankLine = {
+  tokenize: tokenizeBlankLine,
+  partial: true
+};
+function tokenizeBlankLine(effects, ok4, nok) {
+  return start2;
+  function start2(code2) {
+    return markdownSpace(code2) ? factorySpace(effects, after, "linePrefix")(code2) : after(code2);
+  }
+  function after(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok4(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/block-quote.js
+var blockQuote = {
+  name: "blockQuote",
+  tokenize: tokenizeBlockQuoteStart,
+  continuation: {
+    tokenize: tokenizeBlockQuoteContinuation
+  },
+  exit
+};
+function tokenizeBlockQuoteStart(effects, ok4, nok) {
+  const self2 = this;
+  return start2;
+  function start2(code2) {
+    if (code2 === 62) {
+      const state = self2.containerState;
+      if (!state.open) {
+        effects.enter("blockQuote", {
+          _container: true
+        });
+        state.open = true;
+      }
+      effects.enter("blockQuotePrefix");
+      effects.enter("blockQuoteMarker");
+      effects.consume(code2);
+      effects.exit("blockQuoteMarker");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter("blockQuotePrefixWhitespace");
+      effects.consume(code2);
+      effects.exit("blockQuotePrefixWhitespace");
+      effects.exit("blockQuotePrefix");
+      return ok4;
+    }
+    effects.exit("blockQuotePrefix");
+    return ok4(code2);
+  }
+}
+function tokenizeBlockQuoteContinuation(effects, ok4, nok) {
+  const self2 = this;
+  return contStart;
+  function contStart(code2) {
+    if (markdownSpace(code2)) {
+      return factorySpace(effects, contBefore, "linePrefix", self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4)(code2);
+    }
+    return contBefore(code2);
+  }
+  function contBefore(code2) {
+    return effects.attempt(blockQuote, ok4, nok)(code2);
+  }
+}
+function exit(effects) {
+  effects.exit("blockQuote");
+}
+
+// node_modules/micromark-core-commonmark/lib/character-escape.js
+var characterEscape = {
+  name: "characterEscape",
+  tokenize: tokenizeCharacterEscape
+};
+function tokenizeCharacterEscape(effects, ok4, nok) {
+  return start2;
+  function start2(code2) {
+    effects.enter("characterEscape");
+    effects.enter("escapeMarker");
+    effects.consume(code2);
+    effects.exit("escapeMarker");
+    return inside;
+  }
+  function inside(code2) {
+    if (asciiPunctuation(code2)) {
+      effects.enter("characterEscapeValue");
+      effects.consume(code2);
+      effects.exit("characterEscapeValue");
+      effects.exit("characterEscape");
+      return ok4;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/character-reference.js
+var characterReference = {
+  name: "characterReference",
+  tokenize: tokenizeCharacterReference
+};
+function tokenizeCharacterReference(effects, ok4, nok) {
+  const self2 = this;
+  let size = 0;
+  let max;
+  let test;
+  return start2;
+  function start2(code2) {
+    effects.enter("characterReference");
+    effects.enter("characterReferenceMarker");
+    effects.consume(code2);
+    effects.exit("characterReferenceMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 35) {
+      effects.enter("characterReferenceMarkerNumeric");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarkerNumeric");
+      return numeric;
+    }
+    effects.enter("characterReferenceValue");
+    max = 31;
+    test = asciiAlphanumeric;
+    return value(code2);
+  }
+  function numeric(code2) {
+    if (code2 === 88 || code2 === 120) {
+      effects.enter("characterReferenceMarkerHexadecimal");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarkerHexadecimal");
+      effects.enter("characterReferenceValue");
+      max = 6;
+      test = asciiHexDigit;
+      return value;
+    }
+    effects.enter("characterReferenceValue");
+    max = 7;
+    test = asciiDigit;
+    return value(code2);
+  }
+  function value(code2) {
+    if (code2 === 59 && size) {
+      const token = effects.exit("characterReferenceValue");
+      if (test === asciiAlphanumeric && !decodeNamedCharacterReference(self2.sliceSerialize(token))) {
+        return nok(code2);
+      }
+      effects.enter("characterReferenceMarker");
+      effects.consume(code2);
+      effects.exit("characterReferenceMarker");
+      effects.exit("characterReference");
+      return ok4;
+    }
+    if (test(code2) && size++ < max) {
+      effects.consume(code2);
+      return value;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-fenced.js
+var nonLazyContinuation = {
+  tokenize: tokenizeNonLazyContinuation,
+  partial: true
+};
+var codeFenced = {
+  name: "codeFenced",
+  tokenize: tokenizeCodeFenced,
+  concrete: true
+};
+function tokenizeCodeFenced(effects, ok4, nok) {
+  const self2 = this;
+  const closeStart = {
+    tokenize: tokenizeCloseStart,
+    partial: true
+  };
+  let initialPrefix = 0;
+  let sizeOpen = 0;
+  let marker;
+  return start2;
+  function start2(code2) {
+    return beforeSequenceOpen(code2);
+  }
+  function beforeSequenceOpen(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    initialPrefix = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+    marker = code2;
+    effects.enter("codeFenced");
+    effects.enter("codeFencedFence");
+    effects.enter("codeFencedFenceSequence");
+    return sequenceOpen(code2);
+  }
+  function sequenceOpen(code2) {
+    if (code2 === marker) {
+      sizeOpen++;
+      effects.consume(code2);
+      return sequenceOpen;
+    }
+    if (sizeOpen < 3) {
+      return nok(code2);
+    }
+    effects.exit("codeFencedFenceSequence");
+    return markdownSpace(code2) ? factorySpace(effects, infoBefore, "whitespace")(code2) : infoBefore(code2);
+  }
+  function infoBefore(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFencedFence");
+      return self2.interrupt ? ok4(code2) : effects.check(nonLazyContinuation, atNonLazyBreak, after)(code2);
+    }
+    effects.enter("codeFencedFenceInfo");
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return info(code2);
+  }
+  function info(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceInfo");
+      return infoBefore(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceInfo");
+      return factorySpace(effects, metaBefore, "whitespace")(code2);
+    }
+    if (code2 === 96 && code2 === marker) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return info;
+  }
+  function metaBefore(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return infoBefore(code2);
+    }
+    effects.enter("codeFencedFenceMeta");
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return meta(code2);
+  }
+  function meta(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      effects.exit("codeFencedFenceMeta");
+      return infoBefore(code2);
+    }
+    if (code2 === 96 && code2 === marker) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return meta;
+  }
+  function atNonLazyBreak(code2) {
+    return effects.attempt(closeStart, after, contentBefore)(code2);
+  }
+  function contentBefore(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return contentStart;
+  }
+  function contentStart(code2) {
+    return initialPrefix > 0 && markdownSpace(code2) ? factorySpace(effects, beforeContentChunk, "linePrefix", initialPrefix + 1)(code2) : beforeContentChunk(code2);
+  }
+  function beforeContentChunk(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return effects.check(nonLazyContinuation, atNonLazyBreak, after)(code2);
+    }
+    effects.enter("codeFlowValue");
+    return contentChunk(code2);
+  }
+  function contentChunk(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFlowValue");
+      return beforeContentChunk(code2);
+    }
+    effects.consume(code2);
+    return contentChunk;
+  }
+  function after(code2) {
+    effects.exit("codeFenced");
+    return ok4(code2);
+  }
+  function tokenizeCloseStart(effects2, ok5, nok2) {
+    let size = 0;
+    return startBefore;
+    function startBefore(code2) {
+      effects2.enter("lineEnding");
+      effects2.consume(code2);
+      effects2.exit("lineEnding");
+      return start3;
+    }
+    function start3(code2) {
+      effects2.enter("codeFencedFence");
+      return markdownSpace(code2) ? factorySpace(effects2, beforeSequenceClose, "linePrefix", self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4)(code2) : beforeSequenceClose(code2);
+    }
+    function beforeSequenceClose(code2) {
+      if (code2 === marker) {
+        effects2.enter("codeFencedFenceSequence");
+        return sequenceClose(code2);
+      }
+      return nok2(code2);
+    }
+    function sequenceClose(code2) {
+      if (code2 === marker) {
+        size++;
+        effects2.consume(code2);
+        return sequenceClose;
+      }
+      if (size >= sizeOpen) {
+        effects2.exit("codeFencedFenceSequence");
+        return markdownSpace(code2) ? factorySpace(effects2, sequenceCloseAfter, "whitespace")(code2) : sequenceCloseAfter(code2);
+      }
+      return nok2(code2);
+    }
+    function sequenceCloseAfter(code2) {
+      if (code2 === null || markdownLineEnding(code2)) {
+        effects2.exit("codeFencedFence");
+        return ok5(code2);
+      }
+      return nok2(code2);
+    }
+  }
+}
+function tokenizeNonLazyContinuation(effects, ok4, nok) {
+  const self2 = this;
+  return start2;
+  function start2(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return lineStart;
+  }
+  function lineStart(code2) {
+    return self2.parser.lazy[self2.now().line] ? nok(code2) : ok4(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-indented.js
+var codeIndented = {
+  name: "codeIndented",
+  tokenize: tokenizeCodeIndented
+};
+var furtherStart = {
+  tokenize: tokenizeFurtherStart,
+  partial: true
+};
+function tokenizeCodeIndented(effects, ok4, nok) {
+  const self2 = this;
+  return start2;
+  function start2(code2) {
+    effects.enter("codeIndented");
+    return factorySpace(effects, afterPrefix, "linePrefix", 4 + 1)(code2);
+  }
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4 ? atBreak(code2) : nok(code2);
+  }
+  function atBreak(code2) {
+    if (code2 === null) {
+      return after(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.attempt(furtherStart, atBreak, after)(code2);
+    }
+    effects.enter("codeFlowValue");
+    return inside(code2);
+  }
+  function inside(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("codeFlowValue");
+      return atBreak(code2);
+    }
+    effects.consume(code2);
+    return inside;
+  }
+  function after(code2) {
+    effects.exit("codeIndented");
+    return ok4(code2);
+  }
+}
+function tokenizeFurtherStart(effects, ok4, nok) {
+  const self2 = this;
+  return furtherStart2;
+  function furtherStart2(code2) {
+    if (self2.parser.lazy[self2.now().line]) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return furtherStart2;
+    }
+    return factorySpace(effects, afterPrefix, "linePrefix", 4 + 1)(code2);
+  }
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4 ? ok4(code2) : markdownLineEnding(code2) ? furtherStart2(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/code-text.js
+var codeText = {
+  name: "codeText",
+  tokenize: tokenizeCodeText,
+  resolve: resolveCodeText,
+  previous
+};
+function resolveCodeText(events) {
+  let tailExitIndex = events.length - 4;
+  let headEnterIndex = 3;
+  let index2;
+  let enter;
+  if ((events[headEnterIndex][1].type === "lineEnding" || events[headEnterIndex][1].type === "space") && (events[tailExitIndex][1].type === "lineEnding" || events[tailExitIndex][1].type === "space")) {
+    index2 = headEnterIndex;
+    while (++index2 < tailExitIndex) {
+      if (events[index2][1].type === "codeTextData") {
+        events[headEnterIndex][1].type = "codeTextPadding";
+        events[tailExitIndex][1].type = "codeTextPadding";
+        headEnterIndex += 2;
+        tailExitIndex -= 2;
+        break;
+      }
+    }
+  }
+  index2 = headEnterIndex - 1;
+  tailExitIndex++;
+  while (++index2 <= tailExitIndex) {
+    if (enter === void 0) {
+      if (index2 !== tailExitIndex && events[index2][1].type !== "lineEnding") {
+        enter = index2;
+      }
+    } else if (index2 === tailExitIndex || events[index2][1].type === "lineEnding") {
+      events[enter][1].type = "codeTextData";
+      if (index2 !== enter + 2) {
+        events[enter][1].end = events[index2 - 1][1].end;
+        events.splice(enter + 2, index2 - enter - 2);
+        tailExitIndex -= index2 - enter - 2;
+        index2 = enter + 2;
+      }
+      enter = void 0;
+    }
+  }
+  return events;
+}
+function previous(code2) {
+  return code2 !== 96 || this.events[this.events.length - 1][1].type === "characterEscape";
+}
+function tokenizeCodeText(effects, ok4, nok) {
+  const self2 = this;
+  let sizeOpen = 0;
+  let size;
+  let token;
+  return start2;
+  function start2(code2) {
+    effects.enter("codeText");
+    effects.enter("codeTextSequence");
+    return sequenceOpen(code2);
+  }
+  function sequenceOpen(code2) {
+    if (code2 === 96) {
+      effects.consume(code2);
+      sizeOpen++;
+      return sequenceOpen;
+    }
+    effects.exit("codeTextSequence");
+    return between(code2);
+  }
+  function between(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 32) {
+      effects.enter("space");
+      effects.consume(code2);
+      effects.exit("space");
+      return between;
+    }
+    if (code2 === 96) {
+      token = effects.enter("codeTextSequence");
+      size = 0;
+      return sequenceClose(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return between;
+    }
+    effects.enter("codeTextData");
+    return data2(code2);
+  }
+  function data2(code2) {
+    if (code2 === null || code2 === 32 || code2 === 96 || markdownLineEnding(code2)) {
+      effects.exit("codeTextData");
+      return between(code2);
+    }
+    effects.consume(code2);
+    return data2;
+  }
+  function sequenceClose(code2) {
+    if (code2 === 96) {
+      effects.consume(code2);
+      size++;
+      return sequenceClose;
+    }
+    if (size === sizeOpen) {
+      effects.exit("codeTextSequence");
+      effects.exit("codeText");
+      return ok4(code2);
+    }
+    token.type = "codeTextData";
+    return data2(code2);
+  }
+}
+
+// node_modules/micromark-util-subtokenize/lib/splice-buffer.js
+var SpliceBuffer = class {
+  /**
+   * @param {ReadonlyArray<T> | null | undefined} [initial]
+   *   Initial items (optional).
+   * @returns
+   *   Splice buffer.
+   */
+  constructor(initial) {
+    this.left = initial ? [...initial] : [];
+    this.right = [];
+  }
+  /**
+   * Array access;
+   * does not move the cursor.
+   *
+   * @param {number} index
+   *   Index.
+   * @return {T}
+   *   Item.
+   */
+  get(index2) {
+    if (index2 < 0 || index2 >= this.left.length + this.right.length) {
+      throw new RangeError("Cannot access index `" + index2 + "` in a splice buffer of size `" + (this.left.length + this.right.length) + "`");
+    }
+    if (index2 < this.left.length) return this.left[index2];
+    return this.right[this.right.length - index2 + this.left.length - 1];
+  }
+  /**
+   * The length of the splice buffer, one greater than the largest index in the
+   * array.
+   */
+  get length() {
+    return this.left.length + this.right.length;
+  }
+  /**
+   * Remove and return `list[0]`;
+   * moves the cursor to `0`.
+   *
+   * @returns {T | undefined}
+   *   Item, optional.
+   */
+  shift() {
+    this.setCursor(0);
+    return this.right.pop();
+  }
+  /**
+   * Slice the buffer to get an array;
+   * does not move the cursor.
+   *
+   * @param {number} start
+   *   Start.
+   * @param {number | null | undefined} [end]
+   *   End (optional).
+   * @returns {Array<T>}
+   *   Array of items.
+   */
+  slice(start2, end) {
+    const stop = end === null || end === void 0 ? Number.POSITIVE_INFINITY : end;
+    if (stop < this.left.length) {
+      return this.left.slice(start2, stop);
+    }
+    if (start2 > this.left.length) {
+      return this.right.slice(this.right.length - stop + this.left.length, this.right.length - start2 + this.left.length).reverse();
+    }
+    return this.left.slice(start2).concat(this.right.slice(this.right.length - stop + this.left.length).reverse());
+  }
+  /**
+   * Mimics the behavior of Array.prototype.splice() except for the change of
+   * interface necessary to avoid segfaults when patching in very large arrays.
+   *
+   * This operation moves cursor is moved to `start` and results in the cursor
+   * placed after any inserted items.
+   *
+   * @param {number} start
+   *   Start;
+   *   zero-based index at which to start changing the array;
+   *   negative numbers count backwards from the end of the array and values
+   *   that are out-of bounds are clamped to the appropriate end of the array.
+   * @param {number | null | undefined} [deleteCount=0]
+   *   Delete count (default: `0`);
+   *   maximum number of elements to delete, starting from start.
+   * @param {Array<T> | null | undefined} [items=[]]
+   *   Items to include in place of the deleted items (default: `[]`).
+   * @return {Array<T>}
+   *   Any removed items.
+   */
+  splice(start2, deleteCount, items) {
+    const count = deleteCount || 0;
+    this.setCursor(Math.trunc(start2));
+    const removed = this.right.splice(this.right.length - count, Number.POSITIVE_INFINITY);
+    if (items) chunkedPush(this.left, items);
+    return removed.reverse();
+  }
+  /**
+   * Remove and return the highest-numbered item in the array, so
+   * `list[list.length - 1]`;
+   * Moves the cursor to `length`.
+   *
+   * @returns {T | undefined}
+   *   Item, optional.
+   */
+  pop() {
+    this.setCursor(Number.POSITIVE_INFINITY);
+    return this.left.pop();
+  }
+  /**
+   * Inserts a single item to the high-numbered side of the array;
+   * moves the cursor to `length`.
+   *
+   * @param {T} item
+   *   Item.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  push(item) {
+    this.setCursor(Number.POSITIVE_INFINITY);
+    this.left.push(item);
+  }
+  /**
+   * Inserts many items to the high-numbered side of the array.
+   * Moves the cursor to `length`.
+   *
+   * @param {Array<T>} items
+   *   Items.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  pushMany(items) {
+    this.setCursor(Number.POSITIVE_INFINITY);
+    chunkedPush(this.left, items);
+  }
+  /**
+   * Inserts a single item to the low-numbered side of the array;
+   * Moves the cursor to `0`.
+   *
+   * @param {T} item
+   *   Item.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  unshift(item) {
+    this.setCursor(0);
+    this.right.push(item);
+  }
+  /**
+   * Inserts many items to the low-numbered side of the array;
+   * moves the cursor to `0`.
+   *
+   * @param {Array<T>} items
+   *   Items.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  unshiftMany(items) {
+    this.setCursor(0);
+    chunkedPush(this.right, items.reverse());
+  }
+  /**
+   * Move the cursor to a specific position in the array. Requires
+   * time proportional to the distance moved.
+   *
+   * If `n < 0`, the cursor will end up at the beginning.
+   * If `n > length`, the cursor will end up at the end.
+   *
+   * @param {number} n
+   *   Position.
+   * @return {undefined}
+   *   Nothing.
+   */
+  setCursor(n) {
+    if (n === this.left.length || n > this.left.length && this.right.length === 0 || n < 0 && this.left.length === 0) return;
+    if (n < this.left.length) {
+      const removed = this.left.splice(n, Number.POSITIVE_INFINITY);
+      chunkedPush(this.right, removed.reverse());
+    } else {
+      const removed = this.right.splice(this.left.length + this.right.length - n, Number.POSITIVE_INFINITY);
+      chunkedPush(this.left, removed.reverse());
+    }
+  }
+};
+function chunkedPush(list3, right) {
+  let chunkStart = 0;
+  if (right.length < 1e4) {
+    list3.push(...right);
+  } else {
+    while (chunkStart < right.length) {
+      list3.push(...right.slice(chunkStart, chunkStart + 1e4));
+      chunkStart += 1e4;
+    }
+  }
+}
+
+// node_modules/micromark-util-subtokenize/index.js
+function subtokenize(eventsArray) {
+  const jumps = {};
+  let index2 = -1;
+  let event;
+  let lineIndex;
+  let otherIndex;
+  let otherEvent;
+  let parameters;
+  let subevents;
+  let more;
+  const events = new SpliceBuffer(eventsArray);
+  while (++index2 < events.length) {
+    while (index2 in jumps) {
+      index2 = jumps[index2];
+    }
+    event = events.get(index2);
+    if (index2 && event[1].type === "chunkFlow" && events.get(index2 - 1)[1].type === "listItemPrefix") {
+      subevents = event[1]._tokenizer.events;
+      otherIndex = 0;
+      if (otherIndex < subevents.length && subevents[otherIndex][1].type === "lineEndingBlank") {
+        otherIndex += 2;
+      }
+      if (otherIndex < subevents.length && subevents[otherIndex][1].type === "content") {
+        while (++otherIndex < subevents.length) {
+          if (subevents[otherIndex][1].type === "content") {
+            break;
+          }
+          if (subevents[otherIndex][1].type === "chunkText") {
+            subevents[otherIndex][1]._isInFirstContentOfListItem = true;
+            otherIndex++;
+          }
+        }
+      }
+    }
+    if (event[0] === "enter") {
+      if (event[1].contentType) {
+        Object.assign(jumps, subcontent(events, index2));
+        index2 = jumps[index2];
+        more = true;
+      }
+    } else if (event[1]._container) {
+      otherIndex = index2;
+      lineIndex = void 0;
+      while (otherIndex--) {
+        otherEvent = events.get(otherIndex);
+        if (otherEvent[1].type === "lineEnding" || otherEvent[1].type === "lineEndingBlank") {
+          if (otherEvent[0] === "enter") {
+            if (lineIndex) {
+              events.get(lineIndex)[1].type = "lineEndingBlank";
+            }
+            otherEvent[1].type = "lineEnding";
+            lineIndex = otherIndex;
+          }
+        } else {
+          break;
+        }
+      }
+      if (lineIndex) {
+        event[1].end = Object.assign({}, events.get(lineIndex)[1].start);
+        parameters = events.slice(lineIndex, index2);
+        parameters.unshift(event);
+        events.splice(lineIndex, index2 - lineIndex + 1, parameters);
+      }
+    }
+  }
+  splice(eventsArray, 0, Number.POSITIVE_INFINITY, events.slice(0));
+  return !more;
+}
+function subcontent(events, eventIndex) {
+  const token = events.get(eventIndex)[1];
+  const context = events.get(eventIndex)[2];
+  let startPosition = eventIndex - 1;
+  const startPositions = [];
+  const tokenizer2 = token._tokenizer || context.parser[token.contentType](token.start);
+  const childEvents = tokenizer2.events;
+  const jumps = [];
+  const gaps = {};
+  let stream;
+  let previous2;
+  let index2 = -1;
+  let current2 = token;
+  let adjust = 0;
+  let start2 = 0;
+  const breaks = [start2];
+  while (current2) {
+    while (events.get(++startPosition)[1] !== current2) {
+    }
+    startPositions.push(startPosition);
+    if (!current2._tokenizer) {
+      stream = context.sliceStream(current2);
+      if (!current2.next) {
+        stream.push(null);
+      }
+      if (previous2) {
+        tokenizer2.defineSkip(current2.start);
+      }
+      if (current2._isInFirstContentOfListItem) {
+        tokenizer2._gfmTasklistFirstContentOfListItem = true;
+      }
+      tokenizer2.write(stream);
+      if (current2._isInFirstContentOfListItem) {
+        tokenizer2._gfmTasklistFirstContentOfListItem = void 0;
+      }
+    }
+    previous2 = current2;
+    current2 = current2.next;
+  }
+  current2 = token;
+  while (++index2 < childEvents.length) {
+    if (
+      // Find a void token that includes a break.
+      childEvents[index2][0] === "exit" && childEvents[index2 - 1][0] === "enter" && childEvents[index2][1].type === childEvents[index2 - 1][1].type && childEvents[index2][1].start.line !== childEvents[index2][1].end.line
+    ) {
+      start2 = index2 + 1;
+      breaks.push(start2);
+      current2._tokenizer = void 0;
+      current2.previous = void 0;
+      current2 = current2.next;
+    }
+  }
+  tokenizer2.events = [];
+  if (current2) {
+    current2._tokenizer = void 0;
+    current2.previous = void 0;
+  } else {
+    breaks.pop();
+  }
+  index2 = breaks.length;
+  while (index2--) {
+    const slice2 = childEvents.slice(breaks[index2], breaks[index2 + 1]);
+    const start3 = startPositions.pop();
+    jumps.push([start3, start3 + slice2.length - 1]);
+    events.splice(start3, 2, slice2);
+  }
+  jumps.reverse();
+  index2 = -1;
+  while (++index2 < jumps.length) {
+    gaps[adjust + jumps[index2][0]] = adjust + jumps[index2][1];
+    adjust += jumps[index2][1] - jumps[index2][0] - 1;
+  }
+  return gaps;
+}
+
+// node_modules/micromark-core-commonmark/lib/content.js
+var content = {
+  tokenize: tokenizeContent,
+  resolve: resolveContent
+};
+var continuationConstruct = {
+  tokenize: tokenizeContinuation,
+  partial: true
+};
+function resolveContent(events) {
+  subtokenize(events);
+  return events;
+}
+function tokenizeContent(effects, ok4) {
+  let previous2;
+  return chunkStart;
+  function chunkStart(code2) {
+    effects.enter("content");
+    previous2 = effects.enter("chunkContent", {
+      contentType: "content"
+    });
+    return chunkInside(code2);
+  }
+  function chunkInside(code2) {
+    if (code2 === null) {
+      return contentEnd(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      return effects.check(continuationConstruct, contentContinue, contentEnd)(code2);
+    }
+    effects.consume(code2);
+    return chunkInside;
+  }
+  function contentEnd(code2) {
+    effects.exit("chunkContent");
+    effects.exit("content");
+    return ok4(code2);
+  }
+  function contentContinue(code2) {
+    effects.consume(code2);
+    effects.exit("chunkContent");
+    previous2.next = effects.enter("chunkContent", {
+      contentType: "content",
+      previous: previous2
+    });
+    previous2 = previous2.next;
+    return chunkInside;
+  }
+}
+function tokenizeContinuation(effects, ok4, nok) {
+  const self2 = this;
+  return startLookahead;
+  function startLookahead(code2) {
+    effects.exit("chunkContent");
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, prefixed, "linePrefix");
+  }
+  function prefixed(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    const tail = self2.events[self2.events.length - 1];
+    if (!self2.parser.constructs.disable.null.includes("codeIndented") && tail && tail[1].type === "linePrefix" && tail[2].sliceSerialize(tail[1], true).length >= 4) {
+      return ok4(code2);
+    }
+    return effects.interrupt(self2.parser.constructs.flow, nok, ok4)(code2);
+  }
+}
+
+// node_modules/micromark-factory-destination/index.js
+function factoryDestination(effects, ok4, nok, type, literalType, literalMarkerType, rawType, stringType, max) {
+  const limit = max || Number.POSITIVE_INFINITY;
+  let balance = 0;
+  return start2;
+  function start2(code2) {
+    if (code2 === 60) {
+      effects.enter(type);
+      effects.enter(literalType);
+      effects.enter(literalMarkerType);
+      effects.consume(code2);
+      effects.exit(literalMarkerType);
+      return enclosedBefore;
+    }
+    if (code2 === null || code2 === 32 || code2 === 41 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.enter(type);
+    effects.enter(rawType);
+    effects.enter(stringType);
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return raw(code2);
+  }
+  function enclosedBefore(code2) {
+    if (code2 === 62) {
+      effects.enter(literalMarkerType);
+      effects.consume(code2);
+      effects.exit(literalMarkerType);
+      effects.exit(literalType);
+      effects.exit(type);
+      return ok4;
+    }
+    effects.enter(stringType);
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return enclosed(code2);
+  }
+  function enclosed(code2) {
+    if (code2 === 62) {
+      effects.exit("chunkString");
+      effects.exit(stringType);
+      return enclosedBefore(code2);
+    }
+    if (code2 === null || code2 === 60 || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? enclosedEscape : enclosed;
+  }
+  function enclosedEscape(code2) {
+    if (code2 === 60 || code2 === 62 || code2 === 92) {
+      effects.consume(code2);
+      return enclosed;
+    }
+    return enclosed(code2);
+  }
+  function raw(code2) {
+    if (!balance && (code2 === null || code2 === 41 || markdownLineEndingOrSpace(code2))) {
+      effects.exit("chunkString");
+      effects.exit(stringType);
+      effects.exit(rawType);
+      effects.exit(type);
+      return ok4(code2);
+    }
+    if (balance < limit && code2 === 40) {
+      effects.consume(code2);
+      balance++;
+      return raw;
+    }
+    if (code2 === 41) {
+      effects.consume(code2);
+      balance--;
+      return raw;
+    }
+    if (code2 === null || code2 === 32 || code2 === 40 || asciiControl(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? rawEscape : raw;
+  }
+  function rawEscape(code2) {
+    if (code2 === 40 || code2 === 41 || code2 === 92) {
+      effects.consume(code2);
+      return raw;
+    }
+    return raw(code2);
+  }
+}
+
+// node_modules/micromark-factory-label/index.js
+function factoryLabel(effects, ok4, nok, type, markerType, stringType) {
+  const self2 = this;
+  let size = 0;
+  let seen;
+  return start2;
+  function start2(code2) {
+    effects.enter(type);
+    effects.enter(markerType);
+    effects.consume(code2);
+    effects.exit(markerType);
+    effects.enter(stringType);
+    return atBreak;
+  }
+  function atBreak(code2) {
+    if (size > 999 || code2 === null || code2 === 91 || code2 === 93 && !seen || // To do: remove in the future once we’ve switched from
+    // `micromark-extension-footnote` to `micromark-extension-gfm-footnote`,
+    // which doesn’t need this.
+    // Hidden footnotes hook.
+    /* c8 ignore next 3 */
+    code2 === 94 && !size && "_hiddenFootnoteSupport" in self2.parser.constructs) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      effects.exit(stringType);
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok4;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return atBreak;
+    }
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return labelInside(code2);
+  }
+  function labelInside(code2) {
+    if (code2 === null || code2 === 91 || code2 === 93 || markdownLineEnding(code2) || size++ > 999) {
+      effects.exit("chunkString");
+      return atBreak(code2);
+    }
+    effects.consume(code2);
+    if (!seen) seen = !markdownSpace(code2);
+    return code2 === 92 ? labelEscape : labelInside;
+  }
+  function labelEscape(code2) {
+    if (code2 === 91 || code2 === 92 || code2 === 93) {
+      effects.consume(code2);
+      size++;
+      return labelInside;
+    }
+    return labelInside(code2);
+  }
+}
+
+// node_modules/micromark-factory-title/index.js
+function factoryTitle(effects, ok4, nok, type, markerType, stringType) {
+  let marker;
+  return start2;
+  function start2(code2) {
+    if (code2 === 34 || code2 === 39 || code2 === 40) {
+      effects.enter(type);
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      marker = code2 === 40 ? 41 : code2;
+      return begin;
+    }
+    return nok(code2);
+  }
+  function begin(code2) {
+    if (code2 === marker) {
+      effects.enter(markerType);
+      effects.consume(code2);
+      effects.exit(markerType);
+      effects.exit(type);
+      return ok4;
+    }
+    effects.enter(stringType);
+    return atBreak(code2);
+  }
+  function atBreak(code2) {
+    if (code2 === marker) {
+      effects.exit(stringType);
+      return begin(marker);
+    }
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return factorySpace(effects, atBreak, "linePrefix");
+    }
+    effects.enter("chunkString", {
+      contentType: "string"
+    });
+    return inside(code2);
+  }
+  function inside(code2) {
+    if (code2 === marker || code2 === null || markdownLineEnding(code2)) {
+      effects.exit("chunkString");
+      return atBreak(code2);
+    }
+    effects.consume(code2);
+    return code2 === 92 ? escape : inside;
+  }
+  function escape(code2) {
+    if (code2 === marker || code2 === 92) {
+      effects.consume(code2);
+      return inside;
+    }
+    return inside(code2);
+  }
+}
+
+// node_modules/micromark-factory-whitespace/index.js
+function factoryWhitespace(effects, ok4) {
+  let seen;
+  return start2;
+  function start2(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      seen = true;
+      return start2;
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(
+        effects,
+        start2,
+        seen ? "linePrefix" : "lineSuffix"
+      )(code2);
+    }
+    return ok4(code2);
+  }
+}
+
+// node_modules/micromark-util-normalize-identifier/index.js
+function normalizeIdentifier(value) {
+  return value.replace(/[\t\n\r ]+/g, " ").replace(/^ | $/g, "").toLowerCase().toUpperCase();
+}
+
+// node_modules/micromark-core-commonmark/lib/definition.js
+var definition = {
+  name: "definition",
+  tokenize: tokenizeDefinition
+};
+var titleBefore = {
+  tokenize: tokenizeTitleBefore,
+  partial: true
+};
+function tokenizeDefinition(effects, ok4, nok) {
+  const self2 = this;
+  let identifier;
+  return start2;
+  function start2(code2) {
+    effects.enter("definition");
+    return before(code2);
+  }
+  function before(code2) {
+    return factoryLabel.call(
+      self2,
+      effects,
+      labelAfter,
+      // Note: we don’t need to reset the way `markdown-rs` does.
+      nok,
+      "definitionLabel",
+      "definitionLabelMarker",
+      "definitionLabelString"
+    )(code2);
+  }
+  function labelAfter(code2) {
+    identifier = normalizeIdentifier(self2.sliceSerialize(self2.events[self2.events.length - 1][1]).slice(1, -1));
+    if (code2 === 58) {
+      effects.enter("definitionMarker");
+      effects.consume(code2);
+      effects.exit("definitionMarker");
+      return markerAfter;
+    }
+    return nok(code2);
+  }
+  function markerAfter(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, destinationBefore)(code2) : destinationBefore(code2);
+  }
+  function destinationBefore(code2) {
+    return factoryDestination(
+      effects,
+      destinationAfter,
+      // Note: we don’t need to reset the way `markdown-rs` does.
+      nok,
+      "definitionDestination",
+      "definitionDestinationLiteral",
+      "definitionDestinationLiteralMarker",
+      "definitionDestinationRaw",
+      "definitionDestinationString"
+    )(code2);
+  }
+  function destinationAfter(code2) {
+    return effects.attempt(titleBefore, after, after)(code2);
+  }
+  function after(code2) {
+    return markdownSpace(code2) ? factorySpace(effects, afterWhitespace, "whitespace")(code2) : afterWhitespace(code2);
+  }
+  function afterWhitespace(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("definition");
+      self2.parser.defined.push(identifier);
+      return ok4(code2);
+    }
+    return nok(code2);
+  }
+}
+function tokenizeTitleBefore(effects, ok4, nok) {
+  return titleBefore2;
+  function titleBefore2(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, beforeMarker)(code2) : nok(code2);
+  }
+  function beforeMarker(code2) {
+    return factoryTitle(effects, titleAfter, nok, "definitionTitle", "definitionTitleMarker", "definitionTitleString")(code2);
+  }
+  function titleAfter(code2) {
+    return markdownSpace(code2) ? factorySpace(effects, titleAfterOptionalWhitespace, "whitespace")(code2) : titleAfterOptionalWhitespace(code2);
+  }
+  function titleAfterOptionalWhitespace(code2) {
+    return code2 === null || markdownLineEnding(code2) ? ok4(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/hard-break-escape.js
+var hardBreakEscape = {
+  name: "hardBreakEscape",
+  tokenize: tokenizeHardBreakEscape
+};
+function tokenizeHardBreakEscape(effects, ok4, nok) {
+  return start2;
+  function start2(code2) {
+    effects.enter("hardBreakEscape");
+    effects.consume(code2);
+    return after;
+  }
+  function after(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.exit("hardBreakEscape");
+      return ok4(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/heading-atx.js
+var headingAtx = {
+  name: "headingAtx",
+  tokenize: tokenizeHeadingAtx,
+  resolve: resolveHeadingAtx
+};
+function resolveHeadingAtx(events, context) {
+  let contentEnd = events.length - 2;
+  let contentStart = 3;
+  let content3;
+  let text5;
+  if (events[contentStart][1].type === "whitespace") {
+    contentStart += 2;
+  }
+  if (contentEnd - 2 > contentStart && events[contentEnd][1].type === "whitespace") {
+    contentEnd -= 2;
+  }
+  if (events[contentEnd][1].type === "atxHeadingSequence" && (contentStart === contentEnd - 1 || contentEnd - 4 > contentStart && events[contentEnd - 2][1].type === "whitespace")) {
+    contentEnd -= contentStart + 1 === contentEnd ? 2 : 4;
+  }
+  if (contentEnd > contentStart) {
+    content3 = {
+      type: "atxHeadingText",
+      start: events[contentStart][1].start,
+      end: events[contentEnd][1].end
+    };
+    text5 = {
+      type: "chunkText",
+      start: events[contentStart][1].start,
+      end: events[contentEnd][1].end,
+      contentType: "text"
+    };
+    splice(events, contentStart, contentEnd - contentStart + 1, [["enter", content3, context], ["enter", text5, context], ["exit", text5, context], ["exit", content3, context]]);
+  }
+  return events;
+}
+function tokenizeHeadingAtx(effects, ok4, nok) {
+  let size = 0;
+  return start2;
+  function start2(code2) {
+    effects.enter("atxHeading");
+    return before(code2);
+  }
+  function before(code2) {
+    effects.enter("atxHeadingSequence");
+    return sequenceOpen(code2);
+  }
+  function sequenceOpen(code2) {
+    if (code2 === 35 && size++ < 6) {
+      effects.consume(code2);
+      return sequenceOpen;
+    }
+    if (code2 === null || markdownLineEndingOrSpace(code2)) {
+      effects.exit("atxHeadingSequence");
+      return atBreak(code2);
+    }
+    return nok(code2);
+  }
+  function atBreak(code2) {
+    if (code2 === 35) {
+      effects.enter("atxHeadingSequence");
+      return sequenceFurther(code2);
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("atxHeading");
+      return ok4(code2);
+    }
+    if (markdownSpace(code2)) {
+      return factorySpace(effects, atBreak, "whitespace")(code2);
+    }
+    effects.enter("atxHeadingText");
+    return data2(code2);
+  }
+  function sequenceFurther(code2) {
+    if (code2 === 35) {
+      effects.consume(code2);
+      return sequenceFurther;
+    }
+    effects.exit("atxHeadingSequence");
+    return atBreak(code2);
+  }
+  function data2(code2) {
+    if (code2 === null || code2 === 35 || markdownLineEndingOrSpace(code2)) {
+      effects.exit("atxHeadingText");
+      return atBreak(code2);
+    }
+    effects.consume(code2);
+    return data2;
+  }
+}
+
+// node_modules/micromark-util-html-tag-name/index.js
+var htmlBlockNames = [
+  "address",
+  "article",
+  "aside",
+  "base",
+  "basefont",
+  "blockquote",
+  "body",
+  "caption",
+  "center",
+  "col",
+  "colgroup",
+  "dd",
+  "details",
+  "dialog",
+  "dir",
+  "div",
+  "dl",
+  "dt",
+  "fieldset",
+  "figcaption",
+  "figure",
+  "footer",
+  "form",
+  "frame",
+  "frameset",
+  "h1",
+  "h2",
+  "h3",
+  "h4",
+  "h5",
+  "h6",
+  "head",
+  "header",
+  "hr",
+  "html",
+  "iframe",
+  "legend",
+  "li",
+  "link",
+  "main",
+  "menu",
+  "menuitem",
+  "nav",
+  "noframes",
+  "ol",
+  "optgroup",
+  "option",
+  "p",
+  "param",
+  "search",
+  "section",
+  "summary",
+  "table",
+  "tbody",
+  "td",
+  "tfoot",
+  "th",
+  "thead",
+  "title",
+  "tr",
+  "track",
+  "ul"
+];
+var htmlRawNames = ["pre", "script", "style", "textarea"];
+
+// node_modules/micromark-core-commonmark/lib/html-flow.js
+var htmlFlow = {
+  name: "htmlFlow",
+  tokenize: tokenizeHtmlFlow,
+  resolveTo: resolveToHtmlFlow,
+  concrete: true
+};
+var blankLineBefore = {
+  tokenize: tokenizeBlankLineBefore,
+  partial: true
+};
+var nonLazyContinuationStart = {
+  tokenize: tokenizeNonLazyContinuationStart,
+  partial: true
+};
+function resolveToHtmlFlow(events) {
+  let index2 = events.length;
+  while (index2--) {
+    if (events[index2][0] === "enter" && events[index2][1].type === "htmlFlow") {
+      break;
+    }
+  }
+  if (index2 > 1 && events[index2 - 2][1].type === "linePrefix") {
+    events[index2][1].start = events[index2 - 2][1].start;
+    events[index2 + 1][1].start = events[index2 - 2][1].start;
+    events.splice(index2 - 2, 2);
+  }
+  return events;
+}
+function tokenizeHtmlFlow(effects, ok4, nok) {
+  const self2 = this;
+  let marker;
+  let closingTag;
+  let buffer;
+  let index2;
+  let markerB;
+  return start2;
+  function start2(code2) {
+    return before(code2);
+  }
+  function before(code2) {
+    effects.enter("htmlFlow");
+    effects.enter("htmlFlowData");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 33) {
+      effects.consume(code2);
+      return declarationOpen;
+    }
+    if (code2 === 47) {
+      effects.consume(code2);
+      closingTag = true;
+      return tagCloseStart;
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      marker = 3;
+      return self2.interrupt ? ok4 : continuationDeclarationInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      buffer = String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function declarationOpen(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      marker = 2;
+      return commentOpenInside;
+    }
+    if (code2 === 91) {
+      effects.consume(code2);
+      marker = 5;
+      index2 = 0;
+      return cdataOpenInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      marker = 4;
+      return self2.interrupt ? ok4 : continuationDeclarationInside;
+    }
+    return nok(code2);
+  }
+  function commentOpenInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return self2.interrupt ? ok4 : continuationDeclarationInside;
+    }
+    return nok(code2);
+  }
+  function cdataOpenInside(code2) {
+    const value = "CDATA[";
+    if (code2 === value.charCodeAt(index2++)) {
+      effects.consume(code2);
+      if (index2 === value.length) {
+        return self2.interrupt ? ok4 : continuation;
+      }
+      return cdataOpenInside;
+    }
+    return nok(code2);
+  }
+  function tagCloseStart(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      buffer = String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function tagName(code2) {
+    if (code2 === null || code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      const slash = code2 === 47;
+      const name2 = buffer.toLowerCase();
+      if (!slash && !closingTag && htmlRawNames.includes(name2)) {
+        marker = 1;
+        return self2.interrupt ? ok4(code2) : continuation(code2);
+      }
+      if (htmlBlockNames.includes(buffer.toLowerCase())) {
+        marker = 6;
+        if (slash) {
+          effects.consume(code2);
+          return basicSelfClosing;
+        }
+        return self2.interrupt ? ok4(code2) : continuation(code2);
+      }
+      marker = 7;
+      return self2.interrupt && !self2.parser.lazy[self2.now().line] ? nok(code2) : closingTag ? completeClosingTagAfter(code2) : completeAttributeNameBefore(code2);
+    }
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      buffer += String.fromCharCode(code2);
+      return tagName;
+    }
+    return nok(code2);
+  }
+  function basicSelfClosing(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return self2.interrupt ? ok4 : continuation;
+    }
+    return nok(code2);
+  }
+  function completeClosingTagAfter(code2) {
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeClosingTagAfter;
+    }
+    return completeEnd(code2);
+  }
+  function completeAttributeNameBefore(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return completeEnd;
+    }
+    if (code2 === 58 || code2 === 95 || asciiAlpha(code2)) {
+      effects.consume(code2);
+      return completeAttributeName;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeNameBefore;
+    }
+    return completeEnd(code2);
+  }
+  function completeAttributeName(code2) {
+    if (code2 === 45 || code2 === 46 || code2 === 58 || code2 === 95 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return completeAttributeName;
+    }
+    return completeAttributeNameAfter(code2);
+  }
+  function completeAttributeNameAfter(code2) {
+    if (code2 === 61) {
+      effects.consume(code2);
+      return completeAttributeValueBefore;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeNameAfter;
+    }
+    return completeAttributeNameBefore(code2);
+  }
+  function completeAttributeValueBefore(code2) {
+    if (code2 === null || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 34 || code2 === 39) {
+      effects.consume(code2);
+      markerB = code2;
+      return completeAttributeValueQuoted;
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAttributeValueBefore;
+    }
+    return completeAttributeValueUnquoted(code2);
+  }
+  function completeAttributeValueQuoted(code2) {
+    if (code2 === markerB) {
+      effects.consume(code2);
+      markerB = null;
+      return completeAttributeValueQuotedAfter;
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      return nok(code2);
+    }
+    effects.consume(code2);
+    return completeAttributeValueQuoted;
+  }
+  function completeAttributeValueUnquoted(code2) {
+    if (code2 === null || code2 === 34 || code2 === 39 || code2 === 47 || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96 || markdownLineEndingOrSpace(code2)) {
+      return completeAttributeNameAfter(code2);
+    }
+    effects.consume(code2);
+    return completeAttributeValueUnquoted;
+  }
+  function completeAttributeValueQuotedAfter(code2) {
+    if (code2 === 47 || code2 === 62 || markdownSpace(code2)) {
+      return completeAttributeNameBefore(code2);
+    }
+    return nok(code2);
+  }
+  function completeEnd(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return completeAfter;
+    }
+    return nok(code2);
+  }
+  function completeAfter(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return continuation(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return completeAfter;
+    }
+    return nok(code2);
+  }
+  function continuation(code2) {
+    if (code2 === 45 && marker === 2) {
+      effects.consume(code2);
+      return continuationCommentInside;
+    }
+    if (code2 === 60 && marker === 1) {
+      effects.consume(code2);
+      return continuationRawTagOpen;
+    }
+    if (code2 === 62 && marker === 4) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (code2 === 63 && marker === 3) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    if (code2 === 93 && marker === 5) {
+      effects.consume(code2);
+      return continuationCdataInside;
+    }
+    if (markdownLineEnding(code2) && (marker === 6 || marker === 7)) {
+      effects.exit("htmlFlowData");
+      return effects.check(blankLineBefore, continuationAfter, continuationStart)(code2);
+    }
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("htmlFlowData");
+      return continuationStart(code2);
+    }
+    effects.consume(code2);
+    return continuation;
+  }
+  function continuationStart(code2) {
+    return effects.check(nonLazyContinuationStart, continuationStartNonLazy, continuationAfter)(code2);
+  }
+  function continuationStartNonLazy(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return continuationBefore;
+  }
+  function continuationBefore(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      return continuationStart(code2);
+    }
+    effects.enter("htmlFlowData");
+    return continuation(code2);
+  }
+  function continuationCommentInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationRawTagOpen(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      buffer = "";
+      return continuationRawEndTag;
+    }
+    return continuation(code2);
+  }
+  function continuationRawEndTag(code2) {
+    if (code2 === 62) {
+      const name2 = buffer.toLowerCase();
+      if (htmlRawNames.includes(name2)) {
+        effects.consume(code2);
+        return continuationClose;
+      }
+      return continuation(code2);
+    }
+    if (asciiAlpha(code2) && buffer.length < 8) {
+      effects.consume(code2);
+      buffer += String.fromCharCode(code2);
+      return continuationRawEndTag;
+    }
+    return continuation(code2);
+  }
+  function continuationCdataInside(code2) {
+    if (code2 === 93) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationDeclarationInside(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      return continuationClose;
+    }
+    if (code2 === 45 && marker === 2) {
+      effects.consume(code2);
+      return continuationDeclarationInside;
+    }
+    return continuation(code2);
+  }
+  function continuationClose(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("htmlFlowData");
+      return continuationAfter(code2);
+    }
+    effects.consume(code2);
+    return continuationClose;
+  }
+  function continuationAfter(code2) {
+    effects.exit("htmlFlow");
+    return ok4(code2);
+  }
+}
+function tokenizeNonLazyContinuationStart(effects, ok4, nok) {
+  const self2 = this;
+  return start2;
+  function start2(code2) {
+    if (markdownLineEnding(code2)) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return self2.parser.lazy[self2.now().line] ? nok(code2) : ok4(code2);
+  }
+}
+function tokenizeBlankLineBefore(effects, ok4, nok) {
+  return start2;
+  function start2(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return effects.attempt(blankLine, ok4, nok);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/html-text.js
+var htmlText = {
+  name: "htmlText",
+  tokenize: tokenizeHtmlText
+};
+function tokenizeHtmlText(effects, ok4, nok) {
+  const self2 = this;
+  let marker;
+  let index2;
+  let returnState;
+  return start2;
+  function start2(code2) {
+    effects.enter("htmlText");
+    effects.enter("htmlTextData");
+    effects.consume(code2);
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 33) {
+      effects.consume(code2);
+      return declarationOpen;
+    }
+    if (code2 === 47) {
+      effects.consume(code2);
+      return tagCloseStart;
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      return instruction;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagOpen;
+    }
+    return nok(code2);
+  }
+  function declarationOpen(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentOpenInside;
+    }
+    if (code2 === 91) {
+      effects.consume(code2);
+      index2 = 0;
+      return cdataOpenInside;
+    }
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return declaration;
+    }
+    return nok(code2);
+  }
+  function commentOpenInside(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentEnd;
+    }
+    return nok(code2);
+  }
+  function comment2(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = comment2;
+      return lineEndingBefore(code2);
+    }
+    effects.consume(code2);
+    return comment2;
+  }
+  function commentClose(code2) {
+    if (code2 === 45) {
+      effects.consume(code2);
+      return commentEnd;
+    }
+    return comment2(code2);
+  }
+  function commentEnd(code2) {
+    return code2 === 62 ? end(code2) : code2 === 45 ? commentClose(code2) : comment2(code2);
+  }
+  function cdataOpenInside(code2) {
+    const value = "CDATA[";
+    if (code2 === value.charCodeAt(index2++)) {
+      effects.consume(code2);
+      return index2 === value.length ? cdata : cdataOpenInside;
+    }
+    return nok(code2);
+  }
+  function cdata(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = cdata;
+      return lineEndingBefore(code2);
+    }
+    effects.consume(code2);
+    return cdata;
+  }
+  function cdataClose(code2) {
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataEnd;
+    }
+    return cdata(code2);
+  }
+  function cdataEnd(code2) {
+    if (code2 === 62) {
+      return end(code2);
+    }
+    if (code2 === 93) {
+      effects.consume(code2);
+      return cdataEnd;
+    }
+    return cdata(code2);
+  }
+  function declaration(code2) {
+    if (code2 === null || code2 === 62) {
+      return end(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = declaration;
+      return lineEndingBefore(code2);
+    }
+    effects.consume(code2);
+    return declaration;
+  }
+  function instruction(code2) {
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (code2 === 63) {
+      effects.consume(code2);
+      return instructionClose;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = instruction;
+      return lineEndingBefore(code2);
+    }
+    effects.consume(code2);
+    return instruction;
+  }
+  function instructionClose(code2) {
+    return code2 === 62 ? end(code2) : instruction(code2);
+  }
+  function tagCloseStart(code2) {
+    if (asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagClose;
+    }
+    return nok(code2);
+  }
+  function tagClose(code2) {
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagClose;
+    }
+    return tagCloseBetween(code2);
+  }
+  function tagCloseBetween(code2) {
+    if (markdownLineEnding(code2)) {
+      returnState = tagCloseBetween;
+      return lineEndingBefore(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagCloseBetween;
+    }
+    return end(code2);
+  }
+  function tagOpen(code2) {
+    if (code2 === 45 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagOpen;
+    }
+    if (code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    return nok(code2);
+  }
+  function tagOpenBetween(code2) {
+    if (code2 === 47) {
+      effects.consume(code2);
+      return end;
+    }
+    if (code2 === 58 || code2 === 95 || asciiAlpha(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeName;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenBetween;
+      return lineEndingBefore(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenBetween;
+    }
+    return end(code2);
+  }
+  function tagOpenAttributeName(code2) {
+    if (code2 === 45 || code2 === 46 || code2 === 58 || code2 === 95 || asciiAlphanumeric(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeName;
+    }
+    return tagOpenAttributeNameAfter(code2);
+  }
+  function tagOpenAttributeNameAfter(code2) {
+    if (code2 === 61) {
+      effects.consume(code2);
+      return tagOpenAttributeValueBefore;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeNameAfter;
+      return lineEndingBefore(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeNameAfter;
+    }
+    return tagOpenBetween(code2);
+  }
+  function tagOpenAttributeValueBefore(code2) {
+    if (code2 === null || code2 === 60 || code2 === 61 || code2 === 62 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 34 || code2 === 39) {
+      effects.consume(code2);
+      marker = code2;
+      return tagOpenAttributeValueQuoted;
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeValueBefore;
+      return lineEndingBefore(code2);
+    }
+    if (markdownSpace(code2)) {
+      effects.consume(code2);
+      return tagOpenAttributeValueBefore;
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueUnquoted;
+  }
+  function tagOpenAttributeValueQuoted(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      marker = void 0;
+      return tagOpenAttributeValueQuotedAfter;
+    }
+    if (code2 === null) {
+      return nok(code2);
+    }
+    if (markdownLineEnding(code2)) {
+      returnState = tagOpenAttributeValueQuoted;
+      return lineEndingBefore(code2);
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueQuoted;
+  }
+  function tagOpenAttributeValueUnquoted(code2) {
+    if (code2 === null || code2 === 34 || code2 === 39 || code2 === 60 || code2 === 61 || code2 === 96) {
+      return nok(code2);
+    }
+    if (code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    effects.consume(code2);
+    return tagOpenAttributeValueUnquoted;
+  }
+  function tagOpenAttributeValueQuotedAfter(code2) {
+    if (code2 === 47 || code2 === 62 || markdownLineEndingOrSpace(code2)) {
+      return tagOpenBetween(code2);
+    }
+    return nok(code2);
+  }
+  function end(code2) {
+    if (code2 === 62) {
+      effects.consume(code2);
+      effects.exit("htmlTextData");
+      effects.exit("htmlText");
+      return ok4;
+    }
+    return nok(code2);
+  }
+  function lineEndingBefore(code2) {
+    effects.exit("htmlTextData");
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return lineEndingAfter;
+  }
+  function lineEndingAfter(code2) {
+    return markdownSpace(code2) ? factorySpace(effects, lineEndingAfterPrefix, "linePrefix", self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4)(code2) : lineEndingAfterPrefix(code2);
+  }
+  function lineEndingAfterPrefix(code2) {
+    effects.enter("htmlTextData");
+    return returnState(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-end.js
+var labelEnd = {
+  name: "labelEnd",
+  tokenize: tokenizeLabelEnd,
+  resolveTo: resolveToLabelEnd,
+  resolveAll: resolveAllLabelEnd
+};
+var resourceConstruct = {
+  tokenize: tokenizeResource
+};
+var referenceFullConstruct = {
+  tokenize: tokenizeReferenceFull
+};
+var referenceCollapsedConstruct = {
+  tokenize: tokenizeReferenceCollapsed
+};
+function resolveAllLabelEnd(events) {
+  let index2 = -1;
+  while (++index2 < events.length) {
+    const token = events[index2][1];
+    if (token.type === "labelImage" || token.type === "labelLink" || token.type === "labelEnd") {
+      events.splice(index2 + 1, token.type === "labelImage" ? 4 : 2);
+      token.type = "data";
+      index2++;
+    }
+  }
+  return events;
+}
+function resolveToLabelEnd(events, context) {
+  let index2 = events.length;
+  let offset2 = 0;
+  let token;
+  let open;
+  let close;
+  let media;
+  while (index2--) {
+    token = events[index2][1];
+    if (open) {
+      if (token.type === "link" || token.type === "labelLink" && token._inactive) {
+        break;
+      }
+      if (events[index2][0] === "enter" && token.type === "labelLink") {
+        token._inactive = true;
+      }
+    } else if (close) {
+      if (events[index2][0] === "enter" && (token.type === "labelImage" || token.type === "labelLink") && !token._balanced) {
+        open = index2;
+        if (token.type !== "labelLink") {
+          offset2 = 2;
+          break;
+        }
+      }
+    } else if (token.type === "labelEnd") {
+      close = index2;
+    }
+  }
+  const group = {
+    type: events[open][1].type === "labelLink" ? "link" : "image",
+    start: Object.assign({}, events[open][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  const label = {
+    type: "label",
+    start: Object.assign({}, events[open][1].start),
+    end: Object.assign({}, events[close][1].end)
+  };
+  const text5 = {
+    type: "labelText",
+    start: Object.assign({}, events[open + offset2 + 2][1].end),
+    end: Object.assign({}, events[close - 2][1].start)
+  };
+  media = [["enter", group, context], ["enter", label, context]];
+  media = push(media, events.slice(open + 1, open + offset2 + 3));
+  media = push(media, [["enter", text5, context]]);
+  media = push(media, resolveAll(context.parser.constructs.insideSpan.null, events.slice(open + offset2 + 4, close - 3), context));
+  media = push(media, [["exit", text5, context], events[close - 2], events[close - 1], ["exit", label, context]]);
+  media = push(media, events.slice(close + 1));
+  media = push(media, [["exit", group, context]]);
+  splice(events, open, events.length, media);
+  return events;
+}
+function tokenizeLabelEnd(effects, ok4, nok) {
+  const self2 = this;
+  let index2 = self2.events.length;
+  let labelStart;
+  let defined;
+  while (index2--) {
+    if ((self2.events[index2][1].type === "labelImage" || self2.events[index2][1].type === "labelLink") && !self2.events[index2][1]._balanced) {
+      labelStart = self2.events[index2][1];
+      break;
+    }
+  }
+  return start2;
+  function start2(code2) {
+    if (!labelStart) {
+      return nok(code2);
+    }
+    if (labelStart._inactive) {
+      return labelEndNok(code2);
+    }
+    defined = self2.parser.defined.includes(normalizeIdentifier(self2.sliceSerialize({
+      start: labelStart.end,
+      end: self2.now()
+    })));
+    effects.enter("labelEnd");
+    effects.enter("labelMarker");
+    effects.consume(code2);
+    effects.exit("labelMarker");
+    effects.exit("labelEnd");
+    return after;
+  }
+  function after(code2) {
+    if (code2 === 40) {
+      return effects.attempt(resourceConstruct, labelEndOk, defined ? labelEndOk : labelEndNok)(code2);
+    }
+    if (code2 === 91) {
+      return effects.attempt(referenceFullConstruct, labelEndOk, defined ? referenceNotFull : labelEndNok)(code2);
+    }
+    return defined ? labelEndOk(code2) : labelEndNok(code2);
+  }
+  function referenceNotFull(code2) {
+    return effects.attempt(referenceCollapsedConstruct, labelEndOk, labelEndNok)(code2);
+  }
+  function labelEndOk(code2) {
+    return ok4(code2);
+  }
+  function labelEndNok(code2) {
+    labelStart._balanced = true;
+    return nok(code2);
+  }
+}
+function tokenizeResource(effects, ok4, nok) {
+  return resourceStart;
+  function resourceStart(code2) {
+    effects.enter("resource");
+    effects.enter("resourceMarker");
+    effects.consume(code2);
+    effects.exit("resourceMarker");
+    return resourceBefore;
+  }
+  function resourceBefore(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, resourceOpen)(code2) : resourceOpen(code2);
+  }
+  function resourceOpen(code2) {
+    if (code2 === 41) {
+      return resourceEnd(code2);
+    }
+    return factoryDestination(effects, resourceDestinationAfter, resourceDestinationMissing, "resourceDestination", "resourceDestinationLiteral", "resourceDestinationLiteralMarker", "resourceDestinationRaw", "resourceDestinationString", 32)(code2);
+  }
+  function resourceDestinationAfter(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, resourceBetween)(code2) : resourceEnd(code2);
+  }
+  function resourceDestinationMissing(code2) {
+    return nok(code2);
+  }
+  function resourceBetween(code2) {
+    if (code2 === 34 || code2 === 39 || code2 === 40) {
+      return factoryTitle(effects, resourceTitleAfter, nok, "resourceTitle", "resourceTitleMarker", "resourceTitleString")(code2);
+    }
+    return resourceEnd(code2);
+  }
+  function resourceTitleAfter(code2) {
+    return markdownLineEndingOrSpace(code2) ? factoryWhitespace(effects, resourceEnd)(code2) : resourceEnd(code2);
+  }
+  function resourceEnd(code2) {
+    if (code2 === 41) {
+      effects.enter("resourceMarker");
+      effects.consume(code2);
+      effects.exit("resourceMarker");
+      effects.exit("resource");
+      return ok4;
+    }
+    return nok(code2);
+  }
+}
+function tokenizeReferenceFull(effects, ok4, nok) {
+  const self2 = this;
+  return referenceFull;
+  function referenceFull(code2) {
+    return factoryLabel.call(self2, effects, referenceFullAfter, referenceFullMissing, "reference", "referenceMarker", "referenceString")(code2);
+  }
+  function referenceFullAfter(code2) {
+    return self2.parser.defined.includes(normalizeIdentifier(self2.sliceSerialize(self2.events[self2.events.length - 1][1]).slice(1, -1))) ? ok4(code2) : nok(code2);
+  }
+  function referenceFullMissing(code2) {
+    return nok(code2);
+  }
+}
+function tokenizeReferenceCollapsed(effects, ok4, nok) {
+  return referenceCollapsedStart;
+  function referenceCollapsedStart(code2) {
+    effects.enter("reference");
+    effects.enter("referenceMarker");
+    effects.consume(code2);
+    effects.exit("referenceMarker");
+    return referenceCollapsedOpen;
+  }
+  function referenceCollapsedOpen(code2) {
+    if (code2 === 93) {
+      effects.enter("referenceMarker");
+      effects.consume(code2);
+      effects.exit("referenceMarker");
+      effects.exit("reference");
+      return ok4;
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-start-image.js
+var labelStartImage = {
+  name: "labelStartImage",
+  tokenize: tokenizeLabelStartImage,
+  resolveAll: labelEnd.resolveAll
+};
+function tokenizeLabelStartImage(effects, ok4, nok) {
+  const self2 = this;
+  return start2;
+  function start2(code2) {
+    effects.enter("labelImage");
+    effects.enter("labelImageMarker");
+    effects.consume(code2);
+    effects.exit("labelImageMarker");
+    return open;
+  }
+  function open(code2) {
+    if (code2 === 91) {
+      effects.enter("labelMarker");
+      effects.consume(code2);
+      effects.exit("labelMarker");
+      effects.exit("labelImage");
+      return after;
+    }
+    return nok(code2);
+  }
+  function after(code2) {
+    return code2 === 94 && "_hiddenFootnoteSupport" in self2.parser.constructs ? nok(code2) : ok4(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/label-start-link.js
+var labelStartLink = {
+  name: "labelStartLink",
+  tokenize: tokenizeLabelStartLink,
+  resolveAll: labelEnd.resolveAll
+};
+function tokenizeLabelStartLink(effects, ok4, nok) {
+  const self2 = this;
+  return start2;
+  function start2(code2) {
+    effects.enter("labelLink");
+    effects.enter("labelMarker");
+    effects.consume(code2);
+    effects.exit("labelMarker");
+    effects.exit("labelLink");
+    return after;
+  }
+  function after(code2) {
+    return code2 === 94 && "_hiddenFootnoteSupport" in self2.parser.constructs ? nok(code2) : ok4(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/line-ending.js
+var lineEnding = {
+  name: "lineEnding",
+  tokenize: tokenizeLineEnding
+};
+function tokenizeLineEnding(effects, ok4) {
+  return start2;
+  function start2(code2) {
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, ok4, "linePrefix");
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/thematic-break.js
+var thematicBreak = {
+  name: "thematicBreak",
+  tokenize: tokenizeThematicBreak
+};
+function tokenizeThematicBreak(effects, ok4, nok) {
+  let size = 0;
+  let marker;
+  return start2;
+  function start2(code2) {
+    effects.enter("thematicBreak");
+    return before(code2);
+  }
+  function before(code2) {
+    marker = code2;
+    return atBreak(code2);
+  }
+  function atBreak(code2) {
+    if (code2 === marker) {
+      effects.enter("thematicBreakSequence");
+      return sequence(code2);
+    }
+    if (size >= 3 && (code2 === null || markdownLineEnding(code2))) {
+      effects.exit("thematicBreak");
+      return ok4(code2);
+    }
+    return nok(code2);
+  }
+  function sequence(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      size++;
+      return sequence;
+    }
+    effects.exit("thematicBreakSequence");
+    return markdownSpace(code2) ? factorySpace(effects, atBreak, "whitespace")(code2) : atBreak(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/list.js
+var list = {
+  name: "list",
+  tokenize: tokenizeListStart,
+  continuation: {
+    tokenize: tokenizeListContinuation
+  },
+  exit: tokenizeListEnd
+};
+var listItemPrefixWhitespaceConstruct = {
+  tokenize: tokenizeListItemPrefixWhitespace,
+  partial: true
+};
+var indentConstruct = {
+  tokenize: tokenizeIndent,
+  partial: true
+};
+function tokenizeListStart(effects, ok4, nok) {
+  const self2 = this;
+  const tail = self2.events[self2.events.length - 1];
+  let initialSize = tail && tail[1].type === "linePrefix" ? tail[2].sliceSerialize(tail[1], true).length : 0;
+  let size = 0;
+  return start2;
+  function start2(code2) {
+    const kind = self2.containerState.type || (code2 === 42 || code2 === 43 || code2 === 45 ? "listUnordered" : "listOrdered");
+    if (kind === "listUnordered" ? !self2.containerState.marker || code2 === self2.containerState.marker : asciiDigit(code2)) {
+      if (!self2.containerState.type) {
+        self2.containerState.type = kind;
+        effects.enter(kind, {
+          _container: true
+        });
+      }
+      if (kind === "listUnordered") {
+        effects.enter("listItemPrefix");
+        return code2 === 42 || code2 === 45 ? effects.check(thematicBreak, nok, atMarker)(code2) : atMarker(code2);
+      }
+      if (!self2.interrupt || code2 === 49) {
+        effects.enter("listItemPrefix");
+        effects.enter("listItemValue");
+        return inside(code2);
+      }
+    }
+    return nok(code2);
+  }
+  function inside(code2) {
+    if (asciiDigit(code2) && ++size < 10) {
+      effects.consume(code2);
+      return inside;
+    }
+    if ((!self2.interrupt || size < 2) && (self2.containerState.marker ? code2 === self2.containerState.marker : code2 === 41 || code2 === 46)) {
+      effects.exit("listItemValue");
+      return atMarker(code2);
+    }
+    return nok(code2);
+  }
+  function atMarker(code2) {
+    effects.enter("listItemMarker");
+    effects.consume(code2);
+    effects.exit("listItemMarker");
+    self2.containerState.marker = self2.containerState.marker || code2;
+    return effects.check(
+      blankLine,
+      // Can’t be empty when interrupting.
+      self2.interrupt ? nok : onBlank,
+      effects.attempt(listItemPrefixWhitespaceConstruct, endOfPrefix, otherPrefix)
+    );
+  }
+  function onBlank(code2) {
+    self2.containerState.initialBlankLine = true;
+    initialSize++;
+    return endOfPrefix(code2);
+  }
+  function otherPrefix(code2) {
+    if (markdownSpace(code2)) {
+      effects.enter("listItemPrefixWhitespace");
+      effects.consume(code2);
+      effects.exit("listItemPrefixWhitespace");
+      return endOfPrefix;
+    }
+    return nok(code2);
+  }
+  function endOfPrefix(code2) {
+    self2.containerState.size = initialSize + self2.sliceSerialize(effects.exit("listItemPrefix"), true).length;
+    return ok4(code2);
+  }
+}
+function tokenizeListContinuation(effects, ok4, nok) {
+  const self2 = this;
+  self2.containerState._closeFlow = void 0;
+  return effects.check(blankLine, onBlank, notBlank);
+  function onBlank(code2) {
+    self2.containerState.furtherBlankLines = self2.containerState.furtherBlankLines || self2.containerState.initialBlankLine;
+    return factorySpace(effects, ok4, "listItemIndent", self2.containerState.size + 1)(code2);
+  }
+  function notBlank(code2) {
+    if (self2.containerState.furtherBlankLines || !markdownSpace(code2)) {
+      self2.containerState.furtherBlankLines = void 0;
+      self2.containerState.initialBlankLine = void 0;
+      return notInCurrentItem(code2);
+    }
+    self2.containerState.furtherBlankLines = void 0;
+    self2.containerState.initialBlankLine = void 0;
+    return effects.attempt(indentConstruct, ok4, notInCurrentItem)(code2);
+  }
+  function notInCurrentItem(code2) {
+    self2.containerState._closeFlow = true;
+    self2.interrupt = void 0;
+    return factorySpace(effects, effects.attempt(list, ok4, nok), "linePrefix", self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4)(code2);
+  }
+}
+function tokenizeIndent(effects, ok4, nok) {
+  const self2 = this;
+  return factorySpace(effects, afterPrefix, "listItemIndent", self2.containerState.size + 1);
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return tail && tail[1].type === "listItemIndent" && tail[2].sliceSerialize(tail[1], true).length === self2.containerState.size ? ok4(code2) : nok(code2);
+  }
+}
+function tokenizeListEnd(effects) {
+  effects.exit(this.containerState.type);
+}
+function tokenizeListItemPrefixWhitespace(effects, ok4, nok) {
+  const self2 = this;
+  return factorySpace(effects, afterPrefix, "listItemPrefixWhitespace", self2.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4 + 1);
+  function afterPrefix(code2) {
+    const tail = self2.events[self2.events.length - 1];
+    return !markdownSpace(code2) && tail && tail[1].type === "listItemPrefixWhitespace" ? ok4(code2) : nok(code2);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/setext-underline.js
+var setextUnderline = {
+  name: "setextUnderline",
+  tokenize: tokenizeSetextUnderline,
+  resolveTo: resolveToSetextUnderline
+};
+function resolveToSetextUnderline(events, context) {
+  let index2 = events.length;
+  let content3;
+  let text5;
+  let definition2;
+  while (index2--) {
+    if (events[index2][0] === "enter") {
+      if (events[index2][1].type === "content") {
+        content3 = index2;
+        break;
+      }
+      if (events[index2][1].type === "paragraph") {
+        text5 = index2;
+      }
+    } else {
+      if (events[index2][1].type === "content") {
+        events.splice(index2, 1);
+      }
+      if (!definition2 && events[index2][1].type === "definition") {
+        definition2 = index2;
+      }
+    }
+  }
+  const heading2 = {
+    type: "setextHeading",
+    start: Object.assign({}, events[text5][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  events[text5][1].type = "setextHeadingText";
+  if (definition2) {
+    events.splice(text5, 0, ["enter", heading2, context]);
+    events.splice(definition2 + 1, 0, ["exit", events[content3][1], context]);
+    events[content3][1].end = Object.assign({}, events[definition2][1].end);
+  } else {
+    events[content3][1] = heading2;
+  }
+  events.push(["exit", heading2, context]);
+  return events;
+}
+function tokenizeSetextUnderline(effects, ok4, nok) {
+  const self2 = this;
+  let marker;
+  return start2;
+  function start2(code2) {
+    let index2 = self2.events.length;
+    let paragraph2;
+    while (index2--) {
+      if (self2.events[index2][1].type !== "lineEnding" && self2.events[index2][1].type !== "linePrefix" && self2.events[index2][1].type !== "content") {
+        paragraph2 = self2.events[index2][1].type === "paragraph";
+        break;
+      }
+    }
+    if (!self2.parser.lazy[self2.now().line] && (self2.interrupt || paragraph2)) {
+      effects.enter("setextHeadingLine");
+      marker = code2;
+      return before(code2);
+    }
+    return nok(code2);
+  }
+  function before(code2) {
+    effects.enter("setextHeadingLineSequence");
+    return inside(code2);
+  }
+  function inside(code2) {
+    if (code2 === marker) {
+      effects.consume(code2);
+      return inside;
+    }
+    effects.exit("setextHeadingLineSequence");
+    return markdownSpace(code2) ? factorySpace(effects, after, "lineSuffix")(code2) : after(code2);
+  }
+  function after(code2) {
+    if (code2 === null || markdownLineEnding(code2)) {
+      effects.exit("setextHeadingLine");
+      return ok4(code2);
+    }
+    return nok(code2);
+  }
+}
+
+// node_modules/micromark-extension-mdxjs-esm/lib/syntax.js
+var blankLineBefore2 = {
+  tokenize: tokenizeNextBlank,
+  partial: true
+};
+var trouble3 = "https://github.com/micromark/micromark-extension-mdxjs-esm";
+var allowedAcornTypes = /* @__PURE__ */ new Set(["ExportAllDeclaration", "ExportDefaultDeclaration", "ExportNamedDeclaration", "ImportDeclaration"]);
+function mdxjsEsm(options) {
+  const exportImportConstruct = {
+    tokenize: tokenizeExportImport,
+    concrete: true
+  };
+  if (!options || !options.acorn || !options.acorn.parse) {
+    throw new Error("Expected an `acorn` instance passed in as `options.acorn`");
+  }
+  const acorn = options.acorn;
+  const acornOptions = Object.assign({
+    ecmaVersion: 2024,
+    sourceType: "module"
+  }, options.acornOptions, {
+    locations: true
+  });
+  return {
+    flow: {
+      [101]: exportImportConstruct,
+      [105]: exportImportConstruct
+    }
+  };
+  function tokenizeExportImport(effects, ok4, nok) {
+    const self2 = this;
+    const definedModuleSpecifiers = self2.parser.definedModuleSpecifiers || (self2.parser.definedModuleSpecifiers = []);
+    const eventStart = this.events.length + 1;
+    let buffer = "";
+    return self2.interrupt ? nok : start2;
+    function start2(code2) {
+      if (self2.now().column > 1) return nok(code2);
+      effects.enter("mdxjsEsm");
+      effects.enter("mdxjsEsmData");
+      effects.consume(code2);
+      buffer += String.fromCharCode(code2);
+      return word;
+    }
+    function word(code2) {
+      if (asciiAlpha(code2)) {
+        effects.consume(code2);
+        buffer += String.fromCharCode(code2);
+        return word;
+      }
+      if ((buffer === "import" || buffer === "export") && code2 === 32) {
+        effects.consume(code2);
+        return inside;
+      }
+      return nok(code2);
+    }
+    function inside(code2) {
+      if (code2 === null || markdownLineEnding(code2)) {
+        effects.exit("mdxjsEsmData");
+        return lineStart(code2);
+      }
+      effects.consume(code2);
+      return inside;
+    }
+    function lineStart(code2) {
+      if (code2 === null) {
+        return atEnd(code2);
+      }
+      if (markdownLineEnding(code2)) {
+        return effects.check(blankLineBefore2, atEnd, continuationStart)(code2);
+      }
+      effects.enter("mdxjsEsmData");
+      return inside(code2);
+    }
+    function continuationStart(code2) {
+      effects.enter("lineEnding");
+      effects.consume(code2);
+      effects.exit("lineEnding");
+      return lineStart;
+    }
+    function atEnd(code2) {
+      const result = eventsToAcorn(self2.events.slice(eventStart), {
+        acorn,
+        acornOptions,
+        tokenTypes: ["mdxjsEsmData"],
+        prefix: definedModuleSpecifiers.length > 0 ? "var " + definedModuleSpecifiers.join(",") + "\n" : ""
+      });
+      if (result.error) {
+        if (code2 !== null && result.swallow) {
+          return continuationStart(code2);
+        }
+        const error = new VFileMessage("Could not parse import/exports with acorn", {
+          cause: result.error,
+          place: {
+            line: result.error.loc.line,
+            column: result.error.loc.column + 1,
+            offset: result.error.pos
+          },
+          ruleId: "acorn",
+          source: "micromark-extension-mdxjs-esm"
+        });
+        error.url = trouble3 + "#could-not-parse-importexports-with-acorn";
+        throw error;
+      }
+      if (definedModuleSpecifiers.length > 0) {
+        const declaration = result.estree.body.shift();
+      }
+      let index2 = -1;
+      while (++index2 < result.estree.body.length) {
+        const node2 = result.estree.body[index2];
+        if (!allowedAcornTypes.has(node2.type)) {
+          const error = new VFileMessage("Unexpected `" + node2.type + "` in code: only import/exports are supported", {
+            place: positionFromEstree(node2),
+            ruleId: "non-esm",
+            source: "micromark-extension-mdxjs-esm"
+          });
+          error.url = trouble3 + "#unexpected-type-in-code-only-importexports-are-supported";
+          throw error;
+        }
+        if (node2.type === "ImportDeclaration" && !self2.interrupt) {
+          let index3 = -1;
+          while (++index3 < node2.specifiers.length) {
+            const specifier = node2.specifiers[index3];
+            definedModuleSpecifiers.push(specifier.local.name);
+          }
+        }
+      }
+      Object.assign(effects.exit("mdxjsEsm"), options.addResult ? {
+        estree: result.estree
+      } : void 0);
+      return ok4(code2);
+    }
+  }
+}
+function tokenizeNextBlank(effects, ok4, nok) {
+  return start2;
+  function start2(code2) {
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    return effects.attempt(blankLine, ok4, nok);
+  }
+}
+
+// node_modules/micromark-util-combine-extensions/index.js
+var hasOwnProperty2 = {}.hasOwnProperty;
+function combineExtensions(extensions) {
+  const all3 = {};
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    syntaxExtension(all3, extensions[index2]);
+  }
+  return all3;
+}
+function syntaxExtension(all3, extension2) {
+  let hook;
+  for (hook in extension2) {
+    const maybe = hasOwnProperty2.call(all3, hook) ? all3[hook] : void 0;
+    const left = maybe || (all3[hook] = {});
+    const right = extension2[hook];
+    let code2;
+    if (right) {
+      for (code2 in right) {
+        if (!hasOwnProperty2.call(left, code2)) left[code2] = [];
+        const value = right[code2];
+        constructs(
+          // @ts-expect-error Looks like a list.
+          left[code2],
+          Array.isArray(value) ? value : value ? [value] : []
+        );
+      }
+    }
+  }
+}
+function constructs(existing, list3) {
+  let index2 = -1;
+  const before = [];
+  while (++index2 < list3.length) {
+    ;
+    (list3[index2].add === "after" ? existing : before).push(list3[index2]);
+  }
+  splice(existing, 0, 0, before);
+}
+
+// node_modules/micromark-extension-mdxjs/index.js
+function mdxjs(options) {
+  const settings = Object.assign(
+    {
+      acorn: Parser.extend((0, import_acorn_jsx.default)()),
+      acornOptions: { ecmaVersion: 2024, sourceType: "module" },
+      addResult: true
+    },
+    options
+  );
+  return combineExtensions([
+    mdxjsEsm(settings),
+    mdxExpression(settings),
+    mdxJsx(settings),
+    mdxMd()
+  ]);
+}
+
+// node_modules/remark-mdx/lib/index.js
+var emptyOptions2 = {};
+function remarkMdx(options) {
+  const self2 = (
+    /** @type {Processor} */
+    this
+  );
+  const settings = options || emptyOptions2;
+  const data2 = self2.data();
+  const micromarkExtensions = data2.micromarkExtensions || (data2.micromarkExtensions = []);
+  const fromMarkdownExtensions = data2.fromMarkdownExtensions || (data2.fromMarkdownExtensions = []);
+  const toMarkdownExtensions = data2.toMarkdownExtensions || (data2.toMarkdownExtensions = []);
+  micromarkExtensions.push(mdxjs(settings));
+  fromMarkdownExtensions.push(mdxFromMarkdown());
+  toMarkdownExtensions.push(mdxToMarkdown(settings));
+}
+
+// node_modules/mdast-util-from-markdown/node_modules/mdast-util-to-string/lib/index.js
+var emptyOptions3 = {};
+function toString2(value, options) {
+  const settings = options || emptyOptions3;
+  const includeImageAlt = typeof settings.includeImageAlt === "boolean" ? settings.includeImageAlt : true;
+  const includeHtml = typeof settings.includeHtml === "boolean" ? settings.includeHtml : true;
+  return one(value, includeImageAlt, includeHtml);
+}
+function one(value, includeImageAlt, includeHtml) {
+  if (node(value)) {
+    if ("value" in value) {
+      return value.type === "html" && !includeHtml ? "" : value.value;
+    }
+    if (includeImageAlt && "alt" in value && value.alt) {
+      return value.alt;
+    }
+    if ("children" in value) {
+      return all(value.children, includeImageAlt, includeHtml);
+    }
+  }
+  if (Array.isArray(value)) {
+    return all(value, includeImageAlt, includeHtml);
+  }
+  return "";
+}
+function all(values, includeImageAlt, includeHtml) {
+  const result = [];
+  let index2 = -1;
+  while (++index2 < values.length) {
+    result[index2] = one(values[index2], includeImageAlt, includeHtml);
+  }
+  return result.join("");
+}
+function node(value) {
+  return Boolean(value && typeof value === "object");
+}
+
+// node_modules/micromark-util-decode-numeric-character-reference/index.js
+function decodeNumericCharacterReference(value, base) {
+  const code2 = Number.parseInt(value, base);
+  if (
+    // C0 except for HT, LF, FF, CR, space.
+    code2 < 9 || code2 === 11 || code2 > 13 && code2 < 32 || // Control character (DEL) of C0, and C1 controls.
+    code2 > 126 && code2 < 160 || // Lone high surrogates and low surrogates.
+    code2 > 55295 && code2 < 57344 || // Noncharacters.
+    code2 > 64975 && code2 < 65008 || /* eslint-disable no-bitwise */
+    (code2 & 65535) === 65535 || (code2 & 65535) === 65534 || /* eslint-enable no-bitwise */
+    // Out of range
+    code2 > 1114111
+  ) {
+    return "\uFFFD";
+  }
+  return String.fromCodePoint(code2);
+}
+
+// node_modules/micromark-util-sanitize-uri/index.js
+function normalizeUri(value) {
+  const result = [];
+  let index2 = -1;
+  let start2 = 0;
+  let skip = 0;
+  while (++index2 < value.length) {
+    const code2 = value.charCodeAt(index2);
+    let replace = "";
+    if (code2 === 37 && asciiAlphanumeric(value.charCodeAt(index2 + 1)) && asciiAlphanumeric(value.charCodeAt(index2 + 2))) {
+      skip = 2;
+    } else if (code2 < 128) {
+      if (!/[!#$&-;=?-Z_a-z~]/.test(String.fromCharCode(code2))) {
+        replace = String.fromCharCode(code2);
+      }
+    } else if (code2 > 55295 && code2 < 57344) {
+      const next = value.charCodeAt(index2 + 1);
+      if (code2 < 56320 && next > 56319 && next < 57344) {
+        replace = String.fromCharCode(code2, next);
+        skip = 1;
+      } else {
+        replace = "\uFFFD";
+      }
+    } else {
+      replace = String.fromCharCode(code2);
+    }
+    if (replace) {
+      result.push(value.slice(start2, index2), encodeURIComponent(replace));
+      start2 = index2 + skip + 1;
+      replace = "";
+    }
+    if (skip) {
+      index2 += skip;
+      skip = 0;
+    }
+  }
+  return result.join("") + value.slice(start2);
+}
+
+// node_modules/micromark/lib/initialize/content.js
+var content2 = {
+  tokenize: initializeContent
+};
+function initializeContent(effects) {
+  const contentStart = effects.attempt(
+    this.parser.constructs.contentInitial,
+    afterContentStartConstruct,
+    paragraphInitial
+  );
+  let previous2;
+  return contentStart;
+  function afterContentStartConstruct(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    return factorySpace(effects, contentStart, "linePrefix");
+  }
+  function paragraphInitial(code2) {
+    effects.enter("paragraph");
+    return lineStart(code2);
+  }
+  function lineStart(code2) {
+    const token = effects.enter("chunkText", {
+      contentType: "text",
+      previous: previous2
+    });
+    if (previous2) {
+      previous2.next = token;
+    }
+    previous2 = token;
+    return data2(code2);
+  }
+  function data2(code2) {
+    if (code2 === null) {
+      effects.exit("chunkText");
+      effects.exit("paragraph");
+      effects.consume(code2);
+      return;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.consume(code2);
+      effects.exit("chunkText");
+      return lineStart;
+    }
+    effects.consume(code2);
+    return data2;
+  }
+}
+
+// node_modules/micromark/lib/initialize/document.js
+var document = {
+  tokenize: initializeDocument
+};
+var containerConstruct = {
+  tokenize: tokenizeContainer
+};
+function initializeDocument(effects) {
+  const self2 = this;
+  const stack = [];
+  let continued = 0;
+  let childFlow;
+  let childToken;
+  let lineStartOffset;
+  return start2;
+  function start2(code2) {
+    if (continued < stack.length) {
+      const item = stack[continued];
+      self2.containerState = item[1];
+      return effects.attempt(
+        item[0].continuation,
+        documentContinue,
+        checkNewContainers
+      )(code2);
+    }
+    return checkNewContainers(code2);
+  }
+  function documentContinue(code2) {
+    continued++;
+    if (self2.containerState._closeFlow) {
+      self2.containerState._closeFlow = void 0;
+      if (childFlow) {
+        closeFlow();
+      }
+      const indexBeforeExits = self2.events.length;
+      let indexBeforeFlow = indexBeforeExits;
+      let point4;
+      while (indexBeforeFlow--) {
+        if (self2.events[indexBeforeFlow][0] === "exit" && self2.events[indexBeforeFlow][1].type === "chunkFlow") {
+          point4 = self2.events[indexBeforeFlow][1].end;
+          break;
+        }
+      }
+      exitContainers(continued);
+      let index2 = indexBeforeExits;
+      while (index2 < self2.events.length) {
+        self2.events[index2][1].end = Object.assign({}, point4);
+        index2++;
+      }
+      splice(
+        self2.events,
+        indexBeforeFlow + 1,
+        0,
+        self2.events.slice(indexBeforeExits)
+      );
+      self2.events.length = index2;
+      return checkNewContainers(code2);
+    }
+    return start2(code2);
+  }
+  function checkNewContainers(code2) {
+    if (continued === stack.length) {
+      if (!childFlow) {
+        return documentContinued(code2);
+      }
+      if (childFlow.currentConstruct && childFlow.currentConstruct.concrete) {
+        return flowStart(code2);
+      }
+      self2.interrupt = Boolean(
+        childFlow.currentConstruct && !childFlow._gfmTableDynamicInterruptHack
+      );
+    }
+    self2.containerState = {};
+    return effects.check(
+      containerConstruct,
+      thereIsANewContainer,
+      thereIsNoNewContainer
+    )(code2);
+  }
+  function thereIsANewContainer(code2) {
+    if (childFlow) closeFlow();
+    exitContainers(continued);
+    return documentContinued(code2);
+  }
+  function thereIsNoNewContainer(code2) {
+    self2.parser.lazy[self2.now().line] = continued !== stack.length;
+    lineStartOffset = self2.now().offset;
+    return flowStart(code2);
+  }
+  function documentContinued(code2) {
+    self2.containerState = {};
+    return effects.attempt(
+      containerConstruct,
+      containerContinue,
+      flowStart
+    )(code2);
+  }
+  function containerContinue(code2) {
+    continued++;
+    stack.push([self2.currentConstruct, self2.containerState]);
+    return documentContinued(code2);
+  }
+  function flowStart(code2) {
+    if (code2 === null) {
+      if (childFlow) closeFlow();
+      exitContainers(0);
+      effects.consume(code2);
+      return;
+    }
+    childFlow = childFlow || self2.parser.flow(self2.now());
+    effects.enter("chunkFlow", {
+      contentType: "flow",
+      previous: childToken,
+      _tokenizer: childFlow
+    });
+    return flowContinue(code2);
+  }
+  function flowContinue(code2) {
+    if (code2 === null) {
+      writeToChild(effects.exit("chunkFlow"), true);
+      exitContainers(0);
+      effects.consume(code2);
+      return;
+    }
+    if (markdownLineEnding(code2)) {
+      effects.consume(code2);
+      writeToChild(effects.exit("chunkFlow"));
+      continued = 0;
+      self2.interrupt = void 0;
+      return start2;
+    }
+    effects.consume(code2);
+    return flowContinue;
+  }
+  function writeToChild(token, eof) {
+    const stream = self2.sliceStream(token);
+    if (eof) stream.push(null);
+    token.previous = childToken;
+    if (childToken) childToken.next = token;
+    childToken = token;
+    childFlow.defineSkip(token.start);
+    childFlow.write(stream);
+    if (self2.parser.lazy[token.start.line]) {
+      let index2 = childFlow.events.length;
+      while (index2--) {
+        if (
+          // The token starts before the line ending…
+          childFlow.events[index2][1].start.offset < lineStartOffset && // …and either is not ended yet…
+          (!childFlow.events[index2][1].end || // …or ends after it.
+          childFlow.events[index2][1].end.offset > lineStartOffset)
+        ) {
+          return;
+        }
+      }
+      const indexBeforeExits = self2.events.length;
+      let indexBeforeFlow = indexBeforeExits;
+      let seen;
+      let point4;
+      while (indexBeforeFlow--) {
+        if (self2.events[indexBeforeFlow][0] === "exit" && self2.events[indexBeforeFlow][1].type === "chunkFlow") {
+          if (seen) {
+            point4 = self2.events[indexBeforeFlow][1].end;
+            break;
+          }
+          seen = true;
+        }
+      }
+      exitContainers(continued);
+      index2 = indexBeforeExits;
+      while (index2 < self2.events.length) {
+        self2.events[index2][1].end = Object.assign({}, point4);
+        index2++;
+      }
+      splice(
+        self2.events,
+        indexBeforeFlow + 1,
+        0,
+        self2.events.slice(indexBeforeExits)
+      );
+      self2.events.length = index2;
+    }
+  }
+  function exitContainers(size) {
+    let index2 = stack.length;
+    while (index2-- > size) {
+      const entry = stack[index2];
+      self2.containerState = entry[1];
+      entry[0].exit.call(self2, effects);
+    }
+    stack.length = size;
+  }
+  function closeFlow() {
+    childFlow.write([null]);
+    childToken = void 0;
+    childFlow = void 0;
+    self2.containerState._closeFlow = void 0;
+  }
+}
+function tokenizeContainer(effects, ok4, nok) {
+  return factorySpace(
+    effects,
+    effects.attempt(this.parser.constructs.document, ok4, nok),
+    "linePrefix",
+    this.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4
+  );
+}
+
+// node_modules/micromark/lib/initialize/flow.js
+var flow = {
+  tokenize: initializeFlow
+};
+function initializeFlow(effects) {
+  const self2 = this;
+  const initial = effects.attempt(
+    // Try to parse a blank line.
+    blankLine,
+    atBlankEnding,
+    // Try to parse initial flow (essentially, only code).
+    effects.attempt(
+      this.parser.constructs.flowInitial,
+      afterConstruct,
+      factorySpace(
+        effects,
+        effects.attempt(
+          this.parser.constructs.flow,
+          afterConstruct,
+          effects.attempt(content, afterConstruct)
+        ),
+        "linePrefix"
+      )
+    )
+  );
+  return initial;
+  function atBlankEnding(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEndingBlank");
+    effects.consume(code2);
+    effects.exit("lineEndingBlank");
+    self2.currentConstruct = void 0;
+    return initial;
+  }
+  function afterConstruct(code2) {
+    if (code2 === null) {
+      effects.consume(code2);
+      return;
+    }
+    effects.enter("lineEnding");
+    effects.consume(code2);
+    effects.exit("lineEnding");
+    self2.currentConstruct = void 0;
+    return initial;
+  }
+}
+
+// node_modules/micromark/lib/initialize/text.js
+var resolver = {
+  resolveAll: createResolver()
+};
+var string = initializeFactory("string");
+var text = initializeFactory("text");
+function initializeFactory(field) {
+  return {
+    tokenize: initializeText,
+    resolveAll: createResolver(
+      field === "text" ? resolveAllLineSuffixes : void 0
+    )
+  };
+  function initializeText(effects) {
+    const self2 = this;
+    const constructs2 = this.parser.constructs[field];
+    const text5 = effects.attempt(constructs2, start2, notText);
+    return start2;
+    function start2(code2) {
+      return atBreak(code2) ? text5(code2) : notText(code2);
+    }
+    function notText(code2) {
+      if (code2 === null) {
+        effects.consume(code2);
+        return;
+      }
+      effects.enter("data");
+      effects.consume(code2);
+      return data2;
+    }
+    function data2(code2) {
+      if (atBreak(code2)) {
+        effects.exit("data");
+        return text5(code2);
+      }
+      effects.consume(code2);
+      return data2;
+    }
+    function atBreak(code2) {
+      if (code2 === null) {
+        return true;
+      }
+      const list3 = constructs2[code2];
+      let index2 = -1;
+      if (list3) {
+        while (++index2 < list3.length) {
+          const item = list3[index2];
+          if (!item.previous || item.previous.call(self2, self2.previous)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    }
+  }
+}
+function createResolver(extraResolver) {
+  return resolveAllText;
+  function resolveAllText(events, context) {
+    let index2 = -1;
+    let enter;
+    while (++index2 <= events.length) {
+      if (enter === void 0) {
+        if (events[index2] && events[index2][1].type === "data") {
+          enter = index2;
+          index2++;
+        }
+      } else if (!events[index2] || events[index2][1].type !== "data") {
+        if (index2 !== enter + 2) {
+          events[enter][1].end = events[index2 - 1][1].end;
+          events.splice(enter + 2, index2 - enter - 2);
+          index2 = enter + 2;
+        }
+        enter = void 0;
+      }
+    }
+    return extraResolver ? extraResolver(events, context) : events;
+  }
+}
+function resolveAllLineSuffixes(events, context) {
+  let eventIndex = 0;
+  while (++eventIndex <= events.length) {
+    if ((eventIndex === events.length || events[eventIndex][1].type === "lineEnding") && events[eventIndex - 1][1].type === "data") {
+      const data2 = events[eventIndex - 1][1];
+      const chunks = context.sliceStream(data2);
+      let index2 = chunks.length;
+      let bufferIndex = -1;
+      let size = 0;
+      let tabs;
+      while (index2--) {
+        const chunk = chunks[index2];
+        if (typeof chunk === "string") {
+          bufferIndex = chunk.length;
+          while (chunk.charCodeAt(bufferIndex - 1) === 32) {
+            size++;
+            bufferIndex--;
+          }
+          if (bufferIndex) break;
+          bufferIndex = -1;
+        } else if (chunk === -2) {
+          tabs = true;
+          size++;
+        } else if (chunk === -1) {
+        } else {
+          index2++;
+          break;
+        }
+      }
+      if (size) {
+        const token = {
+          type: eventIndex === events.length || tabs || size < 2 ? "lineSuffix" : "hardBreakTrailing",
+          start: {
+            line: data2.end.line,
+            column: data2.end.column - size,
+            offset: data2.end.offset - size,
+            _index: data2.start._index + index2,
+            _bufferIndex: index2 ? bufferIndex : data2.start._bufferIndex + bufferIndex
+          },
+          end: Object.assign({}, data2.end)
+        };
+        data2.end = Object.assign({}, token.start);
+        if (data2.start.offset === data2.end.offset) {
+          Object.assign(data2, token);
+        } else {
+          events.splice(
+            eventIndex,
+            0,
+            ["enter", token, context],
+            ["exit", token, context]
+          );
+          eventIndex += 2;
+        }
+      }
+      eventIndex++;
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark/lib/create-tokenizer.js
+function createTokenizer(parser, initialize, from) {
+  let point4 = Object.assign(
+    from ? Object.assign({}, from) : {
+      line: 1,
+      column: 1,
+      offset: 0
+    },
+    {
+      _index: 0,
+      _bufferIndex: -1
+    }
+  );
+  const columnStart = {};
+  const resolveAllConstructs = [];
+  let chunks = [];
+  let stack = [];
+  let consumed = true;
+  const effects = {
+    consume,
+    enter,
+    exit: exit2,
+    attempt: constructFactory(onsuccessfulconstruct),
+    check: constructFactory(onsuccessfulcheck),
+    interrupt: constructFactory(onsuccessfulcheck, {
+      interrupt: true
+    })
+  };
+  const context = {
+    previous: null,
+    code: null,
+    containerState: {},
+    events: [],
+    parser,
+    sliceStream,
+    sliceSerialize,
+    now,
+    defineSkip,
+    write
+  };
+  let state = initialize.tokenize.call(context, effects);
+  let expectedCode;
+  if (initialize.resolveAll) {
+    resolveAllConstructs.push(initialize);
+  }
+  return context;
+  function write(slice2) {
+    chunks = push(chunks, slice2);
+    main();
+    if (chunks[chunks.length - 1] !== null) {
+      return [];
+    }
+    addResult(initialize, 0);
+    context.events = resolveAll(resolveAllConstructs, context.events, context);
+    return context.events;
+  }
+  function sliceSerialize(token, expandTabs) {
+    return serializeChunks2(sliceStream(token), expandTabs);
+  }
+  function sliceStream(token) {
+    return sliceChunks(chunks, token);
+  }
+  function now() {
+    const { line, column, offset: offset2, _index, _bufferIndex } = point4;
+    return {
+      line,
+      column,
+      offset: offset2,
+      _index,
+      _bufferIndex
+    };
+  }
+  function defineSkip(value) {
+    columnStart[value.line] = value.column;
+    accountForPotentialSkip();
+  }
+  function main() {
+    let chunkIndex;
+    while (point4._index < chunks.length) {
+      const chunk = chunks[point4._index];
+      if (typeof chunk === "string") {
+        chunkIndex = point4._index;
+        if (point4._bufferIndex < 0) {
+          point4._bufferIndex = 0;
+        }
+        while (point4._index === chunkIndex && point4._bufferIndex < chunk.length) {
+          go(chunk.charCodeAt(point4._bufferIndex));
+        }
+      } else {
+        go(chunk);
+      }
+    }
+  }
+  function go(code2) {
+    consumed = void 0;
+    expectedCode = code2;
+    state = state(code2);
+  }
+  function consume(code2) {
+    if (markdownLineEnding(code2)) {
+      point4.line++;
+      point4.column = 1;
+      point4.offset += code2 === -3 ? 2 : 1;
+      accountForPotentialSkip();
+    } else if (code2 !== -1) {
+      point4.column++;
+      point4.offset++;
+    }
+    if (point4._bufferIndex < 0) {
+      point4._index++;
+    } else {
+      point4._bufferIndex++;
+      if (point4._bufferIndex === chunks[point4._index].length) {
+        point4._bufferIndex = -1;
+        point4._index++;
+      }
+    }
+    context.previous = code2;
+    consumed = true;
+  }
+  function enter(type, fields) {
+    const token = fields || {};
+    token.type = type;
+    token.start = now();
+    context.events.push(["enter", token, context]);
+    stack.push(token);
+    return token;
+  }
+  function exit2(type) {
+    const token = stack.pop();
+    token.end = now();
+    context.events.push(["exit", token, context]);
+    return token;
+  }
+  function onsuccessfulconstruct(construct, info) {
+    addResult(construct, info.from);
+  }
+  function onsuccessfulcheck(_, info) {
+    info.restore();
+  }
+  function constructFactory(onreturn, fields) {
+    return hook;
+    function hook(constructs2, returnState, bogusState) {
+      let listOfConstructs;
+      let constructIndex;
+      let currentConstruct;
+      let info;
+      return Array.isArray(constructs2) ? handleListOfConstructs(constructs2) : "tokenize" in constructs2 ? (
+        // @ts-expect-error Looks like a construct.
+        handleListOfConstructs([constructs2])
+      ) : handleMapOfConstructs(constructs2);
+      function handleMapOfConstructs(map) {
+        return start2;
+        function start2(code2) {
+          const def = code2 !== null && map[code2];
+          const all3 = code2 !== null && map.null;
+          const list3 = [
+            // To do: add more extension tests.
+            /* c8 ignore next 2 */
+            ...Array.isArray(def) ? def : def ? [def] : [],
+            ...Array.isArray(all3) ? all3 : all3 ? [all3] : []
+          ];
+          return handleListOfConstructs(list3)(code2);
+        }
+      }
+      function handleListOfConstructs(list3) {
+        listOfConstructs = list3;
+        constructIndex = 0;
+        if (list3.length === 0) {
+          return bogusState;
+        }
+        return handleConstruct(list3[constructIndex]);
+      }
+      function handleConstruct(construct) {
+        return start2;
+        function start2(code2) {
+          info = store();
+          currentConstruct = construct;
+          if (!construct.partial) {
+            context.currentConstruct = construct;
+          }
+          if (construct.name && context.parser.constructs.disable.null.includes(construct.name)) {
+            return nok(code2);
+          }
+          return construct.tokenize.call(
+            // If we do have fields, create an object w/ `context` as its
+            // prototype.
+            // This allows a “live binding”, which is needed for `interrupt`.
+            fields ? Object.assign(Object.create(context), fields) : context,
+            effects,
+            ok4,
+            nok
+          )(code2);
+        }
+      }
+      function ok4(code2) {
+        consumed = true;
+        onreturn(currentConstruct, info);
+        return returnState;
+      }
+      function nok(code2) {
+        consumed = true;
+        info.restore();
+        if (++constructIndex < listOfConstructs.length) {
+          return handleConstruct(listOfConstructs[constructIndex]);
+        }
+        return bogusState;
+      }
+    }
+  }
+  function addResult(construct, from2) {
+    if (construct.resolveAll && !resolveAllConstructs.includes(construct)) {
+      resolveAllConstructs.push(construct);
+    }
+    if (construct.resolve) {
+      splice(
+        context.events,
+        from2,
+        context.events.length - from2,
+        construct.resolve(context.events.slice(from2), context)
+      );
+    }
+    if (construct.resolveTo) {
+      context.events = construct.resolveTo(context.events, context);
+    }
+  }
+  function store() {
+    const startPoint = now();
+    const startPrevious = context.previous;
+    const startCurrentConstruct = context.currentConstruct;
+    const startEventsIndex = context.events.length;
+    const startStack = Array.from(stack);
+    return {
+      restore,
+      from: startEventsIndex
+    };
+    function restore() {
+      point4 = startPoint;
+      context.previous = startPrevious;
+      context.currentConstruct = startCurrentConstruct;
+      context.events.length = startEventsIndex;
+      stack = startStack;
+      accountForPotentialSkip();
+    }
+  }
+  function accountForPotentialSkip() {
+    if (point4.line in columnStart && point4.column < 2) {
+      point4.column = columnStart[point4.line];
+      point4.offset += columnStart[point4.line] - 1;
+    }
+  }
+}
+function sliceChunks(chunks, token) {
+  const startIndex = token.start._index;
+  const startBufferIndex = token.start._bufferIndex;
+  const endIndex = token.end._index;
+  const endBufferIndex = token.end._bufferIndex;
+  let view;
+  if (startIndex === endIndex) {
+    view = [chunks[startIndex].slice(startBufferIndex, endBufferIndex)];
+  } else {
+    view = chunks.slice(startIndex, endIndex);
+    if (startBufferIndex > -1) {
+      const head = view[0];
+      if (typeof head === "string") {
+        view[0] = head.slice(startBufferIndex);
+      } else {
+        view.shift();
+      }
+    }
+    if (endBufferIndex > 0) {
+      view.push(chunks[endIndex].slice(0, endBufferIndex));
+    }
+  }
+  return view;
+}
+function serializeChunks2(chunks, expandTabs) {
+  let index2 = -1;
+  const result = [];
+  let atTab;
+  while (++index2 < chunks.length) {
+    const chunk = chunks[index2];
+    let value;
+    if (typeof chunk === "string") {
+      value = chunk;
+    } else
+      switch (chunk) {
+        case -5: {
+          value = "\r";
+          break;
+        }
+        case -4: {
+          value = "\n";
+          break;
+        }
+        case -3: {
+          value = "\r\n";
+          break;
+        }
+        case -2: {
+          value = expandTabs ? " " : "	";
+          break;
+        }
+        case -1: {
+          if (!expandTabs && atTab) continue;
+          value = " ";
+          break;
+        }
+        default: {
+          value = String.fromCharCode(chunk);
+        }
+      }
+    atTab = chunk === -2;
+    result.push(value);
+  }
+  return result.join("");
+}
+
+// node_modules/micromark/lib/constructs.js
+var constructs_exports = {};
+__export(constructs_exports, {
+  attentionMarkers: () => attentionMarkers,
+  contentInitial: () => contentInitial,
+  disable: () => disable,
+  document: () => document2,
+  flow: () => flow2,
+  flowInitial: () => flowInitial,
+  insideSpan: () => insideSpan,
+  string: () => string2,
+  text: () => text2
+});
+var document2 = {
+  [42]: list,
+  [43]: list,
+  [45]: list,
+  [48]: list,
+  [49]: list,
+  [50]: list,
+  [51]: list,
+  [52]: list,
+  [53]: list,
+  [54]: list,
+  [55]: list,
+  [56]: list,
+  [57]: list,
+  [62]: blockQuote
+};
+var contentInitial = {
+  [91]: definition
+};
+var flowInitial = {
+  [-2]: codeIndented,
+  [-1]: codeIndented,
+  [32]: codeIndented
+};
+var flow2 = {
+  [35]: headingAtx,
+  [42]: thematicBreak,
+  [45]: [setextUnderline, thematicBreak],
+  [60]: htmlFlow,
+  [61]: setextUnderline,
+  [95]: thematicBreak,
+  [96]: codeFenced,
+  [126]: codeFenced
+};
+var string2 = {
+  [38]: characterReference,
+  [92]: characterEscape
+};
+var text2 = {
+  [-5]: lineEnding,
+  [-4]: lineEnding,
+  [-3]: lineEnding,
+  [33]: labelStartImage,
+  [38]: characterReference,
+  [42]: attention,
+  [60]: [autolink, htmlText],
+  [91]: labelStartLink,
+  [92]: [hardBreakEscape, characterEscape],
+  [93]: labelEnd,
+  [95]: attention,
+  [96]: codeText
+};
+var insideSpan = {
+  null: [attention, resolver]
+};
+var attentionMarkers = {
+  null: [42, 95]
+};
+var disable = {
+  null: []
+};
+
+// node_modules/micromark/lib/parse.js
+function parse3(options) {
+  const settings = options || {};
+  const constructs2 = (
+    /** @type {FullNormalizedExtension} */
+    combineExtensions([constructs_exports, ...settings.extensions || []])
+  );
+  const parser = {
+    defined: [],
+    lazy: {},
+    constructs: constructs2,
+    content: create4(content2),
+    document: create4(document),
+    flow: create4(flow),
+    string: create4(string),
+    text: create4(text)
+  };
+  return parser;
+  function create4(initial) {
+    return creator;
+    function creator(from) {
+      return createTokenizer(parser, initial, from);
+    }
+  }
+}
+
+// node_modules/micromark/lib/postprocess.js
+function postprocess(events) {
+  while (!subtokenize(events)) {
+  }
+  return events;
+}
+
+// node_modules/micromark/lib/preprocess.js
+var search = /[\0\t\n\r]/g;
+function preprocess() {
+  let column = 1;
+  let buffer = "";
+  let start2 = true;
+  let atCarriageReturn;
+  return preprocessor;
+  function preprocessor(value, encoding, end) {
+    const chunks = [];
+    let match;
+    let next;
+    let startPosition;
+    let endPosition;
+    let code2;
+    value = buffer + (typeof value === "string" ? value.toString() : new TextDecoder(encoding || void 0).decode(value));
+    startPosition = 0;
+    buffer = "";
+    if (start2) {
+      if (value.charCodeAt(0) === 65279) {
+        startPosition++;
+      }
+      start2 = void 0;
+    }
+    while (startPosition < value.length) {
+      search.lastIndex = startPosition;
+      match = search.exec(value);
+      endPosition = match && match.index !== void 0 ? match.index : value.length;
+      code2 = value.charCodeAt(endPosition);
+      if (!match) {
+        buffer = value.slice(startPosition);
+        break;
+      }
+      if (code2 === 10 && startPosition === endPosition && atCarriageReturn) {
+        chunks.push(-3);
+        atCarriageReturn = void 0;
+      } else {
+        if (atCarriageReturn) {
+          chunks.push(-5);
+          atCarriageReturn = void 0;
+        }
+        if (startPosition < endPosition) {
+          chunks.push(value.slice(startPosition, endPosition));
+          column += endPosition - startPosition;
+        }
+        switch (code2) {
+          case 0: {
+            chunks.push(65533);
+            column++;
+            break;
+          }
+          case 9: {
+            next = Math.ceil(column / 4) * 4;
+            chunks.push(-2);
+            while (column++ < next) chunks.push(-1);
+            break;
+          }
+          case 10: {
+            chunks.push(-4);
+            column = 1;
+            break;
+          }
+          default: {
+            atCarriageReturn = true;
+            column = 1;
+          }
+        }
+      }
+      startPosition = endPosition + 1;
+    }
+    if (end) {
+      if (atCarriageReturn) chunks.push(-5);
+      if (buffer) chunks.push(buffer);
+      chunks.push(null);
+    }
+    return chunks;
+  }
+}
+
+// node_modules/micromark-util-decode-string/index.js
+var characterEscapeOrReference = /\\([!-/:-@[-`{-~])|&(#(?:\d{1,7}|x[\da-f]{1,6})|[\da-z]{1,31});/gi;
+function decodeString(value) {
+  return value.replace(characterEscapeOrReference, decode);
+}
+function decode($0, $1, $2) {
+  if ($1) {
+    return $1;
+  }
+  const head = $2.charCodeAt(0);
+  if (head === 35) {
+    const head2 = $2.charCodeAt(1);
+    const hex = head2 === 120 || head2 === 88;
+    return decodeNumericCharacterReference($2.slice(hex ? 2 : 1), hex ? 16 : 10);
+  }
+  return decodeNamedCharacterReference($2) || $0;
+}
+
+// node_modules/mdast-util-from-markdown/lib/index.js
+var own3 = {}.hasOwnProperty;
+function fromMarkdown(value, encoding, options) {
+  if (typeof encoding !== "string") {
+    options = encoding;
+    encoding = void 0;
+  }
+  return compiler(options)(postprocess(parse3(options).document().write(preprocess()(value, encoding, true))));
+}
+function compiler(options) {
+  const config = {
+    transforms: [],
+    canContainEols: ["emphasis", "fragment", "heading", "paragraph", "strong"],
+    enter: {
+      autolink: opener(link2),
+      autolinkProtocol: onenterdata,
+      autolinkEmail: onenterdata,
+      atxHeading: opener(heading2),
+      blockQuote: opener(blockQuote2),
+      characterEscape: onenterdata,
+      characterReference: onenterdata,
+      codeFenced: opener(codeFlow),
+      codeFencedFenceInfo: buffer,
+      codeFencedFenceMeta: buffer,
+      codeIndented: opener(codeFlow, buffer),
+      codeText: opener(codeText2, buffer),
+      codeTextData: onenterdata,
+      data: onenterdata,
+      codeFlowValue: onenterdata,
+      definition: opener(definition2),
+      definitionDestinationString: buffer,
+      definitionLabelString: buffer,
+      definitionTitleString: buffer,
+      emphasis: opener(emphasis2),
+      hardBreakEscape: opener(hardBreak2),
+      hardBreakTrailing: opener(hardBreak2),
+      htmlFlow: opener(html5, buffer),
+      htmlFlowData: onenterdata,
+      htmlText: opener(html5, buffer),
+      htmlTextData: onenterdata,
+      image: opener(image2),
+      label: buffer,
+      link: opener(link2),
+      listItem: opener(listItem2),
+      listItemValue: onenterlistitemvalue,
+      listOrdered: opener(list3, onenterlistordered),
+      listUnordered: opener(list3),
+      paragraph: opener(paragraph2),
+      reference: onenterreference,
+      referenceString: buffer,
+      resourceDestinationString: buffer,
+      resourceTitleString: buffer,
+      setextHeading: opener(heading2),
+      strong: opener(strong2),
+      thematicBreak: opener(thematicBreak3)
+    },
+    exit: {
+      atxHeading: closer(),
+      atxHeadingSequence: onexitatxheadingsequence,
+      autolink: closer(),
+      autolinkEmail: onexitautolinkemail,
+      autolinkProtocol: onexitautolinkprotocol,
+      blockQuote: closer(),
+      characterEscapeValue: onexitdata,
+      characterReferenceMarkerHexadecimal: onexitcharacterreferencemarker,
+      characterReferenceMarkerNumeric: onexitcharacterreferencemarker,
+      characterReferenceValue: onexitcharacterreferencevalue,
+      characterReference: onexitcharacterreference,
+      codeFenced: closer(onexitcodefenced),
+      codeFencedFence: onexitcodefencedfence,
+      codeFencedFenceInfo: onexitcodefencedfenceinfo,
+      codeFencedFenceMeta: onexitcodefencedfencemeta,
+      codeFlowValue: onexitdata,
+      codeIndented: closer(onexitcodeindented),
+      codeText: closer(onexitcodetext),
+      codeTextData: onexitdata,
+      data: onexitdata,
+      definition: closer(),
+      definitionDestinationString: onexitdefinitiondestinationstring,
+      definitionLabelString: onexitdefinitionlabelstring,
+      definitionTitleString: onexitdefinitiontitlestring,
+      emphasis: closer(),
+      hardBreakEscape: closer(onexithardbreak),
+      hardBreakTrailing: closer(onexithardbreak),
+      htmlFlow: closer(onexithtmlflow),
+      htmlFlowData: onexitdata,
+      htmlText: closer(onexithtmltext),
+      htmlTextData: onexitdata,
+      image: closer(onexitimage),
+      label: onexitlabel,
+      labelText: onexitlabeltext,
+      lineEnding: onexitlineending,
+      link: closer(onexitlink),
+      listItem: closer(),
+      listOrdered: closer(),
+      listUnordered: closer(),
+      paragraph: closer(),
+      referenceString: onexitreferencestring,
+      resourceDestinationString: onexitresourcedestinationstring,
+      resourceTitleString: onexitresourcetitlestring,
+      resource: onexitresource,
+      setextHeading: closer(onexitsetextheading),
+      setextHeadingLineSequence: onexitsetextheadinglinesequence,
+      setextHeadingText: onexitsetextheadingtext,
+      strong: closer(),
+      thematicBreak: closer()
+    }
+  };
+  configure(config, (options || {}).mdastExtensions || []);
+  const data2 = {};
+  return compile2;
+  function compile2(events) {
+    let tree = {
+      type: "root",
+      children: []
+    };
+    const context = {
+      stack: [tree],
+      tokenStack: [],
+      config,
+      enter,
+      exit: exit2,
+      buffer,
+      resume,
+      data: data2
+    };
+    const listStack = [];
+    let index2 = -1;
+    while (++index2 < events.length) {
+      if (events[index2][1].type === "listOrdered" || events[index2][1].type === "listUnordered") {
+        if (events[index2][0] === "enter") {
+          listStack.push(index2);
+        } else {
+          const tail = listStack.pop();
+          index2 = prepareList(events, tail, index2);
+        }
+      }
+    }
+    index2 = -1;
+    while (++index2 < events.length) {
+      const handler = config[events[index2][0]];
+      if (own3.call(handler, events[index2][1].type)) {
+        handler[events[index2][1].type].call(Object.assign({
+          sliceSerialize: events[index2][2].sliceSerialize
+        }, context), events[index2][1]);
+      }
+    }
+    if (context.tokenStack.length > 0) {
+      const tail = context.tokenStack[context.tokenStack.length - 1];
+      const handler = tail[1] || defaultOnError;
+      handler.call(context, void 0, tail[0]);
+    }
+    tree.position = {
+      start: point2(events.length > 0 ? events[0][1].start : {
+        line: 1,
+        column: 1,
+        offset: 0
+      }),
+      end: point2(events.length > 0 ? events[events.length - 2][1].end : {
+        line: 1,
+        column: 1,
+        offset: 0
+      })
+    };
+    index2 = -1;
+    while (++index2 < config.transforms.length) {
+      tree = config.transforms[index2](tree) || tree;
+    }
+    return tree;
+  }
+  function prepareList(events, start2, length) {
+    let index2 = start2 - 1;
+    let containerBalance = -1;
+    let listSpread = false;
+    let listItem3;
+    let lineIndex;
+    let firstBlankLineIndex;
+    let atMarker;
+    while (++index2 <= length) {
+      const event = events[index2];
+      switch (event[1].type) {
+        case "listUnordered":
+        case "listOrdered":
+        case "blockQuote": {
+          if (event[0] === "enter") {
+            containerBalance++;
+          } else {
+            containerBalance--;
+          }
+          atMarker = void 0;
+          break;
+        }
+        case "lineEndingBlank": {
+          if (event[0] === "enter") {
+            if (listItem3 && !atMarker && !containerBalance && !firstBlankLineIndex) {
+              firstBlankLineIndex = index2;
+            }
+            atMarker = void 0;
+          }
+          break;
+        }
+        case "linePrefix":
+        case "listItemValue":
+        case "listItemMarker":
+        case "listItemPrefix":
+        case "listItemPrefixWhitespace": {
+          break;
+        }
+        default: {
+          atMarker = void 0;
+        }
+      }
+      if (!containerBalance && event[0] === "enter" && event[1].type === "listItemPrefix" || containerBalance === -1 && event[0] === "exit" && (event[1].type === "listUnordered" || event[1].type === "listOrdered")) {
+        if (listItem3) {
+          let tailIndex = index2;
+          lineIndex = void 0;
+          while (tailIndex--) {
+            const tailEvent = events[tailIndex];
+            if (tailEvent[1].type === "lineEnding" || tailEvent[1].type === "lineEndingBlank") {
+              if (tailEvent[0] === "exit") continue;
+              if (lineIndex) {
+                events[lineIndex][1].type = "lineEndingBlank";
+                listSpread = true;
+              }
+              tailEvent[1].type = "lineEnding";
+              lineIndex = tailIndex;
+            } else if (tailEvent[1].type === "linePrefix" || tailEvent[1].type === "blockQuotePrefix" || tailEvent[1].type === "blockQuotePrefixWhitespace" || tailEvent[1].type === "blockQuoteMarker" || tailEvent[1].type === "listItemIndent") {
+            } else {
+              break;
+            }
+          }
+          if (firstBlankLineIndex && (!lineIndex || firstBlankLineIndex < lineIndex)) {
+            listItem3._spread = true;
+          }
+          listItem3.end = Object.assign({}, lineIndex ? events[lineIndex][1].start : event[1].end);
+          events.splice(lineIndex || index2, 0, ["exit", listItem3, event[2]]);
+          index2++;
+          length++;
+        }
+        if (event[1].type === "listItemPrefix") {
+          const item = {
+            type: "listItem",
+            _spread: false,
+            start: Object.assign({}, event[1].start),
+            // @ts-expect-error: we’ll add `end` in a second.
+            end: void 0
+          };
+          listItem3 = item;
+          events.splice(index2, 0, ["enter", item, event[2]]);
+          index2++;
+          length++;
+          firstBlankLineIndex = void 0;
+          atMarker = true;
+        }
+      }
+    }
+    events[start2][1]._spread = listSpread;
+    return length;
+  }
+  function opener(create4, and) {
+    return open;
+    function open(token) {
+      enter.call(this, create4(token), token);
+      if (and) and.call(this, token);
+    }
+  }
+  function buffer() {
+    this.stack.push({
+      type: "fragment",
+      children: []
+    });
+  }
+  function enter(node2, token, errorHandler) {
+    const parent = this.stack[this.stack.length - 1];
+    const siblings = parent.children;
+    siblings.push(node2);
+    this.stack.push(node2);
+    this.tokenStack.push([token, errorHandler]);
+    node2.position = {
+      start: point2(token.start),
+      // @ts-expect-error: `end` will be patched later.
+      end: void 0
+    };
+  }
+  function closer(and) {
+    return close;
+    function close(token) {
+      if (and) and.call(this, token);
+      exit2.call(this, token);
+    }
+  }
+  function exit2(token, onExitError) {
+    const node2 = this.stack.pop();
+    const open = this.tokenStack.pop();
+    if (!open) {
+      throw new Error("Cannot close `" + token.type + "` (" + stringifyPosition({
+        start: token.start,
+        end: token.end
+      }) + "): it\u2019s not open");
+    } else if (open[0].type !== token.type) {
+      if (onExitError) {
+        onExitError.call(this, token, open[0]);
+      } else {
+        const handler = open[1] || defaultOnError;
+        handler.call(this, token, open[0]);
+      }
+    }
+    node2.position.end = point2(token.end);
+  }
+  function resume() {
+    return toString2(this.stack.pop());
+  }
+  function onenterlistordered() {
+    this.data.expectingFirstListItemValue = true;
+  }
+  function onenterlistitemvalue(token) {
+    if (this.data.expectingFirstListItemValue) {
+      const ancestor = this.stack[this.stack.length - 2];
+      ancestor.start = Number.parseInt(this.sliceSerialize(token), 10);
+      this.data.expectingFirstListItemValue = void 0;
+    }
+  }
+  function onexitcodefencedfenceinfo() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.lang = data3;
+  }
+  function onexitcodefencedfencemeta() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.meta = data3;
+  }
+  function onexitcodefencedfence() {
+    if (this.data.flowCodeInside) return;
+    this.buffer();
+    this.data.flowCodeInside = true;
+  }
+  function onexitcodefenced() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.value = data3.replace(/^(\r?\n|\r)|(\r?\n|\r)$/g, "");
+    this.data.flowCodeInside = void 0;
+  }
+  function onexitcodeindented() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.value = data3.replace(/(\r?\n|\r)$/g, "");
+  }
+  function onexitdefinitionlabelstring(token) {
+    const label = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.label = label;
+    node2.identifier = normalizeIdentifier(this.sliceSerialize(token)).toLowerCase();
+  }
+  function onexitdefinitiontitlestring() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.title = data3;
+  }
+  function onexitdefinitiondestinationstring() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.url = data3;
+  }
+  function onexitatxheadingsequence(token) {
+    const node2 = this.stack[this.stack.length - 1];
+    if (!node2.depth) {
+      const depth = this.sliceSerialize(token).length;
+      node2.depth = depth;
+    }
+  }
+  function onexitsetextheadingtext() {
+    this.data.setextHeadingSlurpLineEnding = true;
+  }
+  function onexitsetextheadinglinesequence(token) {
+    const node2 = this.stack[this.stack.length - 1];
+    node2.depth = this.sliceSerialize(token).codePointAt(0) === 61 ? 1 : 2;
+  }
+  function onexitsetextheading() {
+    this.data.setextHeadingSlurpLineEnding = void 0;
+  }
+  function onenterdata(token) {
+    const node2 = this.stack[this.stack.length - 1];
+    const siblings = node2.children;
+    let tail = siblings[siblings.length - 1];
+    if (!tail || tail.type !== "text") {
+      tail = text5();
+      tail.position = {
+        start: point2(token.start),
+        // @ts-expect-error: we’ll add `end` later.
+        end: void 0
+      };
+      siblings.push(tail);
+    }
+    this.stack.push(tail);
+  }
+  function onexitdata(token) {
+    const tail = this.stack.pop();
+    tail.value += this.sliceSerialize(token);
+    tail.position.end = point2(token.end);
+  }
+  function onexitlineending(token) {
+    const context = this.stack[this.stack.length - 1];
+    if (this.data.atHardBreak) {
+      const tail = context.children[context.children.length - 1];
+      tail.position.end = point2(token.end);
+      this.data.atHardBreak = void 0;
+      return;
+    }
+    if (!this.data.setextHeadingSlurpLineEnding && config.canContainEols.includes(context.type)) {
+      onenterdata.call(this, token);
+      onexitdata.call(this, token);
+    }
+  }
+  function onexithardbreak() {
+    this.data.atHardBreak = true;
+  }
+  function onexithtmlflow() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.value = data3;
+  }
+  function onexithtmltext() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.value = data3;
+  }
+  function onexitcodetext() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.value = data3;
+  }
+  function onexitlink() {
+    const node2 = this.stack[this.stack.length - 1];
+    if (this.data.inReference) {
+      const referenceType = this.data.referenceType || "shortcut";
+      node2.type += "Reference";
+      node2.referenceType = referenceType;
+      delete node2.url;
+      delete node2.title;
+    } else {
+      delete node2.identifier;
+      delete node2.label;
+    }
+    this.data.referenceType = void 0;
+  }
+  function onexitimage() {
+    const node2 = this.stack[this.stack.length - 1];
+    if (this.data.inReference) {
+      const referenceType = this.data.referenceType || "shortcut";
+      node2.type += "Reference";
+      node2.referenceType = referenceType;
+      delete node2.url;
+      delete node2.title;
+    } else {
+      delete node2.identifier;
+      delete node2.label;
+    }
+    this.data.referenceType = void 0;
+  }
+  function onexitlabeltext(token) {
+    const string3 = this.sliceSerialize(token);
+    const ancestor = this.stack[this.stack.length - 2];
+    ancestor.label = decodeString(string3);
+    ancestor.identifier = normalizeIdentifier(string3).toLowerCase();
+  }
+  function onexitlabel() {
+    const fragment = this.stack[this.stack.length - 1];
+    const value = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    this.data.inReference = true;
+    if (node2.type === "link") {
+      const children = fragment.children;
+      node2.children = children;
+    } else {
+      node2.alt = value;
+    }
+  }
+  function onexitresourcedestinationstring() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.url = data3;
+  }
+  function onexitresourcetitlestring() {
+    const data3 = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.title = data3;
+  }
+  function onexitresource() {
+    this.data.inReference = void 0;
+  }
+  function onenterreference() {
+    this.data.referenceType = "collapsed";
+  }
+  function onexitreferencestring(token) {
+    const label = this.resume();
+    const node2 = this.stack[this.stack.length - 1];
+    node2.label = label;
+    node2.identifier = normalizeIdentifier(this.sliceSerialize(token)).toLowerCase();
+    this.data.referenceType = "full";
+  }
+  function onexitcharacterreferencemarker(token) {
+    this.data.characterReferenceType = token.type;
+  }
+  function onexitcharacterreferencevalue(token) {
+    const data3 = this.sliceSerialize(token);
+    const type = this.data.characterReferenceType;
+    let value;
+    if (type) {
+      value = decodeNumericCharacterReference(data3, type === "characterReferenceMarkerNumeric" ? 10 : 16);
+      this.data.characterReferenceType = void 0;
+    } else {
+      const result = decodeNamedCharacterReference(data3);
+      value = result;
+    }
+    const tail = this.stack[this.stack.length - 1];
+    tail.value += value;
+  }
+  function onexitcharacterreference(token) {
+    const tail = this.stack.pop();
+    tail.position.end = point2(token.end);
+  }
+  function onexitautolinkprotocol(token) {
+    onexitdata.call(this, token);
+    const node2 = this.stack[this.stack.length - 1];
+    node2.url = this.sliceSerialize(token);
+  }
+  function onexitautolinkemail(token) {
+    onexitdata.call(this, token);
+    const node2 = this.stack[this.stack.length - 1];
+    node2.url = "mailto:" + this.sliceSerialize(token);
+  }
+  function blockQuote2() {
+    return {
+      type: "blockquote",
+      children: []
+    };
+  }
+  function codeFlow() {
+    return {
+      type: "code",
+      lang: null,
+      meta: null,
+      value: ""
+    };
+  }
+  function codeText2() {
+    return {
+      type: "inlineCode",
+      value: ""
+    };
+  }
+  function definition2() {
+    return {
+      type: "definition",
+      identifier: "",
+      label: null,
+      title: null,
+      url: ""
+    };
+  }
+  function emphasis2() {
+    return {
+      type: "emphasis",
+      children: []
+    };
+  }
+  function heading2() {
+    return {
+      type: "heading",
+      // @ts-expect-error `depth` will be set later.
+      depth: 0,
+      children: []
+    };
+  }
+  function hardBreak2() {
+    return {
+      type: "break"
+    };
+  }
+  function html5() {
+    return {
+      type: "html",
+      value: ""
+    };
+  }
+  function image2() {
+    return {
+      type: "image",
+      title: null,
+      url: "",
+      alt: null
+    };
+  }
+  function link2() {
+    return {
+      type: "link",
+      title: null,
+      url: "",
+      children: []
+    };
+  }
+  function list3(token) {
+    return {
+      type: "list",
+      ordered: token.type === "listOrdered",
+      start: null,
+      spread: token._spread,
+      children: []
+    };
+  }
+  function listItem2(token) {
+    return {
+      type: "listItem",
+      spread: token._spread,
+      checked: null,
+      children: []
+    };
+  }
+  function paragraph2() {
+    return {
+      type: "paragraph",
+      children: []
+    };
+  }
+  function strong2() {
+    return {
+      type: "strong",
+      children: []
+    };
+  }
+  function text5() {
+    return {
+      type: "text",
+      value: ""
+    };
+  }
+  function thematicBreak3() {
+    return {
+      type: "thematicBreak"
+    };
+  }
+}
+function point2(d) {
+  return {
+    line: d.line,
+    column: d.column,
+    offset: d.offset
+  };
+}
+function configure(combined, extensions) {
+  let index2 = -1;
+  while (++index2 < extensions.length) {
+    const value = extensions[index2];
+    if (Array.isArray(value)) {
+      configure(combined, value);
+    } else {
+      extension(combined, value);
+    }
+  }
+}
+function extension(combined, extension2) {
+  let key;
+  for (key in extension2) {
+    if (own3.call(extension2, key)) {
+      switch (key) {
+        case "canContainEols": {
+          const right = extension2[key];
+          if (right) {
+            combined[key].push(...right);
+          }
+          break;
+        }
+        case "transforms": {
+          const right = extension2[key];
+          if (right) {
+            combined[key].push(...right);
+          }
+          break;
+        }
+        case "enter":
+        case "exit": {
+          const right = extension2[key];
+          if (right) {
+            Object.assign(combined[key], right);
+          }
+          break;
+        }
+      }
+    }
+  }
+}
+function defaultOnError(left, right) {
+  if (left) {
+    throw new Error("Cannot close `" + left.type + "` (" + stringifyPosition({
+      start: left.start,
+      end: left.end
+    }) + "): a different token (`" + right.type + "`, " + stringifyPosition({
+      start: right.start,
+      end: right.end
+    }) + ") is open");
+  } else {
+    throw new Error("Cannot close document, a token (`" + right.type + "`, " + stringifyPosition({
+      start: right.start,
+      end: right.end
+    }) + ") is still open");
+  }
+}
+
+// node_modules/@mdx-js/mdx/node_modules/remark-parse/lib/index.js
+function remarkParse(options) {
+  const self2 = this;
+  self2.parser = parser;
+  function parser(doc) {
+    return fromMarkdown(doc, {
+      ...self2.data("settings"),
+      ...options,
+      // Note: these options are not in the readme.
+      // The goal is for them to be set by plugins on `data` instead of being
+      // passed by users.
+      extensions: self2.data("micromarkExtensions") || [],
+      mdastExtensions: self2.data("fromMarkdownExtensions") || []
+    });
+  }
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/blockquote.js
+function blockquote(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "blockquote",
+    properties: {},
+    children: state.wrap(state.all(node2), true)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/break.js
+function hardBreak(state, node2) {
+  const result = { type: "element", tagName: "br", properties: {}, children: [] };
+  state.patch(node2, result);
+  return [state.applyData(node2, result), { type: "text", value: "\n" }];
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/code.js
+function code(state, node2) {
+  const value = node2.value ? node2.value + "\n" : "";
+  const properties = {};
+  if (node2.lang) {
+    properties.className = ["language-" + node2.lang];
+  }
+  let result = {
+    type: "element",
+    tagName: "code",
+    properties,
+    children: [{ type: "text", value }]
+  };
+  if (node2.meta) {
+    result.data = { meta: node2.meta };
+  }
+  state.patch(node2, result);
+  result = state.applyData(node2, result);
+  result = { type: "element", tagName: "pre", properties: {}, children: [result] };
+  state.patch(node2, result);
+  return result;
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/delete.js
+function strikethrough(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "del",
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/emphasis.js
+function emphasis(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "em",
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/footnote-reference.js
+function footnoteReference(state, node2) {
+  const clobberPrefix = typeof state.options.clobberPrefix === "string" ? state.options.clobberPrefix : "user-content-";
+  const id = String(node2.identifier).toUpperCase();
+  const safeId = normalizeUri(id.toLowerCase());
+  const index2 = state.footnoteOrder.indexOf(id);
+  let counter;
+  let reuseCounter = state.footnoteCounts.get(id);
+  if (reuseCounter === void 0) {
+    reuseCounter = 0;
+    state.footnoteOrder.push(id);
+    counter = state.footnoteOrder.length;
+  } else {
+    counter = index2 + 1;
+  }
+  reuseCounter += 1;
+  state.footnoteCounts.set(id, reuseCounter);
+  const link2 = {
+    type: "element",
+    tagName: "a",
+    properties: {
+      href: "#" + clobberPrefix + "fn-" + safeId,
+      id: clobberPrefix + "fnref-" + safeId + (reuseCounter > 1 ? "-" + reuseCounter : ""),
+      dataFootnoteRef: true,
+      ariaDescribedBy: ["footnote-label"]
+    },
+    children: [{ type: "text", value: String(counter) }]
+  };
+  state.patch(node2, link2);
+  const sup = {
+    type: "element",
+    tagName: "sup",
+    properties: {},
+    children: [link2]
+  };
+  state.patch(node2, sup);
+  return state.applyData(node2, sup);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/heading.js
+function heading(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "h" + node2.depth,
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/html.js
+function html(state, node2) {
+  if (state.options.allowDangerousHtml) {
+    const result = { type: "raw", value: node2.value };
+    state.patch(node2, result);
+    return state.applyData(node2, result);
+  }
+  return void 0;
+}
+
+// node_modules/mdast-util-to-hast/lib/revert.js
+function revert(state, node2) {
+  const subtype = node2.referenceType;
+  let suffix = "]";
+  if (subtype === "collapsed") {
+    suffix += "[]";
+  } else if (subtype === "full") {
+    suffix += "[" + (node2.label || node2.identifier) + "]";
+  }
+  if (node2.type === "imageReference") {
+    return [{ type: "text", value: "![" + node2.alt + suffix }];
+  }
+  const contents = state.all(node2);
+  const head = contents[0];
+  if (head && head.type === "text") {
+    head.value = "[" + head.value;
+  } else {
+    contents.unshift({ type: "text", value: "[" });
+  }
+  const tail = contents[contents.length - 1];
+  if (tail && tail.type === "text") {
+    tail.value += suffix;
+  } else {
+    contents.push({ type: "text", value: suffix });
+  }
+  return contents;
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/image-reference.js
+function imageReference(state, node2) {
+  const id = String(node2.identifier).toUpperCase();
+  const definition2 = state.definitionById.get(id);
+  if (!definition2) {
+    return revert(state, node2);
+  }
+  const properties = { src: normalizeUri(definition2.url || ""), alt: node2.alt };
+  if (definition2.title !== null && definition2.title !== void 0) {
+    properties.title = definition2.title;
+  }
+  const result = { type: "element", tagName: "img", properties, children: [] };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/image.js
+function image(state, node2) {
+  const properties = { src: normalizeUri(node2.url) };
+  if (node2.alt !== null && node2.alt !== void 0) {
+    properties.alt = node2.alt;
+  }
+  if (node2.title !== null && node2.title !== void 0) {
+    properties.title = node2.title;
+  }
+  const result = { type: "element", tagName: "img", properties, children: [] };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/inline-code.js
+function inlineCode(state, node2) {
+  const text5 = { type: "text", value: node2.value.replace(/\r?\n|\r/g, " ") };
+  state.patch(node2, text5);
+  const result = {
+    type: "element",
+    tagName: "code",
+    properties: {},
+    children: [text5]
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/link-reference.js
+function linkReference(state, node2) {
+  const id = String(node2.identifier).toUpperCase();
+  const definition2 = state.definitionById.get(id);
+  if (!definition2) {
+    return revert(state, node2);
+  }
+  const properties = { href: normalizeUri(definition2.url || "") };
+  if (definition2.title !== null && definition2.title !== void 0) {
+    properties.title = definition2.title;
+  }
+  const result = {
+    type: "element",
+    tagName: "a",
+    properties,
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/link.js
+function link(state, node2) {
+  const properties = { href: normalizeUri(node2.url) };
+  if (node2.title !== null && node2.title !== void 0) {
+    properties.title = node2.title;
+  }
+  const result = {
+    type: "element",
+    tagName: "a",
+    properties,
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/list-item.js
+function listItem(state, node2, parent) {
+  const results = state.all(node2);
+  const loose = parent ? listLoose(parent) : listItemLoose(node2);
+  const properties = {};
+  const children = [];
+  if (typeof node2.checked === "boolean") {
+    const head = results[0];
+    let paragraph2;
+    if (head && head.type === "element" && head.tagName === "p") {
+      paragraph2 = head;
+    } else {
+      paragraph2 = { type: "element", tagName: "p", properties: {}, children: [] };
+      results.unshift(paragraph2);
+    }
+    if (paragraph2.children.length > 0) {
+      paragraph2.children.unshift({ type: "text", value: " " });
+    }
+    paragraph2.children.unshift({
+      type: "element",
+      tagName: "input",
+      properties: { type: "checkbox", checked: node2.checked, disabled: true },
+      children: []
+    });
+    properties.className = ["task-list-item"];
+  }
+  let index2 = -1;
+  while (++index2 < results.length) {
+    const child = results[index2];
+    if (loose || index2 !== 0 || child.type !== "element" || child.tagName !== "p") {
+      children.push({ type: "text", value: "\n" });
+    }
+    if (child.type === "element" && child.tagName === "p" && !loose) {
+      children.push(...child.children);
+    } else {
+      children.push(child);
+    }
+  }
+  const tail = results[results.length - 1];
+  if (tail && (loose || tail.type !== "element" || tail.tagName !== "p")) {
+    children.push({ type: "text", value: "\n" });
+  }
+  const result = { type: "element", tagName: "li", properties, children };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+function listLoose(node2) {
+  let loose = false;
+  if (node2.type === "list") {
+    loose = node2.spread || false;
+    const children = node2.children;
+    let index2 = -1;
+    while (!loose && ++index2 < children.length) {
+      loose = listItemLoose(children[index2]);
+    }
+  }
+  return loose;
+}
+function listItemLoose(node2) {
+  const spread = node2.spread;
+  return spread === null || spread === void 0 ? node2.children.length > 1 : spread;
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/list.js
+function list2(state, node2) {
+  const properties = {};
+  const results = state.all(node2);
+  let index2 = -1;
+  if (typeof node2.start === "number" && node2.start !== 1) {
+    properties.start = node2.start;
+  }
+  while (++index2 < results.length) {
+    const child = results[index2];
+    if (child.type === "element" && child.tagName === "li" && child.properties && Array.isArray(child.properties.className) && child.properties.className.includes("task-list-item")) {
+      properties.className = ["contains-task-list"];
+      break;
+    }
+  }
+  const result = {
+    type: "element",
+    tagName: node2.ordered ? "ol" : "ul",
+    properties,
+    children: state.wrap(results, true)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/paragraph.js
+function paragraph(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "p",
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/root.js
+function root(state, node2) {
+  const result = { type: "root", children: state.wrap(state.all(node2)) };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/strong.js
+function strong(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "strong",
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/unist-util-position/lib/index.js
+var pointEnd = point3("end");
+var pointStart = point3("start");
+function point3(type) {
+  return point4;
+  function point4(node2) {
+    const point5 = node2 && node2.position && node2.position[type] || {};
+    if (typeof point5.line === "number" && point5.line > 0 && typeof point5.column === "number" && point5.column > 0) {
+      return {
+        line: point5.line,
+        column: point5.column,
+        offset: typeof point5.offset === "number" && point5.offset > -1 ? point5.offset : void 0
+      };
+    }
+  }
+}
+function position2(node2) {
+  const start2 = pointStart(node2);
+  const end = pointEnd(node2);
+  if (start2 && end) {
+    return { start: start2, end };
+  }
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/table.js
+function table(state, node2) {
+  const rows = state.all(node2);
+  const firstRow = rows.shift();
+  const tableContent = [];
+  if (firstRow) {
+    const head = {
+      type: "element",
+      tagName: "thead",
+      properties: {},
+      children: state.wrap([firstRow], true)
+    };
+    state.patch(node2.children[0], head);
+    tableContent.push(head);
+  }
+  if (rows.length > 0) {
+    const body = {
+      type: "element",
+      tagName: "tbody",
+      properties: {},
+      children: state.wrap(rows, true)
+    };
+    const start2 = pointStart(node2.children[1]);
+    const end = pointEnd(node2.children[node2.children.length - 1]);
+    if (start2 && end) body.position = { start: start2, end };
+    tableContent.push(body);
+  }
+  const result = {
+    type: "element",
+    tagName: "table",
+    properties: {},
+    children: state.wrap(tableContent, true)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/table-row.js
+function tableRow(state, node2, parent) {
+  const siblings = parent ? parent.children : void 0;
+  const rowIndex = siblings ? siblings.indexOf(node2) : 1;
+  const tagName = rowIndex === 0 ? "th" : "td";
+  const align = parent && parent.type === "table" ? parent.align : void 0;
+  const length = align ? align.length : node2.children.length;
+  let cellIndex = -1;
+  const cells = [];
+  while (++cellIndex < length) {
+    const cell = node2.children[cellIndex];
+    const properties = {};
+    const alignValue = align ? align[cellIndex] : void 0;
+    if (alignValue) {
+      properties.align = alignValue;
+    }
+    let result2 = { type: "element", tagName, properties, children: [] };
+    if (cell) {
+      result2.children = state.all(cell);
+      state.patch(cell, result2);
+      result2 = state.applyData(cell, result2);
+    }
+    cells.push(result2);
+  }
+  const result = {
+    type: "element",
+    tagName: "tr",
+    properties: {},
+    children: state.wrap(cells, true)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/table-cell.js
+function tableCell(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "td",
+    // Assume body cell.
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/trim-lines/index.js
+var tab = 9;
+var space = 32;
+function trimLines(value) {
+  const source = String(value);
+  const search2 = /\r?\n|\r/g;
+  let match = search2.exec(source);
+  let last = 0;
+  const lines = [];
+  while (match) {
+    lines.push(
+      trimLine(source.slice(last, match.index), last > 0, true),
+      match[0]
+    );
+    last = match.index + match[0].length;
+    match = search2.exec(source);
+  }
+  lines.push(trimLine(source.slice(last), last > 0, false));
+  return lines.join("");
+}
+function trimLine(value, start2, end) {
+  let startIndex = 0;
+  let endIndex = value.length;
+  if (start2) {
+    let code2 = value.codePointAt(startIndex);
+    while (code2 === tab || code2 === space) {
+      startIndex++;
+      code2 = value.codePointAt(startIndex);
+    }
+  }
+  if (end) {
+    let code2 = value.codePointAt(endIndex - 1);
+    while (code2 === tab || code2 === space) {
+      endIndex--;
+      code2 = value.codePointAt(endIndex - 1);
+    }
+  }
+  return endIndex > startIndex ? value.slice(startIndex, endIndex) : "";
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/text.js
+function text3(state, node2) {
+  const result = { type: "text", value: trimLines(String(node2.value)) };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/thematic-break.js
+function thematicBreak2(state, node2) {
+  const result = {
+    type: "element",
+    tagName: "hr",
+    properties: {},
+    children: []
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+
+// node_modules/mdast-util-to-hast/lib/handlers/index.js
+var handlers = {
+  blockquote,
+  break: hardBreak,
+  code,
+  delete: strikethrough,
+  emphasis,
+  footnoteReference,
+  heading,
+  html,
+  imageReference,
+  image,
+  inlineCode,
+  linkReference,
+  link,
+  listItem,
+  list: list2,
+  paragraph,
+  // @ts-expect-error: root is different, but hard to type.
+  root,
+  strong,
+  table,
+  tableCell,
+  tableRow,
+  text: text3,
+  thematicBreak: thematicBreak2,
+  toml: ignore,
+  yaml: ignore,
+  definition: ignore,
+  footnoteDefinition: ignore
+};
+function ignore() {
+  return void 0;
+}
+
+// node_modules/@ungap/structured-clone/esm/types.js
+var VOID = -1;
+var PRIMITIVE = 0;
+var ARRAY = 1;
+var OBJECT = 2;
+var DATE = 3;
+var REGEXP = 4;
+var MAP = 5;
+var SET = 6;
+var ERROR = 7;
+var BIGINT = 8;
+
+// node_modules/@ungap/structured-clone/esm/deserialize.js
+var env = typeof self === "object" ? self : globalThis;
+var deserializer = ($, _) => {
+  const as = (out, index2) => {
+    $.set(index2, out);
+    return out;
+  };
+  const unpair = (index2) => {
+    if ($.has(index2))
+      return $.get(index2);
+    const [type, value] = _[index2];
+    switch (type) {
+      case PRIMITIVE:
+      case VOID:
+        return as(value, index2);
+      case ARRAY: {
+        const arr = as([], index2);
+        for (const index3 of value)
+          arr.push(unpair(index3));
+        return arr;
+      }
+      case OBJECT: {
+        const object = as({}, index2);
+        for (const [key, index3] of value)
+          object[unpair(key)] = unpair(index3);
+        return object;
+      }
+      case DATE:
+        return as(new Date(value), index2);
+      case REGEXP: {
+        const { source, flags } = value;
+        return as(new RegExp(source, flags), index2);
+      }
+      case MAP: {
+        const map = as(/* @__PURE__ */ new Map(), index2);
+        for (const [key, index3] of value)
+          map.set(unpair(key), unpair(index3));
+        return map;
+      }
+      case SET: {
+        const set = as(/* @__PURE__ */ new Set(), index2);
+        for (const index3 of value)
+          set.add(unpair(index3));
+        return set;
+      }
+      case ERROR: {
+        const { name: name2, message } = value;
+        return as(new env[name2](message), index2);
+      }
+      case BIGINT:
+        return as(BigInt(value), index2);
+      case "BigInt":
+        return as(Object(BigInt(value)), index2);
+    }
+    return as(new env[type](value), index2);
+  };
+  return unpair;
+};
+var deserialize = (serialized) => deserializer(/* @__PURE__ */ new Map(), serialized)(0);
+
+// node_modules/@ungap/structured-clone/esm/serialize.js
+var EMPTY = "";
+var { toString: toString3 } = {};
+var { keys } = Object;
+var typeOf = (value) => {
+  const type = typeof value;
+  if (type !== "object" || !value)
+    return [PRIMITIVE, type];
+  const asString = toString3.call(value).slice(8, -1);
+  switch (asString) {
+    case "Array":
+      return [ARRAY, EMPTY];
+    case "Object":
+      return [OBJECT, EMPTY];
+    case "Date":
+      return [DATE, EMPTY];
+    case "RegExp":
+      return [REGEXP, EMPTY];
+    case "Map":
+      return [MAP, EMPTY];
+    case "Set":
+      return [SET, EMPTY];
+  }
+  if (asString.includes("Array"))
+    return [ARRAY, asString];
+  if (asString.includes("Error"))
+    return [ERROR, asString];
+  return [OBJECT, asString];
+};
+var shouldSkip = ([TYPE, type]) => TYPE === PRIMITIVE && (type === "function" || type === "symbol");
+var serializer = (strict, json, $, _) => {
+  const as = (out, value) => {
+    const index2 = _.push(out) - 1;
+    $.set(value, index2);
+    return index2;
+  };
+  const pair = (value) => {
+    if ($.has(value))
+      return $.get(value);
+    let [TYPE, type] = typeOf(value);
+    switch (TYPE) {
+      case PRIMITIVE: {
+        let entry = value;
+        switch (type) {
+          case "bigint":
+            TYPE = BIGINT;
+            entry = value.toString();
+            break;
+          case "function":
+          case "symbol":
+            if (strict)
+              throw new TypeError("unable to serialize " + type);
+            entry = null;
+            break;
+          case "undefined":
+            return as([VOID], value);
+        }
+        return as([TYPE, entry], value);
+      }
+      case ARRAY: {
+        if (type)
+          return as([type, [...value]], value);
+        const arr = [];
+        const index2 = as([TYPE, arr], value);
+        for (const entry of value)
+          arr.push(pair(entry));
+        return index2;
+      }
+      case OBJECT: {
+        if (type) {
+          switch (type) {
+            case "BigInt":
+              return as([type, value.toString()], value);
+            case "Boolean":
+            case "Number":
+            case "String":
+              return as([type, value.valueOf()], value);
+          }
+        }
+        if (json && "toJSON" in value)
+          return pair(value.toJSON());
+        const entries = [];
+        const index2 = as([TYPE, entries], value);
+        for (const key of keys(value)) {
+          if (strict || !shouldSkip(typeOf(value[key])))
+            entries.push([pair(key), pair(value[key])]);
+        }
+        return index2;
+      }
+      case DATE:
+        return as([TYPE, value.toISOString()], value);
+      case REGEXP: {
+        const { source, flags } = value;
+        return as([TYPE, { source, flags }], value);
+      }
+      case MAP: {
+        const entries = [];
+        const index2 = as([TYPE, entries], value);
+        for (const [key, entry] of value) {
+          if (strict || !(shouldSkip(typeOf(key)) || shouldSkip(typeOf(entry))))
+            entries.push([pair(key), pair(entry)]);
+        }
+        return index2;
+      }
+      case SET: {
+        const entries = [];
+        const index2 = as([TYPE, entries], value);
+        for (const entry of value) {
+          if (strict || !shouldSkip(typeOf(entry)))
+            entries.push(pair(entry));
+        }
+        return index2;
+      }
+    }
+    const { message } = value;
+    return as([TYPE, { name: type, message }], value);
+  };
+  return pair;
+};
+var serialize = (value, { json, lossy } = {}) => {
+  const _ = [];
+  return serializer(!(json || lossy), !!json, /* @__PURE__ */ new Map(), _)(value), _;
+};
+
+// node_modules/@ungap/structured-clone/esm/index.js
+var esm_default = typeof structuredClone === "function" ? (
+  /* c8 ignore start */
+  (any, options) => options && ("json" in options || "lossy" in options) ? deserialize(serialize(any, options)) : structuredClone(any)
+) : (any, options) => deserialize(serialize(any, options));
+
+// node_modules/mdast-util-to-hast/lib/footer.js
+function defaultFootnoteBackContent(_, rereferenceIndex) {
+  const result = [{ type: "text", value: "\u21A9" }];
+  if (rereferenceIndex > 1) {
+    result.push({
+      type: "element",
+      tagName: "sup",
+      properties: {},
+      children: [{ type: "text", value: String(rereferenceIndex) }]
+    });
+  }
+  return result;
+}
+function defaultFootnoteBackLabel(referenceIndex, rereferenceIndex) {
+  return "Back to reference " + (referenceIndex + 1) + (rereferenceIndex > 1 ? "-" + rereferenceIndex : "");
+}
+function footer(state) {
+  const clobberPrefix = typeof state.options.clobberPrefix === "string" ? state.options.clobberPrefix : "user-content-";
+  const footnoteBackContent = state.options.footnoteBackContent || defaultFootnoteBackContent;
+  const footnoteBackLabel = state.options.footnoteBackLabel || defaultFootnoteBackLabel;
+  const footnoteLabel = state.options.footnoteLabel || "Footnotes";
+  const footnoteLabelTagName = state.options.footnoteLabelTagName || "h2";
+  const footnoteLabelProperties = state.options.footnoteLabelProperties || {
+    className: ["sr-only"]
+  };
+  const listItems = [];
+  let referenceIndex = -1;
+  while (++referenceIndex < state.footnoteOrder.length) {
+    const definition2 = state.footnoteById.get(
+      state.footnoteOrder[referenceIndex]
+    );
+    if (!definition2) {
+      continue;
+    }
+    const content3 = state.all(definition2);
+    const id = String(definition2.identifier).toUpperCase();
+    const safeId = normalizeUri(id.toLowerCase());
+    let rereferenceIndex = 0;
+    const backReferences = [];
+    const counts = state.footnoteCounts.get(id);
+    while (counts !== void 0 && ++rereferenceIndex <= counts) {
+      if (backReferences.length > 0) {
+        backReferences.push({ type: "text", value: " " });
+      }
+      let children = typeof footnoteBackContent === "string" ? footnoteBackContent : footnoteBackContent(referenceIndex, rereferenceIndex);
+      if (typeof children === "string") {
+        children = { type: "text", value: children };
+      }
+      backReferences.push({
+        type: "element",
+        tagName: "a",
+        properties: {
+          href: "#" + clobberPrefix + "fnref-" + safeId + (rereferenceIndex > 1 ? "-" + rereferenceIndex : ""),
+          dataFootnoteBackref: "",
+          ariaLabel: typeof footnoteBackLabel === "string" ? footnoteBackLabel : footnoteBackLabel(referenceIndex, rereferenceIndex),
+          className: ["data-footnote-backref"]
+        },
+        children: Array.isArray(children) ? children : [children]
+      });
+    }
+    const tail = content3[content3.length - 1];
+    if (tail && tail.type === "element" && tail.tagName === "p") {
+      const tailTail = tail.children[tail.children.length - 1];
+      if (tailTail && tailTail.type === "text") {
+        tailTail.value += " ";
+      } else {
+        tail.children.push({ type: "text", value: " " });
+      }
+      tail.children.push(...backReferences);
+    } else {
+      content3.push(...backReferences);
+    }
+    const listItem2 = {
+      type: "element",
+      tagName: "li",
+      properties: { id: clobberPrefix + "fn-" + safeId },
+      children: state.wrap(content3, true)
+    };
+    state.patch(definition2, listItem2);
+    listItems.push(listItem2);
+  }
+  if (listItems.length === 0) {
+    return;
+  }
+  return {
+    type: "element",
+    tagName: "section",
+    properties: { dataFootnotes: true, className: ["footnotes"] },
+    children: [
+      {
+        type: "element",
+        tagName: footnoteLabelTagName,
+        properties: {
+          ...esm_default(footnoteLabelProperties),
+          id: "footnote-label"
+        },
+        children: [{ type: "text", value: footnoteLabel }]
+      },
+      { type: "text", value: "\n" },
+      {
+        type: "element",
+        tagName: "ol",
+        properties: {},
+        children: state.wrap(listItems, true)
+      },
+      { type: "text", value: "\n" }
+    ]
+  };
+}
+
+// node_modules/mdast-util-to-hast/node_modules/unist-util-is/lib/index.js
+var convert = (
+  // Note: overloads in JSDoc can’t yet use different `@template`s.
+  /**
+   * @type {(
+   *   (<Condition extends string>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & {type: Condition}) &
+   *   (<Condition extends Props>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Condition) &
+   *   (<Condition extends TestFunction>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Predicate<Condition, Node>) &
+   *   ((test?: null | undefined) => (node?: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node) &
+   *   ((test?: Test) => Check)
+   * )}
+   */
+  /**
+   * @param {Test} [test]
+   * @returns {Check}
+   */
+  function(test) {
+    if (test === null || test === void 0) {
+      return ok2;
+    }
+    if (typeof test === "function") {
+      return castFactory(test);
+    }
+    if (typeof test === "object") {
+      return Array.isArray(test) ? anyFactory(test) : propsFactory(test);
+    }
+    if (typeof test === "string") {
+      return typeFactory(test);
+    }
+    throw new Error("Expected function, string, or object as test");
+  }
+);
+function anyFactory(tests) {
+  const checks2 = [];
+  let index2 = -1;
+  while (++index2 < tests.length) {
+    checks2[index2] = convert(tests[index2]);
+  }
+  return castFactory(any);
+  function any(...parameters) {
+    let index3 = -1;
+    while (++index3 < checks2.length) {
+      if (checks2[index3].apply(this, parameters)) return true;
+    }
+    return false;
+  }
+}
+function propsFactory(check) {
+  const checkAsRecord = (
+    /** @type {Record<string, unknown>} */
+    check
+  );
+  return castFactory(all3);
+  function all3(node2) {
+    const nodeAsRecord = (
+      /** @type {Record<string, unknown>} */
+      /** @type {unknown} */
+      node2
+    );
+    let key;
+    for (key in check) {
+      if (nodeAsRecord[key] !== checkAsRecord[key]) return false;
+    }
+    return true;
+  }
+}
+function typeFactory(check) {
+  return castFactory(type);
+  function type(node2) {
+    return node2 && node2.type === check;
+  }
+}
+function castFactory(testFunction) {
+  return check;
+  function check(value, index2, parent) {
+    return Boolean(
+      looksLikeANode(value) && testFunction.call(
+        this,
+        value,
+        typeof index2 === "number" ? index2 : void 0,
+        parent || void 0
+      )
+    );
+  }
+}
+function ok2() {
+  return true;
+}
+function looksLikeANode(value) {
+  return value !== null && typeof value === "object" && "type" in value;
+}
+
+// node_modules/mdast-util-to-hast/node_modules/unist-util-visit-parents/lib/color.node.js
+function color2(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/mdast-util-to-hast/node_modules/unist-util-visit-parents/lib/index.js
+var empty3 = [];
+var CONTINUE2 = true;
+var EXIT2 = false;
+var SKIP2 = "skip";
+function visitParents(tree, test, visitor, reverse) {
+  let check;
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+  } else {
+    check = test;
+  }
+  const is3 = convert(check);
+  const step = reverse ? -1 : 1;
+  factory(tree, void 0, [])();
+  function factory(node2, index2, parents) {
+    const value = (
+      /** @type {Record<string, unknown>} */
+      node2 && typeof node2 === "object" ? node2 : {}
+    );
+    if (typeof value.type === "string") {
+      const name2 = (
+        // `hast`
+        typeof value.tagName === "string" ? value.tagName : (
+          // `xast`
+          typeof value.name === "string" ? value.name : void 0
+        )
+      );
+      Object.defineProperty(visit4, "name", {
+        value: "node (" + color2(node2.type + (name2 ? "<" + name2 + ">" : "")) + ")"
+      });
+    }
+    return visit4;
+    function visit4() {
+      let result = empty3;
+      let subresult;
+      let offset2;
+      let grandparents;
+      if (!test || is3(node2, index2, parents[parents.length - 1] || void 0)) {
+        result = toResult2(visitor(node2, parents));
+        if (result[0] === EXIT2) {
+          return result;
+        }
+      }
+      if ("children" in node2 && node2.children) {
+        const nodeAsParent = (
+          /** @type {UnistParent} */
+          node2
+        );
+        if (nodeAsParent.children && result[0] !== SKIP2) {
+          offset2 = (reverse ? nodeAsParent.children.length : -1) + step;
+          grandparents = parents.concat(nodeAsParent);
+          while (offset2 > -1 && offset2 < nodeAsParent.children.length) {
+            const child = nodeAsParent.children[offset2];
+            subresult = factory(child, offset2, grandparents)();
+            if (subresult[0] === EXIT2) {
+              return subresult;
+            }
+            offset2 = typeof subresult[1] === "number" ? subresult[1] : offset2 + step;
+          }
+        }
+      }
+      return result;
+    }
+  }
+}
+function toResult2(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE2, value];
+  }
+  return value === null || value === void 0 ? empty3 : [value];
+}
+
+// node_modules/mdast-util-to-hast/node_modules/unist-util-visit/lib/index.js
+function visit2(tree, testOrVisitor, visitorOrReverse, maybeReverse) {
+  let reverse;
+  let test;
+  let visitor;
+  if (typeof testOrVisitor === "function" && typeof visitorOrReverse !== "function") {
+    test = void 0;
+    visitor = testOrVisitor;
+    reverse = visitorOrReverse;
+  } else {
+    test = testOrVisitor;
+    visitor = visitorOrReverse;
+    reverse = maybeReverse;
+  }
+  visitParents(tree, test, overload, reverse);
+  function overload(node2, parents) {
+    const parent = parents[parents.length - 1];
+    const index2 = parent ? parent.children.indexOf(node2) : void 0;
+    return visitor(node2, index2, parent);
+  }
+}
+
+// node_modules/mdast-util-to-hast/lib/state.js
+var own4 = {}.hasOwnProperty;
+var emptyOptions4 = {};
+function createState(tree, options) {
+  const settings = options || emptyOptions4;
+  const definitionById = /* @__PURE__ */ new Map();
+  const footnoteById = /* @__PURE__ */ new Map();
+  const footnoteCounts = /* @__PURE__ */ new Map();
+  const handlers3 = { ...handlers, ...settings.handlers };
+  const state = {
+    all: all3,
+    applyData,
+    definitionById,
+    footnoteById,
+    footnoteCounts,
+    footnoteOrder: [],
+    handlers: handlers3,
+    one: one2,
+    options: settings,
+    patch,
+    wrap
+  };
+  visit2(tree, function(node2) {
+    if (node2.type === "definition" || node2.type === "footnoteDefinition") {
+      const map = node2.type === "definition" ? definitionById : footnoteById;
+      const id = String(node2.identifier).toUpperCase();
+      if (!map.has(id)) {
+        map.set(id, node2);
+      }
+    }
+  });
+  return state;
+  function one2(node2, parent) {
+    const type = node2.type;
+    const handle = state.handlers[type];
+    if (own4.call(state.handlers, type) && handle) {
+      return handle(state, node2, parent);
+    }
+    if (state.options.passThrough && state.options.passThrough.includes(type)) {
+      if ("children" in node2) {
+        const { children, ...shallow } = node2;
+        const result = esm_default(shallow);
+        result.children = state.all(node2);
+        return result;
+      }
+      return esm_default(node2);
+    }
+    const unknown2 = state.options.unknownHandler || defaultUnknownHandler;
+    return unknown2(state, node2, parent);
+  }
+  function all3(parent) {
+    const values = [];
+    if ("children" in parent) {
+      const nodes = parent.children;
+      let index2 = -1;
+      while (++index2 < nodes.length) {
+        const result = state.one(nodes[index2], parent);
+        if (result) {
+          if (index2 && nodes[index2 - 1].type === "break") {
+            if (!Array.isArray(result) && result.type === "text") {
+              result.value = trimMarkdownSpaceStart(result.value);
+            }
+            if (!Array.isArray(result) && result.type === "element") {
+              const head = result.children[0];
+              if (head && head.type === "text") {
+                head.value = trimMarkdownSpaceStart(head.value);
+              }
+            }
+          }
+          if (Array.isArray(result)) {
+            values.push(...result);
+          } else {
+            values.push(result);
+          }
+        }
+      }
+    }
+    return values;
+  }
+}
+function patch(from, to) {
+  if (from.position) to.position = position2(from);
+}
+function applyData(from, to) {
+  let result = to;
+  if (from && from.data) {
+    const hName = from.data.hName;
+    const hChildren = from.data.hChildren;
+    const hProperties = from.data.hProperties;
+    if (typeof hName === "string") {
+      if (result.type === "element") {
+        result.tagName = hName;
+      } else {
+        const children = "children" in result ? result.children : [result];
+        result = { type: "element", tagName: hName, properties: {}, children };
+      }
+    }
+    if (result.type === "element" && hProperties) {
+      Object.assign(result.properties, esm_default(hProperties));
+    }
+    if ("children" in result && result.children && hChildren !== null && hChildren !== void 0) {
+      result.children = hChildren;
+    }
+  }
+  return result;
+}
+function defaultUnknownHandler(state, node2) {
+  const data2 = node2.data || {};
+  const result = "value" in node2 && !(own4.call(data2, "hProperties") || own4.call(data2, "hChildren")) ? { type: "text", value: node2.value } : {
+    type: "element",
+    tagName: "div",
+    properties: {},
+    children: state.all(node2)
+  };
+  state.patch(node2, result);
+  return state.applyData(node2, result);
+}
+function wrap(nodes, loose) {
+  const result = [];
+  let index2 = -1;
+  if (loose) {
+    result.push({ type: "text", value: "\n" });
+  }
+  while (++index2 < nodes.length) {
+    if (index2) result.push({ type: "text", value: "\n" });
+    result.push(nodes[index2]);
+  }
+  if (loose && nodes.length > 0) {
+    result.push({ type: "text", value: "\n" });
+  }
+  return result;
+}
+function trimMarkdownSpaceStart(value) {
+  let index2 = 0;
+  let code2 = value.charCodeAt(index2);
+  while (code2 === 9 || code2 === 32) {
+    index2++;
+    code2 = value.charCodeAt(index2);
+  }
+  return value.slice(index2);
+}
+
+// node_modules/mdast-util-to-hast/lib/index.js
+function toHast(tree, options) {
+  const state = createState(tree, options);
+  const node2 = state.one(tree, void 0);
+  const foot = footer(state);
+  const result = Array.isArray(node2) ? { type: "root", children: node2 } : node2 || { type: "root", children: [] };
+  if (foot) {
+    ok("children" in result);
+    result.children.push({ type: "text", value: "\n" }, foot);
+  }
+  return result;
+}
+
+// node_modules/remark-rehype/lib/index.js
+function remarkRehype(destination, options) {
+  if (destination && "run" in destination) {
+    return async function(tree, file) {
+      const hastTree = (
+        /** @type {HastRoot} */
+        toHast(tree, { file, ...options })
+      );
+      await destination.run(hastTree, file);
+    };
+  }
+  return function(tree, file) {
+    return (
+      /** @type {HastRoot} */
+      toHast(tree, { file, ...options || destination })
+    );
+  };
+}
+
+// node_modules/unified/node_modules/bail/index.js
+function bail(error) {
+  if (error) {
+    throw error;
+  }
+}
+
+// node_modules/unified/lib/index.js
+var import_extend = __toESM(require_extend(), 1);
+
+// node_modules/unified/node_modules/is-plain-obj/index.js
+function isPlainObject(value) {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return (prototype === null || prototype === Object.prototype || Object.getPrototypeOf(prototype) === null) && !(Symbol.toStringTag in value) && !(Symbol.iterator in value);
+}
+
+// node_modules/unified/node_modules/trough/lib/index.js
+function trough() {
+  const fns = [];
+  const pipeline = { run: run2, use };
+  return pipeline;
+  function run2(...values) {
+    let middlewareIndex = -1;
+    const callback = values.pop();
+    if (typeof callback !== "function") {
+      throw new TypeError("Expected function as last argument, not " + callback);
+    }
+    next(null, ...values);
+    function next(error, ...output) {
+      const fn = fns[++middlewareIndex];
+      let index2 = -1;
+      if (error) {
+        callback(error);
+        return;
+      }
+      while (++index2 < values.length) {
+        if (output[index2] === null || output[index2] === void 0) {
+          output[index2] = values[index2];
+        }
+      }
+      values = output;
+      if (fn) {
+        wrap2(fn, next)(...output);
+      } else {
+        callback(null, ...output);
+      }
+    }
+  }
+  function use(middelware) {
+    if (typeof middelware !== "function") {
+      throw new TypeError(
+        "Expected `middelware` to be a function, not " + middelware
+      );
+    }
+    fns.push(middelware);
+    return pipeline;
+  }
+}
+function wrap2(middleware, callback) {
+  let called;
+  return wrapped;
+  function wrapped(...parameters) {
+    const fnExpectsCallback = middleware.length > parameters.length;
+    let result;
+    if (fnExpectsCallback) {
+      parameters.push(done);
+    }
+    try {
+      result = middleware.apply(this, parameters);
+    } catch (error) {
+      const exception = (
+        /** @type {Error} */
+        error
+      );
+      if (fnExpectsCallback && called) {
+        throw exception;
+      }
+      return done(exception);
+    }
+    if (!fnExpectsCallback) {
+      if (result && result.then && typeof result.then === "function") {
+        result.then(then, done);
+      } else if (result instanceof Error) {
+        done(result);
+      } else {
+        then(result);
+      }
+    }
+  }
+  function done(error, ...output) {
+    if (!called) {
+      called = true;
+      callback(error, ...output);
+    }
+  }
+  function then(value) {
+    done(null, value);
+  }
+}
+
+// node_modules/unified/node_modules/vfile/lib/minpath.js
+// var import_node_path2 = __toESM(require("node:path"), 1);
+
+// node_modules/unified/node_modules/vfile/lib/minproc.js
+// var import_node_process2 = __toESM(require("node:process"), 1);
+
+// node_modules/unified/node_modules/vfile/lib/minurl.js
+// var import_node_url2 = require("node:url");
+
+// node_modules/unified/node_modules/vfile/lib/minurl.shared.js
+function isUrl2(fileUrlOrPath) {
+  return Boolean(
+    fileUrlOrPath !== null && typeof fileUrlOrPath === "object" && "href" in fileUrlOrPath && fileUrlOrPath.href && "protocol" in fileUrlOrPath && fileUrlOrPath.protocol && // @ts-expect-error: indexing is fine.
+    fileUrlOrPath.auth === void 0
+  );
+}
+
+// node_modules/unified/node_modules/vfile/lib/index.js
+var order2 = (
+  /** @type {const} */
+  [
+    "history",
+    "path",
+    "basename",
+    "stem",
+    "extname",
+    "dirname"
+  ]
+);
+var VFile2 = class {
+  /**
+   * Create a new virtual file.
+   *
+   * `options` is treated as:
+   *
+   * *   `string` or `Uint8Array` — `{value: options}`
+   * *   `URL` — `{path: options}`
+   * *   `VFile` — shallow copies its data over to the new file
+   * *   `object` — all fields are shallow copied over to the new file
+   *
+   * Path related fields are set in the following order (least specific to
+   * most specific): `history`, `path`, `basename`, `stem`, `extname`,
+   * `dirname`.
+   *
+   * You cannot set `dirname` or `extname` without setting either `history`,
+   * `path`, `basename`, or `stem` too.
+   *
+   * @param {Compatible | null | undefined} [value]
+   *   File value.
+   * @returns
+   *   New instance.
+   */
+  constructor(value) {
+    let options;
+    if (!value) {
+      options = {};
+    } else if (isUrl2(value)) {
+      options = { path: value };
+    } else if (typeof value === "string" || isUint8Array2(value)) {
+      options = { value };
+    } else {
+      options = value;
+    }
+    this.cwd = PROCESS.cwd();
+    this.data = {};
+    this.history = [];
+    this.messages = [];
+    this.value;
+    this.map;
+    this.result;
+    this.stored;
+    let index2 = -1;
+    while (++index2 < order2.length) {
+      const prop2 = order2[index2];
+      if (prop2 in options && options[prop2] !== void 0 && options[prop2] !== null) {
+        this[prop2] = prop2 === "history" ? [...options[prop2]] : options[prop2];
+      }
+    }
+    let prop;
+    for (prop in options) {
+      if (!order2.includes(prop)) {
+        this[prop] = options[prop];
+      }
+    }
+  }
+  /**
+   * Get the basename (including extname) (example: `'index.min.js'`).
+   *
+   * @returns {string | undefined}
+   *   Basename.
+   */
+  get basename() {
+    return typeof this.path === "string" ? PATH.basename(this.path) : void 0;
+  }
+  /**
+   * Set basename (including extname) (`'index.min.js'`).
+   *
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be nullified (use `file.path = file.dirname` instead).
+   *
+   * @param {string} basename
+   *   Basename.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set basename(basename) {
+    assertNonEmpty2(basename, "basename");
+    assertPart2(basename, "basename");
+    this.path = PATH.join(this.dirname || "", basename);
+  }
+  /**
+   * Get the parent path (example: `'~'`).
+   *
+   * @returns {string | undefined}
+   *   Dirname.
+   */
+  get dirname() {
+    return typeof this.path === "string" ? PATH.dirname(this.path) : void 0;
+  }
+  /**
+   * Set the parent path (example: `'~'`).
+   *
+   * Cannot be set if there’s no `path` yet.
+   *
+   * @param {string | undefined} dirname
+   *   Dirname.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set dirname(dirname) {
+    assertPath2(this.basename, "dirname");
+    this.path = PATH.join(dirname || "", this.basename);
+  }
+  /**
+   * Get the extname (including dot) (example: `'.js'`).
+   *
+   * @returns {string | undefined}
+   *   Extname.
+   */
+  get extname() {
+    return typeof this.path === "string" ? PATH.extname(this.path) : void 0;
+  }
+  /**
+   * Set the extname (including dot) (example: `'.js'`).
+   *
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be set if there’s no `path` yet.
+   *
+   * @param {string | undefined} extname
+   *   Extname.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set extname(extname) {
+    assertPart2(extname, "extname");
+    assertPath2(this.dirname, "extname");
+    if (extname) {
+      if (extname.codePointAt(0) !== 46) {
+        throw new Error("`extname` must start with `.`");
+      }
+      if (extname.includes(".", 1)) {
+        throw new Error("`extname` cannot contain multiple dots");
+      }
+    }
+    this.path = PATH.join(this.dirname, this.stem + (extname || ""));
+  }
+  /**
+   * Get the full path (example: `'~/index.min.js'`).
+   *
+   * @returns {string}
+   *   Path.
+   */
+  get path() {
+    return this.history[this.history.length - 1];
+  }
+  /**
+   * Set the full path (example: `'~/index.min.js'`).
+   *
+   * Cannot be nullified.
+   * You can set a file URL (a `URL` object with a `file:` protocol) which will
+   * be turned into a path with `url.fileURLToPath`.
+   *
+   * @param {URL | string} path
+   *   Path.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set path(path) {
+    if (isUrl2(path)) {
+      path = (0, URL.fileURLToPath)(path);
+    }
+    assertNonEmpty2(path, "path");
+    if (this.path !== path) {
+      this.history.push(path);
+    }
+  }
+  /**
+   * Get the stem (basename w/o extname) (example: `'index.min'`).
+   *
+   * @returns {string | undefined}
+   *   Stem.
+   */
+  get stem() {
+    return typeof this.path === "string" ? PATH.basename(this.path, this.extname) : void 0;
+  }
+  /**
+   * Set the stem (basename w/o extname) (example: `'index.min'`).
+   *
+   * Cannot contain path separators (`'/'` on unix, macOS, and browsers, `'\'`
+   * on windows).
+   * Cannot be nullified (use `file.path = file.dirname` instead).
+   *
+   * @param {string} stem
+   *   Stem.
+   * @returns {undefined}
+   *   Nothing.
+   */
+  set stem(stem) {
+    assertNonEmpty2(stem, "stem");
+    assertPart2(stem, "stem");
+    this.path = PATH.join(this.dirname || "", stem + (this.extname || ""));
+  }
+  // Normal prototypal methods.
+  /**
+   * Create a fatal message for `reason` associated with the file.
+   *
+   * The `fatal` field of the message is set to `true` (error; file not usable)
+   * and the `file` field is set to the current file path.
+   * The message is added to the `messages` field on `file`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {MessageOptions | null | undefined} [options]
+   * @returns {never}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns {never}
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | MessageOptions | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns {never}
+   *   Never.
+   * @throws {VFileMessage}
+   *   Message.
+   */
+  fail(causeOrReason, optionsOrParentOrPlace, origin) {
+    const message = this.message(causeOrReason, optionsOrParentOrPlace, origin);
+    message.fatal = true;
+    throw message;
+  }
+  /**
+   * Create an info message for `reason` associated with the file.
+   *
+   * The `fatal` field of the message is set to `undefined` (info; change
+   * likely not needed) and the `file` field is set to the current file path.
+   * The message is added to the `messages` field on `file`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {MessageOptions | null | undefined} [options]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | MessageOptions | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns {VFileMessage}
+   *   Message.
+   */
+  info(causeOrReason, optionsOrParentOrPlace, origin) {
+    const message = this.message(causeOrReason, optionsOrParentOrPlace, origin);
+    message.fatal = void 0;
+    return message;
+  }
+  /**
+   * Create a message for `reason` associated with the file.
+   *
+   * The `fatal` field of the message is set to `false` (warning; change may be
+   * needed) and the `file` field is set to the current file path.
+   * The message is added to the `messages` field on `file`.
+   *
+   * > 🪦 **Note**: also has obsolete signatures.
+   *
+   * @overload
+   * @param {string} reason
+   * @param {MessageOptions | null | undefined} [options]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {string} reason
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Node | NodeLike | null | undefined} parent
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {Point | Position | null | undefined} place
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @overload
+   * @param {Error | VFileMessage} cause
+   * @param {string | null | undefined} [origin]
+   * @returns {VFileMessage}
+   *
+   * @param {Error | VFileMessage | string} causeOrReason
+   *   Reason for message, should use markdown.
+   * @param {Node | NodeLike | MessageOptions | Point | Position | string | null | undefined} [optionsOrParentOrPlace]
+   *   Configuration (optional).
+   * @param {string | null | undefined} [origin]
+   *   Place in code where the message originates (example:
+   *   `'my-package:my-rule'` or `'my-rule'`).
+   * @returns {VFileMessage}
+   *   Message.
+   */
+  message(causeOrReason, optionsOrParentOrPlace, origin) {
+    const message = new VFileMessage(
+      // @ts-expect-error: the overloads are fine.
+      causeOrReason,
+      optionsOrParentOrPlace,
+      origin
+    );
+    if (this.path) {
+      message.name = this.path + ":" + message.name;
+      message.file = this.path;
+    }
+    message.fatal = false;
+    this.messages.push(message);
+    return message;
+  }
+  /**
+   * Serialize the file.
+   *
+   * > **Note**: which encodings are supported depends on the engine.
+   * > For info on Node.js, see:
+   * > <https://nodejs.org/api/util.html#whatwg-supported-encodings>.
+   *
+   * @param {string | null | undefined} [encoding='utf8']
+   *   Character encoding to understand `value` as when it’s a `Uint8Array`
+   *   (default: `'utf-8'`).
+   * @returns {string}
+   *   Serialized file.
+   */
+  toString(encoding) {
+    if (this.value === void 0) {
+      return "";
+    }
+    if (typeof this.value === "string") {
+      return this.value;
+    }
+    const decoder = new TextDecoder(encoding || void 0);
+    return decoder.decode(this.value);
+  }
+};
+function assertPart2(part, name2) {
+  if (part && part.includes(PATH.sep)) {
+    throw new Error(
+      "`" + name2 + "` cannot be a path: did not expect `" + PATH.sep + "`"
+    );
+  }
+}
+function assertNonEmpty2(part, name2) {
+  if (!part) {
+    throw new Error("`" + name2 + "` cannot be empty");
+  }
+}
+function assertPath2(path, name2) {
+  if (!path) {
+    throw new Error("Setting `" + name2 + "` requires `path` to be set too");
+  }
+}
+function isUint8Array2(value) {
+  return Boolean(
+    value && typeof value === "object" && "byteLength" in value && "byteOffset" in value
+  );
+}
+
+// node_modules/unified/lib/callable-instance.js
+var CallableInstance = (
+  /**
+   * @type {new <Parameters extends Array<unknown>, Result>(property: string | symbol) => (...parameters: Parameters) => Result}
+   */
+  /** @type {unknown} */
+  /**
+   * @this {Function}
+   * @param {string | symbol} property
+   * @returns {(...parameters: Array<unknown>) => unknown}
+   */
+  function(property) {
+    const self2 = this;
+    const constr = self2.constructor;
+    const proto = (
+      /** @type {Record<string | symbol, Function>} */
+      // Prototypes do exist.
+      // type-coverage:ignore-next-line
+      constr.prototype
+    );
+    const value = proto[property];
+    const apply = function() {
+      return value.apply(apply, arguments);
+    };
+    Object.setPrototypeOf(apply, proto);
+    return apply;
+  }
+);
+
+// node_modules/unified/lib/index.js
+var own5 = {}.hasOwnProperty;
+var Processor = class _Processor extends CallableInstance {
+  /**
+   * Create a processor.
+   */
+  constructor() {
+    super("copy");
+    this.Compiler = void 0;
+    this.Parser = void 0;
+    this.attachers = [];
+    this.compiler = void 0;
+    this.freezeIndex = -1;
+    this.frozen = void 0;
+    this.namespace = {};
+    this.parser = void 0;
+    this.transformers = trough();
+  }
+  /**
+   * Copy a processor.
+   *
+   * @deprecated
+   *   This is a private internal method and should not be used.
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *   New *unfrozen* processor ({@linkcode Processor}) that is
+   *   configured to work the same as its ancestor.
+   *   When the descendant processor is configured in the future it does not
+   *   affect the ancestral processor.
+   */
+  copy() {
+    const destination = (
+      /** @type {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>} */
+      new _Processor()
+    );
+    let index2 = -1;
+    while (++index2 < this.attachers.length) {
+      const attacher = this.attachers[index2];
+      destination.use(...attacher);
+    }
+    destination.data((0, import_extend.default)(true, {}, this.namespace));
+    return destination;
+  }
+  /**
+   * Configure the processor with info available to all plugins.
+   * Information is stored in an object.
+   *
+   * Typically, options can be given to a specific plugin, but sometimes it
+   * makes sense to have information shared with several plugins.
+   * For example, a list of HTML elements that are self-closing, which is
+   * needed during all phases.
+   *
+   * > **Note**: setting information cannot occur on *frozen* processors.
+   * > Call the processor first to create a new unfrozen processor.
+   *
+   * > **Note**: to register custom data in TypeScript, augment the
+   * > {@linkcode Data} interface.
+   *
+   * @example
+   *   This example show how to get and set info:
+   *
+   *   ```js
+   *   import {unified} from 'unified'
+   *
+   *   const processor = unified().data('alpha', 'bravo')
+   *
+   *   processor.data('alpha') // => 'bravo'
+   *
+   *   processor.data() // => {alpha: 'bravo'}
+   *
+   *   processor.data({charlie: 'delta'})
+   *
+   *   processor.data() // => {charlie: 'delta'}
+   *   ```
+   *
+   * @template {keyof Data} Key
+   *
+   * @overload
+   * @returns {Data}
+   *
+   * @overload
+   * @param {Data} dataset
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *
+   * @overload
+   * @param {Key} key
+   * @returns {Data[Key]}
+   *
+   * @overload
+   * @param {Key} key
+   * @param {Data[Key]} value
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *
+   * @param {Data | Key} [key]
+   *   Key to get or set, or entire dataset to set, or nothing to get the
+   *   entire dataset (optional).
+   * @param {Data[Key]} [value]
+   *   Value to set (optional).
+   * @returns {unknown}
+   *   The current processor when setting, the value at `key` when getting, or
+   *   the entire dataset when getting without key.
+   */
+  data(key, value) {
+    if (typeof key === "string") {
+      if (arguments.length === 2) {
+        assertUnfrozen("data", this.frozen);
+        this.namespace[key] = value;
+        return this;
+      }
+      return own5.call(this.namespace, key) && this.namespace[key] || void 0;
+    }
+    if (key) {
+      assertUnfrozen("data", this.frozen);
+      this.namespace = key;
+      return this;
+    }
+    return this.namespace;
+  }
+  /**
+   * Freeze a processor.
+   *
+   * Frozen processors are meant to be extended and not to be configured
+   * directly.
+   *
+   * When a processor is frozen it cannot be unfrozen.
+   * New processors working the same way can be created by calling the
+   * processor.
+   *
+   * It’s possible to freeze processors explicitly by calling `.freeze()`.
+   * Processors freeze automatically when `.parse()`, `.run()`, `.runSync()`,
+   * `.stringify()`, `.process()`, or `.processSync()` are called.
+   *
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *   The current processor.
+   */
+  freeze() {
+    if (this.frozen) {
+      return this;
+    }
+    const self2 = (
+      /** @type {Processor} */
+      /** @type {unknown} */
+      this
+    );
+    while (++this.freezeIndex < this.attachers.length) {
+      const [attacher, ...options] = this.attachers[this.freezeIndex];
+      if (options[0] === false) {
+        continue;
+      }
+      if (options[0] === true) {
+        options[0] = void 0;
+      }
+      const transformer = attacher.call(self2, ...options);
+      if (typeof transformer === "function") {
+        this.transformers.use(transformer);
+      }
+    }
+    this.frozen = true;
+    this.freezeIndex = Number.POSITIVE_INFINITY;
+    return this;
+  }
+  /**
+   * Parse text to a syntax tree.
+   *
+   * > **Note**: `parse` freezes the processor if not already *frozen*.
+   *
+   * > **Note**: `parse` performs the parse phase, not the run phase or other
+   * > phases.
+   *
+   * @param {Compatible | undefined} [file]
+   *   file to parse (optional); typically `string` or `VFile`; any value
+   *   accepted as `x` in `new VFile(x)`.
+   * @returns {ParseTree extends undefined ? Node : ParseTree}
+   *   Syntax tree representing `file`.
+   */
+  parse(file) {
+    this.freeze();
+    const realFile = vfile(file);
+    const parser = this.parser || this.Parser;
+    assertParser("parse", parser);
+    return parser(String(realFile), realFile);
+  }
+  /**
+   * Process the given file as configured on the processor.
+   *
+   * > **Note**: `process` freezes the processor if not already *frozen*.
+   *
+   * > **Note**: `process` performs the parse, run, and stringify phases.
+   *
+   * @overload
+   * @param {Compatible | undefined} file
+   * @param {ProcessCallback<VFileWithOutput<CompileResult>>} done
+   * @returns {undefined}
+   *
+   * @overload
+   * @param {Compatible | undefined} [file]
+   * @returns {Promise<VFileWithOutput<CompileResult>>}
+   *
+   * @param {Compatible | undefined} [file]
+   *   File (optional); typically `string` or `VFile`]; any value accepted as
+   *   `x` in `new VFile(x)`.
+   * @param {ProcessCallback<VFileWithOutput<CompileResult>> | undefined} [done]
+   *   Callback (optional).
+   * @returns {Promise<VFile> | undefined}
+   *   Nothing if `done` is given.
+   *   Otherwise a promise, rejected with a fatal error or resolved with the
+   *   processed file.
+   *
+   *   The parsed, transformed, and compiled value is available at
+   *   `file.value` (see note).
+   *
+   *   > **Note**: unified typically compiles by serializing: most
+   *   > compilers return `string` (or `Uint8Array`).
+   *   > Some compilers, such as the one configured with
+   *   > [`rehype-react`][rehype-react], return other values (in this case, a
+   *   > React tree).
+   *   > If you’re using a compiler that doesn’t serialize, expect different
+   *   > result values.
+   *   >
+   *   > To register custom results in TypeScript, add them to
+   *   > {@linkcode CompileResultMap}.
+   *
+   *   [rehype-react]: https://github.com/rehypejs/rehype-react
+   */
+  process(file, done) {
+    const self2 = this;
+    this.freeze();
+    assertParser("process", this.parser || this.Parser);
+    assertCompiler("process", this.compiler || this.Compiler);
+    return done ? executor(void 0, done) : new Promise(executor);
+    function executor(resolve, reject) {
+      const realFile = vfile(file);
+      const parseTree = (
+        /** @type {HeadTree extends undefined ? Node : HeadTree} */
+        /** @type {unknown} */
+        self2.parse(realFile)
+      );
+      self2.run(parseTree, realFile, function(error, tree, file2) {
+        if (error || !tree || !file2) {
+          return realDone(error);
+        }
+        const compileTree = (
+          /** @type {CompileTree extends undefined ? Node : CompileTree} */
+          /** @type {unknown} */
+          tree
+        );
+        const compileResult = self2.stringify(compileTree, file2);
+        if (looksLikeAValue(compileResult)) {
+          file2.value = compileResult;
+        } else {
+          file2.result = compileResult;
+        }
+        realDone(
+          error,
+          /** @type {VFileWithOutput<CompileResult>} */
+          file2
+        );
+      });
+      function realDone(error, file2) {
+        if (error || !file2) {
+          reject(error);
+        } else if (resolve) {
+          resolve(file2);
+        } else {
+          ok(done, "`done` is defined if `resolve` is not");
+          done(void 0, file2);
+        }
+      }
+    }
+  }
+  /**
+   * Process the given file as configured on the processor.
+   *
+   * An error is thrown if asynchronous transforms are configured.
+   *
+   * > **Note**: `processSync` freezes the processor if not already *frozen*.
+   *
+   * > **Note**: `processSync` performs the parse, run, and stringify phases.
+   *
+   * @param {Compatible | undefined} [file]
+   *   File (optional); typically `string` or `VFile`; any value accepted as
+   *   `x` in `new VFile(x)`.
+   * @returns {VFileWithOutput<CompileResult>}
+   *   The processed file.
+   *
+   *   The parsed, transformed, and compiled value is available at
+   *   `file.value` (see note).
+   *
+   *   > **Note**: unified typically compiles by serializing: most
+   *   > compilers return `string` (or `Uint8Array`).
+   *   > Some compilers, such as the one configured with
+   *   > [`rehype-react`][rehype-react], return other values (in this case, a
+   *   > React tree).
+   *   > If you’re using a compiler that doesn’t serialize, expect different
+   *   > result values.
+   *   >
+   *   > To register custom results in TypeScript, add them to
+   *   > {@linkcode CompileResultMap}.
+   *
+   *   [rehype-react]: https://github.com/rehypejs/rehype-react
+   */
+  processSync(file) {
+    let complete = false;
+    let result;
+    this.freeze();
+    assertParser("processSync", this.parser || this.Parser);
+    assertCompiler("processSync", this.compiler || this.Compiler);
+    this.process(file, realDone);
+    assertDone("processSync", "process", complete);
+    ok(result, "we either bailed on an error or have a tree");
+    return result;
+    function realDone(error, file2) {
+      complete = true;
+      bail(error);
+      result = file2;
+    }
+  }
+  /**
+   * Run *transformers* on a syntax tree.
+   *
+   * > **Note**: `run` freezes the processor if not already *frozen*.
+   *
+   * > **Note**: `run` performs the run phase, not other phases.
+   *
+   * @overload
+   * @param {HeadTree extends undefined ? Node : HeadTree} tree
+   * @param {RunCallback<TailTree extends undefined ? Node : TailTree>} done
+   * @returns {undefined}
+   *
+   * @overload
+   * @param {HeadTree extends undefined ? Node : HeadTree} tree
+   * @param {Compatible | undefined} file
+   * @param {RunCallback<TailTree extends undefined ? Node : TailTree>} done
+   * @returns {undefined}
+   *
+   * @overload
+   * @param {HeadTree extends undefined ? Node : HeadTree} tree
+   * @param {Compatible | undefined} [file]
+   * @returns {Promise<TailTree extends undefined ? Node : TailTree>}
+   *
+   * @param {HeadTree extends undefined ? Node : HeadTree} tree
+   *   Tree to transform and inspect.
+   * @param {(
+   *   RunCallback<TailTree extends undefined ? Node : TailTree> |
+   *   Compatible
+   * )} [file]
+   *   File associated with `node` (optional); any value accepted as `x` in
+   *   `new VFile(x)`.
+   * @param {RunCallback<TailTree extends undefined ? Node : TailTree>} [done]
+   *   Callback (optional).
+   * @returns {Promise<TailTree extends undefined ? Node : TailTree> | undefined}
+   *   Nothing if `done` is given.
+   *   Otherwise, a promise rejected with a fatal error or resolved with the
+   *   transformed tree.
+   */
+  run(tree, file, done) {
+    assertNode(tree);
+    this.freeze();
+    const transformers = this.transformers;
+    if (!done && typeof file === "function") {
+      done = file;
+      file = void 0;
+    }
+    return done ? executor(void 0, done) : new Promise(executor);
+    function executor(resolve, reject) {
+      ok(
+        typeof file !== "function",
+        "`file` can\u2019t be a `done` anymore, we checked"
+      );
+      const realFile = vfile(file);
+      transformers.run(tree, realFile, realDone);
+      function realDone(error, outputTree, file2) {
+        const resultingTree = (
+          /** @type {TailTree extends undefined ? Node : TailTree} */
+          outputTree || tree
+        );
+        if (error) {
+          reject(error);
+        } else if (resolve) {
+          resolve(resultingTree);
+        } else {
+          ok(done, "`done` is defined if `resolve` is not");
+          done(void 0, resultingTree, file2);
+        }
+      }
+    }
+  }
+  /**
+   * Run *transformers* on a syntax tree.
+   *
+   * An error is thrown if asynchronous transforms are configured.
+   *
+   * > **Note**: `runSync` freezes the processor if not already *frozen*.
+   *
+   * > **Note**: `runSync` performs the run phase, not other phases.
+   *
+   * @param {HeadTree extends undefined ? Node : HeadTree} tree
+   *   Tree to transform and inspect.
+   * @param {Compatible | undefined} [file]
+   *   File associated with `node` (optional); any value accepted as `x` in
+   *   `new VFile(x)`.
+   * @returns {TailTree extends undefined ? Node : TailTree}
+   *   Transformed tree.
+   */
+  runSync(tree, file) {
+    let complete = false;
+    let result;
+    this.run(tree, file, realDone);
+    assertDone("runSync", "run", complete);
+    ok(result, "we either bailed on an error or have a tree");
+    return result;
+    function realDone(error, tree2) {
+      bail(error);
+      result = tree2;
+      complete = true;
+    }
+  }
+  /**
+   * Compile a syntax tree.
+   *
+   * > **Note**: `stringify` freezes the processor if not already *frozen*.
+   *
+   * > **Note**: `stringify` performs the stringify phase, not the run phase
+   * > or other phases.
+   *
+   * @param {CompileTree extends undefined ? Node : CompileTree} tree
+   *   Tree to compile.
+   * @param {Compatible | undefined} [file]
+   *   File associated with `node` (optional); any value accepted as `x` in
+   *   `new VFile(x)`.
+   * @returns {CompileResult extends undefined ? Value : CompileResult}
+   *   Textual representation of the tree (see note).
+   *
+   *   > **Note**: unified typically compiles by serializing: most compilers
+   *   > return `string` (or `Uint8Array`).
+   *   > Some compilers, such as the one configured with
+   *   > [`rehype-react`][rehype-react], return other values (in this case, a
+   *   > React tree).
+   *   > If you’re using a compiler that doesn’t serialize, expect different
+   *   > result values.
+   *   >
+   *   > To register custom results in TypeScript, add them to
+   *   > {@linkcode CompileResultMap}.
+   *
+   *   [rehype-react]: https://github.com/rehypejs/rehype-react
+   */
+  stringify(tree, file) {
+    this.freeze();
+    const realFile = vfile(file);
+    const compiler2 = this.compiler || this.Compiler;
+    assertCompiler("stringify", compiler2);
+    assertNode(tree);
+    return compiler2(tree, realFile);
+  }
+  /**
+   * Configure the processor to use a plugin, a list of usable values, or a
+   * preset.
+   *
+   * If the processor is already using a plugin, the previous plugin
+   * configuration is changed based on the options that are passed in.
+   * In other words, the plugin is not added a second time.
+   *
+   * > **Note**: `use` cannot be called on *frozen* processors.
+   * > Call the processor first to create a new unfrozen processor.
+   *
+   * @example
+   *   There are many ways to pass plugins to `.use()`.
+   *   This example gives an overview:
+   *
+   *   ```js
+   *   import {unified} from 'unified'
+   *
+   *   unified()
+   *     // Plugin with options:
+   *     .use(pluginA, {x: true, y: true})
+   *     // Passing the same plugin again merges configuration (to `{x: true, y: false, z: true}`):
+   *     .use(pluginA, {y: false, z: true})
+   *     // Plugins:
+   *     .use([pluginB, pluginC])
+   *     // Two plugins, the second with options:
+   *     .use([pluginD, [pluginE, {}]])
+   *     // Preset with plugins and settings:
+   *     .use({plugins: [pluginF, [pluginG, {}]], settings: {position: false}})
+   *     // Settings only:
+   *     .use({settings: {position: false}})
+   *   ```
+   *
+   * @template {Array<unknown>} [Parameters=[]]
+   * @template {Node | string | undefined} [Input=undefined]
+   * @template [Output=Input]
+   *
+   * @overload
+   * @param {Preset | null | undefined} [preset]
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *
+   * @overload
+   * @param {PluggableList} list
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *
+   * @overload
+   * @param {Plugin<Parameters, Input, Output>} plugin
+   * @param {...(Parameters | [boolean])} parameters
+   * @returns {UsePlugin<ParseTree, HeadTree, TailTree, CompileTree, CompileResult, Input, Output>}
+   *
+   * @param {PluggableList | Plugin | Preset | null | undefined} value
+   *   Usable value.
+   * @param {...unknown} parameters
+   *   Parameters, when a plugin is given as a usable value.
+   * @returns {Processor<ParseTree, HeadTree, TailTree, CompileTree, CompileResult>}
+   *   Current processor.
+   */
+  use(value, ...parameters) {
+    const attachers = this.attachers;
+    const namespace = this.namespace;
+    assertUnfrozen("use", this.frozen);
+    if (value === null || value === void 0) {
+    } else if (typeof value === "function") {
+      addPlugin(value, parameters);
+    } else if (typeof value === "object") {
+      if (Array.isArray(value)) {
+        addList(value);
+      } else {
+        addPreset(value);
+      }
+    } else {
+      throw new TypeError("Expected usable value, not `" + value + "`");
+    }
+    return this;
+    function add(value2) {
+      if (typeof value2 === "function") {
+        addPlugin(value2, []);
+      } else if (typeof value2 === "object") {
+        if (Array.isArray(value2)) {
+          const [plugin, ...parameters2] = (
+            /** @type {PluginTuple<Array<unknown>>} */
+            value2
+          );
+          addPlugin(plugin, parameters2);
+        } else {
+          addPreset(value2);
+        }
+      } else {
+        throw new TypeError("Expected usable value, not `" + value2 + "`");
+      }
+    }
+    function addPreset(result) {
+      if (!("plugins" in result) && !("settings" in result)) {
+        throw new Error(
+          "Expected usable value but received an empty preset, which is probably a mistake: presets typically come with `plugins` and sometimes with `settings`, but this has neither"
+        );
+      }
+      addList(result.plugins);
+      if (result.settings) {
+        namespace.settings = (0, import_extend.default)(true, namespace.settings, result.settings);
+      }
+    }
+    function addList(plugins) {
+      let index2 = -1;
+      if (plugins === null || plugins === void 0) {
+      } else if (Array.isArray(plugins)) {
+        while (++index2 < plugins.length) {
+          const thing = plugins[index2];
+          add(thing);
+        }
+      } else {
+        throw new TypeError("Expected a list of plugins, not `" + plugins + "`");
+      }
+    }
+    function addPlugin(plugin, parameters2) {
+      let index2 = -1;
+      let entryIndex = -1;
+      while (++index2 < attachers.length) {
+        if (attachers[index2][0] === plugin) {
+          entryIndex = index2;
+          break;
+        }
+      }
+      if (entryIndex === -1) {
+        attachers.push([plugin, ...parameters2]);
+      } else if (parameters2.length > 0) {
+        let [primary, ...rest] = parameters2;
+        const currentPrimary = attachers[entryIndex][1];
+        if (isPlainObject(currentPrimary) && isPlainObject(primary)) {
+          primary = (0, import_extend.default)(true, currentPrimary, primary);
+        }
+        attachers[entryIndex] = [plugin, primary, ...rest];
+      }
+    }
+  }
+};
+var unified = new Processor().freeze();
+function assertParser(name2, value) {
+  if (typeof value !== "function") {
+    throw new TypeError("Cannot `" + name2 + "` without `parser`");
+  }
+}
+function assertCompiler(name2, value) {
+  if (typeof value !== "function") {
+    throw new TypeError("Cannot `" + name2 + "` without `compiler`");
+  }
+}
+function assertUnfrozen(name2, frozen) {
+  if (frozen) {
+    throw new Error(
+      "Cannot call `" + name2 + "` on a frozen processor.\nCreate a new processor first, by calling it: use `processor()` instead of `processor`."
+    );
+  }
+}
+function assertNode(node2) {
+  if (!isPlainObject(node2) || typeof node2.type !== "string") {
+    throw new TypeError("Expected node, got `" + node2 + "`");
+  }
+}
+function assertDone(name2, asyncName, complete) {
+  if (!complete) {
+    throw new Error(
+      "`" + name2 + "` finished async. Use `" + asyncName + "` instead"
+    );
+  }
+}
+function vfile(value) {
+  return looksLikeAVFile2(value) ? value : new VFile2(value);
+}
+function looksLikeAVFile2(value) {
+  return Boolean(
+    value && typeof value === "object" && "message" in value && "messages" in value
+  );
+}
+function looksLikeAValue(value) {
+  return typeof value === "string" || isUint8Array3(value);
+}
+function isUint8Array3(value) {
+  return Boolean(
+    value && typeof value === "object" && "byteLength" in value && "byteOffset" in value
+  );
+}
+
+// node_modules/estree-walker/src/walker.js
+var WalkerBase = class {
+  constructor() {
+    this.should_skip = false;
+    this.should_remove = false;
+    this.replacement = null;
+    this.context = {
+      skip: () => this.should_skip = true,
+      remove: () => this.should_remove = true,
+      replace: (node2) => this.replacement = node2
+    };
+  }
+  /**
+   * @template {Node} Parent
+   * @param {Parent | null | undefined} parent
+   * @param {keyof Parent | null | undefined} prop
+   * @param {number | null | undefined} index
+   * @param {Node} node
+   */
+  replace(parent, prop, index2, node2) {
+    if (parent && prop) {
+      if (index2 != null) {
+        parent[prop][index2] = node2;
+      } else {
+        parent[prop] = node2;
+      }
+    }
+  }
+  /**
+   * @template {Node} Parent
+   * @param {Parent | null | undefined} parent
+   * @param {keyof Parent | null | undefined} prop
+   * @param {number | null | undefined} index
+   */
+  remove(parent, prop, index2) {
+    if (parent && prop) {
+      if (index2 !== null && index2 !== void 0) {
+        parent[prop].splice(index2, 1);
+      } else {
+        delete parent[prop];
+      }
+    }
+  }
+};
+
+// node_modules/estree-walker/src/sync.js
+var SyncWalker = class extends WalkerBase {
+  /**
+   *
+   * @param {SyncHandler} [enter]
+   * @param {SyncHandler} [leave]
+   */
+  constructor(enter, leave) {
+    super();
+    this.should_skip = false;
+    this.should_remove = false;
+    this.replacement = null;
+    this.context = {
+      skip: () => this.should_skip = true,
+      remove: () => this.should_remove = true,
+      replace: (node2) => this.replacement = node2
+    };
+    this.enter = enter;
+    this.leave = leave;
+  }
+  /**
+   * @template {Node} Parent
+   * @param {Node} node
+   * @param {Parent | null} parent
+   * @param {keyof Parent} [prop]
+   * @param {number | null} [index]
+   * @returns {Node | null}
+   */
+  visit(node2, parent, prop, index2) {
+    if (node2) {
+      if (this.enter) {
+        const _should_skip = this.should_skip;
+        const _should_remove = this.should_remove;
+        const _replacement = this.replacement;
+        this.should_skip = false;
+        this.should_remove = false;
+        this.replacement = null;
+        this.enter.call(this.context, node2, parent, prop, index2);
+        if (this.replacement) {
+          node2 = this.replacement;
+          this.replace(parent, prop, index2, node2);
+        }
+        if (this.should_remove) {
+          this.remove(parent, prop, index2);
+        }
+        const skipped = this.should_skip;
+        const removed = this.should_remove;
+        this.should_skip = _should_skip;
+        this.should_remove = _should_remove;
+        this.replacement = _replacement;
+        if (skipped) return node2;
+        if (removed) return null;
+      }
+      let key;
+      for (key in node2) {
+        const value = node2[key];
+        if (value && typeof value === "object") {
+          if (Array.isArray(value)) {
+            const nodes = (
+              /** @type {Array<unknown>} */
+              value
+            );
+            for (let i = 0; i < nodes.length; i += 1) {
+              const item = nodes[i];
+              if (isNode(item)) {
+                if (!this.visit(item, node2, key, i)) {
+                  i--;
+                }
+              }
+            }
+          } else if (isNode(value)) {
+            this.visit(value, node2, key, null);
+          }
+        }
+      }
+      if (this.leave) {
+        const _replacement = this.replacement;
+        const _should_remove = this.should_remove;
+        this.replacement = null;
+        this.should_remove = false;
+        this.leave.call(this.context, node2, parent, prop, index2);
+        if (this.replacement) {
+          node2 = this.replacement;
+          this.replace(parent, prop, index2, node2);
+        }
+        if (this.should_remove) {
+          this.remove(parent, prop, index2);
+        }
+        const removed = this.should_remove;
+        this.replacement = _replacement;
+        this.should_remove = _should_remove;
+        if (removed) return null;
+      }
+    }
+    return node2;
+  }
+};
+function isNode(value) {
+  return value !== null && typeof value === "object" && "type" in value && typeof value.type === "string";
+}
+
+// node_modules/estree-walker/src/index.js
+function walk(ast, { enter, leave }) {
+  const instance = new SyncWalker(enter, leave);
+  return instance.visit(ast, null);
+}
+
+// node_modules/periscopic/node_modules/is-reference/src/index.js
+function is_reference(node2, parent) {
+  if (node2.type === "MemberExpression") {
+    return !node2.computed && is_reference(node2.object, node2);
+  }
+  if (node2.type === "Identifier") {
+    if (!parent) return true;
+    switch (parent.type) {
+      case "MemberExpression":
+        return parent.computed || node2 === parent.object;
+      case "MethodDefinition":
+        return parent.computed;
+      case "PropertyDefinition":
+        return parent.computed || node2 === parent.value;
+      case "Property":
+        return parent.computed || node2 === parent.value;
+      case "ExportSpecifier":
+      case "ImportSpecifier":
+        return node2 === parent.local;
+      case "LabeledStatement":
+      case "BreakStatement":
+      case "ContinueStatement":
+        return false;
+      default:
+        return true;
+    }
+  }
+  return false;
+}
+
+// node_modules/periscopic/src/index.js
+function analyze(expression) {
+  const map = /* @__PURE__ */ new WeakMap();
+  const globals = /* @__PURE__ */ new Map();
+  const scope = new Scope3(null, false);
+  const references = [];
+  let current_scope = scope;
+  walk(expression, {
+    enter(node2, parent) {
+      switch (node2.type) {
+        case "Identifier":
+          if (parent && is_reference(node2, parent)) {
+            references.push([current_scope, node2]);
+          }
+          break;
+        case "ImportDeclaration":
+          node2.specifiers.forEach((specifier) => {
+            current_scope.declarations.set(specifier.local.name, specifier);
+          });
+          break;
+        case "FunctionExpression":
+        case "FunctionDeclaration":
+        case "ArrowFunctionExpression":
+          if (node2.type === "FunctionDeclaration") {
+            if (node2.id) {
+              current_scope.declarations.set(node2.id.name, node2);
+            }
+            map.set(node2, current_scope = new Scope3(current_scope, false));
+          } else {
+            map.set(node2, current_scope = new Scope3(current_scope, false));
+            if (node2.type === "FunctionExpression" && node2.id) {
+              current_scope.declarations.set(node2.id.name, node2);
+            }
+          }
+          node2.params.forEach((param) => {
+            extract_names(param).forEach((name2) => {
+              current_scope.declarations.set(name2, node2);
+            });
+          });
+          break;
+        case "ForStatement":
+        case "ForInStatement":
+        case "ForOfStatement":
+          map.set(node2, current_scope = new Scope3(current_scope, true));
+          break;
+        case "BlockStatement":
+          map.set(node2, current_scope = new Scope3(current_scope, true));
+          break;
+        case "ClassDeclaration":
+        case "VariableDeclaration":
+          current_scope.add_declaration(node2);
+          break;
+        case "CatchClause":
+          map.set(node2, current_scope = new Scope3(current_scope, true));
+          if (node2.param) {
+            extract_names(node2.param).forEach((name2) => {
+              if (node2.param) {
+                current_scope.declarations.set(name2, node2.param);
+              }
+            });
+          }
+          break;
+      }
+    },
+    leave(node2) {
+      if (map.has(node2) && current_scope !== null && current_scope.parent) {
+        current_scope = current_scope.parent;
+      }
+    }
+  });
+  for (let i = references.length - 1; i >= 0; --i) {
+    const [scope2, reference] = references[i];
+    if (!scope2.references.has(reference.name)) {
+      add_reference(scope2, reference.name);
+    }
+    if (!scope2.find_owner(reference.name)) {
+      globals.set(reference.name, reference);
+    }
+  }
+  return { map, scope, globals };
+}
+function add_reference(scope, name2) {
+  scope.references.add(name2);
+  if (scope.parent) add_reference(scope.parent, name2);
+}
+var Scope3 = class {
+  /**
+   * @param {Scope | null} parent 
+   * @param {boolean} block 
+   */
+  constructor(parent, block) {
+    this.parent = parent;
+    this.block = block;
+    this.declarations = /* @__PURE__ */ new Map();
+    this.initialised_declarations = /* @__PURE__ */ new Set();
+    this.references = /* @__PURE__ */ new Set();
+  }
+  /**
+   * @param {import('estree').VariableDeclaration | import('estree').ClassDeclaration} node
+   */
+  add_declaration(node2) {
+    if (node2.type === "VariableDeclaration") {
+      if (node2.kind === "var" && this.block && this.parent) {
+        this.parent.add_declaration(node2);
+      } else {
+        const handle_declarator = (declarator) => {
+          extract_names(declarator.id).forEach((name2) => {
+            this.declarations.set(name2, node2);
+            if (declarator.init) this.initialised_declarations.add(name2);
+          });
+          ;
+        };
+        node2.declarations.forEach(handle_declarator);
+      }
+    } else if (node2.id) {
+      this.declarations.set(node2.id.name, node2);
+    }
+  }
+  /**
+   * @param {string} name
+   * @returns {Scope | null}
+   */
+  find_owner(name2) {
+    if (this.declarations.has(name2)) return this;
+    return this.parent && this.parent.find_owner(name2);
+  }
+  /**
+   * @param {string} name
+   * @returns {boolean}
+   */
+  has(name2) {
+    return this.declarations.has(name2) || !!this.parent && this.parent.has(name2);
+  }
+};
+function extract_names(param) {
+  return extract_identifiers(param).map((node2) => node2.name);
+}
+function extract_identifiers(param, nodes = []) {
+  switch (param.type) {
+    case "Identifier":
+      nodes.push(param);
+      break;
+    case "MemberExpression":
+      let object = param;
+      while (object.type === "MemberExpression") {
+        object = /** @type {any} */
+        object.object;
+      }
+      nodes.push(
+        /** @type {any} */
+        object
+      );
+      break;
+    case "ObjectPattern":
+      const handle_prop = (prop) => {
+        if (prop.type === "RestElement") {
+          extract_identifiers(prop.argument, nodes);
+        } else {
+          extract_identifiers(prop.value, nodes);
+        }
+      };
+      param.properties.forEach(handle_prop);
+      break;
+    case "ArrayPattern":
+      const handle_element = (element2) => {
+        if (element2) extract_identifiers(element2, nodes);
+      };
+      param.elements.forEach((element2) => {
+        if (element2) {
+          handle_element(element2);
+        }
+      });
+      break;
+    case "RestElement":
+      extract_identifiers(param.argument, nodes);
+      break;
+    case "AssignmentPattern":
+      extract_identifiers(param.left, nodes);
+      break;
+  }
+  return nodes;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-create.js
+function create(from, to) {
+  const fields = ["start", "end", "loc", "range", "comments"];
+  let index2 = -1;
+  while (++index2 < fields.length) {
+    const field = fields[index2];
+    if (field in from) {
+      to[field] = from[field];
+    }
+  }
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-declaration-to-expression.js
+function declarationToExpression(declaration) {
+  if (declaration.type === "FunctionDeclaration") {
+    return { ...declaration, type: "FunctionExpression" };
+  }
+  ok(declaration.type === "ClassDeclaration", "unexpected node type");
+  return { ...declaration, type: "ClassExpression" };
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-is-declaration.js
+function isDeclaration(node2) {
+  return Boolean(
+    node2.type === "FunctionDeclaration" || node2.type === "ClassDeclaration" || node2.type === "VariableDeclaration"
+  );
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-specifiers-to-declarations.js
+function specifiersToDeclarations(specifiers, init) {
+  let index2 = -1;
+  const declarations = [];
+  const otherSpecifiers = [];
+  let importNamespaceSpecifier;
+  while (++index2 < specifiers.length) {
+    const specifier = specifiers[index2];
+    if (specifier.type === "ImportNamespaceSpecifier") {
+      importNamespaceSpecifier = specifier;
+    } else {
+      otherSpecifiers.push(specifier);
+    }
+  }
+  if (importNamespaceSpecifier) {
+    const declarator = {
+      type: "VariableDeclarator",
+      id: importNamespaceSpecifier.local,
+      init
+    };
+    create(importNamespaceSpecifier, declarator);
+    declarations.push(declarator);
+  }
+  declarations.push({
+    type: "VariableDeclarator",
+    id: {
+      type: "ObjectPattern",
+      properties: otherSpecifiers.map(function(specifier) {
+        let key = specifier.type === "ImportSpecifier" ? specifier.imported : specifier.type === "ExportSpecifier" ? specifier.exported : { type: "Identifier", name: "default" };
+        let value = specifier.local;
+        if (specifier.type === "ExportSpecifier") {
+          value = key;
+          key = specifier.local;
+        }
+        const property = {
+          type: "Property",
+          kind: "init",
+          shorthand: key.name === value.name,
+          method: false,
+          computed: false,
+          key,
+          value
+        };
+        create(specifier, property);
+        return property;
+      })
+    },
+    init: importNamespaceSpecifier ? { type: "Identifier", name: importNamespaceSpecifier.local.name } : init
+  });
+  return declarations;
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-to-id-or-member-expression.js
+function toIdOrMemberExpression(ids) {
+  let index2 = -1;
+  let object;
+  while (++index2 < ids.length) {
+    const name2 = ids[index2];
+    const id = typeof name2 === "string" && name(name2) ? { type: "Identifier", name: name2 } : { type: "Literal", value: name2 };
+    object = object ? {
+      type: "MemberExpression",
+      object,
+      property: id,
+      computed: id.type === "Literal",
+      optional: false
+    } : id;
+  }
+  ok(object, "expected non-empty `ids` to be passed");
+  ok(object.type !== "Literal", "expected identifier as left-most value");
+  return object;
+}
+function toJsxIdOrMemberExpression(ids) {
+  let index2 = -1;
+  let object;
+  while (++index2 < ids.length) {
+    const name2 = ids[index2];
+    ok(
+      typeof name2 === "string" && name(name2, { jsx: true }),
+      "expected valid jsx identifier, not `" + name2 + "`"
+    );
+    const id = { type: "JSXIdentifier", name: name2 };
+    object = object ? { type: "JSXMemberExpression", object, property: id } : id;
+  }
+  ok(object, "expected non-empty `ids` to be passed");
+  return object;
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-document.js
+function recmaDocument(options) {
+  const baseUrl = options.baseUrl || void 0;
+  const baseHref = typeof baseUrl === "object" ? baseUrl.href : baseUrl;
+  const outputFormat = options.outputFormat || "program";
+  const pragma = options.pragma === void 0 ? "React.createElement" : options.pragma;
+  const pragmaFrag = options.pragmaFrag === void 0 ? "React.Fragment" : options.pragmaFrag;
+  const pragmaImportSource = options.pragmaImportSource || "react";
+  const jsxImportSource = options.jsxImportSource || "react";
+  const jsxRuntime = options.jsxRuntime || "automatic";
+  return function(tree, file) {
+    const exportedIdentifiers = [];
+    const replacement = [];
+    let exportAllCount = 0;
+    let layout;
+    let content3;
+    let child;
+    if (jsxRuntime === "classic" && pragmaFrag) {
+      injectPragma(tree, "@jsxFrag", pragmaFrag);
+    }
+    if (jsxRuntime === "classic" && pragma) {
+      injectPragma(tree, "@jsx", pragma);
+    }
+    if (jsxRuntime === "automatic" && jsxImportSource) {
+      injectPragma(tree, "@jsxImportSource", jsxImportSource);
+    }
+    if (jsxRuntime) {
+      injectPragma(tree, "@jsxRuntime", jsxRuntime);
+    }
+    if (jsxRuntime === "classic" && pragmaImportSource) {
+      if (!pragma) {
+        throw new Error(
+          "Missing `pragma` in classic runtime with `pragmaImportSource`"
+        );
+      }
+      handleEsm({
+        type: "ImportDeclaration",
+        specifiers: [
+          {
+            type: "ImportDefaultSpecifier",
+            local: { type: "Identifier", name: pragma.split(".")[0] }
+          }
+        ],
+        source: { type: "Literal", value: pragmaImportSource }
+      });
+    }
+    for (child of tree.body) {
+      if (child.type === "ExportDefaultDeclaration") {
+        if (layout) {
+          file.fail(
+            "Unexpected duplicate layout, expected a single layout (previous: " + stringifyPosition(positionFromEstree(layout)) + ")",
+            {
+              ancestors: [tree, child],
+              place: positionFromEstree(child),
+              ruleId: "duplicate-layout",
+              source: "recma-document"
+            }
+          );
+        }
+        layout = child;
+        replacement.push({
+          type: "VariableDeclaration",
+          kind: "const",
+          declarations: [
+            {
+              type: "VariableDeclarator",
+              id: { type: "Identifier", name: "MDXLayout" },
+              init: isDeclaration(child.declaration) ? declarationToExpression(child.declaration) : child.declaration
+            }
+          ]
+        });
+      } else if (child.type === "ExportNamedDeclaration" && child.source) {
+        const source = (
+          /** @type {SimpleLiteral} */
+          child.source
+        );
+        child.specifiers = child.specifiers.filter(function(specifier) {
+          if (specifier.exported.name === "default") {
+            if (layout) {
+              file.fail(
+                "Unexpected duplicate layout, expected a single layout (previous: " + stringifyPosition(positionFromEstree(layout)) + ")",
+                {
+                  ancestors: [tree, child, specifier],
+                  place: positionFromEstree(child),
+                  ruleId: "duplicate-layout",
+                  source: "recma-document"
+                }
+              );
+            }
+            layout = specifier;
+            const specifiers = [];
+            if (specifier.local.name === "default") {
+              specifiers.push({
+                type: "ImportDefaultSpecifier",
+                local: { type: "Identifier", name: "MDXLayout" }
+              });
+            } else {
+              const importSpecifier = {
+                type: "ImportSpecifier",
+                imported: specifier.local,
+                local: { type: "Identifier", name: "MDXLayout" }
+              };
+              create(specifier.local, importSpecifier);
+              specifiers.push(importSpecifier);
+            }
+            const from = { type: "Literal", value: source.value };
+            create(source, from);
+            const declaration = {
+              type: "ImportDeclaration",
+              specifiers,
+              source: from
+            };
+            create(specifier, declaration);
+            handleEsm(declaration);
+            return false;
+          }
+          return true;
+        });
+        if (child.specifiers.length > 0) {
+          handleExport(child);
+        }
+      } else if (child.type === "ExportNamedDeclaration" || child.type === "ExportAllDeclaration") {
+        handleExport(child);
+      } else if (child.type === "ImportDeclaration") {
+        handleEsm(child);
+      } else if (child.type === "ExpressionStatement" && (child.expression.type === "JSXElement" || // @ts-expect-error: `estree-jsx` does not register `JSXFragment` as an expression.
+      child.expression.type === "JSXFragment")) {
+        content3 = true;
+        replacement.push(
+          ...createMdxContent(child.expression, outputFormat, Boolean(layout))
+        );
+      } else {
+        replacement.push(child);
+      }
+    }
+    if (!content3) {
+      replacement.push(
+        ...createMdxContent(void 0, outputFormat, Boolean(layout))
+      );
+    }
+    exportedIdentifiers.push(["MDXContent", "default"]);
+    if (outputFormat === "function-body") {
+      replacement.push({
+        type: "ReturnStatement",
+        argument: {
+          type: "ObjectExpression",
+          properties: [
+            ...Array.from({ length: exportAllCount }).map(
+              /**
+               * @param {undefined} _
+               *   Nothing.
+               * @param {number} index
+               *   Index.
+               * @returns {SpreadElement}
+               *   Node.
+               */
+              function(_, index2) {
+                return {
+                  type: "SpreadElement",
+                  argument: {
+                    type: "Identifier",
+                    name: "_exportAll" + (index2 + 1)
+                  }
+                };
+              }
+            ),
+            ...exportedIdentifiers.map(function(d) {
+              const property = {
+                type: "Property",
+                kind: "init",
+                method: false,
+                computed: false,
+                shorthand: typeof d === "string",
+                key: {
+                  type: "Identifier",
+                  name: typeof d === "string" ? d : d[1]
+                },
+                value: {
+                  type: "Identifier",
+                  name: typeof d === "string" ? d : d[0]
+                }
+              };
+              return property;
+            })
+          ]
+        }
+      });
+    }
+    tree.body = replacement;
+    let usesImportMetaUrlVariable = false;
+    let usesResolveDynamicHelper = false;
+    if (baseHref || outputFormat === "function-body") {
+      walk(tree, {
+        enter(node2) {
+          if ((node2.type === "ExportAllDeclaration" || node2.type === "ExportNamedDeclaration" || node2.type === "ImportDeclaration") && node2.source) {
+            ok(baseHref, "unexpected missing `baseHref` in branch");
+            let value = node2.source.value;
+            ok(typeof value === "string", "expected string source");
+            try {
+              new URL(value);
+            } catch {
+              if (value.startsWith("/") || value.startsWith("./") || value.startsWith("../")) {
+                value = new URL(value, baseHref).href;
+              } else {
+              }
+            }
+            const replacement2 = { type: "Literal", value };
+            create(node2.source, replacement2);
+            node2.source = replacement2;
+            return;
+          }
+          if (node2.type === "ImportExpression") {
+            usesResolveDynamicHelper = true;
+            const replacement2 = {
+              type: "CallExpression",
+              callee: { type: "Identifier", name: "_resolveDynamicMdxSpecifier" },
+              arguments: [node2.source],
+              optional: false
+            };
+            node2.source = replacement2;
+            return;
+          }
+          if (node2.type === "MemberExpression" && "object" in node2 && node2.object.type === "MetaProperty" && node2.property.type === "Identifier" && node2.object.meta.name === "import" && node2.object.property.name === "meta" && node2.property.name === "url") {
+            usesImportMetaUrlVariable = true;
+            const replacement2 = { type: "Identifier", name: "_importMetaUrl" };
+            create(node2, replacement2);
+            this.replace(replacement2);
+          }
+        }
+      });
+    }
+    if (usesResolveDynamicHelper) {
+      if (!baseHref) {
+        usesImportMetaUrlVariable = true;
+      }
+      tree.body.push(
+        resolveDynamicMdxSpecifier(
+          baseHref ? { type: "Literal", value: baseHref } : { type: "Identifier", name: "_importMetaUrl" }
+        )
+      );
+    }
+    if (usesImportMetaUrlVariable) {
+      ok(
+        outputFormat === "function-body",
+        "expected `function-body` when using dynamic url injection"
+      );
+      tree.body.unshift(...createImportMetaUrlVariable());
+    }
+    function handleExport(node2) {
+      if (node2.type === "ExportNamedDeclaration") {
+        if (node2.declaration) {
+          exportedIdentifiers.push(
+            ...analyze(node2.declaration).scope.declarations.keys()
+          );
+        }
+        for (child of node2.specifiers) {
+          exportedIdentifiers.push(child.exported.name);
+        }
+      }
+      handleEsm(node2);
+    }
+    function handleEsm(node2) {
+      let replace;
+      let init;
+      if (outputFormat === "function-body") {
+        if (
+          // Always have a source:
+          node2.type === "ImportDeclaration" || node2.type === "ExportAllDeclaration" || // Source optional:
+          node2.type === "ExportNamedDeclaration" && node2.source
+        ) {
+          ok(node2.source, "expected `node.source` to be defined");
+          const argument = { type: "ImportExpression", source: node2.source };
+          create(node2, argument);
+          init = { type: "AwaitExpression", argument };
+          if ((node2.type === "ImportDeclaration" || node2.type === "ExportNamedDeclaration") && node2.specifiers.length === 0) {
+            replace = { type: "ExpressionStatement", expression: init };
+          } else {
+            replace = {
+              type: "VariableDeclaration",
+              kind: "const",
+              declarations: node2.type === "ExportAllDeclaration" ? [
+                {
+                  type: "VariableDeclarator",
+                  id: {
+                    type: "Identifier",
+                    name: "_exportAll" + ++exportAllCount
+                  },
+                  init
+                }
+              ] : specifiersToDeclarations(node2.specifiers, init)
+            };
+          }
+        } else if (node2.declaration) {
+          replace = node2.declaration;
+        } else {
+          const declarators = node2.specifiers.filter(function(specifier) {
+            return specifier.local.name !== specifier.exported.name;
+          }).map(function(specifier) {
+            return {
+              type: "VariableDeclarator",
+              id: specifier.exported,
+              init: specifier.local
+            };
+          });
+          if (declarators.length > 0) {
+            replace = {
+              type: "VariableDeclaration",
+              kind: "const",
+              declarations: declarators
+            };
+          }
+        }
+      } else {
+        replace = node2;
+      }
+      if (replace) {
+        replacement.push(replace);
+      }
+    }
+  };
+  function createMdxContent(content3, outputFormat2, hasInternalLayout) {
+    const element2 = {
+      type: "JSXElement",
+      openingElement: {
+        type: "JSXOpeningElement",
+        name: { type: "JSXIdentifier", name: "MDXLayout" },
+        attributes: [
+          {
+            type: "JSXSpreadAttribute",
+            argument: { type: "Identifier", name: "props" }
+          }
+        ],
+        selfClosing: false
+      },
+      closingElement: {
+        type: "JSXClosingElement",
+        name: { type: "JSXIdentifier", name: "MDXLayout" }
+      },
+      children: [
+        {
+          type: "JSXElement",
+          openingElement: {
+            type: "JSXOpeningElement",
+            name: { type: "JSXIdentifier", name: "_createMdxContent" },
+            attributes: [
+              {
+                type: "JSXSpreadAttribute",
+                argument: { type: "Identifier", name: "props" }
+              }
+            ],
+            selfClosing: true
+          },
+          closingElement: null,
+          children: []
+        }
+      ]
+    };
+    let result = (
+      /** @type {Expression} */
+      element2
+    );
+    if (!hasInternalLayout) {
+      result = {
+        type: "ConditionalExpression",
+        test: { type: "Identifier", name: "MDXLayout" },
+        consequent: result,
+        alternate: {
+          type: "CallExpression",
+          callee: { type: "Identifier", name: "_createMdxContent" },
+          arguments: [{ type: "Identifier", name: "props" }],
+          optional: false
+        }
+      };
+    }
+    let argument = (
+      // Cast because TS otherwise does not think `JSXFragment`s are expressions.
+      /** @type {Readonly<Expression> | Readonly<JSXFragment>} */
+      content3 || { type: "Identifier", name: "undefined" }
+    );
+    if (argument.type === "JSXFragment" && argument.children.length === 1 && argument.children[0].type === "JSXElement") {
+      argument = argument.children[0];
+    }
+    let awaitExpression = false;
+    walk(argument, {
+      enter(node2) {
+        if (node2.type === "ArrowFunctionExpression" || node2.type === "FunctionDeclaration" || node2.type === "FunctionExpression") {
+          return this.skip();
+        }
+        if (node2.type === "AwaitExpression" || /* c8 ignore next 2 -- can only occur in a function (which then can
+         * only be async, so skipped it) */
+        node2.type === "ForOfStatement" && node2.await) {
+          awaitExpression = true;
+        }
+      }
+    });
+    const declaration = {
+      type: "FunctionDeclaration",
+      id: { type: "Identifier", name: "MDXContent" },
+      params: [
+        {
+          type: "AssignmentPattern",
+          left: { type: "Identifier", name: "props" },
+          right: { type: "ObjectExpression", properties: [] }
+        }
+      ],
+      body: {
+        type: "BlockStatement",
+        body: [{ type: "ReturnStatement", argument: result }]
+      }
+    };
+    return [
+      {
+        type: "FunctionDeclaration",
+        async: awaitExpression,
+        id: { type: "Identifier", name: "_createMdxContent" },
+        params: [{ type: "Identifier", name: "props" }],
+        body: {
+          type: "BlockStatement",
+          body: [
+            {
+              type: "ReturnStatement",
+              // Cast because TS doesn’t think `JSXFragment` is an expression.
+              // eslint-disable-next-line object-shorthand
+              argument: (
+                /** @type {Expression} */
+                argument
+              )
+            }
+          ]
+        }
+      },
+      outputFormat2 === "program" ? { type: "ExportDefaultDeclaration", declaration } : declaration
+    ];
+  }
+}
+function injectPragma(tree, name2, value) {
+  tree.comments?.unshift({
+    type: "Block",
+    value: name2 + " " + value,
+    data: { _mdxIsPragmaComment: true }
+  });
+}
+function resolveDynamicMdxSpecifier(importMetaUrl) {
+  return {
+    type: "FunctionDeclaration",
+    id: { type: "Identifier", name: "_resolveDynamicMdxSpecifier" },
+    generator: false,
+    async: false,
+    params: [{ type: "Identifier", name: "d" }],
+    body: {
+      type: "BlockStatement",
+      body: [
+        {
+          type: "IfStatement",
+          test: {
+            type: "BinaryExpression",
+            left: {
+              type: "UnaryExpression",
+              operator: "typeof",
+              prefix: true,
+              argument: { type: "Identifier", name: "d" }
+            },
+            operator: "!==",
+            right: { type: "Literal", value: "string" }
+          },
+          consequent: {
+            type: "ReturnStatement",
+            argument: { type: "Identifier", name: "d" }
+          },
+          alternate: null
+        },
+        // To do: use `URL.canParse` when widely supported (see commented
+        // out code below).
+        {
+          type: "TryStatement",
+          block: {
+            type: "BlockStatement",
+            body: [
+              {
+                type: "ExpressionStatement",
+                expression: {
+                  type: "NewExpression",
+                  callee: { type: "Identifier", name: "URL" },
+                  arguments: [{ type: "Identifier", name: "d" }]
+                }
+              },
+              {
+                type: "ReturnStatement",
+                argument: { type: "Identifier", name: "d" }
+              }
+            ]
+          },
+          handler: {
+            type: "CatchClause",
+            param: null,
+            body: { type: "BlockStatement", body: [] }
+          },
+          finalizer: null
+        },
+        // To do: use `URL.canParse` when widely supported.
+        // {
+        //   type: 'IfStatement',
+        //   test: {
+        //     type: 'CallExpression',
+        //     callee: toIdOrMemberExpression(['URL', 'canParse']),
+        //     arguments: [{type: 'Identifier', name: 'd'}],
+        //     optional: false
+        //   },
+        //   consequent: {
+        //     type: 'ReturnStatement',
+        //     argument: {type: 'Identifier', name: 'd'}
+        //   },
+        //   alternate: null
+        // },
+        {
+          type: "IfStatement",
+          test: {
+            type: "LogicalExpression",
+            left: {
+              type: "LogicalExpression",
+              left: {
+                type: "CallExpression",
+                callee: toIdOrMemberExpression(["d", "startsWith"]),
+                arguments: [{ type: "Literal", value: "/" }],
+                optional: false
+              },
+              operator: "||",
+              right: {
+                type: "CallExpression",
+                callee: toIdOrMemberExpression(["d", "startsWith"]),
+                arguments: [{ type: "Literal", value: "./" }],
+                optional: false
+              }
+            },
+            operator: "||",
+            right: {
+              type: "CallExpression",
+              callee: toIdOrMemberExpression(["d", "startsWith"]),
+              arguments: [{ type: "Literal", value: "../" }],
+              optional: false
+            }
+          },
+          consequent: {
+            type: "ReturnStatement",
+            argument: {
+              type: "MemberExpression",
+              object: {
+                type: "NewExpression",
+                callee: { type: "Identifier", name: "URL" },
+                arguments: [{ type: "Identifier", name: "d" }, importMetaUrl]
+              },
+              property: { type: "Identifier", name: "href" },
+              computed: false,
+              optional: false
+            }
+          },
+          alternate: null
+        },
+        {
+          type: "ReturnStatement",
+          argument: { type: "Identifier", name: "d" }
+        }
+      ]
+    }
+  };
+}
+function createImportMetaUrlVariable() {
+  return [
+    {
+      type: "VariableDeclaration",
+      declarations: [
+        {
+          type: "VariableDeclarator",
+          id: { type: "Identifier", name: "_importMetaUrl" },
+          init: toIdOrMemberExpression(["arguments", 0, "baseUrl"])
+        }
+      ],
+      kind: "const"
+    },
+    {
+      type: "IfStatement",
+      test: {
+        type: "UnaryExpression",
+        operator: "!",
+        prefix: true,
+        argument: { type: "Identifier", name: "_importMetaUrl" }
+      },
+      consequent: {
+        type: "ThrowStatement",
+        argument: {
+          type: "NewExpression",
+          callee: { type: "Identifier", name: "Error" },
+          arguments: [
+            {
+              type: "Literal",
+              value: "Unexpected missing `options.baseUrl` needed to support `export \u2026 from`, `import`, or `import.meta.url` when generating `function-body`"
+            }
+          ]
+        }
+      },
+      alternate: null
+    }
+  ];
+}
+
+// node_modules/estree-util-build-jsx/lib/index.js
+var regex = /@(jsx|jsxFrag|jsxImportSource|jsxRuntime)\s+(\S+)/g;
+function buildJsx(tree, options) {
+  const config = options || {};
+  let automatic = config.runtime === "automatic";
+  const annotations = {};
+  const imports = {};
+  walk(tree, {
+    enter(node2) {
+      if (node2.type === "Program") {
+        const comments = node2.comments || [];
+        let index2 = -1;
+        while (++index2 < comments.length) {
+          regex.lastIndex = 0;
+          let match = regex.exec(comments[index2].value);
+          while (match) {
+            annotations[match[1]] = match[2];
+            match = regex.exec(comments[index2].value);
+          }
+        }
+        if (annotations.jsxRuntime) {
+          if (annotations.jsxRuntime === "automatic") {
+            automatic = true;
+            if (annotations.jsx) {
+              throw new Error("Unexpected `@jsx` pragma w/ automatic runtime");
+            }
+            if (annotations.jsxFrag) {
+              throw new Error(
+                "Unexpected `@jsxFrag` pragma w/ automatic runtime"
+              );
+            }
+          } else if (annotations.jsxRuntime === "classic") {
+            automatic = false;
+            if (annotations.jsxImportSource) {
+              throw new Error(
+                "Unexpected `@jsxImportSource` w/ classic runtime"
+              );
+            }
+          } else {
+            throw new Error(
+              "Unexpected `jsxRuntime` `" + annotations.jsxRuntime + "`, expected `automatic` or `classic`"
+            );
+          }
+        }
+      }
+    },
+    // eslint-disable-next-line complexity
+    leave(node2) {
+      if (node2.type === "Program") {
+        const specifiers = [];
+        if (imports.fragment) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "Fragment" },
+            local: { type: "Identifier", name: "_Fragment" }
+          });
+        }
+        if (imports.jsx) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "jsx" },
+            local: { type: "Identifier", name: "_jsx" }
+          });
+        }
+        if (imports.jsxs) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "jsxs" },
+            local: { type: "Identifier", name: "_jsxs" }
+          });
+        }
+        if (imports.jsxDEV) {
+          specifiers.push({
+            type: "ImportSpecifier",
+            imported: { type: "Identifier", name: "jsxDEV" },
+            local: { type: "Identifier", name: "_jsxDEV" }
+          });
+        }
+        if (specifiers.length > 0) {
+          let injectIndex = 0;
+          while (injectIndex < node2.body.length) {
+            const child = node2.body[injectIndex];
+            if ("directive" in child && child.directive) {
+              injectIndex++;
+            } else {
+              break;
+            }
+          }
+          node2.body.splice(injectIndex, 0, {
+            type: "ImportDeclaration",
+            specifiers,
+            source: {
+              type: "Literal",
+              value: (annotations.jsxImportSource || config.importSource || "react") + (config.development ? "/jsx-dev-runtime" : "/jsx-runtime")
+            }
+          });
+        }
+      }
+      if (node2.type !== "JSXElement" && node2.type !== "JSXFragment") {
+        return;
+      }
+      const children = [];
+      let index2 = -1;
+      while (++index2 < node2.children.length) {
+        const child = node2.children[index2];
+        if (child.type === "JSXExpressionContainer") {
+          if (child.expression.type !== "JSXEmptyExpression") {
+            children.push(child.expression);
+          }
+        } else if (child.type === "JSXText") {
+          const value = child.value.replace(/\t/g, " ").replace(/ *(\r?\n|\r) */g, "\n").replace(/\n+/g, "\n").replace(/\n+$/, "").replace(/^\n+/, "").replace(/\n/g, " ");
+          if (value) {
+            const text5 = { type: "Literal", value };
+            create2(child, text5);
+            children.push(text5);
+          }
+        } else {
+          ok(
+            child.type !== "JSXElement" && child.type !== "JSXFragment" && child.type !== "JSXSpreadChild"
+          );
+          children.push(child);
+        }
+      }
+      let name2;
+      const fields = [];
+      let parameters = [];
+      let key;
+      if (node2.type === "JSXElement") {
+        name2 = toIdentifier(node2.openingElement.name);
+        if (name2.type === "Identifier" && /^[a-z]/.test(name2.name)) {
+          const next = { type: "Literal", value: name2.name };
+          create2(name2, next);
+          name2 = next;
+        }
+        let spread;
+        const attributes = node2.openingElement.attributes;
+        let index3 = -1;
+        while (++index3 < attributes.length) {
+          const attribute = attributes[index3];
+          if (attribute.type === "JSXSpreadAttribute") {
+            if (attribute.argument.type === "ObjectExpression") {
+              fields.push(...attribute.argument.properties);
+            } else {
+              fields.push({ type: "SpreadElement", argument: attribute.argument });
+            }
+            spread = true;
+          } else {
+            const prop = toProperty(attribute);
+            if (automatic && prop.key.type === "Identifier" && prop.key.name === "key") {
+              if (spread) {
+                throw new Error(
+                  "Expected `key` to come before any spread expressions"
+                );
+              }
+              const value = prop.value;
+              ok(
+                value.type !== "AssignmentPattern" && value.type !== "ArrayPattern" && value.type !== "ObjectPattern" && value.type !== "RestElement"
+              );
+              key = value;
+            } else {
+              fields.push(prop);
+            }
+          }
+        }
+      } else if (automatic) {
+        imports.fragment = true;
+        name2 = { type: "Identifier", name: "_Fragment" };
+      } else {
+        name2 = toMemberExpression(
+          annotations.jsxFrag || config.pragmaFrag || "React.Fragment"
+        );
+      }
+      if (automatic) {
+        if (children.length > 0) {
+          fields.push({
+            type: "Property",
+            key: { type: "Identifier", name: "children" },
+            value: children.length > 1 ? { type: "ArrayExpression", elements: children } : children[0],
+            kind: "init",
+            method: false,
+            shorthand: false,
+            computed: false
+          });
+        }
+      } else {
+        parameters = children;
+      }
+      let callee;
+      if (automatic) {
+        parameters.push({ type: "ObjectExpression", properties: fields });
+        if (key) {
+          parameters.push(key);
+        } else if (config.development) {
+          parameters.push({ type: "Identifier", name: "undefined" });
+        }
+        const isStaticChildren = children.length > 1;
+        if (config.development) {
+          imports.jsxDEV = true;
+          callee = {
+            type: "Identifier",
+            name: "_jsxDEV"
+          };
+          parameters.push({ type: "Literal", value: isStaticChildren });
+          const source = {
+            type: "ObjectExpression",
+            properties: [
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: "init",
+                key: { type: "Identifier", name: "fileName" },
+                value: {
+                  type: "Literal",
+                  value: config.filePath || "<source.js>"
+                }
+              }
+            ]
+          };
+          if (node2.loc) {
+            source.properties.push(
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: "init",
+                key: { type: "Identifier", name: "lineNumber" },
+                value: { type: "Literal", value: node2.loc.start.line }
+              },
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                kind: "init",
+                key: { type: "Identifier", name: "columnNumber" },
+                value: { type: "Literal", value: node2.loc.start.column + 1 }
+              }
+            );
+          }
+          parameters.push(source, { type: "ThisExpression" });
+        } else if (isStaticChildren) {
+          imports.jsxs = true;
+          callee = { type: "Identifier", name: "_jsxs" };
+        } else {
+          imports.jsx = true;
+          callee = { type: "Identifier", name: "_jsx" };
+        }
+      } else {
+        if (fields.length > 0) {
+          parameters.unshift({ type: "ObjectExpression", properties: fields });
+        } else if (parameters.length > 0) {
+          parameters.unshift({ type: "Literal", value: null });
+        }
+        callee = toMemberExpression(
+          annotations.jsx || config.pragma || "React.createElement"
+        );
+      }
+      parameters.unshift(name2);
+      const call = {
+        type: "CallExpression",
+        callee,
+        arguments: parameters,
+        optional: false
+      };
+      create2(node2, call);
+      this.replace(call);
+    }
+  });
+}
+function toProperty(node2) {
+  let value;
+  if (node2.value) {
+    if (node2.value.type === "JSXExpressionContainer") {
+      const valueExpression = node2.value.expression;
+      ok(
+        valueExpression.type !== "JSXEmptyExpression",
+        "`JSXEmptyExpression` is not allowed in props."
+      );
+      value = valueExpression;
+    } else {
+      const nodeValue = node2.value;
+      ok(
+        nodeValue.type !== "JSXElement" && nodeValue.type !== "JSXFragment",
+        "JSX{Element,Fragment} are already compiled to `CallExpression`"
+      );
+      value = nodeValue;
+      delete value.raw;
+    }
+  } else {
+    value = { type: "Literal", value: true };
+  }
+  const replacement = {
+    type: "Property",
+    key: toIdentifier(node2.name),
+    value,
+    kind: "init",
+    method: false,
+    shorthand: false,
+    computed: false
+  };
+  create2(node2, replacement);
+  return replacement;
+}
+function toIdentifier(node2) {
+  let replace;
+  if (node2.type === "JSXMemberExpression") {
+    const id = toIdentifier(node2.property);
+    replace = {
+      type: "MemberExpression",
+      object: toIdentifier(node2.object),
+      property: id,
+      computed: id.type === "Literal",
+      optional: false
+    };
+  } else if (node2.type === "JSXNamespacedName") {
+    replace = {
+      type: "Literal",
+      value: node2.namespace.name + ":" + node2.name.name
+    };
+  } else {
+    replace = name(node2.name) ? { type: "Identifier", name: node2.name } : { type: "Literal", value: node2.name };
+  }
+  create2(node2, replace);
+  return replace;
+}
+function toMemberExpression(id) {
+  const identifiers = id.split(".");
+  let index2 = -1;
+  let result;
+  while (++index2 < identifiers.length) {
+    const prop = name(identifiers[index2]) ? { type: "Identifier", name: identifiers[index2] } : { type: "Literal", value: identifiers[index2] };
+    result = result ? {
+      type: "MemberExpression",
+      object: result,
+      property: prop,
+      computed: Boolean(index2 && prop.type === "Literal"),
+      optional: false
+    } : prop;
+  }
+  ok(result, "always a result");
+  return result;
+}
+function create2(from, to) {
+  const fields = ["start", "end", "loc", "range", "comments"];
+  let index2 = -1;
+  while (++index2 < fields.length) {
+    const field = fields[index2];
+    if (field in from) {
+      to[field] = from[field];
+    }
+  }
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-jsx-build.js
+function recmaJsxBuild(options) {
+  const { development, outputFormat } = options || {};
+  return function(tree, file) {
+    buildJsx(tree, { development, filePath: file.history[0] });
+    if (tree.comments) {
+      tree.comments = tree.comments.filter(function(d) {
+        return !d.data?._mdxIsPragmaComment;
+      });
+    }
+    if (outputFormat === "function-body") {
+      let index2 = 0;
+      while (index2 < tree.body.length) {
+        const child = tree.body[index2];
+        if ("directive" in child && child.directive) {
+          index2++;
+        } else {
+          break;
+        }
+      }
+      const declaration = tree.body[index2];
+      if (declaration && declaration.type === "ImportDeclaration" && typeof declaration.source.value === "string" && /\/jsx-(dev-)?runtime$/.test(declaration.source.value)) {
+        tree.body[index2] = {
+          type: "VariableDeclaration",
+          kind: "const",
+          declarations: specifiersToDeclarations(
+            declaration.specifiers,
+            toIdOrMemberExpression(["arguments", 0])
+          )
+        };
+      }
+    }
+  };
+}
+
+// node_modules/@mdx-js/mdx/lib/util/estree-util-to-binary-addition.js
+function toBinaryAddition(expressions) {
+  let index2 = -1;
+  let left;
+  while (++index2 < expressions.length) {
+    const right = expressions[index2];
+    left = left ? { type: "BinaryExpression", left, operator: "+", right } : right;
+  }
+  ok(left, "expected non-empty `expressions` to be passed");
+  return left;
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-jsx-rewrite.js
+function recmaJsxRewrite(options) {
+  const { development, outputFormat, providerImportSource } = options;
+  return function(tree, file) {
+    const scopeInfo = analyze(tree);
+    const functionStack = [];
+    let importProvider = false;
+    let createErrorHelper = false;
+    let currentScope;
+    walk(tree, {
+      enter(node2) {
+        const newScope = (
+          /** @type {Scope | undefined} */
+          scopeInfo.map.get(node2)
+        );
+        if (node2.type === "FunctionDeclaration" || node2.type === "FunctionExpression" || node2.type === "ArrowFunctionExpression") {
+          functionStack.push({
+            components: [],
+            idToInvalidComponentName: /* @__PURE__ */ new Map(),
+            node: node2,
+            objects: [],
+            references: {},
+            tags: []
+          });
+          if (isNamedFunction(node2, "MDXContent") && newScope && !inScope(newScope, "MDXLayout")) {
+            functionStack[0].components.push("MDXLayout");
+          }
+        }
+        const functionScope = functionStack[0];
+        if (!functionScope || !isNamedFunction(functionScope.node, "_createMdxContent") && !providerImportSource) {
+          return;
+        }
+        if (newScope) {
+          newScope.node = node2;
+          currentScope = newScope;
+        }
+        if (currentScope && node2.type === "JSXElement") {
+          let name2 = node2.openingElement.name;
+          if (name2.type === "JSXMemberExpression") {
+            const ids = [];
+            while (name2.type === "JSXMemberExpression") {
+              ids.unshift(name2.property.name);
+              name2 = name2.object;
+            }
+            ids.unshift(name2.name);
+            const fullId = ids.join(".");
+            const id = name2.name;
+            const isInScope = inScope(currentScope, id);
+            if (!Object.hasOwn(functionScope.references, fullId)) {
+              const parentScope = (
+                /** @type {Scope | undefined} */
+                currentScope.parent
+              );
+              if (!isInScope || // If the parent scope is `_createMdxContent`, then this
+              // references a component we can add a check statement for.
+              parentScope && parentScope.node.type === "FunctionDeclaration" && isNamedFunction(parentScope.node, "_createMdxContent")) {
+                functionScope.references[fullId] = { component: true, node: node2 };
+              }
+            }
+            if (!functionScope.objects.includes(id) && !isInScope) {
+              functionScope.objects.push(id);
+            }
+          } else if (name2.type === "JSXNamespacedName") {
+          } else if (name(name2.name) && !/^[a-z]/.test(name2.name)) {
+            const id = name2.name;
+            if (!inScope(currentScope, id)) {
+              if (id !== "MDXLayout" && !Object.hasOwn(functionScope.references, id)) {
+                functionScope.references[id] = { component: true, node: node2 };
+              }
+              if (!functionScope.components.includes(id)) {
+                functionScope.components.push(id);
+              }
+            }
+          } else if (node2.data && node2.data._mdxExplicitJsx) {
+          } else {
+            const id = name2.name;
+            if (!functionScope.tags.includes(id)) {
+              functionScope.tags.push(id);
+            }
+            let jsxIdExpression = ["_components", id];
+            if (name(id) === false) {
+              let invalidComponentName = functionScope.idToInvalidComponentName.get(id);
+              if (invalidComponentName === void 0) {
+                invalidComponentName = `_component${functionScope.idToInvalidComponentName.size}`;
+                functionScope.idToInvalidComponentName.set(
+                  id,
+                  invalidComponentName
+                );
+              }
+              jsxIdExpression = [invalidComponentName];
+            }
+            node2.openingElement.name = toJsxIdOrMemberExpression(jsxIdExpression);
+            if (node2.closingElement) {
+              node2.closingElement.name = toJsxIdOrMemberExpression(jsxIdExpression);
+            }
+          }
+        }
+      },
+      leave(node2) {
+        const defaults = [];
+        const actual = [];
+        const parameters = [];
+        const declarations = [];
+        if (currentScope && currentScope.node === node2) {
+          currentScope = /** @type {Scope} */
+          currentScope.parent;
+        }
+        if (node2.type === "FunctionDeclaration" || node2.type === "FunctionExpression" || node2.type === "ArrowFunctionExpression") {
+          const scopeNode = node2;
+          const scope = functionStack[functionStack.length - 1];
+          let name2;
+          for (name2 of scope.tags.sort()) {
+            defaults.push({
+              type: "Property",
+              kind: "init",
+              key: name(name2) ? { type: "Identifier", name: name2 } : { type: "Literal", value: name2 },
+              value: { type: "Literal", value: name2 },
+              method: false,
+              shorthand: false,
+              computed: false
+            });
+          }
+          actual.push(...scope.components);
+          for (name2 of scope.objects) {
+            if (!actual.includes(name2)) {
+              actual.push(name2);
+            }
+          }
+          actual.sort();
+          const statements = [];
+          if (defaults.length > 0 || actual.length > 0 || scope.idToInvalidComponentName.size > 0) {
+            if (providerImportSource) {
+              importProvider = true;
+              parameters.push({
+                type: "CallExpression",
+                callee: { type: "Identifier", name: "_provideComponents" },
+                arguments: [],
+                optional: false
+              });
+            }
+            if (isNamedFunction(scope.node, "MDXContent") || isNamedFunction(scope.node, "_createMdxContent")) {
+              parameters.push(toIdOrMemberExpression(["props", "components"]));
+            }
+            if (defaults.length > 0 || parameters.length > 1) {
+              for (const parameter of parameters) {
+                defaults.push({ type: "SpreadElement", argument: parameter });
+              }
+            }
+            let componentsInit = defaults.length > 0 ? { type: "ObjectExpression", properties: defaults } : (
+              // If we’re only getting components from `props.components`,
+              // make sure it’s defined.
+              {
+                type: "LogicalExpression",
+                operator: "||",
+                left: parameters[0],
+                right: { type: "ObjectExpression", properties: [] }
+              }
+            );
+            let componentsPattern;
+            if (actual.length > 0) {
+              componentsPattern = {
+                type: "ObjectPattern",
+                properties: actual.map(function(name3) {
+                  return {
+                    type: "Property",
+                    kind: "init",
+                    key: {
+                      type: "Identifier",
+                      name: name3 === "MDXLayout" ? "wrapper" : name3
+                    },
+                    value: { type: "Identifier", name: name3 },
+                    method: false,
+                    shorthand: name3 !== "MDXLayout",
+                    computed: false
+                  };
+                })
+              };
+            }
+            if (scope.tags.length > 0) {
+              declarations.push({
+                type: "VariableDeclarator",
+                id: { type: "Identifier", name: "_components" },
+                init: componentsInit
+              });
+              componentsInit = { type: "Identifier", name: "_components" };
+            }
+            if (isNamedFunction(scope.node, "_createMdxContent")) {
+              for (const [id, componentName] of [
+                ...scope.idToInvalidComponentName
+              ].sort(function([a], [b]) {
+                return a.localeCompare(b);
+              })) {
+                declarations.push({
+                  type: "VariableDeclarator",
+                  id: {
+                    type: "Identifier",
+                    name: componentName
+                  },
+                  init: {
+                    type: "MemberExpression",
+                    object: { type: "Identifier", name: "_components" },
+                    property: { type: "Literal", value: id },
+                    computed: true,
+                    optional: false
+                  }
+                });
+              }
+            }
+            if (componentsPattern) {
+              declarations.push({
+                type: "VariableDeclarator",
+                id: componentsPattern,
+                init: componentsInit
+              });
+            }
+            if (declarations.length > 0) {
+              statements.push({
+                type: "VariableDeclaration",
+                kind: "const",
+                declarations
+              });
+            }
+          }
+          let key;
+          for (key in scope.references) {
+            if (Object.hasOwn(scope.references, key)) {
+              const parts = key.split(".");
+              let index3 = 0;
+              while (++index3 < parts.length) {
+                const partial = parts.slice(0, index3).join(".");
+                if (!Object.hasOwn(scope.references, partial)) {
+                  scope.references[partial] = {
+                    component: false,
+                    node: scope.references[key].node
+                  };
+                }
+              }
+            }
+          }
+          const references = Object.keys(scope.references).sort();
+          let index2 = -1;
+          while (++index2 < references.length) {
+            const id = references[index2];
+            const info = scope.references[id];
+            const place = stringifyPosition(positionFromEstree(info.node));
+            const parameters2 = [
+              { type: "Literal", value: id },
+              { type: "Literal", value: info.component }
+            ];
+            createErrorHelper = true;
+            if (development && place) {
+              parameters2.push({ type: "Literal", value: place });
+            }
+            statements.push({
+              type: "IfStatement",
+              test: {
+                type: "UnaryExpression",
+                operator: "!",
+                prefix: true,
+                argument: toIdOrMemberExpression(id.split("."))
+              },
+              consequent: {
+                type: "ExpressionStatement",
+                expression: {
+                  type: "CallExpression",
+                  callee: { type: "Identifier", name: "_missingMdxReference" },
+                  arguments: parameters2,
+                  optional: false
+                }
+              },
+              alternate: void 0
+            });
+          }
+          if (statements.length > 0) {
+            if (scopeNode.body.type !== "BlockStatement") {
+              scopeNode.body = {
+                type: "BlockStatement",
+                body: [{ type: "ReturnStatement", argument: scopeNode.body }]
+              };
+            }
+            scopeNode.body.body.unshift(...statements);
+          }
+          functionStack.pop();
+        }
+      }
+    });
+    if (importProvider && providerImportSource) {
+      tree.body.unshift(
+        createImportProvider(providerImportSource, outputFormat)
+      );
+    }
+    if (createErrorHelper) {
+      const message = [
+        { type: "Literal", value: "Expected " },
+        {
+          type: "ConditionalExpression",
+          test: { type: "Identifier", name: "component" },
+          consequent: { type: "Literal", value: "component" },
+          alternate: { type: "Literal", value: "object" }
+        },
+        { type: "Literal", value: " `" },
+        { type: "Identifier", name: "id" },
+        {
+          type: "Literal",
+          value: "` to be defined: you likely forgot to import, pass, or provide it."
+        }
+      ];
+      const parameters = [
+        { type: "Identifier", name: "id" },
+        { type: "Identifier", name: "component" }
+      ];
+      if (development) {
+        message.push({
+          type: "ConditionalExpression",
+          test: { type: "Identifier", name: "place" },
+          consequent: toBinaryAddition([
+            { type: "Literal", value: "\nIt\u2019s referenced in your code at `" },
+            { type: "Identifier", name: "place" },
+            {
+              type: "Literal",
+              value: (file.path ? "` in `" + file.path : "") + "`"
+            }
+          ]),
+          alternate: { type: "Literal", value: "" }
+        });
+        parameters.push({ type: "Identifier", name: "place" });
+      }
+      tree.body.push({
+        type: "FunctionDeclaration",
+        id: { type: "Identifier", name: "_missingMdxReference" },
+        generator: false,
+        async: false,
+        params: parameters,
+        body: {
+          type: "BlockStatement",
+          body: [
+            {
+              type: "ThrowStatement",
+              argument: {
+                type: "NewExpression",
+                callee: { type: "Identifier", name: "Error" },
+                arguments: [toBinaryAddition(message)]
+              }
+            }
+          ]
+        }
+      });
+    }
+    if (outputFormat === "function-body") {
+      tree.body.unshift({
+        type: "ExpressionStatement",
+        expression: { type: "Literal", value: "use strict" },
+        directive: "use strict"
+      });
+    }
+  };
+}
+function createImportProvider(providerImportSource, outputFormat) {
+  const specifiers = [
+    {
+      type: "ImportSpecifier",
+      imported: { type: "Identifier", name: "useMDXComponents" },
+      local: { type: "Identifier", name: "_provideComponents" }
+    }
+  ];
+  return outputFormat === "function-body" ? {
+    type: "VariableDeclaration",
+    kind: "const",
+    declarations: specifiersToDeclarations(
+      specifiers,
+      toIdOrMemberExpression(["arguments", 0])
+    )
+  } : {
+    type: "ImportDeclaration",
+    specifiers,
+    source: { type: "Literal", value: providerImportSource }
+  };
+}
+function isNamedFunction(node2, name2) {
+  return Boolean(node2 && "id" in node2 && node2.id && node2.id.name === name2);
+}
+function inScope(scope, id) {
+  let currentScope = scope;
+  while (currentScope) {
+    if (currentScope.declarations.has(id)) {
+      return true;
+    }
+    currentScope = /** @type {Scope | undefined} */
+    currentScope.parent || void 0;
+  }
+  return false;
+}
+
+// node_modules/astring/dist/astring.mjs
+var { stringify } = JSON;
+if (!String.prototype.repeat) {
+  throw new Error(
+    "String.prototype.repeat is undefined, see https://github.com/davidbonnet/astring#installation"
+  );
+}
+if (!String.prototype.endsWith) {
+  throw new Error(
+    "String.prototype.endsWith is undefined, see https://github.com/davidbonnet/astring#installation"
+  );
+}
+var OPERATOR_PRECEDENCE = {
+  "||": 2,
+  "??": 3,
+  "&&": 4,
+  "|": 5,
+  "^": 6,
+  "&": 7,
+  "==": 8,
+  "!=": 8,
+  "===": 8,
+  "!==": 8,
+  "<": 9,
+  ">": 9,
+  "<=": 9,
+  ">=": 9,
+  in: 9,
+  instanceof: 9,
+  "<<": 10,
+  ">>": 10,
+  ">>>": 10,
+  "+": 11,
+  "-": 11,
+  "*": 12,
+  "%": 12,
+  "/": 12,
+  "**": 13
+};
+var NEEDS_PARENTHESES = 17;
+var EXPRESSIONS_PRECEDENCE = {
+  // Definitions
+  ArrayExpression: 20,
+  TaggedTemplateExpression: 20,
+  ThisExpression: 20,
+  Identifier: 20,
+  PrivateIdentifier: 20,
+  Literal: 18,
+  TemplateLiteral: 20,
+  Super: 20,
+  SequenceExpression: 20,
+  // Operations
+  MemberExpression: 19,
+  ChainExpression: 19,
+  CallExpression: 19,
+  NewExpression: 19,
+  // Other definitions
+  ArrowFunctionExpression: NEEDS_PARENTHESES,
+  ClassExpression: NEEDS_PARENTHESES,
+  FunctionExpression: NEEDS_PARENTHESES,
+  ObjectExpression: NEEDS_PARENTHESES,
+  // Other operations
+  UpdateExpression: 16,
+  UnaryExpression: 15,
+  AwaitExpression: 15,
+  BinaryExpression: 14,
+  LogicalExpression: 13,
+  ConditionalExpression: 4,
+  AssignmentExpression: 3,
+  YieldExpression: 2,
+  RestElement: 1
+};
+function formatSequence(state, nodes) {
+  const { generator } = state;
+  state.write("(");
+  if (nodes != null && nodes.length > 0) {
+    generator[nodes[0].type](nodes[0], state);
+    const { length } = nodes;
+    for (let i = 1; i < length; i++) {
+      const param = nodes[i];
+      state.write(", ");
+      generator[param.type](param, state);
+    }
+  }
+  state.write(")");
+}
+function expressionNeedsParenthesis(state, node2, parentNode, isRightHand) {
+  const nodePrecedence = state.expressionsPrecedence[node2.type];
+  if (nodePrecedence === NEEDS_PARENTHESES) {
+    return true;
+  }
+  const parentNodePrecedence = state.expressionsPrecedence[parentNode.type];
+  if (nodePrecedence !== parentNodePrecedence) {
+    return !isRightHand && nodePrecedence === 15 && parentNodePrecedence === 14 && parentNode.operator === "**" || nodePrecedence < parentNodePrecedence;
+  }
+  if (nodePrecedence !== 13 && nodePrecedence !== 14) {
+    return false;
+  }
+  if (node2.operator === "**" && parentNode.operator === "**") {
+    return !isRightHand;
+  }
+  if (nodePrecedence === 13 && parentNodePrecedence === 13 && (node2.operator === "??" || parentNode.operator === "??")) {
+    return true;
+  }
+  if (isRightHand) {
+    return OPERATOR_PRECEDENCE[node2.operator] <= OPERATOR_PRECEDENCE[parentNode.operator];
+  }
+  return OPERATOR_PRECEDENCE[node2.operator] < OPERATOR_PRECEDENCE[parentNode.operator];
+}
+function formatExpression(state, node2, parentNode, isRightHand) {
+  const { generator } = state;
+  if (expressionNeedsParenthesis(state, node2, parentNode, isRightHand)) {
+    state.write("(");
+    generator[node2.type](node2, state);
+    state.write(")");
+  } else {
+    generator[node2.type](node2, state);
+  }
+}
+function reindent(state, text5, indent2, lineEnd) {
+  const lines = text5.split("\n");
+  const end = lines.length - 1;
+  state.write(lines[0].trim());
+  if (end > 0) {
+    state.write(lineEnd);
+    for (let i = 1; i < end; i++) {
+      state.write(indent2 + lines[i].trim() + lineEnd);
+    }
+    state.write(indent2 + lines[end].trim());
+  }
+}
+function formatComments(state, comments, indent2, lineEnd) {
+  const { length } = comments;
+  for (let i = 0; i < length; i++) {
+    const comment2 = comments[i];
+    state.write(indent2);
+    if (comment2.type[0] === "L") {
+      state.write("// " + comment2.value.trim() + "\n", comment2);
+    } else {
+      state.write("/*");
+      reindent(state, comment2.value, indent2, lineEnd);
+      state.write("*/" + lineEnd);
+    }
+  }
+}
+function hasCallExpression(node2) {
+  let currentNode = node2;
+  while (currentNode != null) {
+    const { type } = currentNode;
+    if (type[0] === "C" && type[1] === "a") {
+      return true;
+    } else if (type[0] === "M" && type[1] === "e" && type[2] === "m") {
+      currentNode = currentNode.object;
+    } else {
+      return false;
+    }
+  }
+}
+function formatVariableDeclaration(state, node2) {
+  const { generator } = state;
+  const { declarations } = node2;
+  state.write(node2.kind + " ");
+  const { length } = declarations;
+  if (length > 0) {
+    generator.VariableDeclarator(declarations[0], state);
+    for (let i = 1; i < length; i++) {
+      state.write(", ");
+      generator.VariableDeclarator(declarations[i], state);
+    }
+  }
+}
+var ForInStatement;
+var FunctionDeclaration;
+var RestElement;
+var BinaryExpression;
+var ArrayExpression;
+var BlockStatement;
+var GENERATOR = {
+  /*
+  Default generator.
+  */
+  Program(node2, state) {
+    const indent2 = state.indent.repeat(state.indentLevel);
+    const { lineEnd, writeComments } = state;
+    if (writeComments && node2.comments != null) {
+      formatComments(state, node2.comments, indent2, lineEnd);
+    }
+    const statements = node2.body;
+    const { length } = statements;
+    for (let i = 0; i < length; i++) {
+      const statement = statements[i];
+      if (writeComments && statement.comments != null) {
+        formatComments(state, statement.comments, indent2, lineEnd);
+      }
+      state.write(indent2);
+      this[statement.type](statement, state);
+      state.write(lineEnd);
+    }
+    if (writeComments && node2.trailingComments != null) {
+      formatComments(state, node2.trailingComments, indent2, lineEnd);
+    }
+  },
+  BlockStatement: BlockStatement = function(node2, state) {
+    const indent2 = state.indent.repeat(state.indentLevel++);
+    const { lineEnd, writeComments } = state;
+    const statementIndent = indent2 + state.indent;
+    state.write("{");
+    const statements = node2.body;
+    if (statements != null && statements.length > 0) {
+      state.write(lineEnd);
+      if (writeComments && node2.comments != null) {
+        formatComments(state, node2.comments, statementIndent, lineEnd);
+      }
+      const { length } = statements;
+      for (let i = 0; i < length; i++) {
+        const statement = statements[i];
+        if (writeComments && statement.comments != null) {
+          formatComments(state, statement.comments, statementIndent, lineEnd);
+        }
+        state.write(statementIndent);
+        this[statement.type](statement, state);
+        state.write(lineEnd);
+      }
+      state.write(indent2);
+    } else {
+      if (writeComments && node2.comments != null) {
+        state.write(lineEnd);
+        formatComments(state, node2.comments, statementIndent, lineEnd);
+        state.write(indent2);
+      }
+    }
+    if (writeComments && node2.trailingComments != null) {
+      formatComments(state, node2.trailingComments, statementIndent, lineEnd);
+    }
+    state.write("}");
+    state.indentLevel--;
+  },
+  ClassBody: BlockStatement,
+  StaticBlock(node2, state) {
+    state.write("static ");
+    this.BlockStatement(node2, state);
+  },
+  EmptyStatement(node2, state) {
+    state.write(";");
+  },
+  ExpressionStatement(node2, state) {
+    const precedence = state.expressionsPrecedence[node2.expression.type];
+    if (precedence === NEEDS_PARENTHESES || precedence === 3 && node2.expression.left.type[0] === "O") {
+      state.write("(");
+      this[node2.expression.type](node2.expression, state);
+      state.write(")");
+    } else {
+      this[node2.expression.type](node2.expression, state);
+    }
+    state.write(";");
+  },
+  IfStatement(node2, state) {
+    state.write("if (");
+    this[node2.test.type](node2.test, state);
+    state.write(") ");
+    this[node2.consequent.type](node2.consequent, state);
+    if (node2.alternate != null) {
+      state.write(" else ");
+      this[node2.alternate.type](node2.alternate, state);
+    }
+  },
+  LabeledStatement(node2, state) {
+    this[node2.label.type](node2.label, state);
+    state.write(": ");
+    this[node2.body.type](node2.body, state);
+  },
+  BreakStatement(node2, state) {
+    state.write("break");
+    if (node2.label != null) {
+      state.write(" ");
+      this[node2.label.type](node2.label, state);
+    }
+    state.write(";");
+  },
+  ContinueStatement(node2, state) {
+    state.write("continue");
+    if (node2.label != null) {
+      state.write(" ");
+      this[node2.label.type](node2.label, state);
+    }
+    state.write(";");
+  },
+  WithStatement(node2, state) {
+    state.write("with (");
+    this[node2.object.type](node2.object, state);
+    state.write(") ");
+    this[node2.body.type](node2.body, state);
+  },
+  SwitchStatement(node2, state) {
+    const indent2 = state.indent.repeat(state.indentLevel++);
+    const { lineEnd, writeComments } = state;
+    state.indentLevel++;
+    const caseIndent = indent2 + state.indent;
+    const statementIndent = caseIndent + state.indent;
+    state.write("switch (");
+    this[node2.discriminant.type](node2.discriminant, state);
+    state.write(") {" + lineEnd);
+    const { cases: occurences } = node2;
+    const { length: occurencesCount } = occurences;
+    for (let i = 0; i < occurencesCount; i++) {
+      const occurence = occurences[i];
+      if (writeComments && occurence.comments != null) {
+        formatComments(state, occurence.comments, caseIndent, lineEnd);
+      }
+      if (occurence.test) {
+        state.write(caseIndent + "case ");
+        this[occurence.test.type](occurence.test, state);
+        state.write(":" + lineEnd);
+      } else {
+        state.write(caseIndent + "default:" + lineEnd);
+      }
+      const { consequent } = occurence;
+      const { length: consequentCount } = consequent;
+      for (let i2 = 0; i2 < consequentCount; i2++) {
+        const statement = consequent[i2];
+        if (writeComments && statement.comments != null) {
+          formatComments(state, statement.comments, statementIndent, lineEnd);
+        }
+        state.write(statementIndent);
+        this[statement.type](statement, state);
+        state.write(lineEnd);
+      }
+    }
+    state.indentLevel -= 2;
+    state.write(indent2 + "}");
+  },
+  ReturnStatement(node2, state) {
+    state.write("return");
+    if (node2.argument) {
+      state.write(" ");
+      this[node2.argument.type](node2.argument, state);
+    }
+    state.write(";");
+  },
+  ThrowStatement(node2, state) {
+    state.write("throw ");
+    this[node2.argument.type](node2.argument, state);
+    state.write(";");
+  },
+  TryStatement(node2, state) {
+    state.write("try ");
+    this[node2.block.type](node2.block, state);
+    if (node2.handler) {
+      const { handler } = node2;
+      if (handler.param == null) {
+        state.write(" catch ");
+      } else {
+        state.write(" catch (");
+        this[handler.param.type](handler.param, state);
+        state.write(") ");
+      }
+      this[handler.body.type](handler.body, state);
+    }
+    if (node2.finalizer) {
+      state.write(" finally ");
+      this[node2.finalizer.type](node2.finalizer, state);
+    }
+  },
+  WhileStatement(node2, state) {
+    state.write("while (");
+    this[node2.test.type](node2.test, state);
+    state.write(") ");
+    this[node2.body.type](node2.body, state);
+  },
+  DoWhileStatement(node2, state) {
+    state.write("do ");
+    this[node2.body.type](node2.body, state);
+    state.write(" while (");
+    this[node2.test.type](node2.test, state);
+    state.write(");");
+  },
+  ForStatement(node2, state) {
+    state.write("for (");
+    if (node2.init != null) {
+      const { init } = node2;
+      if (init.type[0] === "V") {
+        formatVariableDeclaration(state, init);
+      } else {
+        this[init.type](init, state);
+      }
+    }
+    state.write("; ");
+    if (node2.test) {
+      this[node2.test.type](node2.test, state);
+    }
+    state.write("; ");
+    if (node2.update) {
+      this[node2.update.type](node2.update, state);
+    }
+    state.write(") ");
+    this[node2.body.type](node2.body, state);
+  },
+  ForInStatement: ForInStatement = function(node2, state) {
+    state.write(`for ${node2.await ? "await " : ""}(`);
+    const { left } = node2;
+    if (left.type[0] === "V") {
+      formatVariableDeclaration(state, left);
+    } else {
+      this[left.type](left, state);
+    }
+    state.write(node2.type[3] === "I" ? " in " : " of ");
+    this[node2.right.type](node2.right, state);
+    state.write(") ");
+    this[node2.body.type](node2.body, state);
+  },
+  ForOfStatement: ForInStatement,
+  DebuggerStatement(node2, state) {
+    state.write("debugger;", node2);
+  },
+  FunctionDeclaration: FunctionDeclaration = function(node2, state) {
+    state.write(
+      (node2.async ? "async " : "") + (node2.generator ? "function* " : "function ") + (node2.id ? node2.id.name : ""),
+      node2
+    );
+    formatSequence(state, node2.params);
+    state.write(" ");
+    this[node2.body.type](node2.body, state);
+  },
+  FunctionExpression: FunctionDeclaration,
+  VariableDeclaration(node2, state) {
+    formatVariableDeclaration(state, node2);
+    state.write(";");
+  },
+  VariableDeclarator(node2, state) {
+    this[node2.id.type](node2.id, state);
+    if (node2.init != null) {
+      state.write(" = ");
+      this[node2.init.type](node2.init, state);
+    }
+  },
+  ClassDeclaration(node2, state) {
+    state.write("class " + (node2.id ? `${node2.id.name} ` : ""), node2);
+    if (node2.superClass) {
+      state.write("extends ");
+      const { superClass } = node2;
+      const { type } = superClass;
+      const precedence = state.expressionsPrecedence[type];
+      if ((type[0] !== "C" || type[1] !== "l" || type[5] !== "E") && (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.ClassExpression)) {
+        state.write("(");
+        this[node2.superClass.type](superClass, state);
+        state.write(")");
+      } else {
+        this[superClass.type](superClass, state);
+      }
+      state.write(" ");
+    }
+    this.ClassBody(node2.body, state);
+  },
+  ImportDeclaration(node2, state) {
+    state.write("import ");
+    const { specifiers } = node2;
+    const { length } = specifiers;
+    let i = 0;
+    if (length > 0) {
+      for (; i < length; ) {
+        if (i > 0) {
+          state.write(", ");
+        }
+        const specifier = specifiers[i];
+        const type = specifier.type[6];
+        if (type === "D") {
+          state.write(specifier.local.name, specifier);
+          i++;
+        } else if (type === "N") {
+          state.write("* as " + specifier.local.name, specifier);
+          i++;
+        } else {
+          break;
+        }
+      }
+      if (i < length) {
+        state.write("{");
+        for (; ; ) {
+          const specifier = specifiers[i];
+          const { name: name2 } = specifier.imported;
+          state.write(name2, specifier);
+          if (name2 !== specifier.local.name) {
+            state.write(" as " + specifier.local.name);
+          }
+          if (++i < length) {
+            state.write(", ");
+          } else {
+            break;
+          }
+        }
+        state.write("}");
+      }
+      state.write(" from ");
+    }
+    this.Literal(node2.source, state);
+    state.write(";");
+  },
+  ImportExpression(node2, state) {
+    state.write("import(");
+    this[node2.source.type](node2.source, state);
+    state.write(")");
+  },
+  ExportDefaultDeclaration(node2, state) {
+    state.write("export default ");
+    this[node2.declaration.type](node2.declaration, state);
+    if (state.expressionsPrecedence[node2.declaration.type] != null && node2.declaration.type[0] !== "F") {
+      state.write(";");
+    }
+  },
+  ExportNamedDeclaration(node2, state) {
+    state.write("export ");
+    if (node2.declaration) {
+      this[node2.declaration.type](node2.declaration, state);
+    } else {
+      state.write("{");
+      const { specifiers } = node2, { length } = specifiers;
+      if (length > 0) {
+        for (let i = 0; ; ) {
+          const specifier = specifiers[i];
+          const { name: name2 } = specifier.local;
+          state.write(name2, specifier);
+          if (name2 !== specifier.exported.name) {
+            state.write(" as " + specifier.exported.name);
+          }
+          if (++i < length) {
+            state.write(", ");
+          } else {
+            break;
+          }
+        }
+      }
+      state.write("}");
+      if (node2.source) {
+        state.write(" from ");
+        this.Literal(node2.source, state);
+      }
+      state.write(";");
+    }
+  },
+  ExportAllDeclaration(node2, state) {
+    if (node2.exported != null) {
+      state.write("export * as " + node2.exported.name + " from ");
+    } else {
+      state.write("export * from ");
+    }
+    this.Literal(node2.source, state);
+    state.write(";");
+  },
+  MethodDefinition(node2, state) {
+    if (node2.static) {
+      state.write("static ");
+    }
+    const kind = node2.kind[0];
+    if (kind === "g" || kind === "s") {
+      state.write(node2.kind + " ");
+    }
+    if (node2.value.async) {
+      state.write("async ");
+    }
+    if (node2.value.generator) {
+      state.write("*");
+    }
+    if (node2.computed) {
+      state.write("[");
+      this[node2.key.type](node2.key, state);
+      state.write("]");
+    } else {
+      this[node2.key.type](node2.key, state);
+    }
+    formatSequence(state, node2.value.params);
+    state.write(" ");
+    this[node2.value.body.type](node2.value.body, state);
+  },
+  ClassExpression(node2, state) {
+    this.ClassDeclaration(node2, state);
+  },
+  ArrowFunctionExpression(node2, state) {
+    state.write(node2.async ? "async " : "", node2);
+    const { params } = node2;
+    if (params != null) {
+      if (params.length === 1 && params[0].type[0] === "I") {
+        state.write(params[0].name, params[0]);
+      } else {
+        formatSequence(state, node2.params);
+      }
+    }
+    state.write(" => ");
+    if (node2.body.type[0] === "O") {
+      state.write("(");
+      this.ObjectExpression(node2.body, state);
+      state.write(")");
+    } else {
+      this[node2.body.type](node2.body, state);
+    }
+  },
+  ThisExpression(node2, state) {
+    state.write("this", node2);
+  },
+  Super(node2, state) {
+    state.write("super", node2);
+  },
+  RestElement: RestElement = function(node2, state) {
+    state.write("...");
+    this[node2.argument.type](node2.argument, state);
+  },
+  SpreadElement: RestElement,
+  YieldExpression(node2, state) {
+    state.write(node2.delegate ? "yield*" : "yield");
+    if (node2.argument) {
+      state.write(" ");
+      this[node2.argument.type](node2.argument, state);
+    }
+  },
+  AwaitExpression(node2, state) {
+    state.write("await ", node2);
+    formatExpression(state, node2.argument, node2);
+  },
+  TemplateLiteral(node2, state) {
+    const { quasis, expressions } = node2;
+    state.write("`");
+    const { length } = expressions;
+    for (let i = 0; i < length; i++) {
+      const expression = expressions[i];
+      const quasi2 = quasis[i];
+      state.write(quasi2.value.raw, quasi2);
+      state.write("${");
+      this[expression.type](expression, state);
+      state.write("}");
+    }
+    const quasi = quasis[quasis.length - 1];
+    state.write(quasi.value.raw, quasi);
+    state.write("`");
+  },
+  TemplateElement(node2, state) {
+    state.write(node2.value.raw, node2);
+  },
+  TaggedTemplateExpression(node2, state) {
+    formatExpression(state, node2.tag, node2);
+    this[node2.quasi.type](node2.quasi, state);
+  },
+  ArrayExpression: ArrayExpression = function(node2, state) {
+    state.write("[");
+    if (node2.elements.length > 0) {
+      const { elements } = node2, { length } = elements;
+      for (let i = 0; ; ) {
+        const element2 = elements[i];
+        if (element2 != null) {
+          this[element2.type](element2, state);
+        }
+        if (++i < length) {
+          state.write(", ");
+        } else {
+          if (element2 == null) {
+            state.write(", ");
+          }
+          break;
+        }
+      }
+    }
+    state.write("]");
+  },
+  ArrayPattern: ArrayExpression,
+  ObjectExpression(node2, state) {
+    const indent2 = state.indent.repeat(state.indentLevel++);
+    const { lineEnd, writeComments } = state;
+    const propertyIndent = indent2 + state.indent;
+    state.write("{");
+    if (node2.properties.length > 0) {
+      state.write(lineEnd);
+      if (writeComments && node2.comments != null) {
+        formatComments(state, node2.comments, propertyIndent, lineEnd);
+      }
+      const comma = "," + lineEnd;
+      const { properties } = node2, { length } = properties;
+      for (let i = 0; ; ) {
+        const property = properties[i];
+        if (writeComments && property.comments != null) {
+          formatComments(state, property.comments, propertyIndent, lineEnd);
+        }
+        state.write(propertyIndent);
+        this[property.type](property, state);
+        if (++i < length) {
+          state.write(comma);
+        } else {
+          break;
+        }
+      }
+      state.write(lineEnd);
+      if (writeComments && node2.trailingComments != null) {
+        formatComments(state, node2.trailingComments, propertyIndent, lineEnd);
+      }
+      state.write(indent2 + "}");
+    } else if (writeComments) {
+      if (node2.comments != null) {
+        state.write(lineEnd);
+        formatComments(state, node2.comments, propertyIndent, lineEnd);
+        if (node2.trailingComments != null) {
+          formatComments(state, node2.trailingComments, propertyIndent, lineEnd);
+        }
+        state.write(indent2 + "}");
+      } else if (node2.trailingComments != null) {
+        state.write(lineEnd);
+        formatComments(state, node2.trailingComments, propertyIndent, lineEnd);
+        state.write(indent2 + "}");
+      } else {
+        state.write("}");
+      }
+    } else {
+      state.write("}");
+    }
+    state.indentLevel--;
+  },
+  Property(node2, state) {
+    if (node2.method || node2.kind[0] !== "i") {
+      this.MethodDefinition(node2, state);
+    } else {
+      if (!node2.shorthand) {
+        if (node2.computed) {
+          state.write("[");
+          this[node2.key.type](node2.key, state);
+          state.write("]");
+        } else {
+          this[node2.key.type](node2.key, state);
+        }
+        state.write(": ");
+      }
+      this[node2.value.type](node2.value, state);
+    }
+  },
+  PropertyDefinition(node2, state) {
+    if (node2.static) {
+      state.write("static ");
+    }
+    if (node2.computed) {
+      state.write("[");
+    }
+    this[node2.key.type](node2.key, state);
+    if (node2.computed) {
+      state.write("]");
+    }
+    if (node2.value == null) {
+      if (node2.key.type[0] !== "F") {
+        state.write(";");
+      }
+      return;
+    }
+    state.write(" = ");
+    this[node2.value.type](node2.value, state);
+    state.write(";");
+  },
+  ObjectPattern(node2, state) {
+    state.write("{");
+    if (node2.properties.length > 0) {
+      const { properties } = node2, { length } = properties;
+      for (let i = 0; ; ) {
+        this[properties[i].type](properties[i], state);
+        if (++i < length) {
+          state.write(", ");
+        } else {
+          break;
+        }
+      }
+    }
+    state.write("}");
+  },
+  SequenceExpression(node2, state) {
+    formatSequence(state, node2.expressions);
+  },
+  UnaryExpression(node2, state) {
+    if (node2.prefix) {
+      const {
+        operator,
+        argument,
+        argument: { type }
+      } = node2;
+      state.write(operator);
+      const needsParentheses = expressionNeedsParenthesis(state, argument, node2);
+      if (!needsParentheses && (operator.length > 1 || type[0] === "U" && (type[1] === "n" || type[1] === "p") && argument.prefix && argument.operator[0] === operator && (operator === "+" || operator === "-"))) {
+        state.write(" ");
+      }
+      if (needsParentheses) {
+        state.write(operator.length > 1 ? " (" : "(");
+        this[type](argument, state);
+        state.write(")");
+      } else {
+        this[type](argument, state);
+      }
+    } else {
+      this[node2.argument.type](node2.argument, state);
+      state.write(node2.operator);
+    }
+  },
+  UpdateExpression(node2, state) {
+    if (node2.prefix) {
+      state.write(node2.operator);
+      this[node2.argument.type](node2.argument, state);
+    } else {
+      this[node2.argument.type](node2.argument, state);
+      state.write(node2.operator);
+    }
+  },
+  AssignmentExpression(node2, state) {
+    this[node2.left.type](node2.left, state);
+    state.write(" " + node2.operator + " ");
+    this[node2.right.type](node2.right, state);
+  },
+  AssignmentPattern(node2, state) {
+    this[node2.left.type](node2.left, state);
+    state.write(" = ");
+    this[node2.right.type](node2.right, state);
+  },
+  BinaryExpression: BinaryExpression = function(node2, state) {
+    const isIn = node2.operator === "in";
+    if (isIn) {
+      state.write("(");
+    }
+    formatExpression(state, node2.left, node2, false);
+    state.write(" " + node2.operator + " ");
+    formatExpression(state, node2.right, node2, true);
+    if (isIn) {
+      state.write(")");
+    }
+  },
+  LogicalExpression: BinaryExpression,
+  ConditionalExpression(node2, state) {
+    const { test } = node2;
+    const precedence = state.expressionsPrecedence[test.type];
+    if (precedence === NEEDS_PARENTHESES || precedence <= state.expressionsPrecedence.ConditionalExpression) {
+      state.write("(");
+      this[test.type](test, state);
+      state.write(")");
+    } else {
+      this[test.type](test, state);
+    }
+    state.write(" ? ");
+    this[node2.consequent.type](node2.consequent, state);
+    state.write(" : ");
+    this[node2.alternate.type](node2.alternate, state);
+  },
+  NewExpression(node2, state) {
+    state.write("new ");
+    const precedence = state.expressionsPrecedence[node2.callee.type];
+    if (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.CallExpression || hasCallExpression(node2.callee)) {
+      state.write("(");
+      this[node2.callee.type](node2.callee, state);
+      state.write(")");
+    } else {
+      this[node2.callee.type](node2.callee, state);
+    }
+    formatSequence(state, node2["arguments"]);
+  },
+  CallExpression(node2, state) {
+    const precedence = state.expressionsPrecedence[node2.callee.type];
+    if (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.CallExpression) {
+      state.write("(");
+      this[node2.callee.type](node2.callee, state);
+      state.write(")");
+    } else {
+      this[node2.callee.type](node2.callee, state);
+    }
+    if (node2.optional) {
+      state.write("?.");
+    }
+    formatSequence(state, node2["arguments"]);
+  },
+  ChainExpression(node2, state) {
+    this[node2.expression.type](node2.expression, state);
+  },
+  MemberExpression(node2, state) {
+    const precedence = state.expressionsPrecedence[node2.object.type];
+    if (precedence === NEEDS_PARENTHESES || precedence < state.expressionsPrecedence.MemberExpression) {
+      state.write("(");
+      this[node2.object.type](node2.object, state);
+      state.write(")");
+    } else {
+      this[node2.object.type](node2.object, state);
+    }
+    if (node2.computed) {
+      if (node2.optional) {
+        state.write("?.");
+      }
+      state.write("[");
+      this[node2.property.type](node2.property, state);
+      state.write("]");
+    } else {
+      if (node2.optional) {
+        state.write("?.");
+      } else {
+        state.write(".");
+      }
+      this[node2.property.type](node2.property, state);
+    }
+  },
+  MetaProperty(node2, state) {
+    state.write(node2.meta.name + "." + node2.property.name, node2);
+  },
+  Identifier(node2, state) {
+    state.write(node2.name, node2);
+  },
+  PrivateIdentifier(node2, state) {
+    state.write(`#${node2.name}`, node2);
+  },
+  Literal(node2, state) {
+    if (node2.raw != null) {
+      state.write(node2.raw, node2);
+    } else if (node2.regex != null) {
+      this.RegExpLiteral(node2, state);
+    } else if (node2.bigint != null) {
+      state.write(node2.bigint + "n", node2);
+    } else {
+      state.write(stringify(node2.value), node2);
+    }
+  },
+  RegExpLiteral(node2, state) {
+    const { regex: regex2 } = node2;
+    state.write(`/${regex2.pattern}/${regex2.flags}`, node2);
+  }
+};
+var EMPTY_OBJECT = {};
+var State = class {
+  constructor(options) {
+    const setup = options == null ? EMPTY_OBJECT : options;
+    this.output = "";
+    if (setup.output != null) {
+      this.output = setup.output;
+      this.write = this.writeToStream;
+    } else {
+      this.output = "";
+    }
+    this.generator = setup.generator != null ? setup.generator : GENERATOR;
+    this.expressionsPrecedence = setup.expressionsPrecedence != null ? setup.expressionsPrecedence : EXPRESSIONS_PRECEDENCE;
+    this.indent = setup.indent != null ? setup.indent : "  ";
+    this.lineEnd = setup.lineEnd != null ? setup.lineEnd : "\n";
+    this.indentLevel = setup.startingIndentLevel != null ? setup.startingIndentLevel : 0;
+    this.writeComments = setup.comments ? setup.comments : false;
+    if (setup.sourceMap != null) {
+      this.write = setup.output == null ? this.writeAndMap : this.writeToStreamAndMap;
+      this.sourceMap = setup.sourceMap;
+      this.line = 1;
+      this.column = 0;
+      this.lineEndSize = this.lineEnd.split("\n").length - 1;
+      this.mapping = {
+        original: null,
+        // Uses the entire state to avoid generating ephemeral objects
+        generated: this,
+        name: void 0,
+        source: setup.sourceMap.file || setup.sourceMap._file
+      };
+    }
+  }
+  write(code2) {
+    this.output += code2;
+  }
+  writeToStream(code2) {
+    this.output.write(code2);
+  }
+  writeAndMap(code2, node2) {
+    this.output += code2;
+    this.map(code2, node2);
+  }
+  writeToStreamAndMap(code2, node2) {
+    this.output.write(code2);
+    this.map(code2, node2);
+  }
+  map(code2, node2) {
+    if (node2 != null) {
+      const { type } = node2;
+      if (type[0] === "L" && type[2] === "n") {
+        this.column = 0;
+        this.line++;
+        return;
+      }
+      if (node2.loc != null) {
+        const { mapping } = this;
+        mapping.original = node2.loc.start;
+        mapping.name = node2.name;
+        this.sourceMap.addMapping(mapping);
+      }
+      if (type[0] === "T" && type[8] === "E" || type[0] === "L" && type[1] === "i" && typeof node2.value === "string") {
+        const { length: length2 } = code2;
+        let { column, line } = this;
+        for (let i = 0; i < length2; i++) {
+          if (code2[i] === "\n") {
+            column = 0;
+            line++;
+          } else {
+            column++;
+          }
+        }
+        this.column = column;
+        this.line = line;
+        return;
+      }
+    }
+    const { length } = code2;
+    const { lineEnd } = this;
+    if (length > 0) {
+      if (this.lineEndSize > 0 && (lineEnd.length === 1 ? code2[length - 1] === lineEnd : code2.endsWith(lineEnd))) {
+        this.line += this.lineEndSize;
+        this.column = 0;
+      } else {
+        this.column += length;
+      }
+    }
+  }
+  toString() {
+    return this.output;
+  }
+};
+function generate(node2, options) {
+  const state = new State(options);
+  state.generator[node2.type](node2, state);
+  return state.output;
+}
+
+// node_modules/estree-util-to-js/lib/index.js
+var emptyOptions5 = {};
+function toJs(tree, options) {
+  const { SourceMapGenerator, filePath, handlers: handlers3 } = options || emptyOptions5;
+  const sourceMap = SourceMapGenerator ? new SourceMapGenerator({ file: filePath || "<unknown>.js" }) : void 0;
+  const value = generate(
+    tree,
+    // @ts-expect-error: `sourceMap` can be undefined, `astring` types are buggy.
+    {
+      comments: true,
+      generator: { ...GENERATOR, ...handlers3 },
+      sourceMap: sourceMap || void 0
+    }
+  );
+  const map = sourceMap ? sourceMap.toJSON() : void 0;
+  return { value, map };
+}
+
+// node_modules/estree-util-to-js/lib/jsx.js
+var jsx = {
+  JSXAttribute: jsxAttribute,
+  JSXClosingElement: jsxClosingElement,
+  JSXClosingFragment: jsxClosingFragment,
+  JSXElement: jsxElement,
+  JSXEmptyExpression: jsxEmptyExpression,
+  JSXExpressionContainer: jsxExpressionContainer,
+  JSXFragment: jsxFragment,
+  JSXIdentifier: jsxIdentifier,
+  JSXMemberExpression: jsxMemberExpression,
+  JSXNamespacedName: jsxNamespacedName,
+  JSXOpeningElement: jsxOpeningElement,
+  JSXOpeningFragment: jsxOpeningFragment,
+  JSXSpreadAttribute: jsxSpreadAttribute,
+  JSXText: jsxText2
+};
+function jsxAttribute(node2, state) {
+  this[node2.name.type](node2.name, state);
+  if (node2.value !== null && node2.value !== void 0) {
+    state.write("=");
+    if (node2.value.type === "Literal") {
+      state.write(
+        '"' + encodeJsx(String(node2.value.value)).replace(/"/g, "&quot;") + '"',
+        node2
+      );
+    } else {
+      this[node2.value.type](node2.value, state);
+    }
+  }
+}
+function jsxClosingElement(node2, state) {
+  state.write("</");
+  this[node2.name.type](node2.name, state);
+  state.write(">");
+}
+function jsxClosingFragment(node2, state) {
+  state.write("</>", node2);
+}
+function jsxElement(node2, state) {
+  let index2 = -1;
+  this[node2.openingElement.type](node2.openingElement, state);
+  if (node2.children) {
+    while (++index2 < node2.children.length) {
+      const child = node2.children[index2];
+      if (child.type === "JSXSpreadChild") {
+        throw new Error("JSX spread children are not supported");
+      }
+      this[child.type](child, state);
+    }
+  }
+  if (node2.closingElement) {
+    this[node2.closingElement.type](node2.closingElement, state);
+  }
+}
+function jsxEmptyExpression() {
+}
+function jsxExpressionContainer(node2, state) {
+  state.write("{");
+  this[node2.expression.type](node2.expression, state);
+  state.write("}");
+}
+function jsxFragment(node2, state) {
+  let index2 = -1;
+  this[node2.openingFragment.type](node2.openingFragment, state);
+  if (node2.children) {
+    while (++index2 < node2.children.length) {
+      const child = node2.children[index2];
+      if (child.type === "JSXSpreadChild") {
+        throw new Error("JSX spread children are not supported");
+      }
+      this[child.type](child, state);
+    }
+  }
+  this[node2.closingFragment.type](node2.closingFragment, state);
+}
+function jsxIdentifier(node2, state) {
+  state.write(node2.name, node2);
+}
+function jsxMemberExpression(node2, state) {
+  this[node2.object.type](node2.object, state);
+  state.write(".");
+  this[node2.property.type](node2.property, state);
+}
+function jsxNamespacedName(node2, state) {
+  this[node2.namespace.type](node2.namespace, state);
+  state.write(":");
+  this[node2.name.type](node2.name, state);
+}
+function jsxOpeningElement(node2, state) {
+  let index2 = -1;
+  state.write("<");
+  this[node2.name.type](node2.name, state);
+  if (node2.attributes) {
+    while (++index2 < node2.attributes.length) {
+      state.write(" ");
+      this[node2.attributes[index2].type](node2.attributes[index2], state);
+    }
+  }
+  state.write(node2.selfClosing ? " />" : ">");
+}
+function jsxOpeningFragment(node2, state) {
+  state.write("<>", node2);
+}
+function jsxSpreadAttribute(node2, state) {
+  state.write("{");
+  this.SpreadElement(node2, state);
+  state.write("}");
+}
+function jsxText2(node2, state) {
+  state.write(encodeJsx(node2.value).replace(/[<>{}]/g, replaceJsxChar), node2);
+}
+function encodeJsx(value) {
+  return value.replace(/&(?=[#a-z])/gi, "&amp;");
+}
+function replaceJsxChar($0) {
+  return $0 === "<" ? "&lt;" : $0 === ">" ? "&gt;" : $0 === "{" ? "&#123;" : "&#125;";
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/recma-stringify.js
+function recmaStringify(options) {
+  const self2 = (
+    /** @type {Processor} */
+    this
+  );
+  const { SourceMapGenerator } = options;
+  self2.compiler = compiler2;
+  function compiler2(tree, file) {
+    const result = SourceMapGenerator ? toJs(tree, {
+      SourceMapGenerator,
+      filePath: file.path || "unknown.mdx",
+      handlers: jsx
+    }) : toJs(tree, { handlers: jsx });
+    file.map = result.map;
+    return result.value;
+  }
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/comment.js
+function comment(node2, state) {
+  const result = { type: "Block", value: node2.value };
+  state.inherit(node2, result);
+  state.comments.push(result);
+  const expression = {
+    type: "JSXEmptyExpression",
+    // @ts-expect-error: `comments` is custom.
+    comments: [Object.assign({}, result, { leading: false, trailing: true })]
+  };
+  state.patch(node2, expression);
+  const container = { type: "JSXExpressionContainer", expression };
+  state.patch(node2, container);
+  return container;
+}
+
+// node_modules/hast-util-to-estree/node_modules/comma-separated-tokens/index.js
+function stringify2(values, options) {
+  const settings = options || {};
+  const input = values[values.length - 1] === "" ? [...values, ""] : values;
+  return input.join(
+    (settings.padRight ? " " : "") + "," + (settings.padLeft === false ? "" : " ")
+  ).trim();
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/schema.js
+var Schema = class {
+  /**
+   * @constructor
+   * @param {Properties} property
+   * @param {Normal} normal
+   * @param {string} [space]
+   */
+  constructor(property, normal, space2) {
+    this.property = property;
+    this.normal = normal;
+    if (space2) {
+      this.space = space2;
+    }
+  }
+};
+Schema.prototype.property = {};
+Schema.prototype.normal = {};
+Schema.prototype.space = null;
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/merge.js
+function merge(definitions, space2) {
+  const property = {};
+  const normal = {};
+  let index2 = -1;
+  while (++index2 < definitions.length) {
+    Object.assign(property, definitions[index2].property);
+    Object.assign(normal, definitions[index2].normal);
+  }
+  return new Schema(property, normal, space2);
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/normalize.js
+function normalize(value) {
+  return value.toLowerCase();
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/info.js
+var Info = class {
+  /**
+   * @constructor
+   * @param {string} property
+   * @param {string} attribute
+   */
+  constructor(property, attribute) {
+    this.property = property;
+    this.attribute = attribute;
+  }
+};
+Info.prototype.space = null;
+Info.prototype.boolean = false;
+Info.prototype.booleanish = false;
+Info.prototype.overloadedBoolean = false;
+Info.prototype.number = false;
+Info.prototype.commaSeparated = false;
+Info.prototype.spaceSeparated = false;
+Info.prototype.commaOrSpaceSeparated = false;
+Info.prototype.mustUseProperty = false;
+Info.prototype.defined = false;
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/types.js
+var types_exports = {};
+__export(types_exports, {
+  boolean: () => boolean,
+  booleanish: () => booleanish,
+  commaOrSpaceSeparated: () => commaOrSpaceSeparated,
+  commaSeparated: () => commaSeparated,
+  number: () => number,
+  overloadedBoolean: () => overloadedBoolean,
+  spaceSeparated: () => spaceSeparated
+});
+var powers = 0;
+var boolean = increment();
+var booleanish = increment();
+var overloadedBoolean = increment();
+var number = increment();
+var spaceSeparated = increment();
+var commaSeparated = increment();
+var commaOrSpaceSeparated = increment();
+function increment() {
+  return 2 ** ++powers;
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/defined-info.js
+var checks = Object.keys(types_exports);
+var DefinedInfo = class extends Info {
+  /**
+   * @constructor
+   * @param {string} property
+   * @param {string} attribute
+   * @param {number|null} [mask]
+   * @param {string} [space]
+   */
+  constructor(property, attribute, mask, space2) {
+    let index2 = -1;
+    super(property, attribute);
+    mark(this, "space", space2);
+    if (typeof mask === "number") {
+      while (++index2 < checks.length) {
+        const check = checks[index2];
+        mark(this, checks[index2], (mask & types_exports[check]) === types_exports[check]);
+      }
+    }
+  }
+};
+DefinedInfo.prototype.defined = true;
+function mark(values, key, value) {
+  if (value) {
+    values[key] = value;
+  }
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/create.js
+var own6 = {}.hasOwnProperty;
+function create3(definition2) {
+  const property = {};
+  const normal = {};
+  let prop;
+  for (prop in definition2.properties) {
+    if (own6.call(definition2.properties, prop)) {
+      const value = definition2.properties[prop];
+      const info = new DefinedInfo(
+        prop,
+        definition2.transform(definition2.attributes || {}, prop),
+        value,
+        definition2.space
+      );
+      if (definition2.mustUseProperty && definition2.mustUseProperty.includes(prop)) {
+        info.mustUseProperty = true;
+      }
+      property[prop] = info;
+      normal[normalize(prop)] = prop;
+      normal[normalize(info.attribute)] = prop;
+    }
+  }
+  return new Schema(property, normal, definition2.space);
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/xlink.js
+var xlink = create3({
+  space: "xlink",
+  transform(_, prop) {
+    return "xlink:" + prop.slice(5).toLowerCase();
+  },
+  properties: {
+    xLinkActuate: null,
+    xLinkArcRole: null,
+    xLinkHref: null,
+    xLinkRole: null,
+    xLinkShow: null,
+    xLinkTitle: null,
+    xLinkType: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/xml.js
+var xml = create3({
+  space: "xml",
+  transform(_, prop) {
+    return "xml:" + prop.slice(3).toLowerCase();
+  },
+  properties: { xmlLang: null, xmlBase: null, xmlSpace: null }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/case-sensitive-transform.js
+function caseSensitiveTransform(attributes, attribute) {
+  return attribute in attributes ? attributes[attribute] : attribute;
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/util/case-insensitive-transform.js
+function caseInsensitiveTransform(attributes, property) {
+  return caseSensitiveTransform(attributes, property.toLowerCase());
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/xmlns.js
+var xmlns = create3({
+  space: "xmlns",
+  attributes: { xmlnsxlink: "xmlns:xlink" },
+  transform: caseInsensitiveTransform,
+  properties: { xmlns: null, xmlnsXLink: null }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/aria.js
+var aria = create3({
+  transform(_, prop) {
+    return prop === "role" ? prop : "aria-" + prop.slice(4).toLowerCase();
+  },
+  properties: {
+    ariaActiveDescendant: null,
+    ariaAtomic: booleanish,
+    ariaAutoComplete: null,
+    ariaBusy: booleanish,
+    ariaChecked: booleanish,
+    ariaColCount: number,
+    ariaColIndex: number,
+    ariaColSpan: number,
+    ariaControls: spaceSeparated,
+    ariaCurrent: null,
+    ariaDescribedBy: spaceSeparated,
+    ariaDetails: null,
+    ariaDisabled: booleanish,
+    ariaDropEffect: spaceSeparated,
+    ariaErrorMessage: null,
+    ariaExpanded: booleanish,
+    ariaFlowTo: spaceSeparated,
+    ariaGrabbed: booleanish,
+    ariaHasPopup: null,
+    ariaHidden: booleanish,
+    ariaInvalid: null,
+    ariaKeyShortcuts: null,
+    ariaLabel: null,
+    ariaLabelledBy: spaceSeparated,
+    ariaLevel: number,
+    ariaLive: null,
+    ariaModal: booleanish,
+    ariaMultiLine: booleanish,
+    ariaMultiSelectable: booleanish,
+    ariaOrientation: null,
+    ariaOwns: spaceSeparated,
+    ariaPlaceholder: null,
+    ariaPosInSet: number,
+    ariaPressed: booleanish,
+    ariaReadOnly: booleanish,
+    ariaRelevant: null,
+    ariaRequired: booleanish,
+    ariaRoleDescription: spaceSeparated,
+    ariaRowCount: number,
+    ariaRowIndex: number,
+    ariaRowSpan: number,
+    ariaSelected: booleanish,
+    ariaSetSize: number,
+    ariaSort: null,
+    ariaValueMax: number,
+    ariaValueMin: number,
+    ariaValueNow: number,
+    ariaValueText: null,
+    role: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/html.js
+var html2 = create3({
+  space: "html",
+  attributes: {
+    acceptcharset: "accept-charset",
+    classname: "class",
+    htmlfor: "for",
+    httpequiv: "http-equiv"
+  },
+  transform: caseInsensitiveTransform,
+  mustUseProperty: ["checked", "multiple", "muted", "selected"],
+  properties: {
+    // Standard Properties.
+    abbr: null,
+    accept: commaSeparated,
+    acceptCharset: spaceSeparated,
+    accessKey: spaceSeparated,
+    action: null,
+    allow: null,
+    allowFullScreen: boolean,
+    allowPaymentRequest: boolean,
+    allowUserMedia: boolean,
+    alt: null,
+    as: null,
+    async: boolean,
+    autoCapitalize: null,
+    autoComplete: spaceSeparated,
+    autoFocus: boolean,
+    autoPlay: boolean,
+    blocking: spaceSeparated,
+    capture: null,
+    charSet: null,
+    checked: boolean,
+    cite: null,
+    className: spaceSeparated,
+    cols: number,
+    colSpan: null,
+    content: null,
+    contentEditable: booleanish,
+    controls: boolean,
+    controlsList: spaceSeparated,
+    coords: number | commaSeparated,
+    crossOrigin: null,
+    data: null,
+    dateTime: null,
+    decoding: null,
+    default: boolean,
+    defer: boolean,
+    dir: null,
+    dirName: null,
+    disabled: boolean,
+    download: overloadedBoolean,
+    draggable: booleanish,
+    encType: null,
+    enterKeyHint: null,
+    fetchPriority: null,
+    form: null,
+    formAction: null,
+    formEncType: null,
+    formMethod: null,
+    formNoValidate: boolean,
+    formTarget: null,
+    headers: spaceSeparated,
+    height: number,
+    hidden: boolean,
+    high: number,
+    href: null,
+    hrefLang: null,
+    htmlFor: spaceSeparated,
+    httpEquiv: spaceSeparated,
+    id: null,
+    imageSizes: null,
+    imageSrcSet: null,
+    inert: boolean,
+    inputMode: null,
+    integrity: null,
+    is: null,
+    isMap: boolean,
+    itemId: null,
+    itemProp: spaceSeparated,
+    itemRef: spaceSeparated,
+    itemScope: boolean,
+    itemType: spaceSeparated,
+    kind: null,
+    label: null,
+    lang: null,
+    language: null,
+    list: null,
+    loading: null,
+    loop: boolean,
+    low: number,
+    manifest: null,
+    max: null,
+    maxLength: number,
+    media: null,
+    method: null,
+    min: null,
+    minLength: number,
+    multiple: boolean,
+    muted: boolean,
+    name: null,
+    nonce: null,
+    noModule: boolean,
+    noValidate: boolean,
+    onAbort: null,
+    onAfterPrint: null,
+    onAuxClick: null,
+    onBeforeMatch: null,
+    onBeforePrint: null,
+    onBeforeToggle: null,
+    onBeforeUnload: null,
+    onBlur: null,
+    onCancel: null,
+    onCanPlay: null,
+    onCanPlayThrough: null,
+    onChange: null,
+    onClick: null,
+    onClose: null,
+    onContextLost: null,
+    onContextMenu: null,
+    onContextRestored: null,
+    onCopy: null,
+    onCueChange: null,
+    onCut: null,
+    onDblClick: null,
+    onDrag: null,
+    onDragEnd: null,
+    onDragEnter: null,
+    onDragExit: null,
+    onDragLeave: null,
+    onDragOver: null,
+    onDragStart: null,
+    onDrop: null,
+    onDurationChange: null,
+    onEmptied: null,
+    onEnded: null,
+    onError: null,
+    onFocus: null,
+    onFormData: null,
+    onHashChange: null,
+    onInput: null,
+    onInvalid: null,
+    onKeyDown: null,
+    onKeyPress: null,
+    onKeyUp: null,
+    onLanguageChange: null,
+    onLoad: null,
+    onLoadedData: null,
+    onLoadedMetadata: null,
+    onLoadEnd: null,
+    onLoadStart: null,
+    onMessage: null,
+    onMessageError: null,
+    onMouseDown: null,
+    onMouseEnter: null,
+    onMouseLeave: null,
+    onMouseMove: null,
+    onMouseOut: null,
+    onMouseOver: null,
+    onMouseUp: null,
+    onOffline: null,
+    onOnline: null,
+    onPageHide: null,
+    onPageShow: null,
+    onPaste: null,
+    onPause: null,
+    onPlay: null,
+    onPlaying: null,
+    onPopState: null,
+    onProgress: null,
+    onRateChange: null,
+    onRejectionHandled: null,
+    onReset: null,
+    onResize: null,
+    onScroll: null,
+    onScrollEnd: null,
+    onSecurityPolicyViolation: null,
+    onSeeked: null,
+    onSeeking: null,
+    onSelect: null,
+    onSlotChange: null,
+    onStalled: null,
+    onStorage: null,
+    onSubmit: null,
+    onSuspend: null,
+    onTimeUpdate: null,
+    onToggle: null,
+    onUnhandledRejection: null,
+    onUnload: null,
+    onVolumeChange: null,
+    onWaiting: null,
+    onWheel: null,
+    open: boolean,
+    optimum: number,
+    pattern: null,
+    ping: spaceSeparated,
+    placeholder: null,
+    playsInline: boolean,
+    popover: null,
+    popoverTarget: null,
+    popoverTargetAction: null,
+    poster: null,
+    preload: null,
+    readOnly: boolean,
+    referrerPolicy: null,
+    rel: spaceSeparated,
+    required: boolean,
+    reversed: boolean,
+    rows: number,
+    rowSpan: number,
+    sandbox: spaceSeparated,
+    scope: null,
+    scoped: boolean,
+    seamless: boolean,
+    selected: boolean,
+    shadowRootClonable: boolean,
+    shadowRootDelegatesFocus: boolean,
+    shadowRootMode: null,
+    shape: null,
+    size: number,
+    sizes: null,
+    slot: null,
+    span: number,
+    spellCheck: booleanish,
+    src: null,
+    srcDoc: null,
+    srcLang: null,
+    srcSet: null,
+    start: number,
+    step: null,
+    style: null,
+    tabIndex: number,
+    target: null,
+    title: null,
+    translate: null,
+    type: null,
+    typeMustMatch: boolean,
+    useMap: null,
+    value: booleanish,
+    width: number,
+    wrap: null,
+    writingSuggestions: null,
+    // Legacy.
+    // See: https://html.spec.whatwg.org/#other-elements,-attributes-and-apis
+    align: null,
+    // Several. Use CSS `text-align` instead,
+    aLink: null,
+    // `<body>`. Use CSS `a:active {color}` instead
+    archive: spaceSeparated,
+    // `<object>`. List of URIs to archives
+    axis: null,
+    // `<td>` and `<th>`. Use `scope` on `<th>`
+    background: null,
+    // `<body>`. Use CSS `background-image` instead
+    bgColor: null,
+    // `<body>` and table elements. Use CSS `background-color` instead
+    border: number,
+    // `<table>`. Use CSS `border-width` instead,
+    borderColor: null,
+    // `<table>`. Use CSS `border-color` instead,
+    bottomMargin: number,
+    // `<body>`
+    cellPadding: null,
+    // `<table>`
+    cellSpacing: null,
+    // `<table>`
+    char: null,
+    // Several table elements. When `align=char`, sets the character to align on
+    charOff: null,
+    // Several table elements. When `char`, offsets the alignment
+    classId: null,
+    // `<object>`
+    clear: null,
+    // `<br>`. Use CSS `clear` instead
+    code: null,
+    // `<object>`
+    codeBase: null,
+    // `<object>`
+    codeType: null,
+    // `<object>`
+    color: null,
+    // `<font>` and `<hr>`. Use CSS instead
+    compact: boolean,
+    // Lists. Use CSS to reduce space between items instead
+    declare: boolean,
+    // `<object>`
+    event: null,
+    // `<script>`
+    face: null,
+    // `<font>`. Use CSS instead
+    frame: null,
+    // `<table>`
+    frameBorder: null,
+    // `<iframe>`. Use CSS `border` instead
+    hSpace: number,
+    // `<img>` and `<object>`
+    leftMargin: number,
+    // `<body>`
+    link: null,
+    // `<body>`. Use CSS `a:link {color: *}` instead
+    longDesc: null,
+    // `<frame>`, `<iframe>`, and `<img>`. Use an `<a>`
+    lowSrc: null,
+    // `<img>`. Use a `<picture>`
+    marginHeight: number,
+    // `<body>`
+    marginWidth: number,
+    // `<body>`
+    noResize: boolean,
+    // `<frame>`
+    noHref: boolean,
+    // `<area>`. Use no href instead of an explicit `nohref`
+    noShade: boolean,
+    // `<hr>`. Use background-color and height instead of borders
+    noWrap: boolean,
+    // `<td>` and `<th>`
+    object: null,
+    // `<applet>`
+    profile: null,
+    // `<head>`
+    prompt: null,
+    // `<isindex>`
+    rev: null,
+    // `<link>`
+    rightMargin: number,
+    // `<body>`
+    rules: null,
+    // `<table>`
+    scheme: null,
+    // `<meta>`
+    scrolling: booleanish,
+    // `<frame>`. Use overflow in the child context
+    standby: null,
+    // `<object>`
+    summary: null,
+    // `<table>`
+    text: null,
+    // `<body>`. Use CSS `color` instead
+    topMargin: number,
+    // `<body>`
+    valueType: null,
+    // `<param>`
+    version: null,
+    // `<html>`. Use a doctype.
+    vAlign: null,
+    // Several. Use CSS `vertical-align` instead
+    vLink: null,
+    // `<body>`. Use CSS `a:visited {color}` instead
+    vSpace: number,
+    // `<img>` and `<object>`
+    // Non-standard Properties.
+    allowTransparency: null,
+    autoCorrect: null,
+    autoSave: null,
+    disablePictureInPicture: boolean,
+    disableRemotePlayback: boolean,
+    prefix: null,
+    property: null,
+    results: number,
+    security: null,
+    unselectable: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/svg.js
+var svg = create3({
+  space: "svg",
+  attributes: {
+    accentHeight: "accent-height",
+    alignmentBaseline: "alignment-baseline",
+    arabicForm: "arabic-form",
+    baselineShift: "baseline-shift",
+    capHeight: "cap-height",
+    className: "class",
+    clipPath: "clip-path",
+    clipRule: "clip-rule",
+    colorInterpolation: "color-interpolation",
+    colorInterpolationFilters: "color-interpolation-filters",
+    colorProfile: "color-profile",
+    colorRendering: "color-rendering",
+    crossOrigin: "crossorigin",
+    dataType: "datatype",
+    dominantBaseline: "dominant-baseline",
+    enableBackground: "enable-background",
+    fillOpacity: "fill-opacity",
+    fillRule: "fill-rule",
+    floodColor: "flood-color",
+    floodOpacity: "flood-opacity",
+    fontFamily: "font-family",
+    fontSize: "font-size",
+    fontSizeAdjust: "font-size-adjust",
+    fontStretch: "font-stretch",
+    fontStyle: "font-style",
+    fontVariant: "font-variant",
+    fontWeight: "font-weight",
+    glyphName: "glyph-name",
+    glyphOrientationHorizontal: "glyph-orientation-horizontal",
+    glyphOrientationVertical: "glyph-orientation-vertical",
+    hrefLang: "hreflang",
+    horizAdvX: "horiz-adv-x",
+    horizOriginX: "horiz-origin-x",
+    horizOriginY: "horiz-origin-y",
+    imageRendering: "image-rendering",
+    letterSpacing: "letter-spacing",
+    lightingColor: "lighting-color",
+    markerEnd: "marker-end",
+    markerMid: "marker-mid",
+    markerStart: "marker-start",
+    navDown: "nav-down",
+    navDownLeft: "nav-down-left",
+    navDownRight: "nav-down-right",
+    navLeft: "nav-left",
+    navNext: "nav-next",
+    navPrev: "nav-prev",
+    navRight: "nav-right",
+    navUp: "nav-up",
+    navUpLeft: "nav-up-left",
+    navUpRight: "nav-up-right",
+    onAbort: "onabort",
+    onActivate: "onactivate",
+    onAfterPrint: "onafterprint",
+    onBeforePrint: "onbeforeprint",
+    onBegin: "onbegin",
+    onCancel: "oncancel",
+    onCanPlay: "oncanplay",
+    onCanPlayThrough: "oncanplaythrough",
+    onChange: "onchange",
+    onClick: "onclick",
+    onClose: "onclose",
+    onCopy: "oncopy",
+    onCueChange: "oncuechange",
+    onCut: "oncut",
+    onDblClick: "ondblclick",
+    onDrag: "ondrag",
+    onDragEnd: "ondragend",
+    onDragEnter: "ondragenter",
+    onDragExit: "ondragexit",
+    onDragLeave: "ondragleave",
+    onDragOver: "ondragover",
+    onDragStart: "ondragstart",
+    onDrop: "ondrop",
+    onDurationChange: "ondurationchange",
+    onEmptied: "onemptied",
+    onEnd: "onend",
+    onEnded: "onended",
+    onError: "onerror",
+    onFocus: "onfocus",
+    onFocusIn: "onfocusin",
+    onFocusOut: "onfocusout",
+    onHashChange: "onhashchange",
+    onInput: "oninput",
+    onInvalid: "oninvalid",
+    onKeyDown: "onkeydown",
+    onKeyPress: "onkeypress",
+    onKeyUp: "onkeyup",
+    onLoad: "onload",
+    onLoadedData: "onloadeddata",
+    onLoadedMetadata: "onloadedmetadata",
+    onLoadStart: "onloadstart",
+    onMessage: "onmessage",
+    onMouseDown: "onmousedown",
+    onMouseEnter: "onmouseenter",
+    onMouseLeave: "onmouseleave",
+    onMouseMove: "onmousemove",
+    onMouseOut: "onmouseout",
+    onMouseOver: "onmouseover",
+    onMouseUp: "onmouseup",
+    onMouseWheel: "onmousewheel",
+    onOffline: "onoffline",
+    onOnline: "ononline",
+    onPageHide: "onpagehide",
+    onPageShow: "onpageshow",
+    onPaste: "onpaste",
+    onPause: "onpause",
+    onPlay: "onplay",
+    onPlaying: "onplaying",
+    onPopState: "onpopstate",
+    onProgress: "onprogress",
+    onRateChange: "onratechange",
+    onRepeat: "onrepeat",
+    onReset: "onreset",
+    onResize: "onresize",
+    onScroll: "onscroll",
+    onSeeked: "onseeked",
+    onSeeking: "onseeking",
+    onSelect: "onselect",
+    onShow: "onshow",
+    onStalled: "onstalled",
+    onStorage: "onstorage",
+    onSubmit: "onsubmit",
+    onSuspend: "onsuspend",
+    onTimeUpdate: "ontimeupdate",
+    onToggle: "ontoggle",
+    onUnload: "onunload",
+    onVolumeChange: "onvolumechange",
+    onWaiting: "onwaiting",
+    onZoom: "onzoom",
+    overlinePosition: "overline-position",
+    overlineThickness: "overline-thickness",
+    paintOrder: "paint-order",
+    panose1: "panose-1",
+    pointerEvents: "pointer-events",
+    referrerPolicy: "referrerpolicy",
+    renderingIntent: "rendering-intent",
+    shapeRendering: "shape-rendering",
+    stopColor: "stop-color",
+    stopOpacity: "stop-opacity",
+    strikethroughPosition: "strikethrough-position",
+    strikethroughThickness: "strikethrough-thickness",
+    strokeDashArray: "stroke-dasharray",
+    strokeDashOffset: "stroke-dashoffset",
+    strokeLineCap: "stroke-linecap",
+    strokeLineJoin: "stroke-linejoin",
+    strokeMiterLimit: "stroke-miterlimit",
+    strokeOpacity: "stroke-opacity",
+    strokeWidth: "stroke-width",
+    tabIndex: "tabindex",
+    textAnchor: "text-anchor",
+    textDecoration: "text-decoration",
+    textRendering: "text-rendering",
+    transformOrigin: "transform-origin",
+    typeOf: "typeof",
+    underlinePosition: "underline-position",
+    underlineThickness: "underline-thickness",
+    unicodeBidi: "unicode-bidi",
+    unicodeRange: "unicode-range",
+    unitsPerEm: "units-per-em",
+    vAlphabetic: "v-alphabetic",
+    vHanging: "v-hanging",
+    vIdeographic: "v-ideographic",
+    vMathematical: "v-mathematical",
+    vectorEffect: "vector-effect",
+    vertAdvY: "vert-adv-y",
+    vertOriginX: "vert-origin-x",
+    vertOriginY: "vert-origin-y",
+    wordSpacing: "word-spacing",
+    writingMode: "writing-mode",
+    xHeight: "x-height",
+    // These were camelcased in Tiny. Now lowercased in SVG 2
+    playbackOrder: "playbackorder",
+    timelineBegin: "timelinebegin"
+  },
+  transform: caseSensitiveTransform,
+  properties: {
+    about: commaOrSpaceSeparated,
+    accentHeight: number,
+    accumulate: null,
+    additive: null,
+    alignmentBaseline: null,
+    alphabetic: number,
+    amplitude: number,
+    arabicForm: null,
+    ascent: number,
+    attributeName: null,
+    attributeType: null,
+    azimuth: number,
+    bandwidth: null,
+    baselineShift: null,
+    baseFrequency: null,
+    baseProfile: null,
+    bbox: null,
+    begin: null,
+    bias: number,
+    by: null,
+    calcMode: null,
+    capHeight: number,
+    className: spaceSeparated,
+    clip: null,
+    clipPath: null,
+    clipPathUnits: null,
+    clipRule: null,
+    color: null,
+    colorInterpolation: null,
+    colorInterpolationFilters: null,
+    colorProfile: null,
+    colorRendering: null,
+    content: null,
+    contentScriptType: null,
+    contentStyleType: null,
+    crossOrigin: null,
+    cursor: null,
+    cx: null,
+    cy: null,
+    d: null,
+    dataType: null,
+    defaultAction: null,
+    descent: number,
+    diffuseConstant: number,
+    direction: null,
+    display: null,
+    dur: null,
+    divisor: number,
+    dominantBaseline: null,
+    download: boolean,
+    dx: null,
+    dy: null,
+    edgeMode: null,
+    editable: null,
+    elevation: number,
+    enableBackground: null,
+    end: null,
+    event: null,
+    exponent: number,
+    externalResourcesRequired: null,
+    fill: null,
+    fillOpacity: number,
+    fillRule: null,
+    filter: null,
+    filterRes: null,
+    filterUnits: null,
+    floodColor: null,
+    floodOpacity: null,
+    focusable: null,
+    focusHighlight: null,
+    fontFamily: null,
+    fontSize: null,
+    fontSizeAdjust: null,
+    fontStretch: null,
+    fontStyle: null,
+    fontVariant: null,
+    fontWeight: null,
+    format: null,
+    fr: null,
+    from: null,
+    fx: null,
+    fy: null,
+    g1: commaSeparated,
+    g2: commaSeparated,
+    glyphName: commaSeparated,
+    glyphOrientationHorizontal: null,
+    glyphOrientationVertical: null,
+    glyphRef: null,
+    gradientTransform: null,
+    gradientUnits: null,
+    handler: null,
+    hanging: number,
+    hatchContentUnits: null,
+    hatchUnits: null,
+    height: null,
+    href: null,
+    hrefLang: null,
+    horizAdvX: number,
+    horizOriginX: number,
+    horizOriginY: number,
+    id: null,
+    ideographic: number,
+    imageRendering: null,
+    initialVisibility: null,
+    in: null,
+    in2: null,
+    intercept: number,
+    k: number,
+    k1: number,
+    k2: number,
+    k3: number,
+    k4: number,
+    kernelMatrix: commaOrSpaceSeparated,
+    kernelUnitLength: null,
+    keyPoints: null,
+    // SEMI_COLON_SEPARATED
+    keySplines: null,
+    // SEMI_COLON_SEPARATED
+    keyTimes: null,
+    // SEMI_COLON_SEPARATED
+    kerning: null,
+    lang: null,
+    lengthAdjust: null,
+    letterSpacing: null,
+    lightingColor: null,
+    limitingConeAngle: number,
+    local: null,
+    markerEnd: null,
+    markerMid: null,
+    markerStart: null,
+    markerHeight: null,
+    markerUnits: null,
+    markerWidth: null,
+    mask: null,
+    maskContentUnits: null,
+    maskUnits: null,
+    mathematical: null,
+    max: null,
+    media: null,
+    mediaCharacterEncoding: null,
+    mediaContentEncodings: null,
+    mediaSize: number,
+    mediaTime: null,
+    method: null,
+    min: null,
+    mode: null,
+    name: null,
+    navDown: null,
+    navDownLeft: null,
+    navDownRight: null,
+    navLeft: null,
+    navNext: null,
+    navPrev: null,
+    navRight: null,
+    navUp: null,
+    navUpLeft: null,
+    navUpRight: null,
+    numOctaves: null,
+    observer: null,
+    offset: null,
+    onAbort: null,
+    onActivate: null,
+    onAfterPrint: null,
+    onBeforePrint: null,
+    onBegin: null,
+    onCancel: null,
+    onCanPlay: null,
+    onCanPlayThrough: null,
+    onChange: null,
+    onClick: null,
+    onClose: null,
+    onCopy: null,
+    onCueChange: null,
+    onCut: null,
+    onDblClick: null,
+    onDrag: null,
+    onDragEnd: null,
+    onDragEnter: null,
+    onDragExit: null,
+    onDragLeave: null,
+    onDragOver: null,
+    onDragStart: null,
+    onDrop: null,
+    onDurationChange: null,
+    onEmptied: null,
+    onEnd: null,
+    onEnded: null,
+    onError: null,
+    onFocus: null,
+    onFocusIn: null,
+    onFocusOut: null,
+    onHashChange: null,
+    onInput: null,
+    onInvalid: null,
+    onKeyDown: null,
+    onKeyPress: null,
+    onKeyUp: null,
+    onLoad: null,
+    onLoadedData: null,
+    onLoadedMetadata: null,
+    onLoadStart: null,
+    onMessage: null,
+    onMouseDown: null,
+    onMouseEnter: null,
+    onMouseLeave: null,
+    onMouseMove: null,
+    onMouseOut: null,
+    onMouseOver: null,
+    onMouseUp: null,
+    onMouseWheel: null,
+    onOffline: null,
+    onOnline: null,
+    onPageHide: null,
+    onPageShow: null,
+    onPaste: null,
+    onPause: null,
+    onPlay: null,
+    onPlaying: null,
+    onPopState: null,
+    onProgress: null,
+    onRateChange: null,
+    onRepeat: null,
+    onReset: null,
+    onResize: null,
+    onScroll: null,
+    onSeeked: null,
+    onSeeking: null,
+    onSelect: null,
+    onShow: null,
+    onStalled: null,
+    onStorage: null,
+    onSubmit: null,
+    onSuspend: null,
+    onTimeUpdate: null,
+    onToggle: null,
+    onUnload: null,
+    onVolumeChange: null,
+    onWaiting: null,
+    onZoom: null,
+    opacity: null,
+    operator: null,
+    order: null,
+    orient: null,
+    orientation: null,
+    origin: null,
+    overflow: null,
+    overlay: null,
+    overlinePosition: number,
+    overlineThickness: number,
+    paintOrder: null,
+    panose1: null,
+    path: null,
+    pathLength: number,
+    patternContentUnits: null,
+    patternTransform: null,
+    patternUnits: null,
+    phase: null,
+    ping: spaceSeparated,
+    pitch: null,
+    playbackOrder: null,
+    pointerEvents: null,
+    points: null,
+    pointsAtX: number,
+    pointsAtY: number,
+    pointsAtZ: number,
+    preserveAlpha: null,
+    preserveAspectRatio: null,
+    primitiveUnits: null,
+    propagate: null,
+    property: commaOrSpaceSeparated,
+    r: null,
+    radius: null,
+    referrerPolicy: null,
+    refX: null,
+    refY: null,
+    rel: commaOrSpaceSeparated,
+    rev: commaOrSpaceSeparated,
+    renderingIntent: null,
+    repeatCount: null,
+    repeatDur: null,
+    requiredExtensions: commaOrSpaceSeparated,
+    requiredFeatures: commaOrSpaceSeparated,
+    requiredFonts: commaOrSpaceSeparated,
+    requiredFormats: commaOrSpaceSeparated,
+    resource: null,
+    restart: null,
+    result: null,
+    rotate: null,
+    rx: null,
+    ry: null,
+    scale: null,
+    seed: null,
+    shapeRendering: null,
+    side: null,
+    slope: null,
+    snapshotTime: null,
+    specularConstant: number,
+    specularExponent: number,
+    spreadMethod: null,
+    spacing: null,
+    startOffset: null,
+    stdDeviation: null,
+    stemh: null,
+    stemv: null,
+    stitchTiles: null,
+    stopColor: null,
+    stopOpacity: null,
+    strikethroughPosition: number,
+    strikethroughThickness: number,
+    string: null,
+    stroke: null,
+    strokeDashArray: commaOrSpaceSeparated,
+    strokeDashOffset: null,
+    strokeLineCap: null,
+    strokeLineJoin: null,
+    strokeMiterLimit: number,
+    strokeOpacity: number,
+    strokeWidth: null,
+    style: null,
+    surfaceScale: number,
+    syncBehavior: null,
+    syncBehaviorDefault: null,
+    syncMaster: null,
+    syncTolerance: null,
+    syncToleranceDefault: null,
+    systemLanguage: commaOrSpaceSeparated,
+    tabIndex: number,
+    tableValues: null,
+    target: null,
+    targetX: number,
+    targetY: number,
+    textAnchor: null,
+    textDecoration: null,
+    textRendering: null,
+    textLength: null,
+    timelineBegin: null,
+    title: null,
+    transformBehavior: null,
+    type: null,
+    typeOf: commaOrSpaceSeparated,
+    to: null,
+    transform: null,
+    transformOrigin: null,
+    u1: null,
+    u2: null,
+    underlinePosition: number,
+    underlineThickness: number,
+    unicode: null,
+    unicodeBidi: null,
+    unicodeRange: null,
+    unitsPerEm: number,
+    values: null,
+    vAlphabetic: number,
+    vMathematical: number,
+    vectorEffect: null,
+    vHanging: number,
+    vIdeographic: number,
+    version: null,
+    vertAdvY: number,
+    vertOriginX: number,
+    vertOriginY: number,
+    viewBox: null,
+    viewTarget: null,
+    visibility: null,
+    width: null,
+    widths: null,
+    wordSpacing: null,
+    writingMode: null,
+    x: null,
+    x1: null,
+    x2: null,
+    xChannelSelector: null,
+    xHeight: number,
+    y: null,
+    y1: null,
+    y2: null,
+    yChannelSelector: null,
+    z: null,
+    zoomAndPan: null
+  }
+});
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/find.js
+var valid = /^data[-\w.:]+$/i;
+var dash = /-[a-z]/g;
+var cap = /[A-Z]/g;
+function find(schema, value) {
+  const normal = normalize(value);
+  let prop = value;
+  let Type = Info;
+  if (normal in schema.normal) {
+    return schema.property[schema.normal[normal]];
+  }
+  if (normal.length > 4 && normal.slice(0, 4) === "data" && valid.test(value)) {
+    if (value.charAt(4) === "-") {
+      const rest = value.slice(5).replace(dash, camelcase);
+      prop = "data" + rest.charAt(0).toUpperCase() + rest.slice(1);
+    } else {
+      const rest = value.slice(4);
+      if (!dash.test(rest)) {
+        let dashes = rest.replace(cap, kebab);
+        if (dashes.charAt(0) !== "-") {
+          dashes = "-" + dashes;
+        }
+        value = "data" + dashes;
+      }
+    }
+    Type = DefinedInfo;
+  }
+  return new Type(prop, value);
+}
+function kebab($0) {
+  return "-" + $0.toLowerCase();
+}
+function camelcase($0) {
+  return $0.charAt(1).toUpperCase();
+}
+
+// node_modules/hast-util-to-estree/node_modules/property-information/lib/hast-to-react.js
+var hastToReact = {
+  classId: "classID",
+  dataType: "datatype",
+  itemId: "itemID",
+  strokeDashArray: "strokeDasharray",
+  strokeDashOffset: "strokeDashoffset",
+  strokeLineCap: "strokeLinecap",
+  strokeLineJoin: "strokeLinejoin",
+  strokeMiterLimit: "strokeMiterlimit",
+  typeOf: "typeof",
+  xLinkActuate: "xlinkActuate",
+  xLinkArcRole: "xlinkArcrole",
+  xLinkHref: "xlinkHref",
+  xLinkRole: "xlinkRole",
+  xLinkShow: "xlinkShow",
+  xLinkTitle: "xlinkTitle",
+  xLinkType: "xlinkType",
+  xmlnsXLink: "xmlnsXlink"
+};
+
+// node_modules/hast-util-to-estree/node_modules/property-information/index.js
+var html3 = merge([xml, xlink, xmlns, aria, html2], "html");
+var svg2 = merge([xml, xlink, xmlns, aria, svg], "svg");
+
+// node_modules/hast-util-to-estree/node_modules/space-separated-tokens/index.js
+function stringify3(values) {
+  return values.join(" ").trim();
+}
+
+// node_modules/hast-util-to-estree/node_modules/style-to-object/index.mjs
+var import_index = __toESM(require_style_to_object(), 1);
+var style_to_object_default = import_index.default;
+
+// node_modules/hast-util-to-estree/lib/handlers/element.js
+var own7 = {}.hasOwnProperty;
+var cap2 = /[A-Z]/g;
+var dashSomething = /-([a-z])/g;
+var tableCellElement = /* @__PURE__ */ new Set(["td", "th"]);
+function element(node2, state) {
+  const parentSchema = state.schema;
+  let schema = parentSchema;
+  const props = node2.properties || {};
+  if (parentSchema.space === "html" && node2.tagName.toLowerCase() === "svg") {
+    schema = svg2;
+    state.schema = schema;
+  }
+  const children = state.all(node2);
+  const attributes = [];
+  let prop;
+  let alignValue;
+  let styleProperties;
+  for (prop in props) {
+    if (own7.call(props, prop)) {
+      let value = props[prop];
+      const info = find(schema, prop);
+      let attributeValue;
+      if (value === null || value === void 0 || value === false || typeof value === "number" && Number.isNaN(value) || !value && info.boolean) {
+        continue;
+      }
+      prop = state.elementAttributeNameCase === "react" && info.space ? hastToReact[info.property] || info.property : info.attribute;
+      if (Array.isArray(value)) {
+        value = info.commaSeparated ? stringify2(value) : stringify3(value);
+      }
+      if (prop === "style") {
+        let styleObject = typeof value === "object" ? value : parseStyle(String(value), node2.tagName);
+        if (state.stylePropertyNameCase === "css") {
+          styleObject = transformStylesToCssCasing(styleObject);
+        }
+        const cssProperties = [];
+        let cssProp;
+        for (cssProp in styleObject) {
+          if (own7.call(styleObject, cssProp)) {
+            cssProperties.push({
+              type: "Property",
+              method: false,
+              shorthand: false,
+              computed: false,
+              key: name(cssProp) ? { type: "Identifier", name: cssProp } : { type: "Literal", value: cssProp },
+              value: { type: "Literal", value: String(styleObject[cssProp]) },
+              kind: "init"
+            });
+          }
+        }
+        styleProperties = cssProperties;
+        attributeValue = {
+          type: "JSXExpressionContainer",
+          expression: { type: "ObjectExpression", properties: cssProperties }
+        };
+      } else if (value === true) {
+        attributeValue = null;
+      } else if (state.tableCellAlignToStyle && tableCellElement.has(node2.tagName) && prop === "align") {
+        alignValue = String(value);
+        continue;
+      } else {
+        attributeValue = { type: "Literal", value: String(value) };
+      }
+      if (name(prop, { jsx: true })) {
+        attributes.push({
+          type: "JSXAttribute",
+          name: { type: "JSXIdentifier", name: prop },
+          value: attributeValue
+        });
+      } else {
+        attributes.push({
+          type: "JSXSpreadAttribute",
+          argument: {
+            type: "ObjectExpression",
+            properties: [
+              {
+                type: "Property",
+                method: false,
+                shorthand: false,
+                computed: false,
+                key: { type: "Literal", value: String(prop) },
+                // @ts-expect-error No need to worry about `style` (which has a
+                // `JSXExpressionContainer` value) because that’s a valid identifier.
+                value: attributeValue || { type: "Literal", value: true },
+                kind: "init"
+              }
+            ]
+          }
+        });
+      }
+    }
+  }
+  if (alignValue !== void 0) {
+    if (!styleProperties) {
+      styleProperties = [];
+      attributes.push({
+        type: "JSXAttribute",
+        name: { type: "JSXIdentifier", name: "style" },
+        value: {
+          type: "JSXExpressionContainer",
+          expression: { type: "ObjectExpression", properties: styleProperties }
+        }
+      });
+    }
+    const cssProp = state.stylePropertyNameCase === "css" ? transformStyleToCssCasing("textAlign") : "textAlign";
+    styleProperties.push({
+      type: "Property",
+      method: false,
+      shorthand: false,
+      computed: false,
+      key: name(cssProp) ? { type: "Identifier", name: cssProp } : { type: "Literal", value: cssProp },
+      value: { type: "Literal", value: alignValue },
+      kind: "init"
+    });
+  }
+  state.schema = parentSchema;
+  const result = {
+    type: "JSXElement",
+    openingElement: {
+      type: "JSXOpeningElement",
+      attributes,
+      name: state.createJsxElementName(node2.tagName),
+      selfClosing: children.length === 0
+    },
+    closingElement: children.length > 0 ? {
+      type: "JSXClosingElement",
+      name: state.createJsxElementName(node2.tagName)
+    } : null,
+    children
+  };
+  state.inherit(node2, result);
+  return result;
+}
+function parseStyle(value, tagName) {
+  const result = {};
+  try {
+    style_to_object_default(value, iterator);
+  } catch (error) {
+    const cause = (
+      /** @type {Error} */
+      error
+    );
+    const exception = new Error(
+      "Could not parse `style` attribute on `" + tagName + "`",
+      { cause }
+    );
+    throw exception;
+  }
+  return result;
+  function iterator(name2, value2) {
+    let key = name2;
+    if (key.slice(0, 2) !== "--") {
+      if (key.slice(0, 4) === "-ms-") key = "ms-" + key.slice(4);
+      key = key.replace(dashSomething, toCamel);
+    }
+    result[key] = value2;
+  }
+}
+function transformStylesToCssCasing(domCasing) {
+  const cssCasing = {};
+  let from;
+  for (from in domCasing) {
+    if (own7.call(domCasing, from)) {
+      cssCasing[transformStyleToCssCasing(from)] = domCasing[from];
+    }
+  }
+  return cssCasing;
+}
+function transformStyleToCssCasing(from) {
+  let to = from.replace(cap2, toDash);
+  if (to.slice(0, 3) === "ms-") to = "-" + to;
+  return to;
+}
+function toCamel(_, $1) {
+  return $1.toUpperCase();
+}
+function toDash($0) {
+  return "-" + $0.toLowerCase();
+}
+
+// node_modules/estree-util-attach-comments/lib/index.js
+var own8 = {}.hasOwnProperty;
+var emptyComments = [];
+function attachComments(tree, comments) {
+  const list3 = comments ? [...comments].sort(compare) : emptyComments;
+  if (list3.length > 0) walk2(tree, { comments: list3, index: 0 });
+}
+function walk2(node2, state) {
+  if (state.index === state.comments.length) {
+    return;
+  }
+  const children = [];
+  const comments = [];
+  let key;
+  for (key in node2) {
+    if (own8.call(node2, key)) {
+      const value = node2[key];
+      if (value && typeof value === "object" && key !== "comments") {
+        if (Array.isArray(value)) {
+          let index3 = -1;
+          while (++index3 < value.length) {
+            if (value[index3] && typeof value[index3].type === "string") {
+              children.push(value[index3]);
+            }
+          }
+        } else if (typeof value.type === "string") {
+          children.push(value);
+        }
+      }
+    }
+  }
+  children.sort(compare);
+  comments.push(...slice(state, node2, false, { leading: true, trailing: false }));
+  let index2 = -1;
+  while (++index2 < children.length) {
+    walk2(children[index2], state);
+  }
+  comments.push(
+    ...slice(state, node2, true, {
+      leading: false,
+      trailing: children.length > 0
+    })
+  );
+  if (comments.length > 0) {
+    node2.comments = comments;
+  }
+}
+function slice(state, node2, compareEnd, fields) {
+  const result = [];
+  while (state.comments[state.index] && compare(state.comments[state.index], node2, compareEnd) < 1) {
+    result.push(Object.assign({}, state.comments[state.index++], fields));
+  }
+  return result;
+}
+function compare(left, right, compareEnd) {
+  const field = compareEnd ? "end" : "start";
+  if (left.range && right.range) {
+    return left.range[0] - right.range[compareEnd ? 1 : 0];
+  }
+  if (left.loc && left.loc.start && right.loc && right.loc[field]) {
+    return left.loc.start.line - right.loc[field].line || left.loc.start.column - right.loc[field].column;
+  }
+  if ("start" in left && field in right) {
+    return left.start - right[field];
+  }
+  return Number.NaN;
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/mdx-expression.js
+function mdxExpression2(node2, state) {
+  const estree = node2.data && node2.data.estree;
+  const comments = estree && estree.comments || [];
+  let expression;
+  if (estree) {
+    state.comments.push(...comments);
+    attachComments(estree, estree.comments);
+    expression = estree.body[0] && estree.body[0].type === "ExpressionStatement" && estree.body[0].expression || void 0;
+  }
+  if (!expression) {
+    expression = { type: "JSXEmptyExpression" };
+    state.patch(node2, expression);
+  }
+  const result = { type: "JSXExpressionContainer", expression };
+  state.inherit(node2, result);
+  return result;
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/mdx-jsx-element.js
+function mdxJsxElement(node2, state) {
+  const parentSchema = state.schema;
+  let schema = parentSchema;
+  const attrs = node2.attributes || [];
+  let index2 = -1;
+  if (node2.name && parentSchema.space === "html" && node2.name.toLowerCase() === "svg") {
+    schema = svg2;
+    state.schema = schema;
+  }
+  const children = state.all(node2);
+  const attributes = [];
+  while (++index2 < attrs.length) {
+    const attr = attrs[index2];
+    const value = attr.value;
+    let attributeValue;
+    if (attr.type === "mdxJsxAttribute") {
+      if (value === null || value === void 0) {
+        attributeValue = null;
+      } else if (typeof value === "object") {
+        const estree = value.data && value.data.estree;
+        const comments = estree && estree.comments || [];
+        let expression;
+        if (estree) {
+          state.comments.push(...comments);
+          attachComments(estree, estree.comments);
+          expression = estree.body[0] && estree.body[0].type === "ExpressionStatement" && estree.body[0].expression || void 0;
+        }
+        attributeValue = {
+          type: "JSXExpressionContainer",
+          expression: expression || { type: "JSXEmptyExpression" }
+        };
+        state.inherit(value, attributeValue);
+      } else {
+        attributeValue = { type: "Literal", value: String(value) };
+      }
+      const attribute = {
+        type: "JSXAttribute",
+        name: state.createJsxAttributeName(attr.name),
+        value: attributeValue
+      };
+      state.inherit(attr, attribute);
+      attributes.push(attribute);
+    } else {
+      const estree = attr.data && attr.data.estree;
+      const comments = estree && estree.comments || [];
+      let argumentValue;
+      if (estree) {
+        state.comments.push(...comments);
+        attachComments(estree, estree.comments);
+        argumentValue = estree.body[0] && estree.body[0].type === "ExpressionStatement" && estree.body[0].expression && estree.body[0].expression.type === "ObjectExpression" && estree.body[0].expression.properties && estree.body[0].expression.properties[0] && estree.body[0].expression.properties[0].type === "SpreadElement" && estree.body[0].expression.properties[0].argument || void 0;
+      }
+      const attribute = {
+        type: "JSXSpreadAttribute",
+        argument: argumentValue || { type: "ObjectExpression", properties: [] }
+      };
+      state.inherit(attr, attribute);
+      attributes.push(attribute);
+    }
+  }
+  state.schema = parentSchema;
+  const result = node2.name ? {
+    type: "JSXElement",
+    openingElement: {
+      type: "JSXOpeningElement",
+      attributes,
+      name: state.createJsxElementName(node2.name),
+      selfClosing: children.length === 0
+    },
+    closingElement: children.length > 0 ? {
+      type: "JSXClosingElement",
+      name: state.createJsxElementName(node2.name)
+    } : null,
+    children
+  } : {
+    type: "JSXFragment",
+    openingFragment: { type: "JSXOpeningFragment" },
+    closingFragment: { type: "JSXClosingFragment" },
+    children
+  };
+  state.inherit(node2, result);
+  return result;
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/mdxjs-esm.js
+function mdxjsEsm2(node2, state) {
+  const estree = node2.data && node2.data.estree;
+  const comments = estree && estree.comments || [];
+  if (estree) {
+    state.comments.push(...comments);
+    attachComments(estree, comments);
+    state.esm.push(...estree.body);
+  }
+}
+
+// node_modules/hast-util-whitespace/lib/index.js
+var re = /[ \t\n\f\r]/g;
+function whitespace(thing) {
+  return typeof thing === "object" ? thing.type === "text" ? empty4(thing.value) : false : empty4(thing);
+}
+function empty4(value) {
+  return value.replace(re, "") === "";
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/root.js
+function root2(node2, state) {
+  const children = state.all(node2);
+  const cleanChildren = [];
+  let index2 = -1;
+  let queue;
+  while (++index2 < children.length) {
+    const child = children[index2];
+    if (child.type === "JSXExpressionContainer" && child.expression.type === "Literal" && whitespace(String(child.expression.value))) {
+      if (queue) queue.push(child);
+    } else {
+      if (queue) cleanChildren.push(...queue);
+      cleanChildren.push(child);
+      queue = [];
+    }
+  }
+  const result = {
+    type: "JSXFragment",
+    openingFragment: { type: "JSXOpeningFragment" },
+    closingFragment: { type: "JSXClosingFragment" },
+    children: cleanChildren
+  };
+  state.inherit(node2, result);
+  return result;
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/text.js
+function text4(node2, state) {
+  const value = String(node2.value || "");
+  if (value) {
+    const result = { type: "Literal", value };
+    state.inherit(node2, result);
+    const container = { type: "JSXExpressionContainer", expression: result };
+    state.patch(node2, container);
+    return container;
+  }
+}
+
+// node_modules/hast-util-to-estree/lib/handlers/index.js
+var handlers2 = {
+  comment,
+  doctype: ignore2,
+  element,
+  mdxFlowExpression: mdxExpression2,
+  mdxJsxFlowElement: mdxJsxElement,
+  mdxJsxTextElement: mdxJsxElement,
+  mdxTextExpression: mdxExpression2,
+  mdxjsEsm: mdxjsEsm2,
+  root: root2,
+  text: text4
+};
+function ignore2() {
+}
+
+// node_modules/hast-util-to-estree/node_modules/zwitch/index.js
+var own9 = {}.hasOwnProperty;
+function zwitch(key, options) {
+  const settings = options || {};
+  function one2(value, ...parameters) {
+    let fn = one2.invalid;
+    const handlers3 = one2.handlers;
+    if (value && own9.call(value, key)) {
+      const id = String(value[key]);
+      fn = own9.call(handlers3, id) ? handlers3[id] : one2.unknown;
+    }
+    if (fn) {
+      return fn.call(this, value, ...parameters);
+    }
+  }
+  one2.handlers = settings.handlers || {};
+  one2.invalid = settings.invalid;
+  one2.unknown = settings.unknown;
+  return one2;
+}
+
+// node_modules/hast-util-to-estree/lib/state.js
+var own10 = {}.hasOwnProperty;
+var tableElements = /* @__PURE__ */ new Set(["table", "tbody", "thead", "tfoot", "tr"]);
+function createState2(options) {
+  const one2 = zwitch("type", {
+    invalid,
+    unknown,
+    handlers: { ...handlers2, ...options.handlers }
+  });
+  return {
+    // Current space.
+    elementAttributeNameCase: options.elementAttributeNameCase || "react",
+    schema: options.space === "svg" ? svg2 : html3,
+    stylePropertyNameCase: options.stylePropertyNameCase || "dom",
+    tableCellAlignToStyle: options.tableCellAlignToStyle !== false,
+    // Results.
+    comments: [],
+    esm: [],
+    // Useful functions.
+    all: all2,
+    createJsxAttributeName,
+    createJsxElementName,
+    handle,
+    inherit,
+    patch: patch2
+  };
+  function handle(node2) {
+    return one2(node2, this);
+  }
+}
+function invalid(value) {
+  throw new Error("Cannot handle value `" + value + "`, expected node");
+}
+function unknown(node2) {
+  ok(node2 && typeof node2 === "object");
+  ok("type" in node2);
+  throw new Error("Cannot handle unknown node `" + node2.type + "`");
+}
+function all2(parent) {
+  const children = parent.children || [];
+  let index2 = -1;
+  const results = [];
+  const ignoreLineBreak = this.schema.space === "html" && parent.type === "element" && tableElements.has(parent.tagName.toLowerCase());
+  while (++index2 < children.length) {
+    const child = children[index2];
+    if (ignoreLineBreak && child.type === "text" && child.value === "\n") {
+      continue;
+    }
+    const result = this.handle(child);
+    if (Array.isArray(result)) {
+      results.push(...result);
+    } else if (result) {
+      results.push(result);
+    }
+  }
+  return results;
+}
+function inherit(from, to) {
+  const left = (
+    /** @type {Record<string, unknown> | undefined} */
+    from.data
+  );
+  let right;
+  let key;
+  patch2(from, to);
+  if (left) {
+    for (key in left) {
+      if (own10.call(left, key) && key !== "estree") {
+        if (!right) right = {};
+        right[key] = left[key];
+      }
+    }
+    if (right) {
+      to.data = right;
+    }
+  }
+}
+function patch2(from, to) {
+  const p = position2(from);
+  if (p && p.start.offset !== void 0 && p.end.offset !== void 0) {
+    to.start = p.start.offset;
+    to.end = p.end.offset;
+    to.loc = {
+      start: { line: p.start.line, column: p.start.column - 1 },
+      end: { line: p.end.line, column: p.end.column - 1 }
+    };
+    to.range = [p.start.offset, p.end.offset];
+  }
+}
+function createJsxAttributeName(name2) {
+  const node2 = createJsxNameFromString(name2);
+  if (node2.type === "JSXMemberExpression") {
+    throw new Error("Member expressions in attribute names are not supported");
+  }
+  return node2;
+}
+function createJsxElementName(name2) {
+  return createJsxNameFromString(name2);
+}
+function createJsxNameFromString(name2) {
+  if (name2.includes(".")) {
+    const names = name2.split(".");
+    let part = names.shift();
+    ok(part, "Expected `part` to be defined");
+    let node2 = { type: "JSXIdentifier", name: part };
+    while (part = names.shift()) {
+      node2 = {
+        type: "JSXMemberExpression",
+        object: node2,
+        property: { type: "JSXIdentifier", name: part }
+      };
+    }
+    return node2;
+  }
+  if (name2.includes(":")) {
+    const parts = name2.split(":");
+    return {
+      type: "JSXNamespacedName",
+      namespace: { type: "JSXIdentifier", name: parts[0] },
+      name: { type: "JSXIdentifier", name: parts[1] }
+    };
+  }
+  return { type: "JSXIdentifier", name: name2 };
+}
+
+// node_modules/hast-util-to-estree/lib/index.js
+function toEstree(tree, options) {
+  const state = createState2(options || {});
+  let result = state.handle(tree);
+  const body = state.esm;
+  if (result) {
+    if (result.type !== "JSXFragment" && result.type !== "JSXElement") {
+      result = {
+        type: "JSXFragment",
+        openingFragment: { type: "JSXOpeningFragment" },
+        closingFragment: { type: "JSXClosingFragment" },
+        children: [result]
+      };
+      state.patch(tree, result);
+    }
+    const statement = { type: "ExpressionStatement", expression: result };
+    state.patch(tree, statement);
+    body.push(statement);
+  }
+  const program = {
+    type: "Program",
+    body,
+    sourceType: "module",
+    comments: state.comments
+  };
+  state.patch(tree, program);
+  return program;
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/rehype-recma.js
+function rehypeRecma(options) {
+  return function(tree) {
+    return toEstree(tree, options);
+  };
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unist-util-is/lib/index.js
+var convert2 = (
+  // Note: overloads in JSDoc can’t yet use different `@template`s.
+  /**
+   * @type {(
+   *   (<Condition extends string>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & {type: Condition}) &
+   *   (<Condition extends Props>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Condition) &
+   *   (<Condition extends TestFunction>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Predicate<Condition, Node>) &
+   *   ((test?: null | undefined) => (node?: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node) &
+   *   ((test?: Test) => Check)
+   * )}
+   */
+  /**
+   * @param {Test} [test]
+   * @returns {Check}
+   */
+  function(test) {
+    if (test === null || test === void 0) {
+      return ok3;
+    }
+    if (typeof test === "function") {
+      return castFactory2(test);
+    }
+    if (typeof test === "object") {
+      return Array.isArray(test) ? anyFactory2(test) : propsFactory2(test);
+    }
+    if (typeof test === "string") {
+      return typeFactory2(test);
+    }
+    throw new Error("Expected function, string, or object as test");
+  }
+);
+function anyFactory2(tests) {
+  const checks2 = [];
+  let index2 = -1;
+  while (++index2 < tests.length) {
+    checks2[index2] = convert2(tests[index2]);
+  }
+  return castFactory2(any);
+  function any(...parameters) {
+    let index3 = -1;
+    while (++index3 < checks2.length) {
+      if (checks2[index3].apply(this, parameters)) return true;
+    }
+    return false;
+  }
+}
+function propsFactory2(check) {
+  const checkAsRecord = (
+    /** @type {Record<string, unknown>} */
+    check
+  );
+  return castFactory2(all3);
+  function all3(node2) {
+    const nodeAsRecord = (
+      /** @type {Record<string, unknown>} */
+      /** @type {unknown} */
+      node2
+    );
+    let key;
+    for (key in check) {
+      if (nodeAsRecord[key] !== checkAsRecord[key]) return false;
+    }
+    return true;
+  }
+}
+function typeFactory2(check) {
+  return castFactory2(type);
+  function type(node2) {
+    return node2 && node2.type === check;
+  }
+}
+function castFactory2(testFunction) {
+  return check;
+  function check(value, index2, parent) {
+    return Boolean(
+      looksLikeANode2(value) && testFunction.call(
+        this,
+        value,
+        typeof index2 === "number" ? index2 : void 0,
+        parent || void 0
+      )
+    );
+  }
+}
+function ok3() {
+  return true;
+}
+function looksLikeANode2(value) {
+  return value !== null && typeof value === "object" && "type" in value;
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unist-util-visit-parents/lib/color.node.js
+function color3(d) {
+  return "\x1B[33m" + d + "\x1B[39m";
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unist-util-visit-parents/lib/index.js
+var empty5 = [];
+var CONTINUE3 = true;
+var EXIT3 = false;
+var SKIP3 = "skip";
+function visitParents2(tree, test, visitor, reverse) {
+  let check;
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+  } else {
+    check = test;
+  }
+  const is3 = convert2(check);
+  const step = reverse ? -1 : 1;
+  factory(tree, void 0, [])();
+  function factory(node2, index2, parents) {
+    const value = (
+      /** @type {Record<string, unknown>} */
+      node2 && typeof node2 === "object" ? node2 : {}
+    );
+    if (typeof value.type === "string") {
+      const name2 = (
+        // `hast`
+        typeof value.tagName === "string" ? value.tagName : (
+          // `xast`
+          typeof value.name === "string" ? value.name : void 0
+        )
+      );
+      Object.defineProperty(visit4, "name", {
+        value: "node (" + color3(node2.type + (name2 ? "<" + name2 + ">" : "")) + ")"
+      });
+    }
+    return visit4;
+    function visit4() {
+      let result = empty5;
+      let subresult;
+      let offset2;
+      let grandparents;
+      if (!test || is3(node2, index2, parents[parents.length - 1] || void 0)) {
+        result = toResult3(visitor(node2, parents));
+        if (result[0] === EXIT3) {
+          return result;
+        }
+      }
+      if ("children" in node2 && node2.children) {
+        const nodeAsParent = (
+          /** @type {UnistParent} */
+          node2
+        );
+        if (nodeAsParent.children && result[0] !== SKIP3) {
+          offset2 = (reverse ? nodeAsParent.children.length : -1) + step;
+          grandparents = parents.concat(nodeAsParent);
+          while (offset2 > -1 && offset2 < nodeAsParent.children.length) {
+            const child = nodeAsParent.children[offset2];
+            subresult = factory(child, offset2, grandparents)();
+            if (subresult[0] === EXIT3) {
+              return subresult;
+            }
+            offset2 = typeof subresult[1] === "number" ? subresult[1] : offset2 + step;
+          }
+        }
+      }
+      return result;
+    }
+  }
+}
+function toResult3(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE3, value];
+  }
+  return value === null || value === void 0 ? empty5 : [value];
+}
+
+// node_modules/@mdx-js/mdx/node_modules/unist-util-visit/lib/index.js
+function visit3(tree, testOrVisitor, visitorOrReverse, maybeReverse) {
+  let reverse;
+  let test;
+  let visitor;
+  if (typeof testOrVisitor === "function" && typeof visitorOrReverse !== "function") {
+    test = void 0;
+    visitor = testOrVisitor;
+    reverse = visitorOrReverse;
+  } else {
+    test = testOrVisitor;
+    visitor = visitorOrReverse;
+    reverse = maybeReverse;
+  }
+  visitParents2(tree, test, overload, reverse);
+  function overload(node2, parents) {
+    const parent = parents[parents.length - 1];
+    const index2 = parent ? parent.children.indexOf(node2) : void 0;
+    return visitor(node2, index2, parent);
+  }
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/rehype-remove-raw.js
+function rehypeRemoveRaw() {
+  return function(tree) {
+    visit3(tree, "raw", function(_, index2, parent) {
+      if (parent && typeof index2 === "number") {
+        parent.children.splice(index2, 1);
+        return index2;
+      }
+    });
+  };
+}
+
+// node_modules/@mdx-js/mdx/node_modules/collapse-white-space/index.js
+var js = /\s+/g;
+var html4 = /[\t\n\v\f\r ]+/g;
+function collapseWhiteSpace(value, options) {
+  if (!options) {
+    options = {};
+  } else if (typeof options === "string") {
+    options = { style: options };
+  }
+  const replace = options.preserveLineEndings ? replaceLineEnding : replaceSpace;
+  return String(value).replace(
+    options.style === "html" ? html4 : js,
+    options.trim ? trimFactory(replace) : replace
+  );
+}
+function replaceLineEnding(value) {
+  const match = /\r?\n|\r/.exec(value);
+  return match ? match[0] : " ";
+}
+function replaceSpace() {
+  return " ";
+}
+function trimFactory(replace) {
+  return dropOrReplace;
+  function dropOrReplace(value, index2, all3) {
+    return index2 === 0 || index2 + value.length === all3.length ? "" : replace(value);
+  }
+}
+
+// node_modules/@mdx-js/mdx/lib/plugin/remark-mark-and-unravel.js
+function remarkMarkAndUnravel() {
+  return function(tree) {
+    visit3(tree, function(node2, index2, parent) {
+      let offset2 = -1;
+      let all3 = true;
+      let oneOrMore = false;
+      if (parent && typeof index2 === "number" && node2.type === "paragraph") {
+        const children = node2.children;
+        while (++offset2 < children.length) {
+          const child = children[offset2];
+          if (child.type === "mdxJsxTextElement" || child.type === "mdxTextExpression") {
+            oneOrMore = true;
+          } else if (child.type === "text" && collapseWhiteSpace(child.value, { style: "html", trim: true }) === "") {
+          } else {
+            all3 = false;
+            break;
+          }
+        }
+        if (all3 && oneOrMore) {
+          offset2 = -1;
+          const newChildren = [];
+          while (++offset2 < children.length) {
+            const child = children[offset2];
+            if (child.type === "mdxJsxTextElement") {
+              child.type = "mdxJsxFlowElement";
+            }
+            if (child.type === "mdxTextExpression") {
+              child.type = "mdxFlowExpression";
+            }
+            if (child.type === "text" && /^[\t\r\n ]+$/.test(String(child.value))) {
+            } else {
+              newChildren.push(child);
+            }
+          }
+          parent.children.splice(index2, 1, ...newChildren);
+          return index2;
+        }
+      }
+      if (node2.type === "mdxJsxFlowElement" || node2.type === "mdxJsxTextElement") {
+        const data2 = node2.data || (node2.data = {});
+        data2._mdxExplicitJsx = true;
+      }
+    });
+  };
+}
+
+// node_modules/@mdx-js/mdx/lib/node-types.js
+var nodeTypes = (
+  /** @type {const} */
+  [
+    "mdxFlowExpression",
+    "mdxJsxFlowElement",
+    "mdxJsxTextElement",
+    "mdxTextExpression",
+    "mdxjsEsm"
+  ]
+);
+
+// node_modules/@mdx-js/mdx/lib/core.js
+var removedOptions = [
+  "compilers",
+  "filepath",
+  "hastPlugins",
+  "mdPlugins",
+  "skipExport",
+  "wrapExport"
+];
+var warned = false;
+function createProcessor(options) {
+  const settings = options || {};
+  let index2 = -1;
+  while (++index2 < removedOptions.length) {
+    const key = removedOptions[index2];
+    if (key in settings) {
+      unreachable(
+        "Unexpected removed option `" + key + "`; see <https://mdxjs.com/migrating/v2/> on how to migrate"
+      );
+    }
+  }
+  if (settings.format === "detect") {
+    unreachable(
+      "Unexpected `format: 'detect'`, which is not supported by `createProcessor`, expected `'mdx'` or `'md'`"
+    );
+  }
+  if ((settings.jsxRuntime === "classic" || settings.pragma || settings.pragmaFrag || settings.pragmaImportSource) && !warned) {
+    warned = true;
+    console.warn(
+      "Unexpected deprecated option `jsxRuntime: 'classic'`, `pragma`, `pragmaFrag`, or `pragmaImportSource`; see <https://mdxjs.com/migrating/v3/> on how to migrate"
+    );
+  }
+  const pipeline = unified().use(remarkParse);
+  if (settings.format !== "md") {
+    pipeline.use(remarkMdx);
+  }
+  const remarkRehypeOptions = settings.remarkRehypeOptions || {};
+  pipeline.use(remarkMarkAndUnravel).use(settings.remarkPlugins || []).use(remarkRehype, {
+    ...remarkRehypeOptions,
+    allowDangerousHtml: true,
+    passThrough: [...remarkRehypeOptions.passThrough || [], ...nodeTypes]
+  }).use(settings.rehypePlugins || []);
+  if (settings.format === "md") {
+    pipeline.use(rehypeRemoveRaw);
+  }
+  pipeline.use(rehypeRecma, settings).use(recmaDocument, settings).use(recmaJsxRewrite, settings);
+  if (!settings.jsx) {
+    pipeline.use(recmaJsxBuild, settings);
+  }
+  pipeline.use(recmaStringify, settings).use(settings.recmaPlugins || []);
+  return pipeline;
+}
+
+// node_modules/@mdx-js/mdx/lib/compile.js
+function compile(vfileCompatible, compileOptions) {
+  const { file, options } = resolveFileAndOptions(vfileCompatible, compileOptions);
+  return createProcessor(options).process(file);
+}
+function compileSync(vfileCompatible, compileOptions) {
+  const { file, options } = resolveFileAndOptions(vfileCompatible, compileOptions);
+  return createProcessor(options).processSync(file);
+}
+
+// node_modules/@mdx-js/mdx/lib/util/resolve-evaluate-options.js
+function resolveEvaluateOptions(options) {
+  const {
+    Fragment,
+    baseUrl,
+    development,
+    jsx: jsx2,
+    jsxDEV,
+    jsxs,
+    useMDXComponents,
+    ...rest
+  } = options || {};
+  if (!Fragment) throw new Error("Expected `Fragment` given to `evaluate`");
+  if (development) {
+    if (!jsxDEV) throw new Error("Expected `jsxDEV` given to `evaluate`");
+  } else {
+    if (!jsx2) throw new Error("Expected `jsx` given to `evaluate`");
+    if (!jsxs) throw new Error("Expected `jsxs` given to `evaluate`");
+  }
+  return {
+    compiletime: {
+      ...rest,
+      development,
+      outputFormat: "function-body",
+      providerImportSource: useMDXComponents ? "#" : void 0
+    },
+    runtime: { Fragment, baseUrl, jsx: jsx2, jsxDEV, jsxs, useMDXComponents }
+  };
+}
+
+// node_modules/@mdx-js/mdx/lib/run.js
+var AsyncFunction = Object.getPrototypeOf(run).constructor;
+async function run(code2, options) {
+  return new AsyncFunction(String(code2))(options);
+}
+function runSync(code2, options) {
+  return new Function(String(code2))(options);
+}
+
+// node_modules/@mdx-js/mdx/lib/evaluate.js
+async function evaluate(file, options) {
+  const { compiletime, runtime } = resolveEvaluateOptions(options);
+  return run(await compile(file, compiletime), runtime);
+}
+function evaluateSync(file, options) {
+  const { compiletime, runtime } = resolveEvaluateOptions(options);
+  return runSync(compileSync(file, compiletime), runtime);
+}
+// Annotate the CommonJS export names for ESM import in node:
+0 && (module.exports = {
+  compile,
+  compileSync,
+  createProcessor,
+  evaluate,
+  evaluateSync,
+  nodeTypes,
+  run,
+  runSync
+});

--- a/test/__mocks__/remark-gfm-4.0.0-cjs.js
+++ b/test/__mocks__/remark-gfm-4.0.0-cjs.js
@@ -1,0 +1,3577 @@
+var __defProp = Object.defineProperty;
+var __getOwnPropDesc = Object.getOwnPropertyDescriptor;
+var __getOwnPropNames = Object.getOwnPropertyNames;
+var __hasOwnProp = Object.prototype.hasOwnProperty;
+var __export = (target, all2) => {
+  for (var name in all2)
+    __defProp(target, name, { get: all2[name], enumerable: true });
+};
+var __copyProps = (to, from, except, desc) => {
+  if (from && typeof from === "object" || typeof from === "function") {
+    for (let key of __getOwnPropNames(from))
+      if (!__hasOwnProp.call(to, key) && key !== except)
+        __defProp(to, key, { get: () => from[key], enumerable: !(desc = __getOwnPropDesc(from, key)) || desc.enumerable });
+  }
+  return to;
+};
+var __toCommonJS = (mod) => __copyProps(__defProp({}, "__esModule", { value: true }), mod);
+
+// remark-gfm.js
+var remark_gfm_exports = {};
+__export(remark_gfm_exports, {
+  default: () => remark_gfm_default
+});
+module.exports = __toCommonJS(remark_gfm_exports);
+
+// node_modules/ccount/index.js
+function ccount(value, character) {
+  const source = String(value);
+  if (typeof character !== "string") {
+    throw new TypeError("Expected character");
+  }
+  let count = 0;
+  let index = source.indexOf(character);
+  while (index !== -1) {
+    count++;
+    index = source.indexOf(character, index + character.length);
+  }
+  return count;
+}
+
+// node_modules/devlop/lib/default.js
+function ok() {
+}
+
+// node_modules/micromark-util-character/index.js
+var asciiAlpha = regexCheck(/[A-Za-z]/);
+var asciiAlphanumeric = regexCheck(/[\dA-Za-z]/);
+var asciiAtext = regexCheck(/[#-'*+\--9=?A-Z^-~]/);
+function asciiControl(code3) {
+  return (
+    // Special whitespace codes (which have negative values), C0 and Control
+    // character DEL
+    code3 !== null && (code3 < 32 || code3 === 127)
+  );
+}
+var asciiDigit = regexCheck(/\d/);
+var asciiHexDigit = regexCheck(/[\dA-Fa-f]/);
+var asciiPunctuation = regexCheck(/[!-/:-@[-`{-~]/);
+function markdownLineEnding(code3) {
+  return code3 !== null && code3 < -2;
+}
+function markdownLineEndingOrSpace(code3) {
+  return code3 !== null && (code3 < 0 || code3 === 32);
+}
+function markdownSpace(code3) {
+  return code3 === -2 || code3 === -1 || code3 === 32;
+}
+var unicodePunctuation = regexCheck(/\p{P}|\p{S}/u);
+var unicodeWhitespace = regexCheck(/\s/);
+function regexCheck(regex) {
+  return check;
+  function check(code3) {
+    return code3 !== null && code3 > -1 && regex.test(String.fromCharCode(code3));
+  }
+}
+
+// node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp/index.js
+function escapeStringRegexp(string) {
+  if (typeof string !== "string") {
+    throw new TypeError("Expected a string");
+  }
+  return string.replace(/[|\\{}()[\]^$+*?.]/g, "\\$&").replace(/-/g, "\\x2d");
+}
+
+// node_modules/unist-util-visit-parents/node_modules/unist-util-is/lib/index.js
+var convert = (
+  // Note: overloads in JSDoc can’t yet use different `@template`s.
+  /**
+   * @type {(
+   *   (<Condition extends string>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & {type: Condition}) &
+   *   (<Condition extends Props>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Condition) &
+   *   (<Condition extends TestFunction>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Predicate<Condition, Node>) &
+   *   ((test?: null | undefined) => (node?: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node) &
+   *   ((test?: Test) => Check)
+   * )}
+   */
+  /**
+   * @param {Test} [test]
+   * @returns {Check}
+   */
+  function(test) {
+    if (test === null || test === void 0) {
+      return ok2;
+    }
+    if (typeof test === "function") {
+      return castFactory(test);
+    }
+    if (typeof test === "object") {
+      return Array.isArray(test) ? anyFactory(test) : propsFactory(test);
+    }
+    if (typeof test === "string") {
+      return typeFactory(test);
+    }
+    throw new Error("Expected function, string, or object as test");
+  }
+);
+function anyFactory(tests) {
+  const checks = [];
+  let index = -1;
+  while (++index < tests.length) {
+    checks[index] = convert(tests[index]);
+  }
+  return castFactory(any);
+  function any(...parameters) {
+    let index2 = -1;
+    while (++index2 < checks.length) {
+      if (checks[index2].apply(this, parameters)) return true;
+    }
+    return false;
+  }
+}
+function propsFactory(check) {
+  const checkAsRecord = (
+    /** @type {Record<string, unknown>} */
+    check
+  );
+  return castFactory(all2);
+  function all2(node2) {
+    const nodeAsRecord = (
+      /** @type {Record<string, unknown>} */
+      /** @type {unknown} */
+      node2
+    );
+    let key;
+    for (key in check) {
+      if (nodeAsRecord[key] !== checkAsRecord[key]) return false;
+    }
+    return true;
+  }
+}
+function typeFactory(check) {
+  return castFactory(type);
+  function type(node2) {
+    return node2 && node2.type === check;
+  }
+}
+function castFactory(testFunction) {
+  return check;
+  function check(value, index, parent) {
+    return Boolean(
+      looksLikeANode(value) && testFunction.call(
+        this,
+        value,
+        typeof index === "number" ? index : void 0,
+        parent || void 0
+      )
+    );
+  }
+}
+function ok2() {
+  return true;
+}
+function looksLikeANode(value) {
+  return value !== null && typeof value === "object" && "type" in value;
+}
+
+// node_modules/unist-util-visit-parents/lib/color.js
+function color(d) {
+  return d;
+}
+
+// node_modules/unist-util-visit-parents/lib/index.js
+var empty = [];
+var CONTINUE = true;
+var EXIT = false;
+var SKIP = "skip";
+function visitParents(tree, test, visitor, reverse) {
+  let check;
+  if (typeof test === "function" && typeof visitor !== "function") {
+    reverse = visitor;
+    visitor = test;
+  } else {
+    check = test;
+  }
+  const is4 = convert(check);
+  const step = reverse ? -1 : 1;
+  factory(tree, void 0, [])();
+  function factory(node2, index, parents) {
+    const value = (
+      /** @type {Record<string, unknown>} */
+      node2 && typeof node2 === "object" ? node2 : {}
+    );
+    if (typeof value.type === "string") {
+      const name = (
+        // `hast`
+        typeof value.tagName === "string" ? value.tagName : (
+          // `xast`
+          typeof value.name === "string" ? value.name : void 0
+        )
+      );
+      Object.defineProperty(visit2, "name", {
+        value: "node (" + color(node2.type + (name ? "<" + name + ">" : "")) + ")"
+      });
+    }
+    return visit2;
+    function visit2() {
+      let result = empty;
+      let subresult;
+      let offset;
+      let grandparents;
+      if (!test || is4(node2, index, parents[parents.length - 1] || void 0)) {
+        result = toResult(visitor(node2, parents));
+        if (result[0] === EXIT) {
+          return result;
+        }
+      }
+      if ("children" in node2 && node2.children) {
+        const nodeAsParent = (
+          /** @type {UnistParent} */
+          node2
+        );
+        if (nodeAsParent.children && result[0] !== SKIP) {
+          offset = (reverse ? nodeAsParent.children.length : -1) + step;
+          grandparents = parents.concat(nodeAsParent);
+          while (offset > -1 && offset < nodeAsParent.children.length) {
+            const child = nodeAsParent.children[offset];
+            subresult = factory(child, offset, grandparents)();
+            if (subresult[0] === EXIT) {
+              return subresult;
+            }
+            offset = typeof subresult[1] === "number" ? subresult[1] : offset + step;
+          }
+        }
+      }
+      return result;
+    }
+  }
+}
+function toResult(value) {
+  if (Array.isArray(value)) {
+    return value;
+  }
+  if (typeof value === "number") {
+    return [CONTINUE, value];
+  }
+  return value === null || value === void 0 ? empty : [value];
+}
+
+// node_modules/mdast-util-find-and-replace/node_modules/unist-util-is/lib/index.js
+var convert2 = (
+  // Note: overloads in JSDoc can’t yet use different `@template`s.
+  /**
+   * @type {(
+   *   (<Condition extends string>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & {type: Condition}) &
+   *   (<Condition extends Props>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Condition) &
+   *   (<Condition extends TestFunction>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Predicate<Condition, Node>) &
+   *   ((test?: null | undefined) => (node?: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node) &
+   *   ((test?: Test) => Check)
+   * )}
+   */
+  /**
+   * @param {Test} [test]
+   * @returns {Check}
+   */
+  function(test) {
+    if (test === null || test === void 0) {
+      return ok3;
+    }
+    if (typeof test === "function") {
+      return castFactory2(test);
+    }
+    if (typeof test === "object") {
+      return Array.isArray(test) ? anyFactory2(test) : propsFactory2(test);
+    }
+    if (typeof test === "string") {
+      return typeFactory2(test);
+    }
+    throw new Error("Expected function, string, or object as test");
+  }
+);
+function anyFactory2(tests) {
+  const checks = [];
+  let index = -1;
+  while (++index < tests.length) {
+    checks[index] = convert2(tests[index]);
+  }
+  return castFactory2(any);
+  function any(...parameters) {
+    let index2 = -1;
+    while (++index2 < checks.length) {
+      if (checks[index2].apply(this, parameters)) return true;
+    }
+    return false;
+  }
+}
+function propsFactory2(check) {
+  const checkAsRecord = (
+    /** @type {Record<string, unknown>} */
+    check
+  );
+  return castFactory2(all2);
+  function all2(node2) {
+    const nodeAsRecord = (
+      /** @type {Record<string, unknown>} */
+      /** @type {unknown} */
+      node2
+    );
+    let key;
+    for (key in check) {
+      if (nodeAsRecord[key] !== checkAsRecord[key]) return false;
+    }
+    return true;
+  }
+}
+function typeFactory2(check) {
+  return castFactory2(type);
+  function type(node2) {
+    return node2 && node2.type === check;
+  }
+}
+function castFactory2(testFunction) {
+  return check;
+  function check(value, index, parent) {
+    return Boolean(
+      looksLikeANode2(value) && testFunction.call(
+        this,
+        value,
+        typeof index === "number" ? index : void 0,
+        parent || void 0
+      )
+    );
+  }
+}
+function ok3() {
+  return true;
+}
+function looksLikeANode2(value) {
+  return value !== null && typeof value === "object" && "type" in value;
+}
+
+// node_modules/mdast-util-find-and-replace/lib/index.js
+function findAndReplace(tree, list2, options) {
+  const settings = options || {};
+  const ignored = convert2(settings.ignore || []);
+  const pairs = toPairs(list2);
+  let pairIndex = -1;
+  while (++pairIndex < pairs.length) {
+    visitParents(tree, "text", visitor);
+  }
+  function visitor(node2, parents) {
+    let index = -1;
+    let grandparent;
+    while (++index < parents.length) {
+      const parent = parents[index];
+      const siblings = grandparent ? grandparent.children : void 0;
+      if (ignored(
+        parent,
+        siblings ? siblings.indexOf(parent) : void 0,
+        grandparent
+      )) {
+        return;
+      }
+      grandparent = parent;
+    }
+    if (grandparent) {
+      return handler(node2, parents);
+    }
+  }
+  function handler(node2, parents) {
+    const parent = parents[parents.length - 1];
+    const find = pairs[pairIndex][0];
+    const replace2 = pairs[pairIndex][1];
+    let start = 0;
+    const siblings = parent.children;
+    const index = siblings.indexOf(node2);
+    let change = false;
+    let nodes = [];
+    find.lastIndex = 0;
+    let match = find.exec(node2.value);
+    while (match) {
+      const position = match.index;
+      const matchObject = {
+        index: match.index,
+        input: match.input,
+        stack: [...parents, node2]
+      };
+      let value = replace2(...match, matchObject);
+      if (typeof value === "string") {
+        value = value.length > 0 ? { type: "text", value } : void 0;
+      }
+      if (value === false) {
+        find.lastIndex = position + 1;
+      } else {
+        if (start !== position) {
+          nodes.push({
+            type: "text",
+            value: node2.value.slice(start, position)
+          });
+        }
+        if (Array.isArray(value)) {
+          nodes.push(...value);
+        } else if (value) {
+          nodes.push(value);
+        }
+        start = position + match[0].length;
+        change = true;
+      }
+      if (!find.global) {
+        break;
+      }
+      match = find.exec(node2.value);
+    }
+    if (change) {
+      if (start < node2.value.length) {
+        nodes.push({ type: "text", value: node2.value.slice(start) });
+      }
+      parent.children.splice(index, 1, ...nodes);
+    } else {
+      nodes = [node2];
+    }
+    return index + nodes.length;
+  }
+}
+function toPairs(tupleOrList) {
+  const result = [];
+  if (!Array.isArray(tupleOrList)) {
+    throw new TypeError("Expected find and replace tuple or list of tuples");
+  }
+  const list2 = !tupleOrList[0] || Array.isArray(tupleOrList[0]) ? tupleOrList : [tupleOrList];
+  let index = -1;
+  while (++index < list2.length) {
+    const tuple = list2[index];
+    result.push([toExpression(tuple[0]), toFunction(tuple[1])]);
+  }
+  return result;
+}
+function toExpression(find) {
+  return typeof find === "string" ? new RegExp(escapeStringRegexp(find), "g") : find;
+}
+function toFunction(replace2) {
+  return typeof replace2 === "function" ? replace2 : function() {
+    return replace2;
+  };
+}
+
+// node_modules/mdast-util-gfm-autolink-literal/lib/index.js
+var inConstruct = "phrasing";
+var notInConstruct = ["autolink", "link", "image", "label"];
+function gfmAutolinkLiteralFromMarkdown() {
+  return {
+    transforms: [transformGfmAutolinkLiterals],
+    enter: {
+      literalAutolink: enterLiteralAutolink,
+      literalAutolinkEmail: enterLiteralAutolinkValue,
+      literalAutolinkHttp: enterLiteralAutolinkValue,
+      literalAutolinkWww: enterLiteralAutolinkValue
+    },
+    exit: {
+      literalAutolink: exitLiteralAutolink,
+      literalAutolinkEmail: exitLiteralAutolinkEmail,
+      literalAutolinkHttp: exitLiteralAutolinkHttp,
+      literalAutolinkWww: exitLiteralAutolinkWww
+    }
+  };
+}
+function gfmAutolinkLiteralToMarkdown() {
+  return {
+    unsafe: [
+      {
+        character: "@",
+        before: "[+\\-.\\w]",
+        after: "[\\-.\\w]",
+        inConstruct,
+        notInConstruct
+      },
+      {
+        character: ".",
+        before: "[Ww]",
+        after: "[\\-.\\w]",
+        inConstruct,
+        notInConstruct
+      },
+      {
+        character: ":",
+        before: "[ps]",
+        after: "\\/",
+        inConstruct,
+        notInConstruct
+      }
+    ]
+  };
+}
+function enterLiteralAutolink(token) {
+  this.enter({ type: "link", title: null, url: "", children: [] }, token);
+}
+function enterLiteralAutolinkValue(token) {
+  this.config.enter.autolinkProtocol.call(this, token);
+}
+function exitLiteralAutolinkHttp(token) {
+  this.config.exit.autolinkProtocol.call(this, token);
+}
+function exitLiteralAutolinkWww(token) {
+  this.config.exit.data.call(this, token);
+  const node2 = this.stack[this.stack.length - 1];
+  ok(node2.type === "link");
+  node2.url = "http://" + this.sliceSerialize(token);
+}
+function exitLiteralAutolinkEmail(token) {
+  this.config.exit.autolinkEmail.call(this, token);
+}
+function exitLiteralAutolink(token) {
+  this.exit(token);
+}
+function transformGfmAutolinkLiterals(tree) {
+  findAndReplace(
+    tree,
+    [
+      [/(https?:\/\/|www(?=\.))([-.\w]+)([^ \t\r\n]*)/gi, findUrl],
+      [/([-.\w+]+)@([-\w]+(?:\.[-\w]+)+)/g, findEmail]
+    ],
+    { ignore: ["link", "linkReference"] }
+  );
+}
+function findUrl(_, protocol, domain2, path2, match) {
+  let prefix = "";
+  if (!previous(match)) {
+    return false;
+  }
+  if (/^w/i.test(protocol)) {
+    domain2 = protocol + domain2;
+    protocol = "";
+    prefix = "http://";
+  }
+  if (!isCorrectDomain(domain2)) {
+    return false;
+  }
+  const parts = splitUrl(domain2 + path2);
+  if (!parts[0]) return false;
+  const result = {
+    type: "link",
+    title: null,
+    url: prefix + protocol + parts[0],
+    children: [{ type: "text", value: protocol + parts[0] }]
+  };
+  if (parts[1]) {
+    return [result, { type: "text", value: parts[1] }];
+  }
+  return result;
+}
+function findEmail(_, atext, label, match) {
+  if (
+    // Not an expected previous character.
+    !previous(match, true) || // Label ends in not allowed character.
+    /[-\d_]$/.test(label)
+  ) {
+    return false;
+  }
+  return {
+    type: "link",
+    title: null,
+    url: "mailto:" + atext + "@" + label,
+    children: [{ type: "text", value: atext + "@" + label }]
+  };
+}
+function isCorrectDomain(domain2) {
+  const parts = domain2.split(".");
+  if (parts.length < 2 || parts[parts.length - 1] && (/_/.test(parts[parts.length - 1]) || !/[a-zA-Z\d]/.test(parts[parts.length - 1])) || parts[parts.length - 2] && (/_/.test(parts[parts.length - 2]) || !/[a-zA-Z\d]/.test(parts[parts.length - 2]))) {
+    return false;
+  }
+  return true;
+}
+function splitUrl(url) {
+  const trailExec = /[!"&'),.:;<>?\]}]+$/.exec(url);
+  if (!trailExec) {
+    return [url, void 0];
+  }
+  url = url.slice(0, trailExec.index);
+  let trail2 = trailExec[0];
+  let closingParenIndex = trail2.indexOf(")");
+  const openingParens = ccount(url, "(");
+  let closingParens = ccount(url, ")");
+  while (closingParenIndex !== -1 && openingParens > closingParens) {
+    url += trail2.slice(0, closingParenIndex + 1);
+    trail2 = trail2.slice(closingParenIndex + 1);
+    closingParenIndex = trail2.indexOf(")");
+    closingParens++;
+  }
+  return [url, trail2];
+}
+function previous(match, email) {
+  const code3 = match.input.charCodeAt(match.index - 1);
+  return (match.index === 0 || unicodeWhitespace(code3) || unicodePunctuation(code3)) && (!email || code3 !== 47);
+}
+
+// node_modules/micromark-util-normalize-identifier/index.js
+function normalizeIdentifier(value) {
+  return value.replace(/[\t\n\r ]+/g, " ").replace(/^ | $/g, "").toLowerCase().toUpperCase();
+}
+
+// node_modules/mdast-util-gfm-footnote/lib/index.js
+footnoteReference.peek = footnoteReferencePeek;
+function gfmFootnoteFromMarkdown() {
+  return {
+    enter: {
+      gfmFootnoteDefinition: enterFootnoteDefinition,
+      gfmFootnoteDefinitionLabelString: enterFootnoteDefinitionLabelString,
+      gfmFootnoteCall: enterFootnoteCall,
+      gfmFootnoteCallString: enterFootnoteCallString
+    },
+    exit: {
+      gfmFootnoteDefinition: exitFootnoteDefinition,
+      gfmFootnoteDefinitionLabelString: exitFootnoteDefinitionLabelString,
+      gfmFootnoteCall: exitFootnoteCall,
+      gfmFootnoteCallString: exitFootnoteCallString
+    }
+  };
+}
+function gfmFootnoteToMarkdown() {
+  return {
+    // This is on by default already.
+    unsafe: [{ character: "[", inConstruct: ["phrasing", "label", "reference"] }],
+    handlers: { footnoteDefinition, footnoteReference }
+  };
+}
+function enterFootnoteDefinition(token) {
+  this.enter(
+    { type: "footnoteDefinition", identifier: "", label: "", children: [] },
+    token
+  );
+}
+function enterFootnoteDefinitionLabelString() {
+  this.buffer();
+}
+function exitFootnoteDefinitionLabelString(token) {
+  const label = this.resume();
+  const node2 = this.stack[this.stack.length - 1];
+  ok(node2.type === "footnoteDefinition");
+  node2.label = label;
+  node2.identifier = normalizeIdentifier(
+    this.sliceSerialize(token)
+  ).toLowerCase();
+}
+function exitFootnoteDefinition(token) {
+  this.exit(token);
+}
+function enterFootnoteCall(token) {
+  this.enter({ type: "footnoteReference", identifier: "", label: "" }, token);
+}
+function enterFootnoteCallString() {
+  this.buffer();
+}
+function exitFootnoteCallString(token) {
+  const label = this.resume();
+  const node2 = this.stack[this.stack.length - 1];
+  ok(node2.type === "footnoteReference");
+  node2.label = label;
+  node2.identifier = normalizeIdentifier(
+    this.sliceSerialize(token)
+  ).toLowerCase();
+}
+function exitFootnoteCall(token) {
+  this.exit(token);
+}
+function footnoteReference(node2, _, state, info) {
+  const tracker = state.createTracker(info);
+  let value = tracker.move("[^");
+  const exit2 = state.enter("footnoteReference");
+  const subexit = state.enter("reference");
+  value += tracker.move(
+    state.safe(state.associationId(node2), {
+      ...tracker.current(),
+      before: value,
+      after: "]"
+    })
+  );
+  subexit();
+  exit2();
+  value += tracker.move("]");
+  return value;
+}
+function footnoteReferencePeek() {
+  return "[";
+}
+function footnoteDefinition(node2, _, state, info) {
+  const tracker = state.createTracker(info);
+  let value = tracker.move("[^");
+  const exit2 = state.enter("footnoteDefinition");
+  const subexit = state.enter("label");
+  value += tracker.move(
+    state.safe(state.associationId(node2), {
+      ...tracker.current(),
+      before: value,
+      after: "]"
+    })
+  );
+  subexit();
+  value += tracker.move(
+    "]:" + (node2.children && node2.children.length > 0 ? " " : "")
+  );
+  tracker.shift(4);
+  value += tracker.move(
+    state.indentLines(state.containerFlow(node2, tracker.current()), map)
+  );
+  exit2();
+  return value;
+}
+function map(line, index, blank) {
+  if (index === 0) {
+    return line;
+  }
+  return (blank ? "" : "    ") + line;
+}
+
+// node_modules/mdast-util-gfm-strikethrough/lib/index.js
+var constructsWithoutStrikethrough = [
+  "autolink",
+  "destinationLiteral",
+  "destinationRaw",
+  "reference",
+  "titleQuote",
+  "titleApostrophe"
+];
+handleDelete.peek = peekDelete;
+function gfmStrikethroughFromMarkdown() {
+  return {
+    canContainEols: ["delete"],
+    enter: { strikethrough: enterStrikethrough },
+    exit: { strikethrough: exitStrikethrough }
+  };
+}
+function gfmStrikethroughToMarkdown() {
+  return {
+    unsafe: [
+      {
+        character: "~",
+        inConstruct: "phrasing",
+        notInConstruct: constructsWithoutStrikethrough
+      }
+    ],
+    handlers: { delete: handleDelete }
+  };
+}
+function enterStrikethrough(token) {
+  this.enter({ type: "delete", children: [] }, token);
+}
+function exitStrikethrough(token) {
+  this.exit(token);
+}
+function handleDelete(node2, _, state, info) {
+  const tracker = state.createTracker(info);
+  const exit2 = state.enter("strikethrough");
+  let value = tracker.move("~~");
+  value += state.containerPhrasing(node2, {
+    ...tracker.current(),
+    before: value,
+    after: "~"
+  });
+  value += tracker.move("~~");
+  exit2();
+  return value;
+}
+function peekDelete() {
+  return "~";
+}
+
+// node_modules/markdown-table/index.js
+function markdownTable(table, options = {}) {
+  const align = (options.align || []).concat();
+  const stringLength = options.stringLength || defaultStringLength;
+  const alignments = [];
+  const cellMatrix = [];
+  const sizeMatrix = [];
+  const longestCellByColumn = [];
+  let mostCellsPerRow = 0;
+  let rowIndex = -1;
+  while (++rowIndex < table.length) {
+    const row2 = [];
+    const sizes2 = [];
+    let columnIndex2 = -1;
+    if (table[rowIndex].length > mostCellsPerRow) {
+      mostCellsPerRow = table[rowIndex].length;
+    }
+    while (++columnIndex2 < table[rowIndex].length) {
+      const cell = serialize(table[rowIndex][columnIndex2]);
+      if (options.alignDelimiters !== false) {
+        const size = stringLength(cell);
+        sizes2[columnIndex2] = size;
+        if (longestCellByColumn[columnIndex2] === void 0 || size > longestCellByColumn[columnIndex2]) {
+          longestCellByColumn[columnIndex2] = size;
+        }
+      }
+      row2.push(cell);
+    }
+    cellMatrix[rowIndex] = row2;
+    sizeMatrix[rowIndex] = sizes2;
+  }
+  let columnIndex = -1;
+  if (typeof align === "object" && "length" in align) {
+    while (++columnIndex < mostCellsPerRow) {
+      alignments[columnIndex] = toAlignment(align[columnIndex]);
+    }
+  } else {
+    const code3 = toAlignment(align);
+    while (++columnIndex < mostCellsPerRow) {
+      alignments[columnIndex] = code3;
+    }
+  }
+  columnIndex = -1;
+  const row = [];
+  const sizes = [];
+  while (++columnIndex < mostCellsPerRow) {
+    const code3 = alignments[columnIndex];
+    let before = "";
+    let after = "";
+    if (code3 === 99) {
+      before = ":";
+      after = ":";
+    } else if (code3 === 108) {
+      before = ":";
+    } else if (code3 === 114) {
+      after = ":";
+    }
+    let size = options.alignDelimiters === false ? 1 : Math.max(
+      1,
+      longestCellByColumn[columnIndex] - before.length - after.length
+    );
+    const cell = before + "-".repeat(size) + after;
+    if (options.alignDelimiters !== false) {
+      size = before.length + size + after.length;
+      if (size > longestCellByColumn[columnIndex]) {
+        longestCellByColumn[columnIndex] = size;
+      }
+      sizes[columnIndex] = size;
+    }
+    row[columnIndex] = cell;
+  }
+  cellMatrix.splice(1, 0, row);
+  sizeMatrix.splice(1, 0, sizes);
+  rowIndex = -1;
+  const lines = [];
+  while (++rowIndex < cellMatrix.length) {
+    const row2 = cellMatrix[rowIndex];
+    const sizes2 = sizeMatrix[rowIndex];
+    columnIndex = -1;
+    const line = [];
+    while (++columnIndex < mostCellsPerRow) {
+      const cell = row2[columnIndex] || "";
+      let before = "";
+      let after = "";
+      if (options.alignDelimiters !== false) {
+        const size = longestCellByColumn[columnIndex] - (sizes2[columnIndex] || 0);
+        const code3 = alignments[columnIndex];
+        if (code3 === 114) {
+          before = " ".repeat(size);
+        } else if (code3 === 99) {
+          if (size % 2) {
+            before = " ".repeat(size / 2 + 0.5);
+            after = " ".repeat(size / 2 - 0.5);
+          } else {
+            before = " ".repeat(size / 2);
+            after = before;
+          }
+        } else {
+          after = " ".repeat(size);
+        }
+      }
+      if (options.delimiterStart !== false && !columnIndex) {
+        line.push("|");
+      }
+      if (options.padding !== false && // Don’t add the opening space if we’re not aligning and the cell is
+      // empty: there will be a closing space.
+      !(options.alignDelimiters === false && cell === "") && (options.delimiterStart !== false || columnIndex)) {
+        line.push(" ");
+      }
+      if (options.alignDelimiters !== false) {
+        line.push(before);
+      }
+      line.push(cell);
+      if (options.alignDelimiters !== false) {
+        line.push(after);
+      }
+      if (options.padding !== false) {
+        line.push(" ");
+      }
+      if (options.delimiterEnd !== false || columnIndex !== mostCellsPerRow - 1) {
+        line.push("|");
+      }
+    }
+    lines.push(
+      options.delimiterEnd === false ? line.join("").replace(/ +$/, "") : line.join("")
+    );
+  }
+  return lines.join("\n");
+}
+function serialize(value) {
+  return value === null || value === void 0 ? "" : String(value);
+}
+function defaultStringLength(value) {
+  return value.length;
+}
+function toAlignment(value) {
+  const code3 = typeof value === "string" ? value.codePointAt(0) : 0;
+  return code3 === 67 || code3 === 99 ? 99 : code3 === 76 || code3 === 108 ? 108 : code3 === 82 || code3 === 114 ? 114 : 0;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/blockquote.js
+function blockquote(node2, _, state, info) {
+  const exit2 = state.enter("blockquote");
+  const tracker = state.createTracker(info);
+  tracker.move("> ");
+  tracker.shift(2);
+  const value = state.indentLines(
+    state.containerFlow(node2, tracker.current()),
+    map2
+  );
+  exit2();
+  return value;
+}
+function map2(line, _, blank) {
+  return ">" + (blank ? "" : " ") + line;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/pattern-in-scope.js
+function patternInScope(stack, pattern) {
+  return listInScope(stack, pattern.inConstruct, true) && !listInScope(stack, pattern.notInConstruct, false);
+}
+function listInScope(stack, list2, none) {
+  if (typeof list2 === "string") {
+    list2 = [list2];
+  }
+  if (!list2 || list2.length === 0) {
+    return none;
+  }
+  let index = -1;
+  while (++index < list2.length) {
+    if (stack.includes(list2[index])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/break.js
+function hardBreak(_, _1, state, info) {
+  let index = -1;
+  while (++index < state.unsafe.length) {
+    if (state.unsafe[index].character === "\n" && patternInScope(state.stack, state.unsafe[index])) {
+      return /[ \t]/.test(info.before) ? "" : " ";
+    }
+  }
+  return "\\\n";
+}
+
+// node_modules/longest-streak/index.js
+function longestStreak(value, substring) {
+  const source = String(value);
+  let index = source.indexOf(substring);
+  let expected = index;
+  let count = 0;
+  let max = 0;
+  if (typeof substring !== "string") {
+    throw new TypeError("Expected substring");
+  }
+  while (index !== -1) {
+    if (index === expected) {
+      if (++count > max) {
+        max = count;
+      }
+    } else {
+      count = 1;
+    }
+    expected = index + substring.length;
+    index = source.indexOf(substring, expected);
+  }
+  return max;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/format-code-as-indented.js
+function formatCodeAsIndented(node2, state) {
+  return Boolean(
+    state.options.fences === false && node2.value && // If there’s no info…
+    !node2.lang && // And there’s a non-whitespace character…
+    /[^ \r\n]/.test(node2.value) && // And the value doesn’t start or end in a blank…
+    !/^[\t ]*(?:[\r\n]|$)|(?:^|[\r\n])[\t ]*$/.test(node2.value)
+  );
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-fence.js
+function checkFence(state) {
+  const marker = state.options.fence || "`";
+  if (marker !== "`" && marker !== "~") {
+    throw new Error(
+      "Cannot serialize code with `" + marker + "` for `options.fence`, expected `` ` `` or `~`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/code.js
+function code(node2, _, state, info) {
+  const marker = checkFence(state);
+  const raw = node2.value || "";
+  const suffix = marker === "`" ? "GraveAccent" : "Tilde";
+  if (formatCodeAsIndented(node2, state)) {
+    const exit3 = state.enter("codeIndented");
+    const value2 = state.indentLines(raw, map3);
+    exit3();
+    return value2;
+  }
+  const tracker = state.createTracker(info);
+  const sequence = marker.repeat(Math.max(longestStreak(raw, marker) + 1, 3));
+  const exit2 = state.enter("codeFenced");
+  let value = tracker.move(sequence);
+  if (node2.lang) {
+    const subexit = state.enter(`codeFencedLang${suffix}`);
+    value += tracker.move(
+      state.safe(node2.lang, {
+        before: value,
+        after: " ",
+        encode: ["`"],
+        ...tracker.current()
+      })
+    );
+    subexit();
+  }
+  if (node2.lang && node2.meta) {
+    const subexit = state.enter(`codeFencedMeta${suffix}`);
+    value += tracker.move(" ");
+    value += tracker.move(
+      state.safe(node2.meta, {
+        before: value,
+        after: "\n",
+        encode: ["`"],
+        ...tracker.current()
+      })
+    );
+    subexit();
+  }
+  value += tracker.move("\n");
+  if (raw) {
+    value += tracker.move(raw + "\n");
+  }
+  value += tracker.move(sequence);
+  exit2();
+  return value;
+}
+function map3(line, _, blank) {
+  return (blank ? "" : "    ") + line;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-quote.js
+function checkQuote(state) {
+  const marker = state.options.quote || '"';
+  if (marker !== '"' && marker !== "'") {
+    throw new Error(
+      "Cannot serialize title with `" + marker + "` for `options.quote`, expected `\"`, or `'`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/definition.js
+function definition(node2, _, state, info) {
+  const quote = checkQuote(state);
+  const suffix = quote === '"' ? "Quote" : "Apostrophe";
+  const exit2 = state.enter("definition");
+  let subexit = state.enter("label");
+  const tracker = state.createTracker(info);
+  let value = tracker.move("[");
+  value += tracker.move(
+    state.safe(state.associationId(node2), {
+      before: value,
+      after: "]",
+      ...tracker.current()
+    })
+  );
+  value += tracker.move("]: ");
+  subexit();
+  if (
+    // If there’s no url, or…
+    !node2.url || // If there are control characters or whitespace.
+    /[\0- \u007F]/.test(node2.url)
+  ) {
+    subexit = state.enter("destinationLiteral");
+    value += tracker.move("<");
+    value += tracker.move(
+      state.safe(node2.url, { before: value, after: ">", ...tracker.current() })
+    );
+    value += tracker.move(">");
+  } else {
+    subexit = state.enter("destinationRaw");
+    value += tracker.move(
+      state.safe(node2.url, {
+        before: value,
+        after: node2.title ? " " : "\n",
+        ...tracker.current()
+      })
+    );
+  }
+  subexit();
+  if (node2.title) {
+    subexit = state.enter(`title${suffix}`);
+    value += tracker.move(" " + quote);
+    value += tracker.move(
+      state.safe(node2.title, {
+        before: value,
+        after: quote,
+        ...tracker.current()
+      })
+    );
+    value += tracker.move(quote);
+    subexit();
+  }
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-emphasis.js
+function checkEmphasis(state) {
+  const marker = state.options.emphasis || "*";
+  if (marker !== "*" && marker !== "_") {
+    throw new Error(
+      "Cannot serialize emphasis with `" + marker + "` for `options.emphasis`, expected `*`, or `_`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/emphasis.js
+emphasis.peek = emphasisPeek;
+function emphasis(node2, _, state, info) {
+  const marker = checkEmphasis(state);
+  const exit2 = state.enter("emphasis");
+  const tracker = state.createTracker(info);
+  let value = tracker.move(marker);
+  value += tracker.move(
+    state.containerPhrasing(node2, {
+      before: value,
+      after: marker,
+      ...tracker.current()
+    })
+  );
+  value += tracker.move(marker);
+  exit2();
+  return value;
+}
+function emphasisPeek(_, _1, state) {
+  return state.options.emphasis || "*";
+}
+
+// node_modules/mdast-util-to-markdown/node_modules/unist-util-visit/lib/index.js
+function visit(tree, testOrVisitor, visitorOrReverse, maybeReverse) {
+  let reverse;
+  let test;
+  let visitor;
+  if (typeof testOrVisitor === "function" && typeof visitorOrReverse !== "function") {
+    test = void 0;
+    visitor = testOrVisitor;
+    reverse = visitorOrReverse;
+  } else {
+    test = testOrVisitor;
+    visitor = visitorOrReverse;
+    reverse = maybeReverse;
+  }
+  visitParents(tree, test, overload, reverse);
+  function overload(node2, parents) {
+    const parent = parents[parents.length - 1];
+    const index = parent ? parent.children.indexOf(node2) : void 0;
+    return visitor(node2, index, parent);
+  }
+}
+
+// node_modules/mdast-util-to-markdown/node_modules/mdast-util-to-string/lib/index.js
+var emptyOptions = {};
+function toString(value, options) {
+  const settings = options || emptyOptions;
+  const includeImageAlt = typeof settings.includeImageAlt === "boolean" ? settings.includeImageAlt : true;
+  const includeHtml = typeof settings.includeHtml === "boolean" ? settings.includeHtml : true;
+  return one(value, includeImageAlt, includeHtml);
+}
+function one(value, includeImageAlt, includeHtml) {
+  if (node(value)) {
+    if ("value" in value) {
+      return value.type === "html" && !includeHtml ? "" : value.value;
+    }
+    if (includeImageAlt && "alt" in value && value.alt) {
+      return value.alt;
+    }
+    if ("children" in value) {
+      return all(value.children, includeImageAlt, includeHtml);
+    }
+  }
+  if (Array.isArray(value)) {
+    return all(value, includeImageAlt, includeHtml);
+  }
+  return "";
+}
+function all(values, includeImageAlt, includeHtml) {
+  const result = [];
+  let index = -1;
+  while (++index < values.length) {
+    result[index] = one(values[index], includeImageAlt, includeHtml);
+  }
+  return result.join("");
+}
+function node(value) {
+  return Boolean(value && typeof value === "object");
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/format-heading-as-setext.js
+function formatHeadingAsSetext(node2, state) {
+  let literalWithBreak = false;
+  visit(node2, function(node3) {
+    if ("value" in node3 && /\r?\n|\r/.test(node3.value) || node3.type === "break") {
+      literalWithBreak = true;
+      return EXIT;
+    }
+  });
+  return Boolean(
+    (!node2.depth || node2.depth < 3) && toString(node2) && (state.options.setext || literalWithBreak)
+  );
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/heading.js
+function heading(node2, _, state, info) {
+  const rank = Math.max(Math.min(6, node2.depth || 1), 1);
+  const tracker = state.createTracker(info);
+  if (formatHeadingAsSetext(node2, state)) {
+    const exit3 = state.enter("headingSetext");
+    const subexit2 = state.enter("phrasing");
+    const value2 = state.containerPhrasing(node2, {
+      ...tracker.current(),
+      before: "\n",
+      after: "\n"
+    });
+    subexit2();
+    exit3();
+    return value2 + "\n" + (rank === 1 ? "=" : "-").repeat(
+      // The whole size…
+      value2.length - // Minus the position of the character after the last EOL (or
+      // 0 if there is none)…
+      (Math.max(value2.lastIndexOf("\r"), value2.lastIndexOf("\n")) + 1)
+    );
+  }
+  const sequence = "#".repeat(rank);
+  const exit2 = state.enter("headingAtx");
+  const subexit = state.enter("phrasing");
+  tracker.move(sequence + " ");
+  let value = state.containerPhrasing(node2, {
+    before: "# ",
+    after: "\n",
+    ...tracker.current()
+  });
+  if (/^[\t ]/.test(value)) {
+    value = "&#x" + value.charCodeAt(0).toString(16).toUpperCase() + ";" + value.slice(1);
+  }
+  value = value ? sequence + " " + value : sequence;
+  if (state.options.closeAtx) {
+    value += " " + sequence;
+  }
+  subexit();
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/html.js
+html.peek = htmlPeek;
+function html(node2) {
+  return node2.value || "";
+}
+function htmlPeek() {
+  return "<";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/image.js
+image.peek = imagePeek;
+function image(node2, _, state, info) {
+  const quote = checkQuote(state);
+  const suffix = quote === '"' ? "Quote" : "Apostrophe";
+  const exit2 = state.enter("image");
+  let subexit = state.enter("label");
+  const tracker = state.createTracker(info);
+  let value = tracker.move("![");
+  value += tracker.move(
+    state.safe(node2.alt, { before: value, after: "]", ...tracker.current() })
+  );
+  value += tracker.move("](");
+  subexit();
+  if (
+    // If there’s no url but there is a title…
+    !node2.url && node2.title || // If there are control characters or whitespace.
+    /[\0- \u007F]/.test(node2.url)
+  ) {
+    subexit = state.enter("destinationLiteral");
+    value += tracker.move("<");
+    value += tracker.move(
+      state.safe(node2.url, { before: value, after: ">", ...tracker.current() })
+    );
+    value += tracker.move(">");
+  } else {
+    subexit = state.enter("destinationRaw");
+    value += tracker.move(
+      state.safe(node2.url, {
+        before: value,
+        after: node2.title ? " " : ")",
+        ...tracker.current()
+      })
+    );
+  }
+  subexit();
+  if (node2.title) {
+    subexit = state.enter(`title${suffix}`);
+    value += tracker.move(" " + quote);
+    value += tracker.move(
+      state.safe(node2.title, {
+        before: value,
+        after: quote,
+        ...tracker.current()
+      })
+    );
+    value += tracker.move(quote);
+    subexit();
+  }
+  value += tracker.move(")");
+  exit2();
+  return value;
+}
+function imagePeek() {
+  return "!";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/image-reference.js
+imageReference.peek = imageReferencePeek;
+function imageReference(node2, _, state, info) {
+  const type = node2.referenceType;
+  const exit2 = state.enter("imageReference");
+  let subexit = state.enter("label");
+  const tracker = state.createTracker(info);
+  let value = tracker.move("![");
+  const alt = state.safe(node2.alt, {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  value += tracker.move(alt + "][");
+  subexit();
+  const stack = state.stack;
+  state.stack = [];
+  subexit = state.enter("reference");
+  const reference = state.safe(state.associationId(node2), {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  subexit();
+  state.stack = stack;
+  exit2();
+  if (type === "full" || !alt || alt !== reference) {
+    value += tracker.move(reference + "]");
+  } else if (type === "shortcut") {
+    value = value.slice(0, -1);
+  } else {
+    value += tracker.move("]");
+  }
+  return value;
+}
+function imageReferencePeek() {
+  return "!";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/inline-code.js
+inlineCode.peek = inlineCodePeek;
+function inlineCode(node2, _, state) {
+  let value = node2.value || "";
+  let sequence = "`";
+  let index = -1;
+  while (new RegExp("(^|[^`])" + sequence + "([^`]|$)").test(value)) {
+    sequence += "`";
+  }
+  if (/[^ \r\n]/.test(value) && (/^[ \r\n]/.test(value) && /[ \r\n]$/.test(value) || /^`|`$/.test(value))) {
+    value = " " + value + " ";
+  }
+  while (++index < state.unsafe.length) {
+    const pattern = state.unsafe[index];
+    const expression = state.compilePattern(pattern);
+    let match;
+    if (!pattern.atBreak) continue;
+    while (match = expression.exec(value)) {
+      let position = match.index;
+      if (value.charCodeAt(position) === 10 && value.charCodeAt(position - 1) === 13) {
+        position--;
+      }
+      value = value.slice(0, position) + " " + value.slice(match.index + 1);
+    }
+  }
+  return sequence + value + sequence;
+}
+function inlineCodePeek() {
+  return "`";
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/format-link-as-autolink.js
+function formatLinkAsAutolink(node2, state) {
+  const raw = toString(node2);
+  return Boolean(
+    !state.options.resourceLink && // If there’s a url…
+    node2.url && // And there’s a no title…
+    !node2.title && // And the content of `node` is a single text node…
+    node2.children && node2.children.length === 1 && node2.children[0].type === "text" && // And if the url is the same as the content…
+    (raw === node2.url || "mailto:" + raw === node2.url) && // And that starts w/ a protocol…
+    /^[a-z][a-z+.-]+:/i.test(node2.url) && // And that doesn’t contain ASCII control codes (character escapes and
+    // references don’t work), space, or angle brackets…
+    !/[\0- <>\u007F]/.test(node2.url)
+  );
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/link.js
+link.peek = linkPeek;
+function link(node2, _, state, info) {
+  const quote = checkQuote(state);
+  const suffix = quote === '"' ? "Quote" : "Apostrophe";
+  const tracker = state.createTracker(info);
+  let exit2;
+  let subexit;
+  if (formatLinkAsAutolink(node2, state)) {
+    const stack = state.stack;
+    state.stack = [];
+    exit2 = state.enter("autolink");
+    let value2 = tracker.move("<");
+    value2 += tracker.move(
+      state.containerPhrasing(node2, {
+        before: value2,
+        after: ">",
+        ...tracker.current()
+      })
+    );
+    value2 += tracker.move(">");
+    exit2();
+    state.stack = stack;
+    return value2;
+  }
+  exit2 = state.enter("link");
+  subexit = state.enter("label");
+  let value = tracker.move("[");
+  value += tracker.move(
+    state.containerPhrasing(node2, {
+      before: value,
+      after: "](",
+      ...tracker.current()
+    })
+  );
+  value += tracker.move("](");
+  subexit();
+  if (
+    // If there’s no url but there is a title…
+    !node2.url && node2.title || // If there are control characters or whitespace.
+    /[\0- \u007F]/.test(node2.url)
+  ) {
+    subexit = state.enter("destinationLiteral");
+    value += tracker.move("<");
+    value += tracker.move(
+      state.safe(node2.url, { before: value, after: ">", ...tracker.current() })
+    );
+    value += tracker.move(">");
+  } else {
+    subexit = state.enter("destinationRaw");
+    value += tracker.move(
+      state.safe(node2.url, {
+        before: value,
+        after: node2.title ? " " : ")",
+        ...tracker.current()
+      })
+    );
+  }
+  subexit();
+  if (node2.title) {
+    subexit = state.enter(`title${suffix}`);
+    value += tracker.move(" " + quote);
+    value += tracker.move(
+      state.safe(node2.title, {
+        before: value,
+        after: quote,
+        ...tracker.current()
+      })
+    );
+    value += tracker.move(quote);
+    subexit();
+  }
+  value += tracker.move(")");
+  exit2();
+  return value;
+}
+function linkPeek(node2, _, state) {
+  return formatLinkAsAutolink(node2, state) ? "<" : "[";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/link-reference.js
+linkReference.peek = linkReferencePeek;
+function linkReference(node2, _, state, info) {
+  const type = node2.referenceType;
+  const exit2 = state.enter("linkReference");
+  let subexit = state.enter("label");
+  const tracker = state.createTracker(info);
+  let value = tracker.move("[");
+  const text3 = state.containerPhrasing(node2, {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  value += tracker.move(text3 + "][");
+  subexit();
+  const stack = state.stack;
+  state.stack = [];
+  subexit = state.enter("reference");
+  const reference = state.safe(state.associationId(node2), {
+    before: value,
+    after: "]",
+    ...tracker.current()
+  });
+  subexit();
+  state.stack = stack;
+  exit2();
+  if (type === "full" || !text3 || text3 !== reference) {
+    value += tracker.move(reference + "]");
+  } else if (type === "shortcut") {
+    value = value.slice(0, -1);
+  } else {
+    value += tracker.move("]");
+  }
+  return value;
+}
+function linkReferencePeek() {
+  return "[";
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet.js
+function checkBullet(state) {
+  const marker = state.options.bullet || "*";
+  if (marker !== "*" && marker !== "+" && marker !== "-") {
+    throw new Error(
+      "Cannot serialize items with `" + marker + "` for `options.bullet`, expected `*`, `+`, or `-`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet-other.js
+function checkBulletOther(state) {
+  const bullet = checkBullet(state);
+  const bulletOther = state.options.bulletOther;
+  if (!bulletOther) {
+    return bullet === "*" ? "-" : "*";
+  }
+  if (bulletOther !== "*" && bulletOther !== "+" && bulletOther !== "-") {
+    throw new Error(
+      "Cannot serialize items with `" + bulletOther + "` for `options.bulletOther`, expected `*`, `+`, or `-`"
+    );
+  }
+  if (bulletOther === bullet) {
+    throw new Error(
+      "Expected `bullet` (`" + bullet + "`) and `bulletOther` (`" + bulletOther + "`) to be different"
+    );
+  }
+  return bulletOther;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-bullet-ordered.js
+function checkBulletOrdered(state) {
+  const marker = state.options.bulletOrdered || ".";
+  if (marker !== "." && marker !== ")") {
+    throw new Error(
+      "Cannot serialize items with `" + marker + "` for `options.bulletOrdered`, expected `.` or `)`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-rule.js
+function checkRule(state) {
+  const marker = state.options.rule || "*";
+  if (marker !== "*" && marker !== "-" && marker !== "_") {
+    throw new Error(
+      "Cannot serialize rules with `" + marker + "` for `options.rule`, expected `*`, `-`, or `_`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/list.js
+function list(node2, parent, state, info) {
+  const exit2 = state.enter("list");
+  const bulletCurrent = state.bulletCurrent;
+  let bullet = node2.ordered ? checkBulletOrdered(state) : checkBullet(state);
+  const bulletOther = node2.ordered ? bullet === "." ? ")" : "." : checkBulletOther(state);
+  let useDifferentMarker = parent && state.bulletLastUsed ? bullet === state.bulletLastUsed : false;
+  if (!node2.ordered) {
+    const firstListItem = node2.children ? node2.children[0] : void 0;
+    if (
+      // Bullet could be used as a thematic break marker:
+      (bullet === "*" || bullet === "-") && // Empty first list item:
+      firstListItem && (!firstListItem.children || !firstListItem.children[0]) && // Directly in two other list items:
+      state.stack[state.stack.length - 1] === "list" && state.stack[state.stack.length - 2] === "listItem" && state.stack[state.stack.length - 3] === "list" && state.stack[state.stack.length - 4] === "listItem" && // That are each the first child.
+      state.indexStack[state.indexStack.length - 1] === 0 && state.indexStack[state.indexStack.length - 2] === 0 && state.indexStack[state.indexStack.length - 3] === 0
+    ) {
+      useDifferentMarker = true;
+    }
+    if (checkRule(state) === bullet && firstListItem) {
+      let index = -1;
+      while (++index < node2.children.length) {
+        const item = node2.children[index];
+        if (item && item.type === "listItem" && item.children && item.children[0] && item.children[0].type === "thematicBreak") {
+          useDifferentMarker = true;
+          break;
+        }
+      }
+    }
+  }
+  if (useDifferentMarker) {
+    bullet = bulletOther;
+  }
+  state.bulletCurrent = bullet;
+  const value = state.containerFlow(node2, info);
+  state.bulletLastUsed = bullet;
+  state.bulletCurrent = bulletCurrent;
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-list-item-indent.js
+function checkListItemIndent(state) {
+  const style = state.options.listItemIndent || "one";
+  if (style !== "tab" && style !== "one" && style !== "mixed") {
+    throw new Error(
+      "Cannot serialize items with `" + style + "` for `options.listItemIndent`, expected `tab`, `one`, or `mixed`"
+    );
+  }
+  return style;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/list-item.js
+function listItem(node2, parent, state, info) {
+  const listItemIndent = checkListItemIndent(state);
+  let bullet = state.bulletCurrent || checkBullet(state);
+  if (parent && parent.type === "list" && parent.ordered) {
+    bullet = (typeof parent.start === "number" && parent.start > -1 ? parent.start : 1) + (state.options.incrementListMarker === false ? 0 : parent.children.indexOf(node2)) + bullet;
+  }
+  let size = bullet.length + 1;
+  if (listItemIndent === "tab" || listItemIndent === "mixed" && (parent && parent.type === "list" && parent.spread || node2.spread)) {
+    size = Math.ceil(size / 4) * 4;
+  }
+  const tracker = state.createTracker(info);
+  tracker.move(bullet + " ".repeat(size - bullet.length));
+  tracker.shift(size);
+  const exit2 = state.enter("listItem");
+  const value = state.indentLines(
+    state.containerFlow(node2, tracker.current()),
+    map4
+  );
+  exit2();
+  return value;
+  function map4(line, index, blank) {
+    if (index) {
+      return (blank ? "" : " ".repeat(size)) + line;
+    }
+    return (blank ? bullet : bullet + " ".repeat(size - bullet.length)) + line;
+  }
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/paragraph.js
+function paragraph(node2, _, state, info) {
+  const exit2 = state.enter("paragraph");
+  const subexit = state.enter("phrasing");
+  const value = state.containerPhrasing(node2, info);
+  subexit();
+  exit2();
+  return value;
+}
+
+// node_modules/mdast-util-phrasing/node_modules/unist-util-is/lib/index.js
+var convert3 = (
+  // Note: overloads in JSDoc can’t yet use different `@template`s.
+  /**
+   * @type {(
+   *   (<Condition extends string>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & {type: Condition}) &
+   *   (<Condition extends Props>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Condition) &
+   *   (<Condition extends TestFunction>(test: Condition) => (node: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node & Predicate<Condition, Node>) &
+   *   ((test?: null | undefined) => (node?: unknown, index?: number | null | undefined, parent?: Parent | null | undefined, context?: unknown) => node is Node) &
+   *   ((test?: Test) => Check)
+   * )}
+   */
+  /**
+   * @param {Test} [test]
+   * @returns {Check}
+   */
+  function(test) {
+    if (test === null || test === void 0) {
+      return ok4;
+    }
+    if (typeof test === "function") {
+      return castFactory3(test);
+    }
+    if (typeof test === "object") {
+      return Array.isArray(test) ? anyFactory3(test) : propsFactory3(test);
+    }
+    if (typeof test === "string") {
+      return typeFactory3(test);
+    }
+    throw new Error("Expected function, string, or object as test");
+  }
+);
+function anyFactory3(tests) {
+  const checks = [];
+  let index = -1;
+  while (++index < tests.length) {
+    checks[index] = convert3(tests[index]);
+  }
+  return castFactory3(any);
+  function any(...parameters) {
+    let index2 = -1;
+    while (++index2 < checks.length) {
+      if (checks[index2].apply(this, parameters)) return true;
+    }
+    return false;
+  }
+}
+function propsFactory3(check) {
+  const checkAsRecord = (
+    /** @type {Record<string, unknown>} */
+    check
+  );
+  return castFactory3(all2);
+  function all2(node2) {
+    const nodeAsRecord = (
+      /** @type {Record<string, unknown>} */
+      /** @type {unknown} */
+      node2
+    );
+    let key;
+    for (key in check) {
+      if (nodeAsRecord[key] !== checkAsRecord[key]) return false;
+    }
+    return true;
+  }
+}
+function typeFactory3(check) {
+  return castFactory3(type);
+  function type(node2) {
+    return node2 && node2.type === check;
+  }
+}
+function castFactory3(testFunction) {
+  return check;
+  function check(value, index, parent) {
+    return Boolean(
+      looksLikeANode3(value) && testFunction.call(
+        this,
+        value,
+        typeof index === "number" ? index : void 0,
+        parent || void 0
+      )
+    );
+  }
+}
+function ok4() {
+  return true;
+}
+function looksLikeANode3(value) {
+  return value !== null && typeof value === "object" && "type" in value;
+}
+
+// node_modules/mdast-util-phrasing/lib/index.js
+var phrasing = (
+  /** @type {(node?: unknown) => node is Exclude<PhrasingContent, Html>} */
+  convert3([
+    "break",
+    "delete",
+    "emphasis",
+    // To do: next major: removed since footnotes were added to GFM.
+    "footnote",
+    "footnoteReference",
+    "image",
+    "imageReference",
+    "inlineCode",
+    // Enabled by `mdast-util-math`:
+    "inlineMath",
+    "link",
+    "linkReference",
+    // Enabled by `mdast-util-mdx`:
+    "mdxJsxTextElement",
+    // Enabled by `mdast-util-mdx`:
+    "mdxTextExpression",
+    "strong",
+    "text",
+    // Enabled by `mdast-util-directive`:
+    "textDirective"
+  ])
+);
+
+// node_modules/mdast-util-to-markdown/lib/handle/root.js
+function root(node2, _, state, info) {
+  const hasPhrasing = node2.children.some(function(d) {
+    return phrasing(d);
+  });
+  const fn = hasPhrasing ? state.containerPhrasing : state.containerFlow;
+  return fn.call(state, node2, info);
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-strong.js
+function checkStrong(state) {
+  const marker = state.options.strong || "*";
+  if (marker !== "*" && marker !== "_") {
+    throw new Error(
+      "Cannot serialize strong with `" + marker + "` for `options.strong`, expected `*`, or `_`"
+    );
+  }
+  return marker;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/strong.js
+strong.peek = strongPeek;
+function strong(node2, _, state, info) {
+  const marker = checkStrong(state);
+  const exit2 = state.enter("strong");
+  const tracker = state.createTracker(info);
+  let value = tracker.move(marker + marker);
+  value += tracker.move(
+    state.containerPhrasing(node2, {
+      before: value,
+      after: marker,
+      ...tracker.current()
+    })
+  );
+  value += tracker.move(marker + marker);
+  exit2();
+  return value;
+}
+function strongPeek(_, _1, state) {
+  return state.options.strong || "*";
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/text.js
+function text(node2, _, state, info) {
+  return state.safe(node2.value, info);
+}
+
+// node_modules/mdast-util-to-markdown/lib/util/check-rule-repetition.js
+function checkRuleRepetition(state) {
+  const repetition = state.options.ruleRepetition || 3;
+  if (repetition < 3) {
+    throw new Error(
+      "Cannot serialize rules with repetition `" + repetition + "` for `options.ruleRepetition`, expected `3` or more"
+    );
+  }
+  return repetition;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/thematic-break.js
+function thematicBreak(_, _1, state) {
+  const value = (checkRule(state) + (state.options.ruleSpaces ? " " : "")).repeat(checkRuleRepetition(state));
+  return state.options.ruleSpaces ? value.slice(0, -1) : value;
+}
+
+// node_modules/mdast-util-to-markdown/lib/handle/index.js
+var handle = {
+  blockquote,
+  break: hardBreak,
+  code,
+  definition,
+  emphasis,
+  hardBreak,
+  heading,
+  html,
+  image,
+  imageReference,
+  inlineCode,
+  link,
+  linkReference,
+  list,
+  listItem,
+  paragraph,
+  root,
+  strong,
+  text,
+  thematicBreak
+};
+
+// node_modules/mdast-util-gfm-table/lib/index.js
+function gfmTableFromMarkdown() {
+  return {
+    enter: {
+      table: enterTable,
+      tableData: enterCell,
+      tableHeader: enterCell,
+      tableRow: enterRow
+    },
+    exit: {
+      codeText: exitCodeText,
+      table: exitTable,
+      tableData: exit,
+      tableHeader: exit,
+      tableRow: exit
+    }
+  };
+}
+function enterTable(token) {
+  const align = token._align;
+  ok(align, "expected `_align` on table");
+  this.enter(
+    {
+      type: "table",
+      align: align.map(function(d) {
+        return d === "none" ? null : d;
+      }),
+      children: []
+    },
+    token
+  );
+  this.data.inTable = true;
+}
+function exitTable(token) {
+  this.exit(token);
+  this.data.inTable = void 0;
+}
+function enterRow(token) {
+  this.enter({ type: "tableRow", children: [] }, token);
+}
+function exit(token) {
+  this.exit(token);
+}
+function enterCell(token) {
+  this.enter({ type: "tableCell", children: [] }, token);
+}
+function exitCodeText(token) {
+  let value = this.resume();
+  if (this.data.inTable) {
+    value = value.replace(/\\([\\|])/g, replace);
+  }
+  const node2 = this.stack[this.stack.length - 1];
+  ok(node2.type === "inlineCode");
+  node2.value = value;
+  this.exit(token);
+}
+function replace($0, $1) {
+  return $1 === "|" ? $1 : $0;
+}
+function gfmTableToMarkdown(options) {
+  const settings = options || {};
+  const padding = settings.tableCellPadding;
+  const alignDelimiters = settings.tablePipeAlign;
+  const stringLength = settings.stringLength;
+  const around = padding ? " " : "|";
+  return {
+    unsafe: [
+      { character: "\r", inConstruct: "tableCell" },
+      { character: "\n", inConstruct: "tableCell" },
+      // A pipe, when followed by a tab or space (padding), or a dash or colon
+      // (unpadded delimiter row), could result in a table.
+      { atBreak: true, character: "|", after: "[	 :-]" },
+      // A pipe in a cell must be encoded.
+      { character: "|", inConstruct: "tableCell" },
+      // A colon must be followed by a dash, in which case it could start a
+      // delimiter row.
+      { atBreak: true, character: ":", after: "-" },
+      // A delimiter row can also start with a dash, when followed by more
+      // dashes, a colon, or a pipe.
+      // This is a stricter version than the built in check for lists, thematic
+      // breaks, and setex heading underlines though:
+      // <https://github.com/syntax-tree/mdast-util-to-markdown/blob/51a2038/lib/unsafe.js#L57>
+      { atBreak: true, character: "-", after: "[:|-]" }
+    ],
+    handlers: {
+      inlineCode: inlineCodeWithTable,
+      table: handleTable,
+      tableCell: handleTableCell,
+      tableRow: handleTableRow
+    }
+  };
+  function handleTable(node2, _, state, info) {
+    return serializeData(handleTableAsData(node2, state, info), node2.align);
+  }
+  function handleTableRow(node2, _, state, info) {
+    const row = handleTableRowAsData(node2, state, info);
+    const value = serializeData([row]);
+    return value.slice(0, value.indexOf("\n"));
+  }
+  function handleTableCell(node2, _, state, info) {
+    const exit2 = state.enter("tableCell");
+    const subexit = state.enter("phrasing");
+    const value = state.containerPhrasing(node2, {
+      ...info,
+      before: around,
+      after: around
+    });
+    subexit();
+    exit2();
+    return value;
+  }
+  function serializeData(matrix, align) {
+    return markdownTable(matrix, {
+      align,
+      // @ts-expect-error: `markdown-table` types should support `null`.
+      alignDelimiters,
+      // @ts-expect-error: `markdown-table` types should support `null`.
+      padding,
+      // @ts-expect-error: `markdown-table` types should support `null`.
+      stringLength
+    });
+  }
+  function handleTableAsData(node2, state, info) {
+    const children = node2.children;
+    let index = -1;
+    const result = [];
+    const subexit = state.enter("table");
+    while (++index < children.length) {
+      result[index] = handleTableRowAsData(children[index], state, info);
+    }
+    subexit();
+    return result;
+  }
+  function handleTableRowAsData(node2, state, info) {
+    const children = node2.children;
+    let index = -1;
+    const result = [];
+    const subexit = state.enter("tableRow");
+    while (++index < children.length) {
+      result[index] = handleTableCell(children[index], node2, state, info);
+    }
+    subexit();
+    return result;
+  }
+  function inlineCodeWithTable(node2, parent, state) {
+    let value = handle.inlineCode(node2, parent, state);
+    if (state.stack.includes("tableCell")) {
+      value = value.replace(/\|/g, "\\$&");
+    }
+    return value;
+  }
+}
+
+// node_modules/mdast-util-gfm-task-list-item/lib/index.js
+function gfmTaskListItemFromMarkdown() {
+  return {
+    exit: {
+      taskListCheckValueChecked: exitCheck,
+      taskListCheckValueUnchecked: exitCheck,
+      paragraph: exitParagraphWithTaskListItem
+    }
+  };
+}
+function gfmTaskListItemToMarkdown() {
+  return {
+    unsafe: [{ atBreak: true, character: "-", after: "[:|-]" }],
+    handlers: { listItem: listItemWithTaskListItem }
+  };
+}
+function exitCheck(token) {
+  const node2 = this.stack[this.stack.length - 2];
+  ok(node2.type === "listItem");
+  node2.checked = token.type === "taskListCheckValueChecked";
+}
+function exitParagraphWithTaskListItem(token) {
+  const parent = this.stack[this.stack.length - 2];
+  if (parent && parent.type === "listItem" && typeof parent.checked === "boolean") {
+    const node2 = this.stack[this.stack.length - 1];
+    ok(node2.type === "paragraph");
+    const head = node2.children[0];
+    if (head && head.type === "text") {
+      const siblings = parent.children;
+      let index = -1;
+      let firstParaghraph;
+      while (++index < siblings.length) {
+        const sibling = siblings[index];
+        if (sibling.type === "paragraph") {
+          firstParaghraph = sibling;
+          break;
+        }
+      }
+      if (firstParaghraph === node2) {
+        head.value = head.value.slice(1);
+        if (head.value.length === 0) {
+          node2.children.shift();
+        } else if (node2.position && head.position && typeof head.position.start.offset === "number") {
+          head.position.start.column++;
+          head.position.start.offset++;
+          node2.position.start = Object.assign({}, head.position.start);
+        }
+      }
+    }
+  }
+  this.exit(token);
+}
+function listItemWithTaskListItem(node2, parent, state, info) {
+  const head = node2.children[0];
+  const checkable = typeof node2.checked === "boolean" && head && head.type === "paragraph";
+  const checkbox = "[" + (node2.checked ? "x" : " ") + "] ";
+  const tracker = state.createTracker(info);
+  if (checkable) {
+    tracker.move(checkbox);
+  }
+  let value = handle.listItem(node2, parent, state, {
+    ...info,
+    ...tracker.current()
+  });
+  if (checkable) {
+    value = value.replace(/^(?:[*+-]|\d+\.)([\r\n]| {1,3})/, check);
+  }
+  return value;
+  function check($0) {
+    return $0 + checkbox;
+  }
+}
+
+// node_modules/mdast-util-gfm/lib/index.js
+function gfmFromMarkdown() {
+  return [
+    gfmAutolinkLiteralFromMarkdown(),
+    gfmFootnoteFromMarkdown(),
+    gfmStrikethroughFromMarkdown(),
+    gfmTableFromMarkdown(),
+    gfmTaskListItemFromMarkdown()
+  ];
+}
+function gfmToMarkdown(options) {
+  return {
+    extensions: [
+      gfmAutolinkLiteralToMarkdown(),
+      gfmFootnoteToMarkdown(),
+      gfmStrikethroughToMarkdown(),
+      gfmTableToMarkdown(options),
+      gfmTaskListItemToMarkdown()
+    ]
+  };
+}
+
+// node_modules/micromark-util-chunked/index.js
+function splice(list2, start, remove, items) {
+  const end = list2.length;
+  let chunkStart = 0;
+  let parameters;
+  if (start < 0) {
+    start = -start > end ? 0 : end + start;
+  } else {
+    start = start > end ? end : start;
+  }
+  remove = remove > 0 ? remove : 0;
+  if (items.length < 1e4) {
+    parameters = Array.from(items);
+    parameters.unshift(start, remove);
+    list2.splice(...parameters);
+  } else {
+    if (remove) list2.splice(start, remove);
+    while (chunkStart < items.length) {
+      parameters = items.slice(chunkStart, chunkStart + 1e4);
+      parameters.unshift(start, 0);
+      list2.splice(...parameters);
+      chunkStart += 1e4;
+      start += 1e4;
+    }
+  }
+}
+
+// node_modules/micromark-util-combine-extensions/index.js
+var hasOwnProperty = {}.hasOwnProperty;
+function combineExtensions(extensions) {
+  const all2 = {};
+  let index = -1;
+  while (++index < extensions.length) {
+    syntaxExtension(all2, extensions[index]);
+  }
+  return all2;
+}
+function syntaxExtension(all2, extension) {
+  let hook;
+  for (hook in extension) {
+    const maybe = hasOwnProperty.call(all2, hook) ? all2[hook] : void 0;
+    const left = maybe || (all2[hook] = {});
+    const right = extension[hook];
+    let code3;
+    if (right) {
+      for (code3 in right) {
+        if (!hasOwnProperty.call(left, code3)) left[code3] = [];
+        const value = right[code3];
+        constructs(
+          // @ts-expect-error Looks like a list.
+          left[code3],
+          Array.isArray(value) ? value : value ? [value] : []
+        );
+      }
+    }
+  }
+}
+function constructs(existing, list2) {
+  let index = -1;
+  const before = [];
+  while (++index < list2.length) {
+    ;
+    (list2[index].add === "after" ? existing : before).push(list2[index]);
+  }
+  splice(existing, 0, 0, before);
+}
+
+// node_modules/micromark-extension-gfm-autolink-literal/lib/syntax.js
+var wwwPrefix = {
+  tokenize: tokenizeWwwPrefix,
+  partial: true
+};
+var domain = {
+  tokenize: tokenizeDomain,
+  partial: true
+};
+var path = {
+  tokenize: tokenizePath,
+  partial: true
+};
+var trail = {
+  tokenize: tokenizeTrail,
+  partial: true
+};
+var emailDomainDotTrail = {
+  tokenize: tokenizeEmailDomainDotTrail,
+  partial: true
+};
+var wwwAutolink = {
+  name: "wwwAutolink",
+  tokenize: tokenizeWwwAutolink,
+  previous: previousWww
+};
+var protocolAutolink = {
+  name: "protocolAutolink",
+  tokenize: tokenizeProtocolAutolink,
+  previous: previousProtocol
+};
+var emailAutolink = {
+  name: "emailAutolink",
+  tokenize: tokenizeEmailAutolink,
+  previous: previousEmail
+};
+var text2 = {};
+function gfmAutolinkLiteral() {
+  return {
+    text: text2
+  };
+}
+var code2 = 48;
+while (code2 < 123) {
+  text2[code2] = emailAutolink;
+  code2++;
+  if (code2 === 58) code2 = 65;
+  else if (code2 === 91) code2 = 97;
+}
+text2[43] = emailAutolink;
+text2[45] = emailAutolink;
+text2[46] = emailAutolink;
+text2[95] = emailAutolink;
+text2[72] = [emailAutolink, protocolAutolink];
+text2[104] = [emailAutolink, protocolAutolink];
+text2[87] = [emailAutolink, wwwAutolink];
+text2[119] = [emailAutolink, wwwAutolink];
+function tokenizeEmailAutolink(effects, ok5, nok) {
+  const self = this;
+  let dot;
+  let data;
+  return start;
+  function start(code3) {
+    if (!gfmAtext(code3) || !previousEmail.call(self, self.previous) || previousUnbalanced(self.events)) {
+      return nok(code3);
+    }
+    effects.enter("literalAutolink");
+    effects.enter("literalAutolinkEmail");
+    return atext(code3);
+  }
+  function atext(code3) {
+    if (gfmAtext(code3)) {
+      effects.consume(code3);
+      return atext;
+    }
+    if (code3 === 64) {
+      effects.consume(code3);
+      return emailDomain;
+    }
+    return nok(code3);
+  }
+  function emailDomain(code3) {
+    if (code3 === 46) {
+      return effects.check(emailDomainDotTrail, emailDomainAfter, emailDomainDot)(code3);
+    }
+    if (code3 === 45 || code3 === 95 || asciiAlphanumeric(code3)) {
+      data = true;
+      effects.consume(code3);
+      return emailDomain;
+    }
+    return emailDomainAfter(code3);
+  }
+  function emailDomainDot(code3) {
+    effects.consume(code3);
+    dot = true;
+    return emailDomain;
+  }
+  function emailDomainAfter(code3) {
+    if (data && dot && asciiAlpha(self.previous)) {
+      effects.exit("literalAutolinkEmail");
+      effects.exit("literalAutolink");
+      return ok5(code3);
+    }
+    return nok(code3);
+  }
+}
+function tokenizeWwwAutolink(effects, ok5, nok) {
+  const self = this;
+  return wwwStart;
+  function wwwStart(code3) {
+    if (code3 !== 87 && code3 !== 119 || !previousWww.call(self, self.previous) || previousUnbalanced(self.events)) {
+      return nok(code3);
+    }
+    effects.enter("literalAutolink");
+    effects.enter("literalAutolinkWww");
+    return effects.check(wwwPrefix, effects.attempt(domain, effects.attempt(path, wwwAfter), nok), nok)(code3);
+  }
+  function wwwAfter(code3) {
+    effects.exit("literalAutolinkWww");
+    effects.exit("literalAutolink");
+    return ok5(code3);
+  }
+}
+function tokenizeProtocolAutolink(effects, ok5, nok) {
+  const self = this;
+  let buffer = "";
+  let seen = false;
+  return protocolStart;
+  function protocolStart(code3) {
+    if ((code3 === 72 || code3 === 104) && previousProtocol.call(self, self.previous) && !previousUnbalanced(self.events)) {
+      effects.enter("literalAutolink");
+      effects.enter("literalAutolinkHttp");
+      buffer += String.fromCodePoint(code3);
+      effects.consume(code3);
+      return protocolPrefixInside;
+    }
+    return nok(code3);
+  }
+  function protocolPrefixInside(code3) {
+    if (asciiAlpha(code3) && buffer.length < 5) {
+      buffer += String.fromCodePoint(code3);
+      effects.consume(code3);
+      return protocolPrefixInside;
+    }
+    if (code3 === 58) {
+      const protocol = buffer.toLowerCase();
+      if (protocol === "http" || protocol === "https") {
+        effects.consume(code3);
+        return protocolSlashesInside;
+      }
+    }
+    return nok(code3);
+  }
+  function protocolSlashesInside(code3) {
+    if (code3 === 47) {
+      effects.consume(code3);
+      if (seen) {
+        return afterProtocol;
+      }
+      seen = true;
+      return protocolSlashesInside;
+    }
+    return nok(code3);
+  }
+  function afterProtocol(code3) {
+    return code3 === null || asciiControl(code3) || markdownLineEndingOrSpace(code3) || unicodeWhitespace(code3) || unicodePunctuation(code3) ? nok(code3) : effects.attempt(domain, effects.attempt(path, protocolAfter), nok)(code3);
+  }
+  function protocolAfter(code3) {
+    effects.exit("literalAutolinkHttp");
+    effects.exit("literalAutolink");
+    return ok5(code3);
+  }
+}
+function tokenizeWwwPrefix(effects, ok5, nok) {
+  let size = 0;
+  return wwwPrefixInside;
+  function wwwPrefixInside(code3) {
+    if ((code3 === 87 || code3 === 119) && size < 3) {
+      size++;
+      effects.consume(code3);
+      return wwwPrefixInside;
+    }
+    if (code3 === 46 && size === 3) {
+      effects.consume(code3);
+      return wwwPrefixAfter;
+    }
+    return nok(code3);
+  }
+  function wwwPrefixAfter(code3) {
+    return code3 === null ? nok(code3) : ok5(code3);
+  }
+}
+function tokenizeDomain(effects, ok5, nok) {
+  let underscoreInLastSegment;
+  let underscoreInLastLastSegment;
+  let seen;
+  return domainInside;
+  function domainInside(code3) {
+    if (code3 === 46 || code3 === 95) {
+      return effects.check(trail, domainAfter, domainAtPunctuation)(code3);
+    }
+    if (code3 === null || markdownLineEndingOrSpace(code3) || unicodeWhitespace(code3) || code3 !== 45 && unicodePunctuation(code3)) {
+      return domainAfter(code3);
+    }
+    seen = true;
+    effects.consume(code3);
+    return domainInside;
+  }
+  function domainAtPunctuation(code3) {
+    if (code3 === 95) {
+      underscoreInLastSegment = true;
+    } else {
+      underscoreInLastLastSegment = underscoreInLastSegment;
+      underscoreInLastSegment = void 0;
+    }
+    effects.consume(code3);
+    return domainInside;
+  }
+  function domainAfter(code3) {
+    if (underscoreInLastLastSegment || underscoreInLastSegment || !seen) {
+      return nok(code3);
+    }
+    return ok5(code3);
+  }
+}
+function tokenizePath(effects, ok5) {
+  let sizeOpen = 0;
+  let sizeClose = 0;
+  return pathInside;
+  function pathInside(code3) {
+    if (code3 === 40) {
+      sizeOpen++;
+      effects.consume(code3);
+      return pathInside;
+    }
+    if (code3 === 41 && sizeClose < sizeOpen) {
+      return pathAtPunctuation(code3);
+    }
+    if (code3 === 33 || code3 === 34 || code3 === 38 || code3 === 39 || code3 === 41 || code3 === 42 || code3 === 44 || code3 === 46 || code3 === 58 || code3 === 59 || code3 === 60 || code3 === 63 || code3 === 93 || code3 === 95 || code3 === 126) {
+      return effects.check(trail, ok5, pathAtPunctuation)(code3);
+    }
+    if (code3 === null || markdownLineEndingOrSpace(code3) || unicodeWhitespace(code3)) {
+      return ok5(code3);
+    }
+    effects.consume(code3);
+    return pathInside;
+  }
+  function pathAtPunctuation(code3) {
+    if (code3 === 41) {
+      sizeClose++;
+    }
+    effects.consume(code3);
+    return pathInside;
+  }
+}
+function tokenizeTrail(effects, ok5, nok) {
+  return trail2;
+  function trail2(code3) {
+    if (code3 === 33 || code3 === 34 || code3 === 39 || code3 === 41 || code3 === 42 || code3 === 44 || code3 === 46 || code3 === 58 || code3 === 59 || code3 === 63 || code3 === 95 || code3 === 126) {
+      effects.consume(code3);
+      return trail2;
+    }
+    if (code3 === 38) {
+      effects.consume(code3);
+      return trailCharacterReferenceStart;
+    }
+    if (code3 === 93) {
+      effects.consume(code3);
+      return trailBracketAfter;
+    }
+    if (
+      // `<` is an end.
+      code3 === 60 || // So is whitespace.
+      code3 === null || markdownLineEndingOrSpace(code3) || unicodeWhitespace(code3)
+    ) {
+      return ok5(code3);
+    }
+    return nok(code3);
+  }
+  function trailBracketAfter(code3) {
+    if (code3 === null || code3 === 40 || code3 === 91 || markdownLineEndingOrSpace(code3) || unicodeWhitespace(code3)) {
+      return ok5(code3);
+    }
+    return trail2(code3);
+  }
+  function trailCharacterReferenceStart(code3) {
+    return asciiAlpha(code3) ? trailCharacterReferenceInside(code3) : nok(code3);
+  }
+  function trailCharacterReferenceInside(code3) {
+    if (code3 === 59) {
+      effects.consume(code3);
+      return trail2;
+    }
+    if (asciiAlpha(code3)) {
+      effects.consume(code3);
+      return trailCharacterReferenceInside;
+    }
+    return nok(code3);
+  }
+}
+function tokenizeEmailDomainDotTrail(effects, ok5, nok) {
+  return start;
+  function start(code3) {
+    effects.consume(code3);
+    return after;
+  }
+  function after(code3) {
+    return asciiAlphanumeric(code3) ? nok(code3) : ok5(code3);
+  }
+}
+function previousWww(code3) {
+  return code3 === null || code3 === 40 || code3 === 42 || code3 === 95 || code3 === 91 || code3 === 93 || code3 === 126 || markdownLineEndingOrSpace(code3);
+}
+function previousProtocol(code3) {
+  return !asciiAlpha(code3);
+}
+function previousEmail(code3) {
+  return !(code3 === 47 || gfmAtext(code3));
+}
+function gfmAtext(code3) {
+  return code3 === 43 || code3 === 45 || code3 === 46 || code3 === 95 || asciiAlphanumeric(code3);
+}
+function previousUnbalanced(events) {
+  let index = events.length;
+  let result = false;
+  while (index--) {
+    const token = events[index][1];
+    if ((token.type === "labelLink" || token.type === "labelImage") && !token._balanced) {
+      result = true;
+      break;
+    }
+    if (token._gfmAutolinkLiteralWalkedInto) {
+      result = false;
+      break;
+    }
+  }
+  if (events.length > 0 && !result) {
+    events[events.length - 1][1]._gfmAutolinkLiteralWalkedInto = true;
+  }
+  return result;
+}
+
+// node_modules/micromark-util-classify-character/index.js
+function classifyCharacter(code3) {
+  if (code3 === null || markdownLineEndingOrSpace(code3) || unicodeWhitespace(code3)) {
+    return 1;
+  }
+  if (unicodePunctuation(code3)) {
+    return 2;
+  }
+}
+
+// node_modules/micromark-util-resolve-all/index.js
+function resolveAll(constructs2, events, context) {
+  const called = [];
+  let index = -1;
+  while (++index < constructs2.length) {
+    const resolve = constructs2[index].resolveAll;
+    if (resolve && !called.includes(resolve)) {
+      events = resolve(events, context);
+      called.push(resolve);
+    }
+  }
+  return events;
+}
+
+// node_modules/micromark-factory-space/index.js
+function factorySpace(effects, ok5, type, max) {
+  const limit = max ? max - 1 : Number.POSITIVE_INFINITY;
+  let size = 0;
+  return start;
+  function start(code3) {
+    if (markdownSpace(code3)) {
+      effects.enter(type);
+      return prefix(code3);
+    }
+    return ok5(code3);
+  }
+  function prefix(code3) {
+    if (markdownSpace(code3) && size++ < limit) {
+      effects.consume(code3);
+      return prefix;
+    }
+    effects.exit(type);
+    return ok5(code3);
+  }
+}
+
+// node_modules/micromark-core-commonmark/lib/blank-line.js
+var blankLine = {
+  tokenize: tokenizeBlankLine,
+  partial: true
+};
+function tokenizeBlankLine(effects, ok5, nok) {
+  return start;
+  function start(code3) {
+    return markdownSpace(code3) ? factorySpace(effects, after, "linePrefix")(code3) : after(code3);
+  }
+  function after(code3) {
+    return code3 === null || markdownLineEnding(code3) ? ok5(code3) : nok(code3);
+  }
+}
+
+// node_modules/micromark-extension-gfm-footnote/lib/syntax.js
+var indent = {
+  tokenize: tokenizeIndent,
+  partial: true
+};
+function gfmFootnote() {
+  return {
+    document: {
+      [91]: {
+        name: "gfmFootnoteDefinition",
+        tokenize: tokenizeDefinitionStart,
+        continuation: {
+          tokenize: tokenizeDefinitionContinuation
+        },
+        exit: gfmFootnoteDefinitionEnd
+      }
+    },
+    text: {
+      [91]: {
+        name: "gfmFootnoteCall",
+        tokenize: tokenizeGfmFootnoteCall
+      },
+      [93]: {
+        name: "gfmPotentialFootnoteCall",
+        add: "after",
+        tokenize: tokenizePotentialGfmFootnoteCall,
+        resolveTo: resolveToPotentialGfmFootnoteCall
+      }
+    }
+  };
+}
+function tokenizePotentialGfmFootnoteCall(effects, ok5, nok) {
+  const self = this;
+  let index = self.events.length;
+  const defined = self.parser.gfmFootnotes || (self.parser.gfmFootnotes = []);
+  let labelStart;
+  while (index--) {
+    const token = self.events[index][1];
+    if (token.type === "labelImage") {
+      labelStart = token;
+      break;
+    }
+    if (token.type === "gfmFootnoteCall" || token.type === "labelLink" || token.type === "label" || token.type === "image" || token.type === "link") {
+      break;
+    }
+  }
+  return start;
+  function start(code3) {
+    if (!labelStart || !labelStart._balanced) {
+      return nok(code3);
+    }
+    const id = normalizeIdentifier(self.sliceSerialize({
+      start: labelStart.end,
+      end: self.now()
+    }));
+    if (id.codePointAt(0) !== 94 || !defined.includes(id.slice(1))) {
+      return nok(code3);
+    }
+    effects.enter("gfmFootnoteCallLabelMarker");
+    effects.consume(code3);
+    effects.exit("gfmFootnoteCallLabelMarker");
+    return ok5(code3);
+  }
+}
+function resolveToPotentialGfmFootnoteCall(events, context) {
+  let index = events.length;
+  let labelStart;
+  while (index--) {
+    if (events[index][1].type === "labelImage" && events[index][0] === "enter") {
+      labelStart = events[index][1];
+      break;
+    }
+  }
+  events[index + 1][1].type = "data";
+  events[index + 3][1].type = "gfmFootnoteCallLabelMarker";
+  const call = {
+    type: "gfmFootnoteCall",
+    start: Object.assign({}, events[index + 3][1].start),
+    end: Object.assign({}, events[events.length - 1][1].end)
+  };
+  const marker = {
+    type: "gfmFootnoteCallMarker",
+    start: Object.assign({}, events[index + 3][1].end),
+    end: Object.assign({}, events[index + 3][1].end)
+  };
+  marker.end.column++;
+  marker.end.offset++;
+  marker.end._bufferIndex++;
+  const string = {
+    type: "gfmFootnoteCallString",
+    start: Object.assign({}, marker.end),
+    end: Object.assign({}, events[events.length - 1][1].start)
+  };
+  const chunk = {
+    type: "chunkString",
+    contentType: "string",
+    start: Object.assign({}, string.start),
+    end: Object.assign({}, string.end)
+  };
+  const replacement = [
+    // Take the `labelImageMarker` (now `data`, the `!`)
+    events[index + 1],
+    events[index + 2],
+    ["enter", call, context],
+    // The `[`
+    events[index + 3],
+    events[index + 4],
+    // The `^`.
+    ["enter", marker, context],
+    ["exit", marker, context],
+    // Everything in between.
+    ["enter", string, context],
+    ["enter", chunk, context],
+    ["exit", chunk, context],
+    ["exit", string, context],
+    // The ending (`]`, properly parsed and labelled).
+    events[events.length - 2],
+    events[events.length - 1],
+    ["exit", call, context]
+  ];
+  events.splice(index, events.length - index + 1, ...replacement);
+  return events;
+}
+function tokenizeGfmFootnoteCall(effects, ok5, nok) {
+  const self = this;
+  const defined = self.parser.gfmFootnotes || (self.parser.gfmFootnotes = []);
+  let size = 0;
+  let data;
+  return start;
+  function start(code3) {
+    effects.enter("gfmFootnoteCall");
+    effects.enter("gfmFootnoteCallLabelMarker");
+    effects.consume(code3);
+    effects.exit("gfmFootnoteCallLabelMarker");
+    return callStart;
+  }
+  function callStart(code3) {
+    if (code3 !== 94) return nok(code3);
+    effects.enter("gfmFootnoteCallMarker");
+    effects.consume(code3);
+    effects.exit("gfmFootnoteCallMarker");
+    effects.enter("gfmFootnoteCallString");
+    effects.enter("chunkString").contentType = "string";
+    return callData;
+  }
+  function callData(code3) {
+    if (
+      // Too long.
+      size > 999 || // Closing brace with nothing.
+      code3 === 93 && !data || // Space or tab is not supported by GFM for some reason.
+      // `\n` and `[` not being supported makes sense.
+      code3 === null || code3 === 91 || markdownLineEndingOrSpace(code3)
+    ) {
+      return nok(code3);
+    }
+    if (code3 === 93) {
+      effects.exit("chunkString");
+      const token = effects.exit("gfmFootnoteCallString");
+      if (!defined.includes(normalizeIdentifier(self.sliceSerialize(token)))) {
+        return nok(code3);
+      }
+      effects.enter("gfmFootnoteCallLabelMarker");
+      effects.consume(code3);
+      effects.exit("gfmFootnoteCallLabelMarker");
+      effects.exit("gfmFootnoteCall");
+      return ok5;
+    }
+    if (!markdownLineEndingOrSpace(code3)) {
+      data = true;
+    }
+    size++;
+    effects.consume(code3);
+    return code3 === 92 ? callEscape : callData;
+  }
+  function callEscape(code3) {
+    if (code3 === 91 || code3 === 92 || code3 === 93) {
+      effects.consume(code3);
+      size++;
+      return callData;
+    }
+    return callData(code3);
+  }
+}
+function tokenizeDefinitionStart(effects, ok5, nok) {
+  const self = this;
+  const defined = self.parser.gfmFootnotes || (self.parser.gfmFootnotes = []);
+  let identifier;
+  let size = 0;
+  let data;
+  return start;
+  function start(code3) {
+    effects.enter("gfmFootnoteDefinition")._container = true;
+    effects.enter("gfmFootnoteDefinitionLabel");
+    effects.enter("gfmFootnoteDefinitionLabelMarker");
+    effects.consume(code3);
+    effects.exit("gfmFootnoteDefinitionLabelMarker");
+    return labelAtMarker;
+  }
+  function labelAtMarker(code3) {
+    if (code3 === 94) {
+      effects.enter("gfmFootnoteDefinitionMarker");
+      effects.consume(code3);
+      effects.exit("gfmFootnoteDefinitionMarker");
+      effects.enter("gfmFootnoteDefinitionLabelString");
+      effects.enter("chunkString").contentType = "string";
+      return labelInside;
+    }
+    return nok(code3);
+  }
+  function labelInside(code3) {
+    if (
+      // Too long.
+      size > 999 || // Closing brace with nothing.
+      code3 === 93 && !data || // Space or tab is not supported by GFM for some reason.
+      // `\n` and `[` not being supported makes sense.
+      code3 === null || code3 === 91 || markdownLineEndingOrSpace(code3)
+    ) {
+      return nok(code3);
+    }
+    if (code3 === 93) {
+      effects.exit("chunkString");
+      const token = effects.exit("gfmFootnoteDefinitionLabelString");
+      identifier = normalizeIdentifier(self.sliceSerialize(token));
+      effects.enter("gfmFootnoteDefinitionLabelMarker");
+      effects.consume(code3);
+      effects.exit("gfmFootnoteDefinitionLabelMarker");
+      effects.exit("gfmFootnoteDefinitionLabel");
+      return labelAfter;
+    }
+    if (!markdownLineEndingOrSpace(code3)) {
+      data = true;
+    }
+    size++;
+    effects.consume(code3);
+    return code3 === 92 ? labelEscape : labelInside;
+  }
+  function labelEscape(code3) {
+    if (code3 === 91 || code3 === 92 || code3 === 93) {
+      effects.consume(code3);
+      size++;
+      return labelInside;
+    }
+    return labelInside(code3);
+  }
+  function labelAfter(code3) {
+    if (code3 === 58) {
+      effects.enter("definitionMarker");
+      effects.consume(code3);
+      effects.exit("definitionMarker");
+      if (!defined.includes(identifier)) {
+        defined.push(identifier);
+      }
+      return factorySpace(effects, whitespaceAfter, "gfmFootnoteDefinitionWhitespace");
+    }
+    return nok(code3);
+  }
+  function whitespaceAfter(code3) {
+    return ok5(code3);
+  }
+}
+function tokenizeDefinitionContinuation(effects, ok5, nok) {
+  return effects.check(blankLine, ok5, effects.attempt(indent, ok5, nok));
+}
+function gfmFootnoteDefinitionEnd(effects) {
+  effects.exit("gfmFootnoteDefinition");
+}
+function tokenizeIndent(effects, ok5, nok) {
+  const self = this;
+  return factorySpace(effects, afterPrefix, "gfmFootnoteDefinitionIndent", 4 + 1);
+  function afterPrefix(code3) {
+    const tail = self.events[self.events.length - 1];
+    return tail && tail[1].type === "gfmFootnoteDefinitionIndent" && tail[2].sliceSerialize(tail[1], true).length === 4 ? ok5(code3) : nok(code3);
+  }
+}
+
+// node_modules/micromark-extension-gfm-strikethrough/lib/syntax.js
+function gfmStrikethrough(options) {
+  const options_ = options || {};
+  let single = options_.singleTilde;
+  const tokenizer = {
+    name: "strikethrough",
+    tokenize: tokenizeStrikethrough,
+    resolveAll: resolveAllStrikethrough
+  };
+  if (single === null || single === void 0) {
+    single = true;
+  }
+  return {
+    text: {
+      [126]: tokenizer
+    },
+    insideSpan: {
+      null: [tokenizer]
+    },
+    attentionMarkers: {
+      null: [126]
+    }
+  };
+  function resolveAllStrikethrough(events, context) {
+    let index = -1;
+    while (++index < events.length) {
+      if (events[index][0] === "enter" && events[index][1].type === "strikethroughSequenceTemporary" && events[index][1]._close) {
+        let open = index;
+        while (open--) {
+          if (events[open][0] === "exit" && events[open][1].type === "strikethroughSequenceTemporary" && events[open][1]._open && // If the sizes are the same:
+          events[index][1].end.offset - events[index][1].start.offset === events[open][1].end.offset - events[open][1].start.offset) {
+            events[index][1].type = "strikethroughSequence";
+            events[open][1].type = "strikethroughSequence";
+            const strikethrough = {
+              type: "strikethrough",
+              start: Object.assign({}, events[open][1].start),
+              end: Object.assign({}, events[index][1].end)
+            };
+            const text3 = {
+              type: "strikethroughText",
+              start: Object.assign({}, events[open][1].end),
+              end: Object.assign({}, events[index][1].start)
+            };
+            const nextEvents = [["enter", strikethrough, context], ["enter", events[open][1], context], ["exit", events[open][1], context], ["enter", text3, context]];
+            const insideSpan = context.parser.constructs.insideSpan.null;
+            if (insideSpan) {
+              splice(nextEvents, nextEvents.length, 0, resolveAll(insideSpan, events.slice(open + 1, index), context));
+            }
+            splice(nextEvents, nextEvents.length, 0, [["exit", text3, context], ["enter", events[index][1], context], ["exit", events[index][1], context], ["exit", strikethrough, context]]);
+            splice(events, open - 1, index - open + 3, nextEvents);
+            index = open + nextEvents.length - 2;
+            break;
+          }
+        }
+      }
+    }
+    index = -1;
+    while (++index < events.length) {
+      if (events[index][1].type === "strikethroughSequenceTemporary") {
+        events[index][1].type = "data";
+      }
+    }
+    return events;
+  }
+  function tokenizeStrikethrough(effects, ok5, nok) {
+    const previous2 = this.previous;
+    const events = this.events;
+    let size = 0;
+    return start;
+    function start(code3) {
+      if (previous2 === 126 && events[events.length - 1][1].type !== "characterEscape") {
+        return nok(code3);
+      }
+      effects.enter("strikethroughSequenceTemporary");
+      return more(code3);
+    }
+    function more(code3) {
+      const before = classifyCharacter(previous2);
+      if (code3 === 126) {
+        if (size > 1) return nok(code3);
+        effects.consume(code3);
+        size++;
+        return more;
+      }
+      if (size < 2 && !single) return nok(code3);
+      const token = effects.exit("strikethroughSequenceTemporary");
+      const after = classifyCharacter(code3);
+      token._open = !after || after === 2 && Boolean(before);
+      token._close = !before || before === 2 && Boolean(after);
+      return ok5(code3);
+    }
+  }
+}
+
+// node_modules/micromark-extension-gfm-table/lib/edit-map.js
+var EditMap = class {
+  /**
+   * Create a new edit map.
+   */
+  constructor() {
+    this.map = [];
+  }
+  /**
+   * Create an edit: a remove and/or add at a certain place.
+   *
+   * @param {number} index
+   * @param {number} remove
+   * @param {Array<Event>} add
+   * @returns {undefined}
+   */
+  add(index, remove, add) {
+    addImplementation(this, index, remove, add);
+  }
+  // To do: add this when moving to `micromark`.
+  // /**
+  //  * Create an edit: but insert `add` before existing additions.
+  //  *
+  //  * @param {number} index
+  //  * @param {number} remove
+  //  * @param {Array<Event>} add
+  //  * @returns {undefined}
+  //  */
+  // addBefore(index, remove, add) {
+  //   addImplementation(this, index, remove, add, true)
+  // }
+  /**
+   * Done, change the events.
+   *
+   * @param {Array<Event>} events
+   * @returns {undefined}
+   */
+  consume(events) {
+    this.map.sort(function(a, b) {
+      return a[0] - b[0];
+    });
+    if (this.map.length === 0) {
+      return;
+    }
+    let index = this.map.length;
+    const vecs = [];
+    while (index > 0) {
+      index -= 1;
+      vecs.push(events.slice(this.map[index][0] + this.map[index][1]), this.map[index][2]);
+      events.length = this.map[index][0];
+    }
+    vecs.push([...events]);
+    events.length = 0;
+    let slice = vecs.pop();
+    while (slice) {
+      events.push(...slice);
+      slice = vecs.pop();
+    }
+    this.map.length = 0;
+  }
+};
+function addImplementation(editMap, at, remove, add) {
+  let index = 0;
+  if (remove === 0 && add.length === 0) {
+    return;
+  }
+  while (index < editMap.map.length) {
+    if (editMap.map[index][0] === at) {
+      editMap.map[index][1] += remove;
+      editMap.map[index][2].push(...add);
+      return;
+    }
+    index += 1;
+  }
+  editMap.map.push([at, remove, add]);
+}
+
+// node_modules/micromark-extension-gfm-table/lib/infer.js
+function gfmTableAlign(events, index) {
+  let inDelimiterRow = false;
+  const align = [];
+  while (index < events.length) {
+    const event = events[index];
+    if (inDelimiterRow) {
+      if (event[0] === "enter") {
+        if (event[1].type === "tableContent") {
+          align.push(events[index + 1][1].type === "tableDelimiterMarker" ? "left" : "none");
+        }
+      } else if (event[1].type === "tableContent") {
+        if (events[index - 1][1].type === "tableDelimiterMarker") {
+          const alignIndex = align.length - 1;
+          align[alignIndex] = align[alignIndex] === "left" ? "center" : "right";
+        }
+      } else if (event[1].type === "tableDelimiterRow") {
+        break;
+      }
+    } else if (event[0] === "enter" && event[1].type === "tableDelimiterRow") {
+      inDelimiterRow = true;
+    }
+    index += 1;
+  }
+  return align;
+}
+
+// node_modules/micromark-extension-gfm-table/lib/syntax.js
+function gfmTable() {
+  return {
+    flow: {
+      null: {
+        name: "table",
+        tokenize: tokenizeTable,
+        resolveAll: resolveTable
+      }
+    }
+  };
+}
+function tokenizeTable(effects, ok5, nok) {
+  const self = this;
+  let size = 0;
+  let sizeB = 0;
+  let seen;
+  return start;
+  function start(code3) {
+    let index = self.events.length - 1;
+    while (index > -1) {
+      const type = self.events[index][1].type;
+      if (type === "lineEnding" || // Note: markdown-rs uses `whitespace` instead of `linePrefix`
+      type === "linePrefix") index--;
+      else break;
+    }
+    const tail = index > -1 ? self.events[index][1].type : null;
+    const next = tail === "tableHead" || tail === "tableRow" ? bodyRowStart : headRowBefore;
+    if (next === bodyRowStart && self.parser.lazy[self.now().line]) {
+      return nok(code3);
+    }
+    return next(code3);
+  }
+  function headRowBefore(code3) {
+    effects.enter("tableHead");
+    effects.enter("tableRow");
+    return headRowStart(code3);
+  }
+  function headRowStart(code3) {
+    if (code3 === 124) {
+      return headRowBreak(code3);
+    }
+    seen = true;
+    sizeB += 1;
+    return headRowBreak(code3);
+  }
+  function headRowBreak(code3) {
+    if (code3 === null) {
+      return nok(code3);
+    }
+    if (markdownLineEnding(code3)) {
+      if (sizeB > 1) {
+        sizeB = 0;
+        self.interrupt = true;
+        effects.exit("tableRow");
+        effects.enter("lineEnding");
+        effects.consume(code3);
+        effects.exit("lineEnding");
+        return headDelimiterStart;
+      }
+      return nok(code3);
+    }
+    if (markdownSpace(code3)) {
+      return factorySpace(effects, headRowBreak, "whitespace")(code3);
+    }
+    sizeB += 1;
+    if (seen) {
+      seen = false;
+      size += 1;
+    }
+    if (code3 === 124) {
+      effects.enter("tableCellDivider");
+      effects.consume(code3);
+      effects.exit("tableCellDivider");
+      seen = true;
+      return headRowBreak;
+    }
+    effects.enter("data");
+    return headRowData(code3);
+  }
+  function headRowData(code3) {
+    if (code3 === null || code3 === 124 || markdownLineEndingOrSpace(code3)) {
+      effects.exit("data");
+      return headRowBreak(code3);
+    }
+    effects.consume(code3);
+    return code3 === 92 ? headRowEscape : headRowData;
+  }
+  function headRowEscape(code3) {
+    if (code3 === 92 || code3 === 124) {
+      effects.consume(code3);
+      return headRowData;
+    }
+    return headRowData(code3);
+  }
+  function headDelimiterStart(code3) {
+    self.interrupt = false;
+    if (self.parser.lazy[self.now().line]) {
+      return nok(code3);
+    }
+    effects.enter("tableDelimiterRow");
+    seen = false;
+    if (markdownSpace(code3)) {
+      return factorySpace(effects, headDelimiterBefore, "linePrefix", self.parser.constructs.disable.null.includes("codeIndented") ? void 0 : 4)(code3);
+    }
+    return headDelimiterBefore(code3);
+  }
+  function headDelimiterBefore(code3) {
+    if (code3 === 45 || code3 === 58) {
+      return headDelimiterValueBefore(code3);
+    }
+    if (code3 === 124) {
+      seen = true;
+      effects.enter("tableCellDivider");
+      effects.consume(code3);
+      effects.exit("tableCellDivider");
+      return headDelimiterCellBefore;
+    }
+    return headDelimiterNok(code3);
+  }
+  function headDelimiterCellBefore(code3) {
+    if (markdownSpace(code3)) {
+      return factorySpace(effects, headDelimiterValueBefore, "whitespace")(code3);
+    }
+    return headDelimiterValueBefore(code3);
+  }
+  function headDelimiterValueBefore(code3) {
+    if (code3 === 58) {
+      sizeB += 1;
+      seen = true;
+      effects.enter("tableDelimiterMarker");
+      effects.consume(code3);
+      effects.exit("tableDelimiterMarker");
+      return headDelimiterLeftAlignmentAfter;
+    }
+    if (code3 === 45) {
+      sizeB += 1;
+      return headDelimiterLeftAlignmentAfter(code3);
+    }
+    if (code3 === null || markdownLineEnding(code3)) {
+      return headDelimiterCellAfter(code3);
+    }
+    return headDelimiterNok(code3);
+  }
+  function headDelimiterLeftAlignmentAfter(code3) {
+    if (code3 === 45) {
+      effects.enter("tableDelimiterFiller");
+      return headDelimiterFiller(code3);
+    }
+    return headDelimiterNok(code3);
+  }
+  function headDelimiterFiller(code3) {
+    if (code3 === 45) {
+      effects.consume(code3);
+      return headDelimiterFiller;
+    }
+    if (code3 === 58) {
+      seen = true;
+      effects.exit("tableDelimiterFiller");
+      effects.enter("tableDelimiterMarker");
+      effects.consume(code3);
+      effects.exit("tableDelimiterMarker");
+      return headDelimiterRightAlignmentAfter;
+    }
+    effects.exit("tableDelimiterFiller");
+    return headDelimiterRightAlignmentAfter(code3);
+  }
+  function headDelimiterRightAlignmentAfter(code3) {
+    if (markdownSpace(code3)) {
+      return factorySpace(effects, headDelimiterCellAfter, "whitespace")(code3);
+    }
+    return headDelimiterCellAfter(code3);
+  }
+  function headDelimiterCellAfter(code3) {
+    if (code3 === 124) {
+      return headDelimiterBefore(code3);
+    }
+    if (code3 === null || markdownLineEnding(code3)) {
+      if (!seen || size !== sizeB) {
+        return headDelimiterNok(code3);
+      }
+      effects.exit("tableDelimiterRow");
+      effects.exit("tableHead");
+      return ok5(code3);
+    }
+    return headDelimiterNok(code3);
+  }
+  function headDelimiterNok(code3) {
+    return nok(code3);
+  }
+  function bodyRowStart(code3) {
+    effects.enter("tableRow");
+    return bodyRowBreak(code3);
+  }
+  function bodyRowBreak(code3) {
+    if (code3 === 124) {
+      effects.enter("tableCellDivider");
+      effects.consume(code3);
+      effects.exit("tableCellDivider");
+      return bodyRowBreak;
+    }
+    if (code3 === null || markdownLineEnding(code3)) {
+      effects.exit("tableRow");
+      return ok5(code3);
+    }
+    if (markdownSpace(code3)) {
+      return factorySpace(effects, bodyRowBreak, "whitespace")(code3);
+    }
+    effects.enter("data");
+    return bodyRowData(code3);
+  }
+  function bodyRowData(code3) {
+    if (code3 === null || code3 === 124 || markdownLineEndingOrSpace(code3)) {
+      effects.exit("data");
+      return bodyRowBreak(code3);
+    }
+    effects.consume(code3);
+    return code3 === 92 ? bodyRowEscape : bodyRowData;
+  }
+  function bodyRowEscape(code3) {
+    if (code3 === 92 || code3 === 124) {
+      effects.consume(code3);
+      return bodyRowData;
+    }
+    return bodyRowData(code3);
+  }
+}
+function resolveTable(events, context) {
+  let index = -1;
+  let inFirstCellAwaitingPipe = true;
+  let rowKind = 0;
+  let lastCell = [0, 0, 0, 0];
+  let cell = [0, 0, 0, 0];
+  let afterHeadAwaitingFirstBodyRow = false;
+  let lastTableEnd = 0;
+  let currentTable;
+  let currentBody;
+  let currentCell;
+  const map4 = new EditMap();
+  while (++index < events.length) {
+    const event = events[index];
+    const token = event[1];
+    if (event[0] === "enter") {
+      if (token.type === "tableHead") {
+        afterHeadAwaitingFirstBodyRow = false;
+        if (lastTableEnd !== 0) {
+          flushTableEnd(map4, context, lastTableEnd, currentTable, currentBody);
+          currentBody = void 0;
+          lastTableEnd = 0;
+        }
+        currentTable = {
+          type: "table",
+          start: Object.assign({}, token.start),
+          // Note: correct end is set later.
+          end: Object.assign({}, token.end)
+        };
+        map4.add(index, 0, [["enter", currentTable, context]]);
+      } else if (token.type === "tableRow" || token.type === "tableDelimiterRow") {
+        inFirstCellAwaitingPipe = true;
+        currentCell = void 0;
+        lastCell = [0, 0, 0, 0];
+        cell = [0, index + 1, 0, 0];
+        if (afterHeadAwaitingFirstBodyRow) {
+          afterHeadAwaitingFirstBodyRow = false;
+          currentBody = {
+            type: "tableBody",
+            start: Object.assign({}, token.start),
+            // Note: correct end is set later.
+            end: Object.assign({}, token.end)
+          };
+          map4.add(index, 0, [["enter", currentBody, context]]);
+        }
+        rowKind = token.type === "tableDelimiterRow" ? 2 : currentBody ? 3 : 1;
+      } else if (rowKind && (token.type === "data" || token.type === "tableDelimiterMarker" || token.type === "tableDelimiterFiller")) {
+        inFirstCellAwaitingPipe = false;
+        if (cell[2] === 0) {
+          if (lastCell[1] !== 0) {
+            cell[0] = cell[1];
+            currentCell = flushCell(map4, context, lastCell, rowKind, void 0, currentCell);
+            lastCell = [0, 0, 0, 0];
+          }
+          cell[2] = index;
+        }
+      } else if (token.type === "tableCellDivider") {
+        if (inFirstCellAwaitingPipe) {
+          inFirstCellAwaitingPipe = false;
+        } else {
+          if (lastCell[1] !== 0) {
+            cell[0] = cell[1];
+            currentCell = flushCell(map4, context, lastCell, rowKind, void 0, currentCell);
+          }
+          lastCell = cell;
+          cell = [lastCell[1], index, 0, 0];
+        }
+      }
+    } else if (token.type === "tableHead") {
+      afterHeadAwaitingFirstBodyRow = true;
+      lastTableEnd = index;
+    } else if (token.type === "tableRow" || token.type === "tableDelimiterRow") {
+      lastTableEnd = index;
+      if (lastCell[1] !== 0) {
+        cell[0] = cell[1];
+        currentCell = flushCell(map4, context, lastCell, rowKind, index, currentCell);
+      } else if (cell[1] !== 0) {
+        currentCell = flushCell(map4, context, cell, rowKind, index, currentCell);
+      }
+      rowKind = 0;
+    } else if (rowKind && (token.type === "data" || token.type === "tableDelimiterMarker" || token.type === "tableDelimiterFiller")) {
+      cell[3] = index;
+    }
+  }
+  if (lastTableEnd !== 0) {
+    flushTableEnd(map4, context, lastTableEnd, currentTable, currentBody);
+  }
+  map4.consume(context.events);
+  index = -1;
+  while (++index < context.events.length) {
+    const event = context.events[index];
+    if (event[0] === "enter" && event[1].type === "table") {
+      event[1]._align = gfmTableAlign(context.events, index);
+    }
+  }
+  return events;
+}
+function flushCell(map4, context, range, rowKind, rowEnd, previousCell) {
+  const groupName = rowKind === 1 ? "tableHeader" : rowKind === 2 ? "tableDelimiter" : "tableData";
+  const valueName = "tableContent";
+  if (range[0] !== 0) {
+    previousCell.end = Object.assign({}, getPoint(context.events, range[0]));
+    map4.add(range[0], 0, [["exit", previousCell, context]]);
+  }
+  const now = getPoint(context.events, range[1]);
+  previousCell = {
+    type: groupName,
+    start: Object.assign({}, now),
+    // Note: correct end is set later.
+    end: Object.assign({}, now)
+  };
+  map4.add(range[1], 0, [["enter", previousCell, context]]);
+  if (range[2] !== 0) {
+    const relatedStart = getPoint(context.events, range[2]);
+    const relatedEnd = getPoint(context.events, range[3]);
+    const valueToken = {
+      type: valueName,
+      start: Object.assign({}, relatedStart),
+      end: Object.assign({}, relatedEnd)
+    };
+    map4.add(range[2], 0, [["enter", valueToken, context]]);
+    if (rowKind !== 2) {
+      const start = context.events[range[2]];
+      const end = context.events[range[3]];
+      start[1].end = Object.assign({}, end[1].end);
+      start[1].type = "chunkText";
+      start[1].contentType = "text";
+      if (range[3] > range[2] + 1) {
+        const a = range[2] + 1;
+        const b = range[3] - range[2] - 1;
+        map4.add(a, b, []);
+      }
+    }
+    map4.add(range[3] + 1, 0, [["exit", valueToken, context]]);
+  }
+  if (rowEnd !== void 0) {
+    previousCell.end = Object.assign({}, getPoint(context.events, rowEnd));
+    map4.add(rowEnd, 0, [["exit", previousCell, context]]);
+    previousCell = void 0;
+  }
+  return previousCell;
+}
+function flushTableEnd(map4, context, index, table, tableBody) {
+  const exits = [];
+  const related = getPoint(context.events, index);
+  if (tableBody) {
+    tableBody.end = Object.assign({}, related);
+    exits.push(["exit", tableBody, context]);
+  }
+  table.end = Object.assign({}, related);
+  exits.push(["exit", table, context]);
+  map4.add(index + 1, 0, exits);
+}
+function getPoint(events, index) {
+  const event = events[index];
+  const side = event[0] === "enter" ? "start" : "end";
+  return event[1][side];
+}
+
+// node_modules/micromark-extension-gfm-task-list-item/lib/syntax.js
+var tasklistCheck = {
+  name: "tasklistCheck",
+  tokenize: tokenizeTasklistCheck
+};
+function gfmTaskListItem() {
+  return {
+    text: {
+      [91]: tasklistCheck
+    }
+  };
+}
+function tokenizeTasklistCheck(effects, ok5, nok) {
+  const self = this;
+  return open;
+  function open(code3) {
+    if (
+      // Exit if there’s stuff before.
+      self.previous !== null || // Exit if not in the first content that is the first child of a list
+      // item.
+      !self._gfmTasklistFirstContentOfListItem
+    ) {
+      return nok(code3);
+    }
+    effects.enter("taskListCheck");
+    effects.enter("taskListCheckMarker");
+    effects.consume(code3);
+    effects.exit("taskListCheckMarker");
+    return inside;
+  }
+  function inside(code3) {
+    if (markdownLineEndingOrSpace(code3)) {
+      effects.enter("taskListCheckValueUnchecked");
+      effects.consume(code3);
+      effects.exit("taskListCheckValueUnchecked");
+      return close;
+    }
+    if (code3 === 88 || code3 === 120) {
+      effects.enter("taskListCheckValueChecked");
+      effects.consume(code3);
+      effects.exit("taskListCheckValueChecked");
+      return close;
+    }
+    return nok(code3);
+  }
+  function close(code3) {
+    if (code3 === 93) {
+      effects.enter("taskListCheckMarker");
+      effects.consume(code3);
+      effects.exit("taskListCheckMarker");
+      effects.exit("taskListCheck");
+      return after;
+    }
+    return nok(code3);
+  }
+  function after(code3) {
+    if (markdownLineEnding(code3)) {
+      return ok5(code3);
+    }
+    if (markdownSpace(code3)) {
+      return effects.check({
+        tokenize: spaceThenNonSpace
+      }, ok5, nok)(code3);
+    }
+    return nok(code3);
+  }
+}
+function spaceThenNonSpace(effects, ok5, nok) {
+  return factorySpace(effects, after, "whitespace");
+  function after(code3) {
+    return code3 === null ? nok(code3) : ok5(code3);
+  }
+}
+
+// node_modules/micromark-extension-gfm/index.js
+function gfm(options) {
+  return combineExtensions([
+    gfmAutolinkLiteral(),
+    gfmFootnote(),
+    gfmStrikethrough(options),
+    gfmTable(),
+    gfmTaskListItem()
+  ]);
+}
+
+// node_modules/remark-gfm/lib/index.js
+var emptyOptions2 = {};
+function remarkGfm(options) {
+  const self = (
+    /** @type {Processor} */
+    this
+  );
+  const settings = options || emptyOptions2;
+  const data = self.data();
+  const micromarkExtensions = data.micromarkExtensions || (data.micromarkExtensions = []);
+  const fromMarkdownExtensions = data.fromMarkdownExtensions || (data.fromMarkdownExtensions = []);
+  const toMarkdownExtensions = data.toMarkdownExtensions || (data.toMarkdownExtensions = []);
+  micromarkExtensions.push(gfm(settings));
+  fromMarkdownExtensions.push(gfmFromMarkdown());
+  toMarkdownExtensions.push(gfmToMarkdown(settings));
+}
+
+// remark-gfm.js
+var remark_gfm_default = remarkGfm;

--- a/test/setup.js
+++ b/test/setup.js
@@ -9,6 +9,7 @@ import jsdom from 'jsdom';
 import crypto from 'crypto';
 import { advanceBy, advanceTo, clear } from 'jest-date-mock';
 import { mockRandom } from 'jest-mock-random';
+import 'jest-canvas-mock';
 
 import { IntersectionObserver } from '@shopify/jest-dom-mocks';
 // window.requestAnimationFrame = function (callback) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1603,15 +1603,36 @@
     "@douyinfe/semi-animation-styled" "2.60.0"
     classnames "^2.2.6"
 
+"@douyinfe/semi-animation-react@2.61.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-animation-react/-/semi-animation-react-2.61.0.tgz#a5dd9e6368b07628a4548b9eb1c66b1eeb509c71"
+  integrity sha512-KgiBOog7TRQ23wRaV6UU0zEG+5OHafWHEqVIGgfliNrR/A30RhINSWSwa8wWljxHHVIaJDBmz+7EbzAluKrhLQ==
+  dependencies:
+    "@douyinfe/semi-animation" "2.61.0"
+    "@douyinfe/semi-animation-styled" "2.61.0"
+    classnames "^2.2.6"
+
 "@douyinfe/semi-animation-styled@2.60.0":
   version "2.60.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.60.0.tgz#0e935b68aaaed55671c59e92029eed5599d6d207"
   integrity sha512-S5Gun0LmDuIDCkGwLADjcWY4eOU64p7OQH30+yCII1GrS0CSGAPlMzJ0p0zOieGUilcvmyCtWRZ8NeH8lVQLdA==
 
+"@douyinfe/semi-animation-styled@2.61.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.61.0.tgz#400f3329d65ee6a7080780dfe4a02564cef2bc20"
+  integrity sha512-kzI6uFphJFd+4FhRLJc6b3LNR1wzf5dby0CPnI9E7phmqxpv5/I/AVpJ/h/7JKW7tdsy8EqsvuCYvyHSAtPU4A==
+
 "@douyinfe/semi-animation@2.60.0":
   version "2.60.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation/-/semi-animation-2.60.0.tgz#0194eeb5342b092a711a95e5b9ba2a8346fbe0c5"
   integrity sha512-WqLvozsST4hgL8zHRBA3LtopJSIzyb7RdaCe8t0vJHxkH1n5Fe9coYBXEzScNF9xSpm11M7aub4v3x05XQO8bw==
+  dependencies:
+    bezier-easing "^2.1.0"
+
+"@douyinfe/semi-animation@2.61.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-animation/-/semi-animation-2.61.0.tgz#42043e44e6d414d816e560c3c448f68418234baf"
+  integrity sha512-Yr8IAtn1NZXbCK8bJD1wnj6ktiI4mSwA8Kf4hLse0YhUeWfvIY529gQ5PUb30HiceE1RdteYxJEQwJ9IBaiCpw==
   dependencies:
     bezier-easing "^2.1.0"
 
@@ -1630,6 +1651,21 @@
     memoize-one "^5.2.1"
     scroll-into-view-if-needed "^2.2.24"
 
+"@douyinfe/semi-foundation@2.61.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-foundation/-/semi-foundation-2.61.0.tgz#244ba2278de5071fef9b2f3e5b3435f9c68aa809"
+  integrity sha512-8FmVTGcerLv1GCNk4kVvYIOI4PcR+QN7/Rx/tULjwcANd47kLfLEgTSO8WwqtnJSQqXBFuZCZ4bjyG98jOeMpA==
+  dependencies:
+    "@douyinfe/semi-animation" "2.61.0"
+    async-validator "^3.5.0"
+    classnames "^2.2.6"
+    date-fns "^2.29.3"
+    date-fns-tz "^1.3.8"
+    fast-copy "^3.0.1 "
+    lodash "^4.17.21"
+    memoize-one "^5.2.1"
+    scroll-into-view-if-needed "^2.2.24"
+
 "@douyinfe/semi-icons@2.60.0", "@douyinfe/semi-icons@latest":
   version "2.60.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.60.0.tgz#d3a6864517d835720137c5bd195a80a67746db57"
@@ -1637,10 +1673,22 @@
   dependencies:
     classnames "^2.2.6"
 
+"@douyinfe/semi-icons@2.61.0", "@douyinfe/semi-icons@^2.0.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-icons/-/semi-icons-2.61.0.tgz#0cb8ae4cd77bd335b59e057c3b89d9bbf11c1698"
+  integrity sha512-5yulqGUDvlOvZ0TMwMCyj+2c6eJScHOcgX3Xoh/5qXyajRJG6AdzjX4vjWHR8Kf5gXHw5BqmYYQy6p8OyzIRhA==
+  dependencies:
+    classnames "^2.2.6"
+
 "@douyinfe/semi-illustrations@2.60.0":
   version "2.60.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.60.0.tgz#9cef572da3c0f8b36e88ba1cbc3a44365e7d82d5"
   integrity sha512-xoXG9LBxXaukWNSxY8l1aRUv0NGYGtfH3O/kwuQgU4lTQtWHHBKYSfieiVvFJBoAVd1gsl29nqq/x+oIn0LizQ==
+
+"@douyinfe/semi-illustrations@2.61.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-illustrations/-/semi-illustrations-2.61.0.tgz#6748eeeb97886f3c4079e55c86be166c6867d6af"
+  integrity sha512-iELVP0x0iwD84EAfOtot+c31+Cm/jBLbIEg/q2WTtQHMuFN414mkgmLz/tvj9+BKc+CmkdLvyu3I4rKp0iYrLA==
 
 "@douyinfe/semi-scss-compile@2.23.2":
   version "2.23.2"
@@ -1717,6 +1765,33 @@
   version "2.61.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.61.0.tgz#a7e9bf9534721c12af1d0eeb5d5a2de615896a23"
   integrity sha512-obn/DOw4vZyKFAlWvZxHTpBLAK9FO9kygTSm2GROgvi+UDB2PPU6l20cuUCsdGUNWJRSqYlTTVZ1tNYIyFZ5Sg==
+
+"@douyinfe/semi-ui@^2.0.0":
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/@douyinfe/semi-ui/-/semi-ui-2.61.0.tgz#231a0b4cf9a2b5b96f2258c6934a2b4fef84aee4"
+  integrity sha512-PkvifyIDKxs61bPXMjuPJkLYYoiS9ljCk7OGeMueKnsZQBJhtmRgIHBxgtu9mkNuMC7kVBA2/fUwGfPnosq3dA==
+  dependencies:
+    "@dnd-kit/core" "^6.0.8"
+    "@dnd-kit/sortable" "^7.0.2"
+    "@dnd-kit/utilities" "^3.2.1"
+    "@douyinfe/semi-animation" "2.61.0"
+    "@douyinfe/semi-animation-react" "2.61.0"
+    "@douyinfe/semi-foundation" "2.61.0"
+    "@douyinfe/semi-icons" "2.61.0"
+    "@douyinfe/semi-illustrations" "2.61.0"
+    "@douyinfe/semi-theme-default" "2.61.0"
+    async-validator "^3.5.0"
+    classnames "^2.2.6"
+    copy-text-to-clipboard "^2.1.1"
+    date-fns "^2.29.3"
+    date-fns-tz "^1.3.8"
+    fast-copy "^3.0.1 "
+    lodash "^4.17.21"
+    prop-types "^15.7.2"
+    react-resizable "^3.0.5"
+    react-window "^1.8.2"
+    scroll-into-view-if-needed "^2.2.24"
+    utility-types "^3.10.0"
 
 "@douyinfe/semi-ui@latest":
   version "2.60.0"
@@ -9047,7 +9122,7 @@ color-name@1.1.3:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
   integrity sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==
 
-color-name@^1.0.0, color-name@~1.1.4:
+color-name@^1.0.0, color-name@^1.1.4, color-name@~1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
@@ -9901,6 +9976,11 @@ cssfilter@0.0.10:
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
   integrity sha512-FAaLDaplstoRsDR8XGYH51znUN0UY7nMc6Z9/fvE8EXGwvJE9hu7W2vHwx1+bd6gCYnln9nLbzxFTrcO9YQDZw==
+
+cssfontparser@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/cssfontparser/-/cssfontparser-1.2.1.tgz#f4022fc8f9700c68029d542084afbaf425a3f3e3"
+  integrity sha512-6tun4LoZnj7VN6YeegOVb67KBX/7JJsqvj+pv3ZA7F878/eN33AbGa5b/S/wXxS/tcp8nc40xRUrsPlxIyNUPg==
 
 cssnano-preset-default@^4.0.8:
   version "4.0.8"
@@ -11863,6 +11943,11 @@ eslint-plugin-react@^7.20.6, eslint-plugin-react@^7.24.0:
     resolve "^2.0.0-next.5"
     semver "^6.3.1"
     string.prototype.matchall "^4.0.11"
+
+eslint-plugin-semi-design@^2.33.0:
+  version "2.61.0"
+  resolved "https://registry.npmjs.org/eslint-plugin-semi-design/-/eslint-plugin-semi-design-2.61.0.tgz#7195cb76747fe86e93f6de9ce454bd8d98cc6585"
+  integrity sha512-4fdC0HaJPPDdsbP2fWm0s/DEDFxCHbl95PqxmQigiHbYhvOMsI3cJbvCKHkb5Qa/75Av45/tcGx2aqdVV8ZKSA==
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
@@ -16377,6 +16462,14 @@ jake@^10.8.5:
     filelist "^1.0.4"
     minimatch "^3.1.2"
 
+jest-canvas-mock@^2.5.2:
+  version "2.5.2"
+  resolved "https://registry.npmjs.org/jest-canvas-mock/-/jest-canvas-mock-2.5.2.tgz#7e21ebd75e05ab41c890497f6ba8a77f915d2ad6"
+  integrity sha512-vgnpPupjOL6+L5oJXzxTxFrlGEIbHdZqFU+LFNdtLxZ3lRDCl17FlTMM7IatoRQkrcyOTMlDinjUguqmQ6bR2A==
+  dependencies:
+    cssfontparser "^1.2.1"
+    moo-color "^1.0.2"
+
 jest-changed-files@^24.9.0:
   version "24.9.0"
   resolved "https://registry.yarnpkg.com/jest-changed-files/-/jest-changed-files-24.9.0.tgz#08d8c15eb79a7fa3fc98269bc14b451ee82f8039"
@@ -19617,6 +19710,13 @@ monaco-themes@^0.3.3:
   integrity sha512-0yygYHg3hZhMhlYkP2eMAMurLSyVDqA7ZOjHJSz0LNxra2hxuAGjKFdoBGXnG+VykT6u8bc5uZWF8G35NMC3Gw==
   dependencies:
     fast-plist "^0.1.2"
+
+moo-color@^1.0.2:
+  version "1.0.3"
+  resolved "https://registry.npmjs.org/moo-color/-/moo-color-1.0.3.tgz#d56435f8359c8284d83ac58016df7427febece74"
+  integrity sha512-i/+ZKXMDf6aqYtBhuOcej71YSlbjT3wCO/4H1j8rPvxDJEifdwgg5MaFyu6iYAT8GBZJg2z0dkgK4YMzvURALQ==
+  dependencies:
+    color-name "^1.1.4"
 
 moo@^0.5.0:
   version "0.5.2"
@@ -25071,7 +25171,8 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -25088,15 +25189,6 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
-
-"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.0:
   version "2.1.1"
@@ -25225,7 +25317,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -25252,13 +25344,6 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -27856,7 +27941,8 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+  name wrap-ansi-cjs
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27886,15 +27972,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [x] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
v2.62.0-beta.0后增加了 Lottie 、MarkdownRender 组件，他们的依赖
mdx-js、remakr-gfm只有 esm版本，无法直接被 jest消费

- mdx-js v3 、remark-gfm 无法简单地通过 jest.config.js 的  transformIgnorePatterns 参数指定走一遍  esm -> cjs 来解决（会遇到 devlop 这个包的问题，即使把它也指定上，也无法正确运行，同 https://stackoverflow.com/questions/77525472/how-to-test-mdx-js-mdx-with-jest-transformignorepatterns-not-working-on-devel
  - 当前解决方案：直接把 mdx-js 、remark-gfm  build 一个 cjs 版本，通过 moduleNameMapper 映射

- lottie 在jest中运行报错是因为缺少 canvas mock

### Changelog
🇨🇳 Chinese
- Fix: 修复增加 MarkdownRender、Lottie 组件后，Jest 单测无法运行的问题

---

🇺🇸 English
- Fix: fix ...


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
