### PR TITLE
Fix upload callback after unmount

### DIFF
--- a/packages/semi-ui/upload/_story/upload.stories.jsx
+++ b/packages/semi-ui/upload/_story/upload.stories.jsx
@@ -1277,9 +1277,50 @@ export const PastingDemo = () => {
         checked={addOnPasting}
         onChange={e => switchAddOnPasting(e)}
       >
-
       </Switch>
     </div>
 
   )
+};
+
+let first = true;
+
+
+export const Unmount = () => {
+    let action = 'https://api.semi.design/upload';
+    const defaultFileList = [
+        {
+            uid: '1',
+            name: 'music.png',
+            status: 'success',
+            size: '130KB',
+            preview: true,
+            url:
+                'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/Resso.png',
+        }
+    ];
+    const [a, setA] =React.useState(true)
+
+    const toggle = () => {
+      console.log('ready to toggle', !a)
+      setA(!a);
+    }
+
+    return (
+        <>
+            {a&&<Upload
+                action={action}
+                listType="picture"
+                accept="image/*"
+                multiple
+                defaultFileList={defaultFileList}
+                onChange={(value)=>{
+                    console.log('change')
+                }}
+            >
+                <IconPlus size="extra-large" />
+            </Upload>}
+            <button onClick={toggle}>toggle upload mount</button>
+        </>
+    );
 };

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -337,6 +337,7 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     }
 
     componentWillUnmount(): void {
+        console.log('upload componentWillUnmount');
         this.foundation.destroy();
     }
 

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -337,7 +337,6 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     }
 
     componentWillUnmount(): void {
-        console.log('upload componentWillUnmount');
         this.foundation.destroy();
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description


### Changelog
🇨🇳 Chinese
- Fix: 修复 Upload 在组件卸载后，仍然可能因为上传异步请求触发 onChange、onError、onSuccess回调的问题 

---

🇺🇸 English
- Fix: Fixed the issue that onChange, onError, and onSuccess callbacks may still be triggered by asynchronous upload requests after the component is uninstalled 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
