### PR TITLE
fix: Cascader repos Popover when search input change & item remove by…

### DIFF
--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -926,6 +926,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
             filteredKeys: new Set(filteredKeys),
         });
         this._adapter.notifyOnSearch(sugInput);
+        this._adapter.rePositionDropdown();
     }
 
     handleClear() {
@@ -1039,6 +1040,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
         }
         const removedItem = keyEntities[key] ?? {};
         !removedItem?.data?.disable && this._handleMultipleSelect(removedItem);
+        this._adapter.rePositionDropdown();
     }
 
     handleTagRemoveInTrigger = (pos: string) => {


### PR DESCRIPTION
… click close icon

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
内部用户反馈，Cascader 位置在屏幕靠近右侧，搜素时候，popover 的位置没有根据内容重新计算，导致搜索后的选项面板被遮挡。
重新计算弹出层位置只能解决部分问题，如果内容实在太长，需考虑 filterRender 自定义渲染，控制弹出层的长度。

本PR 中修改处理包括两点
1. 在搜索值变化后，触发位置重新计算，解决搜索时候的位置计算问题
2. 多选状态下，通过点击 trigger 中已选项的关闭 icon 取消选中，弹出层位置未重新计算问题。


### Changelog
🇨🇳 Chinese
- Fix: 修复 Cascader 搜索后以及多选，弹出层的位置未重新计算，导致内容较长的面板被遮挡问题。
- Fix: 修复多选的 Cascader 中，通过点击 trigger 中已选项的关闭 icon 取消选中，弹出层位置未重新计算问题。

---

🇺🇸 English
- Fix: Fixed the problem that after Cascader search, the position of the pop-up layer was not recalculated, causing panels with long content to be blocked.
- Fix: Fixed the problem that in multi-selected Cascader, the pop-up layer position is not recalculated by clicking the selected close icon in the trigger to uncheck it.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
