### PR TITLE
style: Fixed the problem that when Cascader has no options and the em…

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -315,6 +315,7 @@ $module: #{$prefix}-cascader;
 
     .#{$module}-option-empty {
         @include font-size-regular;
+        border-radius: $radius-cascader_option_empty;
         min-width: $width-cascader_option;
         color: $color-cascader_option_empty-text-default;
         margin: 0;
@@ -423,6 +424,7 @@ $module: #{$prefix}-cascader;
         word-break: break-all;
         color: $color-cascader_option_main-text-default;
         position: relative;
+
 
         &:hover {
             background-color: $color-cascader_option-bg-hover;

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -1,4 +1,5 @@
 $radius-cascader: var(--semi-border-radius-small); // 级联选择菜单圆角
+$radius-cascader_option_empty: var(--semi-border-radius-medium); // 级联选择菜单空状态圆角
 
 $color-cascader_default-border-default: transparent; // 级联选择描边颜色 - 默认
 $color-cascader_default-border-hover: transparent; // 级联选择描边颜色 - 悬浮


### PR DESCRIPTION
…ptyContent is hovering, the background color will exceed the popup layer area

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #


修复前
![img_v3_02d5_d730b807-b56d-4364-b0d1-1f1955faeedg](https://github.com/user-attachments/assets/3211ab74-38bf-45ac-8805-5af0b2c94558)
修复后
![image](https://github.com/user-attachments/assets/7291f95b-ce23-456b-b3f0-0831e4281716)


### Changelog
🇨🇳 Chinese
- Style: 修复 Cascader 在无选项情况下，emptyContent 在hover时，背景色会超出弹出层区域

---

🇺🇸 English
- Style: Fixed the problem that when Cascader has no options and the emptyContent is hovering, the background color will exceed the popup layer area.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
