### PR TITLE
fix: Fixed a problem with Tooltip display in Slider when tipFormatter…

### DIFF
--- a/packages/semi-foundation/slider/foundation.ts
+++ b/packages/semi-foundation/slider/foundation.ts
@@ -686,9 +686,14 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
         }
     }
 
+    _noTooltip = () => {
+        const { tipFormatter, tooltipVisible } = this.getProps();
+        return tipFormatter === null || tooltipVisible === false;
+    }
+
     onFocus = (e: any, handler: 'min'| 'max') => {
-        const { tipFormatter } = this.getProps();
-        if (tipFormatter === null) {
+        const noTooltip = this._noTooltip();
+        if (noTooltip) {
             return;
         }
         handlePrevent(e);
@@ -707,8 +712,8 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
     }
 
     onBlur = (e: any, handler: 'min'| 'max') => {
-        const { tipFormatter } = this.getProps();
-        if (tipFormatter === null) {
+        const noTooltip = this._noTooltip();
+        if (noTooltip) {
             return;
         }
         const { firstDotFocusVisible, secondDotFocusVisible } = this.getStates();

--- a/packages/semi-foundation/slider/foundation.ts
+++ b/packages/semi-foundation/slider/foundation.ts
@@ -687,6 +687,10 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
     }
 
     onFocus = (e: any, handler: 'min'| 'max') => {
+        const { tipFormatter } = this.getProps();
+        if (tipFormatter === null) {
+            return;
+        }
         handlePrevent(e);
         const { target } = e;
         try {
@@ -703,6 +707,10 @@ export default class SliderFoundation extends BaseFoundation<SliderAdapter> {
     }
 
     onBlur = (e: any, handler: 'min'| 'max') => {
+        const { tipFormatter } = this.getProps();
+        if (tipFormatter === null) {
+            return;
+        }
         const { firstDotFocusVisible, secondDotFocusVisible } = this.getStates();
         if (handler === 'min') {
             firstDotFocusVisible && this._adapter.setStateVal('firstDotFocusVisible', false);

--- a/packages/semi-ui/slider/_story/slider.stories.jsx
+++ b/packages/semi-ui/slider/_story/slider.stories.jsx
@@ -85,6 +85,15 @@ export const HorizontalSlider = () => (
       ></Slider>
     </div>
     <div style={divStyle}>
+      <div>tooltipVisible=false，不显示tooltip</div>
+      <Slider
+        tooltipVisible={false}
+        onChange={value => {
+          console.log('value改变了' + value);
+        }}
+      ></Slider>
+    </div>
+    <div style={divStyle}>
       <div>step=10</div>
       <Slider
         step={10}


### PR DESCRIPTION
… is null and the handler is focused through Tab

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2373 

修复思路：
对于 ally 通过 focus， blur 处理 tooltip 显示的逻辑中，增加 tipFormatter 是否 null 以及 tooltipVisible 是否为 false 的判断，如果为 null，则不处理 focus/blur
的逻辑




### Changelog
🇨🇳 Chinese
- Fix: 修复 tipFormatter 为 null 或者 tooltipVisible 为 false 的 Slider ，通过 Tab 聚焦小圆点时，Tooltip 会显示的问题 #2373 

---

🇺🇸 English
- Fix: Fixed the issue where the Tooltip will be displayed when the handler is focused via Tab in a Slider whose tipFormatter is null or tooltipVisible is false. #2373 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
