### PR TITLE
fix: pinCode onChange on no control mode

### DIFF
--- a/packages/semi-foundation/pincode/foundation.ts
+++ b/packages/semi-foundation/pincode/foundation.ts
@@ -46,9 +46,8 @@ class PinCodeFoundation<P = Record<string, any>, S = Record<string, any>> extend
         await this._adapter.onCurrentActiveIndexChange(i + 1);
         const valueList = [...this.getState("valueList")];
         valueList[i] = singleInputValue;
-        if (isControlledComponent) {
-            this._adapter.notifyValueChange(valueList);
-        } else {
+        this._adapter.notifyValueChange(valueList);
+        if (!isControlledComponent) {
             await this.updateValueList(valueList);
         }
 
@@ -102,11 +101,13 @@ class PinCodeFoundation<P = Record<string, any>, S = Record<string, any>> extend
         if (e.key === "Backspace") {
             valueList[index] = "";
             this.updateValueList(valueList);
+            this._adapter.notifyValueChange(valueList);
             this._adapter.changeSpecificInputFocusState(Math.max(0, index - 1), "focus");
             e.preventDefault();
         } else if (e.key === "Delete") {
             valueList[index] = "";
             this.updateValueList(valueList);
+            this._adapter.notifyValueChange(valueList);
             this._adapter.changeSpecificInputFocusState(Math.min(valueList.length - 1, index + 1), "focus");
             e.preventDefault();
         } else if (e.key === "ArrowLeft") {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 PinCode 在非受控模式下，onChange 不触发的问题

---

🇺🇸 English
- Fix: Fixed the issue where onChange does not trigger in PinCode in uncontrolled mode


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
