### PR TITLE
Try to lock vfile version to support @douyinfe/semi-ui > 2.62.0 preview in codesandbox 

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "useWorkspaces": true,
     "npmClient": "yarn",
-    "version": "2.67.0"
+    "version": "2.67.1-alpha.0"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "useWorkspaces": true,
     "npmClient": "yarn",
-    "version": "2.67.1-alpha.1"
+    "version": "2.67.1-alpha.2"
 }

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
     "useWorkspaces": true,
     "npmClient": "yarn",
-    "version": "2.67.1-alpha.0"
+    "version": "2.67.1-alpha.1"
 }

--- a/packages/semi-foundation/markdownRender/foundation.ts
+++ b/packages/semi-foundation/markdownRender/foundation.ts
@@ -26,7 +26,7 @@ export interface MarkdownRenderBaseState{
 
 class MarkdownRenderFoundation extends BaseFoundation<MarkdownRenderAdapter> {
 
-    private getOptions = ()=>{
+    private getOptions = () => {
         return {
             evaluateOptions: {
                 remarkPlugins: [remarkGfm, ...(this.getProp("remarkPlugins") ?? [])],
@@ -47,11 +47,11 @@ class MarkdownRenderFoundation extends BaseFoundation<MarkdownRenderAdapter> {
         };
     }
 
-    compile = async (mdxRaw: string)=>{
+    compile = async (mdxRaw: string): Promise<any> => {
         return await compile(mdxRaw, this.getOptions().compileOptions);
     }
 
-    evaluate = async (mdxRaw: string)=>{
+    evaluate = async (mdxRaw: string) => {
         return (await evaluate(mdxRaw, {
             ...this.getOptions().runOptions,
             ...this.getOptions().evaluateOptions,
@@ -59,7 +59,7 @@ class MarkdownRenderFoundation extends BaseFoundation<MarkdownRenderAdapter> {
         })).default;
     }
 
-    evaluateSync = (mdxRaw: string)=>{
+    evaluateSync = (mdxRaw: string) => {
         return ( evaluateSync(mdxRaw, {
             ...this.getOptions().runOptions,
             ...this.getOptions().evaluateOptions,

--- a/packages/semi-foundation/package.json
+++ b/packages/semi-foundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-foundation",
-    "version": "2.67.1-alpha.0",
+    "version": "2.67.1-alpha.1",
     "description": "",
     "scripts": {
         "build:lib": "node ./scripts/compileLib.js",

--- a/packages/semi-foundation/package.json
+++ b/packages/semi-foundation/package.json
@@ -29,7 +29,7 @@
         "*.scss",
         "*.css"
     ],
-    "gitHead": "eb34a4f25f002bb4cbcfa51f3df93bed868c831a",
+    "gitHead": "e9b807482bf24c40953739f0f887c193c5dd139d",
     "devDependencies": {
         "@babel/plugin-transform-runtime": "^7.15.8",
         "@babel/preset-env": "^7.15.8",

--- a/packages/semi-foundation/package.json
+++ b/packages/semi-foundation/package.json
@@ -19,7 +19,8 @@
         "memoize-one": "^5.2.1",
         "prismjs": "^1.29.0",
         "remark-gfm": "^4.0.0",
-        "scroll-into-view-if-needed": "^2.2.24"
+        "scroll-into-view-if-needed": "^2.2.24",
+        "vfile": "6.0.1"
     },
     "keywords": [],
     "author": "",

--- a/packages/semi-foundation/package.json
+++ b/packages/semi-foundation/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-foundation",
-    "version": "2.67.0",
+    "version": "2.67.1-alpha.0",
     "description": "",
     "scripts": {
         "build:lib": "node ./scripts/compileLib.js",

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -75,7 +75,7 @@
     ],
     "author": "",
     "license": "MIT",
-    "gitHead": "e78045febe3e4645c8afe6d42cfbcb4e97a67923",
+    "gitHead": "e9b807482bf24c40953739f0f887c193c5dd139d",
     "devDependencies": {
         "@babel/plugin-proposal-decorators": "^7.15.8",
         "@babel/plugin-transform-runtime": "^7.15.8",

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-ui",
-    "version": "2.67.0",
+    "version": "2.67.1-alpha.0",
     "description": "A modern, comprehensive, flexible design system and UI library. Connect DesignOps & DevOps. Quickly build beautiful React apps. Maintained by Douyin-fe team.",
     "main": "lib/cjs/index.js",
     "module": "lib/es/index.js",
@@ -22,7 +22,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@douyinfe/semi-animation": "2.67.0",
         "@douyinfe/semi-animation-react": "2.67.0",
-        "@douyinfe/semi-foundation": "2.67.0",
+        "@douyinfe/semi-foundation": "2.67.1-alpha.0",
         "@douyinfe/semi-icons": "2.67.0",
         "@douyinfe/semi-illustrations": "2.67.0",
         "@douyinfe/semi-theme-default": "2.61.0",

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-ui",
-    "version": "2.67.1-alpha.1",
+    "version": "2.67.1-alpha.2",
     "description": "A modern, comprehensive, flexible design system and UI library. Connect DesignOps & DevOps. Quickly build beautiful React apps. Maintained by Douyin-fe team.",
     "main": "lib/cjs/index.js",
     "module": "lib/es/index.js",

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@douyinfe/semi-ui",
-    "version": "2.67.1-alpha.0",
+    "version": "2.67.1-alpha.1",
     "description": "A modern, comprehensive, flexible design system and UI library. Connect DesignOps & DevOps. Quickly build beautiful React apps. Maintained by Douyin-fe team.",
     "main": "lib/cjs/index.js",
     "module": "lib/es/index.js",
@@ -22,7 +22,7 @@
         "@dnd-kit/utilities": "^3.2.1",
         "@douyinfe/semi-animation": "2.67.0",
         "@douyinfe/semi-animation-react": "2.67.0",
-        "@douyinfe/semi-foundation": "2.67.1-alpha.0",
+        "@douyinfe/semi-foundation": "2.67.1-alpha.1",
         "@douyinfe/semi-icons": "2.67.0",
         "@douyinfe/semi-illustrations": "2.67.0",
         "@douyinfe/semi-theme-default": "2.61.0",

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -37,7 +37,8 @@
         "react-resizable": "^3.0.5",
         "react-window": "^1.8.2",
         "scroll-into-view-if-needed": "^2.2.24",
-        "utility-types": "^3.10.0"
+        "utility-types": "^3.10.0",
+        "vfile": "6.0.1"
     },
     "peerDependencies": {
         "react": ">=16.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1663,7 +1663,7 @@
   dependencies:
     classnames "^2.2.6"
 
-"@douyinfe/semi-icons@2.66.1", "@douyinfe/semi-icons@^2.0.0":
+"@douyinfe/semi-icons@2.66.1":
   version "2.66.1"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.66.1.tgz#d2d845bb9c36e92adf81d405c7b2f4622fea1f39"
   integrity sha512-zQtBKg8hXA3f7Gp6UFWsudFjpdCYE9rxTzM84HpTyd/rvKd3v9p6MD4rBPNbuFV2dS90eXajgsvroPz3S+ss/A==
@@ -11909,11 +11909,6 @@ eslint-plugin-react@^7.20.6, eslint-plugin-react@^7.24.0:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.11"
     string.prototype.repeat "^1.0.0"
-
-eslint-plugin-semi-design@^2.33.0:
-  version "2.66.1"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-semi-design/-/eslint-plugin-semi-design-2.66.1.tgz#533efe5a5026003b24f2ee66e433d7c84afa683d"
-  integrity sha512-k5ZK4NN7xDGAewQkTkTy2W88xTaNHGw1bPhcJEfHDn/mCL8yD4cr0dYK46118RjSAVA93DFbKtzaaTUcJ296Kg==
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
@@ -25115,7 +25110,7 @@ string-similarity@^1.2.2:
     lodash.map "^4.6.0"
     lodash.maxby "^4.6.0"
 
-"string-width-cjs@npm:string-width@^4.2.0", "string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+"string-width-cjs@npm:string-width@^4.2.0":
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -25132,6 +25127,15 @@ string-width@^1.0.1, string-width@^1.0.2:
     code-point-at "^1.0.0"
     is-fullwidth-code-point "^1.0.0"
     strip-ansi "^3.0.0"
+
+"string-width@^1.0.2 || 2 || 3 || 4", string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.2, string-width@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
+  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
+  dependencies:
+    emoji-regex "^8.0.0"
+    is-fullwidth-code-point "^3.0.0"
+    strip-ansi "^6.0.1"
 
 string-width@^2.0.0, string-width@^2.1.0:
   version "2.1.1"
@@ -25276,7 +25280,7 @@ stringify-object@^3.3.0:
     is-obj "^1.0.1"
     is-regexp "^1.0.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -25303,6 +25307,13 @@ strip-ansi@^5.0.0, strip-ansi@^5.1.0, strip-ansi@^5.2.0:
   integrity sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
   dependencies:
     ansi-regex "^4.1.0"
+
+strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
+  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
+  dependencies:
+    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1:
   version "7.1.0"
@@ -27291,6 +27302,15 @@ vfile-message@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-stringify-position "^3.0.0"
 
+vfile@6.0.1:
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/vfile/-/vfile-6.0.1.tgz#1e8327f41eac91947d4fe9d237a2dd9209762536"
+  integrity sha512-1bYqc7pt6NIADBJ98UiG0Bn/CHIVOoZ/IyEkqIruLg0mE1BKzkOXY2D6CSqQIcKqgadppE5lrxgWXJmXd7zZJw==
+  dependencies:
+    "@types/unist" "^3.0.0"
+    unist-util-stringify-position "^4.0.0"
+    vfile-message "^4.0.0"
+
 vfile@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/vfile/-/vfile-3.0.1.tgz#47331d2abe3282424f4a4bb6acd20a44c4121803"
@@ -27885,7 +27905,7 @@ worker-farm@^1.7.0:
   dependencies:
     errno "~0.1.7"
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -27915,6 +27935,15 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+  dependencies:
+    ansi-styles "^4.0.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+
+wrap-ansi@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
+  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- 这个PR当前没有实际解决问题，暂时只用来记录已经做过的尝试。

#### 现状
- 关于 codesandbox无法使用 vfile自v6.0.2 版本起使用的 Subpath imports 语法，详见https://github.com/codesandbox/codesandbox-client/issues/8625
![image](https://github.com/user-attachments/assets/0d68d9e8-7f43-4ab5-bb67-333090eb2f28)
如上是当前的依赖链
unified、mdast-util-to-hast的依赖都声明了 vfile: ^6.0.0

#### 目前我们的尝试
- ❌ 在 semi-foudation中锁定 vfile: 6.0.1，实测对codesandbox无效
- ❌ 在 semi-foudation和 semi-ui中同时锁定 vfile: 6.0.1 ，实测对 codesandbox无效


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
