### PR TITLE
fix: Fixed single-select Cascader, under React18, the expansion behav…

### DIFF
--- a/packages/semi-ui/cascader/index.tsx
+++ b/packages/semi-ui/cascader/index.tsx
@@ -378,9 +378,19 @@ class Cascader extends BaseComponent<CascaderProps, CascaderState> {
                 if (loadData) {
                     new Promise<void>(resolve => {
                         loadData(selectedOpt).then(() => {
-                            callback();
-                            this.setState({ loading: false });
-                            resolve();
+                            /** Why update loading status & call callback function in setTimeout?
+                             *  loadData func will update treeData, treeData change may trigger 
+                             *  selectedKeys & activeKeys change. For Loading data asynchronously，
+                             *  activeKeys should not change， Its implementation depends on loading 
+                             *  & loadedKeys. The update time of Loading & loadedKeys(in callback func)
+                             *  should be later than the update time of treeData(in loaData func) 
+                             *  In React 18, we need to use setTimeout to ensure the above time requirements.
+                             * */ 
+                            setTimeout(() => {
+                                callback();
+                                this.setState({ loading: false });
+                                resolve();
+                            })
                         });
                     });
                 }


### PR DESCRIPTION
…ior is abnormal when loading data asynchronously

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
单选的 Cascader 在 React 18 中会出现此问题。

Cascader 的展开项和 state 中 activeKeys 相关，点击会触发 activeKeys 变化。

在点击项目时，会调用 foundation 中的 handleItemClick -> handleSingleSelect->正确更新 activeKeys，由于需要异步加载数据，因此调用 notifyIfLoadData ->用户设置的 loadData 。

loadData 返回一个 promise，执行会触发treeData 更新， 并 resolve。

1. treeData 更新会触发 componentDidUpdate->foundation 中的 collectOptions -> updateSelectedKey。
2. resolve 后的 then 函数会更新 loading 状态和 loadedKeys（在 callback 函数的调用中）。

在 react 18 之前，treeData 的更新比 then 函数中的 loading 和 loadedKeys 更新快，因此updateSelectedKey函数中，可以借助没更新的 loading 和 loadedKeys 决定不改变 activeKeys。
在 react 18 之后，猜测对 promise 和 then 中的状态更新逻辑发生变化，导致updateSelectedKey执行时，loading 和 loadedKeys 已经变化，因此执行结果不符合预期。activeKeys 被更改。

修改方式为 在 loadData 的 then 函数中，借助 setTimeout 保证执行顺序。保证updateSelectedKey执行时，loading 和 loadedKeys 未变化。



### Changelog
🇨🇳 Chinese
- Fix: 修复单选的 Cascader，在 React 版本大于 18 情况下，异步加载数据展开行为异常问题 #2212

---

🇺🇸 English
- Fix: Fixed single-select Cascader, under React18, the expansion behavior is abnormal when loading data asynchronously #2212 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
