### PR TITLE
feat: form support stopProgation for submit/reset event in nested usage

### DIFF
--- a/packages/semi-ui/form/baseForm.tsx
+++ b/packages/semi-ui/form/baseForm.tsx
@@ -75,6 +75,10 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
         style: PropTypes.object,
         showValidateIcon: PropTypes.bool,
         stopValidateWithError: PropTypes.bool,
+        stopPropagation: PropTypes.shape({
+            submit: PropTypes.bool,
+            reset: PropTypes.bool,
+        }),
         id: PropTypes.string,
         wrapperCol: PropTypes.object, // Control wrapperCol {span: number, offset: number} for all field child nodes
         trigger: PropTypes.oneOfType([
@@ -240,11 +244,17 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
 
     submit(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
+        if (this.props.stopPropagation && this.props.stopPropagation.submit) {
+            e.stopPropagation();
+        }
         this.foundation.submit(e);
     }
 
     reset(e: React.FormEvent<HTMLFormElement>) {
         e.preventDefault();
+        if (this.props.stopPropagation && this.props.stopPropagation.reset) {
+            e.stopPropagation();
+        }
         this.foundation.reset();
     }
 

--- a/packages/semi-ui/form/interface.ts
+++ b/packages/semi-ui/form/interface.ts
@@ -128,5 +128,9 @@ export interface BaseFormProps <Values extends Record<string, any> = any> extend
     disabled?: boolean;
     showValidateIcon?: boolean;
     stopValidateWithError?: boolean;
+    stopPropagation?: {
+        submit?: boolean;
+        reset?: boolean
+    };
     trigger?: FieldValidateTriggerType
 }


### PR DESCRIPTION


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Feat: Form 新增 stopProgation 可用于阻止嵌套Form场景下，submit 、reset事件同时在多级容器触发的问题 #2355 

---

🇺🇸 English
- Feat: Form adds stopProgation to prevent the issue of submit and reset events triggering in multiple levels of containers at the same time in nested Form scenarios #2355 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
