### PR TITLE
fix: [Chat] when status of chat is error & showStopGenerate, stop sig…

### DIFF
--- a/packages/semi-ui/chat/index.tsx
+++ b/packages/semi-ui/chat/index.tsx
@@ -17,7 +17,7 @@ import { Locale } from "../locale/interface";
 import { Button, Upload } from '../index';
 
 const prefixCls = cssClasses.PREFIX;
-const { CHAT_ALIGN, MODE, SEND_HOT_KEY } = strings;
+const { CHAT_ALIGN, MODE, SEND_HOT_KEY, MESSAGE_STATUS } = strings;
 
 class Chat extends BaseComponent<ChatProps, ChatState> {
 
@@ -283,7 +283,7 @@ class Chat extends BaseComponent<ChatProps, ChatState> {
         const lastChat = chats.length > 0 && chats[chats.length - 1];
         let disableSend = false;
         if (lastChat && showStopGenerate) {
-            const lastChatOnGoing = lastChat.status && lastChat.status !== 'complete';
+            const lastChatOnGoing = lastChat.status && [MESSAGE_STATUS.LOADING, MESSAGE_STATUS.INCOMPLETE].includes(lastChat.status);
             disableSend = lastChatOnGoing;
             showStopGenerate && (showStopGenerateFlag = lastChatOnGoing);
         }


### PR DESCRIPTION
…n should not show

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Chat 组件在 showStopGenerate 为 true 时，消息的 status 为 error 会展示停止按钮问题

---

🇺🇸 English
- Fix: Fixed the issue where the Chat component will display the stop button when showStopGenerate is true and the status of the message is error


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
