### PR TITLE
fix: fix modal popupContainer return body

### DIFF
--- a/packages/semi-ui/modal/Modal.tsx
+++ b/packages/semi-ui/modal/Modal.tsx
@@ -137,14 +137,14 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
             disabledBodyScroll: () => {
                 const { getPopupContainer } = this.props;
                 this.bodyOverflow = document.body.style.overflow || '';
-                if (!getPopupContainer && this.bodyOverflow !== 'hidden') {
+                if ((!getPopupContainer || getPopupContainer() === document.body) && this.bodyOverflow !== 'hidden') {
                     document.body.style.overflow = 'hidden';
                     document.body.style.width = `calc(${this.originBodyWidth || '100%'} - ${this.scrollBarWidth}px)`;
                 }
             },
             enabledBodyScroll: () => {
                 const { getPopupContainer } = this.props;
-                if (!getPopupContainer && this.bodyOverflow !== null && this.bodyOverflow !== 'hidden') {
+                if ((!getPopupContainer || getPopupContainer() === document.body) && this.bodyOverflow !== null && this.bodyOverflow !== 'hidden') {
                     document.body.style.overflow = this.bodyOverflow;
                     document.body.style.width = this.originBodyWidth;
                 }
@@ -354,7 +354,7 @@ class Modal extends BaseComponent<ModalReactProps, ModalState> {
         } = {
             zIndex,
         };
-        if (getPopupContainer) {
+        if (getPopupContainer && getPopupContainer() !== document.body) {
             wrapperStyle = {
                 zIndex,
                 position: 'static',

--- a/packages/semi-ui/modal/ModalContent.tsx
+++ b/packages/semi-ui/modal/ModalContent.tsx
@@ -308,7 +308,7 @@ export default class ModalContent extends BaseComponent<ModalContentReactProps, 
         } = this.props;
         const { direction } = this.context;
         const classList = cls(className, {
-            [`${cssClasses.DIALOG}-popup`]: getPopupContainer && !maskFixed,
+            [`${cssClasses.DIALOG}-popup`]: getPopupContainer && getPopupContainer() !== document.body && !maskFixed,
             [`${cssClasses.DIALOG}-fixed`]: maskFixed,
             [`${cssClasses.DIALOG}-rtl`]: direction === 'rtl',
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Modal 在 getPopupContainer 中如果返回 document.body 异常的问题

---

🇺🇸 English
- Fix: Fixed the issue that Modal returns document.body exception in getPopupContainer


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
