### PR TITLE
fix: [Cascader] fix trigger chevron_down icon style error & chevron_r…

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -227,8 +227,6 @@ $module: #{$prefix}-cascader;
         justify-content: center;
         width: $width-cascader-icon;
         color: $color-cascader-icon-default;
-        margin-right: $spacing-cascader_clearBtn-marginRight;
-        margin-left: $spacing-cascader_clearBtn-marginLeft;
     }
 
     &-clearbtn {

--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -228,6 +228,7 @@ $module: #{$prefix}-cascader;
         width: $width-cascader-icon;
         color: $color-cascader-icon-default;
         margin-right: $spacing-cascader_clearBtn-marginRight;
+        margin-left: $spacing-cascader_clearBtn-marginLeft;
     }
 
     &-clearbtn {

--- a/packages/semi-foundation/cascader/rtl.scss
+++ b/packages/semi-foundation/cascader/rtl.scss
@@ -5,12 +5,6 @@ $module: #{$prefix}-cascader;
     .#{$module} {
         direction: rtl;
 
-        &-arrow,
-        &-clearbtn {
-            margin-right: 0;
-            margin-left: $spacing-cascader_clearBtn-marginRight;
-        }
-
         &-inset-label {
             margin-right:  $spacing-cascader_label-marginRight;
             margin-left:  $spacing-cascader_label-marginRight;
@@ -79,12 +73,12 @@ $module: #{$prefix}-cascader;
         direction: rtl;
     }
 
-    .#{$module}-option-lists-rtl ul > li {
+    &.#{$module}-option-lists-rtl ul > li {
         padding-right: $spacing-cascader_option-paddingLeft;
         padding-left: auto;
     }
 
-    .#{$module}-option-lists-rtl .#{$module}-option-list {
+    &.#{$module}-option-lists-rtl .#{$module}-option-list {
         border-left: 0;
         border-right: $width-cascader_option_list-border solid $color-cascader_option_list-border-default;
 
@@ -93,7 +87,7 @@ $module: #{$prefix}-cascader;
         }
     }
 
-    .#{$module}-option-lists-rtl .#{$module}-option {
+    &.#{$module}-option-lists-rtl .#{$module}-option {
         &-icon {
             &-active,
             &-empty {
@@ -108,6 +102,8 @@ $module: #{$prefix}-cascader;
         }
 
         .#{$prefix}-icon-chevron_right {
+            margin-left: 0;
+            margin-right: $spacing-cascader_option_icon-marginLeft;
             transform: scaleX(-1);
         }
     }

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -53,8 +53,6 @@ $spacing-cascader_selection_tag-marginY: 1px; // 级联选择触发器多选时�
 $spacing-cascader_selection_tagInput-marginLeft: - $spacing-extra-tight; // 级联选择触发器多选搜索时 TagInput 的左外边距
 $spacing-cascader_selection_input-marginLeft: $spacing-extra-tight; // 级联选择触发器多选搜索时输入框的左外边距
 $spacing-cascader_selection_n-marginRight: $spacing-extra-tight; // 超出 maxTagCount 后，+n 的右外边距
-$spacing-cascader_clearBtn-marginRight: 8px; // 级联选择触发器清空按钮右侧外边距
-$spacing-cascader_clearBtn-marginLeft: 8px; // 级联选择触发器清空按钮左侧外边距
 $spacing-cascader_option-icon-marginLeft: 8px; // 级联选择菜单项图标左侧外边距
 
 $color-cascader_selection_n-text-default: var(--semi-color-text-0); // 超出 maxTagCount 后，+n 的文字默认颜色
@@ -94,7 +92,7 @@ $height-cascader_large: $height-control-large; // 级联选择触发器高度 - 
 $width-cascader_hover-border: $width-cascader-border; // 级联选择触发器描边宽度 - 悬浮
 $width-cascader_focus-border: $border-thickness-control-focus; // 级联选择触发器描边宽度 - 选中态
 $width-cascader_search-border: 1px; // 级联选择触搜索描边宽度
-$width-cascader-icon: 16px; // 级联选择图标尺寸
+$width-cascader-icon: 32px; // 级联选择图标尺寸
 $width-cascader_option:  150px; // 级联选择各级菜单宽度
 $height-cascader_option_list: 180px; // 级联选择菜单高度
 $height-cascader_selection_tagInput_wrapper_small: 22px;  //级联选择多选搜索时搜索框最小高度 - 小尺寸

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -53,7 +53,8 @@ $spacing-cascader_selection_tag-marginY: 1px; // 级联选择触发器多选时�
 $spacing-cascader_selection_tagInput-marginLeft: - $spacing-extra-tight; // 级联选择触发器多选搜索时 TagInput 的左外边距
 $spacing-cascader_selection_input-marginLeft: $spacing-extra-tight; // 级联选择触发器多选搜索时输入框的左外边距
 $spacing-cascader_selection_n-marginRight: $spacing-extra-tight; // 超出 maxTagCount 后，+n 的右外边距
-$spacing-cascader_clearBtn-marginRight: 12px; // 级联选择触发器清空按钮右侧外边距
+$spacing-cascader_clearBtn-marginRight: 8px; // 级联选择触发器清空按钮右侧外边距
+$spacing-cascader_clearBtn-marginLeft: 8px; // 级联选择触发器清空按钮左侧外边距
 $spacing-cascader_option-icon-marginLeft: 8px; // 级联选择菜单项图标左侧外边距
 
 $color-cascader_selection_n-text-default: var(--semi-color-text-0); // 超出 maxTagCount 后，+n 的文字默认颜色


### PR DESCRIPTION
…ight icon rtl style error

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2472 

** trigger 中的样式问题**
修复前
![image](https://github.com/user-attachments/assets/9363d85d-c0a6-455c-906a-176bbe762a15) 

修复后
![image](https://github.com/user-attachments/assets/3ac1efc9-f6f8-44f2-be1e-dbe7a7ae890f)

** pannel 的 rtl 的样式问题**
修复前
![image](https://github.com/user-attachments/assets/b937d448-2cef-44f2-86c5-3bd90f99bcf6)


修复后
![image](https://github.com/user-attachments/assets/c99ccd97-11c0-4106-93f0-350e25727819)



### Changelog
🇨🇳 Chinese
- Style: 将 Cascader  的 trigger 中内容区域和 icon 间距和 select/treeSelect 保持一致 #2472 
- Style: 修复 Cascader 面板选项在 rtl 模式下，样式不符合预期问题

---

🇺🇸 English
- Style: Keep the content area and icon spacing in Cascader's trigger consistent with select/treeSelect #2472 
- Style: Fixed the issue where the style of Cascader panel options does not meet expectations in rtl mode


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
