### PR TITLE
fix: [InputNumber] Fix the rounded corners of InputNumber, DatePicker…

### DIFF
--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -633,8 +633,8 @@ $module: #{$prefix}-input;
         .#{$prefix}-datepicker,
         .#{$prefix}-timepicker,
         .#{$prefix}-autocomplete {
-            border-radius: 0;
-
+            
+            .#{$module}-wrapper, 
             .#{$prefix}-datepicker-range-input {
                 border-radius: 0;
             }

--- a/packages/semi-foundation/input/input.scss
+++ b/packages/semi-foundation/input/input.scss
@@ -593,7 +593,6 @@ $module: #{$prefix}-input;
         align-content: center;
         flex-wrap: wrap;
 
-        // select与autocomplete的border-radius都是基于select
         .#{$prefix}-select,
         .#{$prefix}-tagInput,
         .#{$prefix}-cascader,

--- a/packages/semi-ui/locale/_story/locale.stories.jsx
+++ b/packages/semi-ui/locale/_story/locale.stories.jsx
@@ -172,16 +172,16 @@ const I18nComponent = () => {
                 <p>More content...</p>
             </Modal>
             <div>
-              <DatePicker style={{ ...style, width: 200 }} open />
-              <DatePicker style={{ ...style,marginLeft:120, width: 250 }} open type="dateTime" presets={presets} presetPosition="left" />
+              <DatePicker style={{ ...style, width: 200 }} open defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
+              <DatePicker style={{ ...style,marginLeft:120, width: 250 }} open type="dateTime" presets={presets} presetPosition="left" defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
               {/* <DatePicker style={{ ...style, width: 250 }} type="dateRange" /> */}
-              <DatePicker style={{ ...style, marginLeft:240, width: 400 }} open type="dateTimeRange" />
+              <DatePicker style={{ ...style, marginLeft:240, width: 400 }} open type="dateTimeRange" defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
             </div>
             <div style={{ marginTop: 400 }}>
-              <DatePicker style={{ ...style, width: 200 }} open autoAdjustOverflow={false} position='bottomLeft' density='compact' />
-              <DatePicker style={{ ...style,marginLeft:120, width: 250 }} open type="dateTime" presets={presets} presetPosition="left" autoAdjustOverflow={false} position='bottomLeft' density='compact' />
+              <DatePicker style={{ ...style, width: 200 }} open autoAdjustOverflow={false} position='bottomLeft' density='compact' defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
+              <DatePicker style={{ ...style,marginLeft:120, width: 250 }} open type="dateTime" presets={presets} presetPosition="left" autoAdjustOverflow={false} position='bottomLeft' density='compact'  defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
               {/* <DatePicker style={{ ...style, width: 250 }} type="dateRange" /> */}
-              <DatePicker style={{ ...style, marginLeft:240, width: 400 }} open type="dateTimeRange" autoAdjustOverflow={false} position='bottomLeft' density='compact' />
+              <DatePicker style={{ ...style, marginLeft:240, width: 400 }} open type="dateTimeRange" autoAdjustOverflow={false} position='bottomLeft' density='compact' defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
             </div>
             <br />
             <br />


### PR DESCRIPTION
…, Time Pick, and AutoComplete located in the middle of the InputGroup are not 0

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2489 

复现代码
```
export const InputGroupTest = () => {
  return <>
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <InputNumber placeholder="InpuNumber" style={{ width: 140 }} innerButtons />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <InputNumber placeholder="InpuNumber" style={{ width: 140 }} innerButtons />
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <InputNumber placeholder="InpuNumber" style={{ width: 140 }} innerButtons />
    </InputGroup>
    <br /><br />
    <h3>InputGroup, 按钮在外部，仅位于 group 中间的时候 border-radius 会有问题</h3>
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <InputNumber placeholder="InpuNumber" style={{ width: 140 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <InputNumber placeholder="InpuNumber" style={{ width: 140 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <InputNumber placeholder="InpuNumber" style={{ width: 140 }} />
    </InputGroup>
    <h3>AutoComplete, 仅位于 group 中间会有问题</h3>
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <AutoComplete placeholder="AutoComplete" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <AutoComplete placeholder="AutoComplete" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <AutoComplete placeholder="AutoComplete" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <h3>DatePicker, 仅位于 group 中间的时候 border-radius 会有问题</h3>
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <DatePicker placeholder="DatePicker" style={{ width: 100 }}/>
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <DatePicker placeholder="DatePicker" style={{ width: 100 }}/>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <DatePicker placeholder="DatePicker" style={{ width: 100 }}/>
    </InputGroup>
    <br /><br />
    <h3>TimePicker, 仅位于 group 中间的时候 border-radius 会有问题</h3>
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <TimePicker placeholder="TimePicker" style={{ width: 100 }}/>
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <TimePicker placeholder="TimePicker" style={{ width: 100 }}/>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
    </InputGroup>
    <br /><br />
    <InputGroup>
      <Input placeholder="Input" style={{ width: 100 }} />
      <Input placeholder="Input" style={{ width: 100 }} />
      <TimePicker placeholder="TimePicker" style={{ width: 100 }}/>
    </InputGroup>
    <br /><br />
  </>
}
```

### Changelog
🇨🇳 Chinese
- Style: 修复位于InputGroup中间位置的 InputNumber，DatePicker， Time Pick，AutoComplete的圆角不为 0 问题 #2489 

---

🇺🇸 English
- Fix: Fixed the problem that the rounded corners of InputNumber, DatePicker, Time Pick, and AutoComplete located in the middle of the InputGroup are not 0 #2489 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
