### PR TITLE
fix: [Chat] Modify the problem that the picture will be deformed when…

### DIFF
--- a/packages/semi-foundation/chat/chat.scss
+++ b/packages/semi-foundation/chat/chat.scss
@@ -474,6 +474,10 @@ $module: #{$prefix}-chat;
         &-img {
             border-radius: $radius-chat_attachment_img;
             vertical-align: top;
+
+            img {
+                object-fit: cover;
+            }
         }
 
         a {

--- a/packages/semi-ui/chat/_story/constant.js
+++ b/packages/semi-ui/chat/_story/constant.js
@@ -69,7 +69,7 @@ const infoWithAttachment = [
             {
                 type: 'image_url',
                 image_url: {
-                    url: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/edit-bag.jpeg',
+                    url: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/other/avatar-vertical.jpeg',
                 },
             },
             {


### PR DESCRIPTION
… the picture ratio is not 1:1

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
在聊天框区域和输入框区域的图片展示效果中 ，未设置 object-fit 属性（默认为 fill 效果，宽高填充）。导致在图片比例非1:1时候，图片会发生变形。因此修改为 cover ，图片以宽高比例填充。
修改前：
![image](https://github.com/user-attachments/assets/0174c8f7-50c3-459f-a7ae-21e83a074c12)

修改后:
![image](https://github.com/user-attachments/assets/96279a04-29a3-4650-a6ba-dfb2d7f83168)




### Changelog
🇨🇳 Chinese
- Style: 修改 Chat 组件聊天框中的图片展示以及输入框中的上传图片展示效果，从填充到保持宽高比例填充(object-fit 从 fill -> cover)，防止图片变形。

---

🇺🇸 English
- Fix: Modify the image display in the Chat component chat box and the uploaded image display effect in the input box, from filling to maintaining width-to-height ratio filling (object-fit from fill -> cover), prevent image deformation.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
