### PR TITLE
fix: fix package.json export error when import file under lib

### DIFF
--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -5,6 +5,14 @@
     "main": "lib/cjs/index.js",
     "module": "lib/es/index.js",
     "typings": "lib/es/index.d.ts",
+    "exports": {
+        ".": {
+            "import": "./lib/es/index.js",
+            "require": "./lib/cjs/index.js"
+        },
+        "./lib/es/*": "./lib/es/*",
+        "./lib/cjs/*": "./lib/cjs/*"
+    },
     "scripts": {
         "clean": "rimraf dist lib",
         "build:lib": "node ./scripts/compileLib.js",


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复直接 import lib 下文件报错找不到 export 的问题 （影响范围 2.63.0）

---

🇺🇸 English
- Fix: Fixed the problem that the file cannot find export when importing lib directly (affecting 2.63.0)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
