### PR TITLE
fix: When the searchRender of the Tree is false, remove the excess pa…

### DIFF
--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -540,6 +540,9 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
             searchPlaceholder,
             showClear
         } = this.props;
+        if (searchRender === false) {
+            return null;
+        }
         const inputcls = cls(`${prefixcls}-input`);
         const { inputValue } = this.state;
         const inputProps = {
@@ -558,9 +561,6 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
                         inputProps.placeholder = searchPlaceholder || get(locale, 'searchPlaceholder');
                         if (isFunction(searchRender)) {
                             return searchRender({ ...inputProps });
-                        }
-                        if (searchRender === false) {
-                            return null;
                         }
                         return (
                             <Input


### PR DESCRIPTION
…dding at the top

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
用户反馈，在 searRender 为 false 时候，顶部会有多余的空间。
当前形式：
![img_v3_02da_88718db5-2133-4565-82f7-f9830826125g](https://github.com/user-attachments/assets/d128b7ef-ce8f-499f-a458-9845a253224b)
修改后
![img_v3_02da_552882e2-212c-493e-8ef5-b78fed69ff0g](https://github.com/user-attachments/assets/0a3e7eac-546b-4240-886b-8aae456a46b7)



### Changelog
🇨🇳 Chinese
- Fix: 当 Tree 的 searchRender 为 false 时 ，去除顶部多余的高度.

---

🇺🇸 English
- Fix: When the searchRender of the Tree is false, remove the excess height at the top


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
