### PR TITLE
Fix/cascader, TreeSelect emptyContent is null

### DIFF
--- a/packages/semi-foundation/treeSelect/treeSelect.scss
+++ b/packages/semi-foundation/treeSelect/treeSelect.scss
@@ -373,6 +373,10 @@ $module: #{$prefix}-tree-select;
         .#{$prefix}-tree-option-list {
             flex: 1;
             min-width: $width-treeSelect_option;
+
+            &-hidden {
+                padding: 0;
+            }
         }
 
         .#{$prefix}-tree-search-wrapper {

--- a/packages/semi-ui/cascader/_story/cascader.stories.jsx
+++ b/packages/semi-ui/cascader/_story/cascader.stories.jsx
@@ -2399,51 +2399,32 @@ export const SearchInTopSlot = () => {
 }
 
 export const suffix = () => {
-  const treeData = [
-    {
-        label: '浙江省',
-        value: 'zhejiang',
-        children: [
-            {
-                label: '杭州市',
-                value: 'hangzhou',
-                children: [
-                    {
-                        label: '西湖区',
-                        value: 'xihu',
-                    },
-                    {
-                        label: '萧山区',
-                        value: 'xiaoshan',
-                    },
-                    {
-                        label: '临安区',
-                        value: 'linan',
-                    },
-                ],
-            },
-            {
-                label: '宁波市',
-                value: 'ningbo',
-                children: [
-                    {
-                        label: '海曙区',
-                        value: 'haishu',
-                    },
-                    {
-                        label: '江北区',
-                        value: 'jiangbei',
-                    }
-                ]
-            },
-        ],
-    }
-  ];
-
   return (<Cascader
     suffix={<IconGift />}
     style={{ width: 300 }}
-    treeData={treeData}
+    treeData={treeData1}
     placeholder="请选择所在地区"
   />);
+}
+
+export const EmptyContent = () => {
+  return (
+  <>
+    <Cascader
+      emptyContent={null}
+      style={{ width: 400 }}
+      treeData={[]}
+      placeholder="点击 trigger 查看 emptyContent 为 null 效果 "
+      filterTreeNode
+    />
+    <br /><br />
+    <Cascader
+      emptyContent={null}
+      style={{ width: 400 }}
+      treeData={treeData1}
+      placeholder="输入 v 查看搜索状态下 emptyContent 为 null 效果"
+      filterTreeNode
+    />
+    <br />
+  </>)
 }

--- a/packages/semi-ui/cascader/item.tsx
+++ b/packages/semi-ui/cascader/item.tsx
@@ -360,6 +360,9 @@ export default class Item extends PureComponent<CascaderItemProps> {
 
     renderEmpty() {
         const { emptyContent } = this.props;
+        if (emptyContent === null) {
+            return null;
+        }
         return (
             <LocaleConsumer componentName="Cascader">
                 {(locale: Locale['Cascader']) => (

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2833,3 +2833,59 @@ export const showFilteredOnly = () => {
       </>
   );
 }
+
+export const EmptyContent = () => {
+  const treeData = [
+    {
+        label: '亚洲',
+        value: 'Asia',
+        key: '0',
+        children: [
+            {
+                label: '中国',
+                value: 'China',
+                key: '0-0',
+                children: [
+                    {
+                        label: '北京',
+                        value: 'Beijing',
+                        key: '0-0-0',
+                    },
+                    {
+                        label: '上海',
+                        value: 'Shanghai',
+                        key: '0-0-1',
+                    },
+                ],
+            },
+        ],
+    },
+    {
+        label: '北美洲',
+        value: 'North America',
+        key: '1',
+    }
+  ];
+  return ( 
+      <>
+        <TreeSelect
+          style={{ width: 400 }}
+          dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+          treeData={[]}
+          placeholder="点击 trigger 查看 emptyContent 为 null 效果"
+          emptyContent={null}
+        />
+        <br /><br />
+        <TreeSelect
+          style={{ width: 400 }}
+          dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+          treeData={treeData}
+          placeholder="输入 v 查看 emptyContent 为 null 效果"
+          filterTreeNode
+          showFilteredOnly
+          searchPosition={"trigger"}
+          emptyContent={null}
+        />
+      </>
+  );
+}

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -1496,12 +1496,12 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             emptyContent
         } = this.props;
         const wrapperCls = cls(`${prefixTree}-wrapper`);
-        const listCls = cls(`${prefixTree}-option-list ${prefixTree}-option-list-block`, {
-            [`${prefixTree}-option-list-hidden`]: emptyContent === null,
-        });
         const searchNoRes = Boolean(inputValue) && !filteredKeys.size;
         const noData = isEmpty(flattenNodes) || (showFilteredOnly && searchNoRes);
         const isDropdownPositionSearch = searchPosition === strings.SEARCH_POSITION_DROPDOWN;
+        const listCls = cls(`${prefixTree}-option-list ${prefixTree}-option-list-block`, {
+            [`${prefixTree}-option-list-hidden`]: emptyContent === null && noData,
+        });
         return (
             <TreeContext.Provider
                 value={{

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -1346,6 +1346,9 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
 
     renderEmpty = () => {
         const { emptyContent } = this.props;
+        if (emptyContent === null) {
+            return null;
+        }
         if (emptyContent) {
             return <TreeNode empty emptyContent={this.props.emptyContent} />;
         } else {
@@ -1490,10 +1493,11 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             renderLabel,
             renderFullLabel,
             checkRelation,
+            emptyContent
         } = this.props;
         const wrapperCls = cls(`${prefixTree}-wrapper`);
-        const listCls = cls(`${prefixTree}-option-list`, {
-            [`${prefixTree}-option-list-block`]: true,
+        const listCls = cls(`${prefixTree}-option-list ${prefixTree}-option-list-block`, {
+            [`${prefixTree}-option-list-hidden`]: emptyContent === null,
         });
         const searchNoRes = Boolean(inputValue) && !filteredKeys.size;
         const noData = isEmpty(flattenNodes) || (showFilteredOnly && searchNoRes);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

**修改前，emptyContent 为 null 时，显示默认内容 **
![image](https://github.com/user-attachments/assets/e019442c-a6a5-45c9-a835-b6544f390938)

**修改后，emptyContent 为 null 时，不展示选项内容 **
![image](https://github.com/user-attachments/assets/9e98292a-4732-494f-862f-c8964deb8af4)



### Changelog
🇨🇳 Chinese
- Fix: 修改 Cascader, TreeSelect 当 emptyContent 为 null 的行为，同 Select 保持一致

---

🇺🇸 English
- Fix: Modify the behavior of Cascader, TreeSelect when emptyContent is null, consistent with Select


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
