### PR TITLE
fix: When the carousel has only one child and autoPlay is true, no switching operation is performed

### DIFF
--- a/packages/semi-foundation/carousel/foundation.ts
+++ b/packages/semi-foundation/carousel/foundation.ts
@@ -7,7 +7,7 @@ export interface CarouselAdapter<P = Record<string, any>, S = Record<string, any
     setNewActiveIndex: (activeIndex: number) => void;
     setPreActiveIndex: (activeIndex: number) => void;
     setIsReverse: (isReverse: boolean) => void;   
-    setIsInit: (isInit: boolean) => void;   
+    setIsInit: (isInit: boolean) => void   
 }
 
 class CarouselFoundation<P = Record<string, any>, S = Record<string, any>> extends BaseFoundation<CarouselAdapter<P, S>, P, S> {
@@ -124,9 +124,11 @@ class CarouselFoundation<P = Record<string, any>, S = Record<string, any>> exten
 
     handleAutoPlay(): void { 
         const { autoPlay } = this.getProps(); 
+        const { children } = this.getStates();
         const autoPlayType = typeof autoPlay;
         // when user manually call the play function, force play
-        if ((autoPlayType === 'boolean' && autoPlay) || isObject(autoPlay) || this._forcePlay) {
+        // only when carousel children length > 1 to start play
+        if (children.length > 1 && ((autoPlayType === 'boolean' && autoPlay) || isObject(autoPlay) || this._forcePlay)) {
             this.play(this.getSwitchingTime());
         }
     }

--- a/packages/semi-ui/carousel/_story/carousel.stories.jsx
+++ b/packages/semi-ui/carousel/_story/carousel.stories.jsx
@@ -511,12 +511,10 @@ fix1482.story = {
 };
 
 
-
-
-
-
-
-
-
-
-
+export const OnlyOneChildrenNotPlay = () => (
+    <Carousel style={style} autoPlay onChange={e => {console.log('onChange', e)}}>
+      <div style={contentPinkStyle}>
+        <h3>1</h3>
+      </div>
+    </Carousel>
+);


### PR DESCRIPTION

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2333

### Changelog
🇨🇳 Chinese
- Fix: Carousel 仅有一个 children 且 autoPlay 为 true 时不执行任何切换操作

---

🇺🇸 English
- Fix: when the carousel has only one child and autoPlay is true, no switching operation is performed


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
