### PR TITLE
fix: Fixed the issue that when TimePicker selects a later time first, the invalid time value will be caused when onChangeWithDateFirst is false

### DIFF
--- a/packages/semi-foundation/timePicker/utils/index.ts
+++ b/packages/semi-foundation/timePicker/utils/index.ts
@@ -17,6 +17,8 @@ export const parseToDate = (input: string | Date | number, formatToken = strings
     } else if (typeof input === 'number') {
         return new Date(toNumber(input));
     } else if (typeof input === 'string') {
+        if (input === '') return undefined;
+
         let curDate = new Date();
 
         // console.log(input, formatToken);

--- a/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
+++ b/packages/semi-ui/timePicker/_story/timepicker.stories.jsx
@@ -375,3 +375,36 @@ export const Fix2082 = () => {
         </ConfigProvider>
     );
 };
+
+
+export const Fix2375 = () => {
+  const [dateString, setDateString] = useState();
+  const onChange = (time) => {
+    setDateString(time);
+  };
+
+  return ( 
+    <div>
+      <TimePicker
+        type="timeRange"
+        value={dateString}
+        onChange={onChange}
+        onChangeWithDateFirst={false}
+      /> 
+      <br/>
+      <br/>
+      <Form layout='horizontal' onValueChange={values=>console.log(values)}>
+        <Form.TimePicker
+          rules={[{ required: true, message: '请设置起始时间' }]}
+          //   validate={(fieldValue, values) => validateTimeRange(fieldValue, values)}
+          label="起始时间"
+          width="md"
+          field="time_range"
+          type="timeRange"
+          onChangeWithDateFirst={false}
+          onChange={(...props) => {console.log('props', props)}}
+        />
+      </Form>
+    </div> 
+  );
+};


### PR DESCRIPTION

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2375

### Changelog
🇨🇳 Chinese
- Fix: 修复 TimePicker 在 onChangeWithDateFirst false 情况下为先选后一个时间导致 invalid time value 问题

---

🇺🇸 English
- Fix: fix the issue that when TimePicker selects a later time first, the invalid time value will be caused when onChangeWithDateFirst is false


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
