### PR TITLE
Fix: rspack plugin no effect on win32 platform

### DIFF
--- a/packages/semi-rspack/src/rule.ts
+++ b/packages/semi-rspack/src/rule.ts
@@ -5,7 +5,7 @@ import { stringifyVariableRecord } from './utils';
 
 export function createSourceSuffixLoaderRule(_opts?: SemiWebpackPluginOptions) {
     return {
-        test: /@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/,
+        test: /@douyinfe(\/|\\)+semi-(ui|icons)(\/|\\)+.+\.js$/,
         use: [{ loader: SOURCE_SUFFIX_LOADER }],
     };
 }
@@ -25,7 +25,7 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
         cssLayer: opts.cssLayer
     };
     const loaderInfo = {
-        test: /@douyinfe\/semi-(ui|icons|foundation)\/lib\/.+\.scss$/,
+        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
         use: [{ loader: THEME_LOADER, options }],
     };
     if (opts.webComponentPath) {
@@ -35,7 +35,7 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
             {
                 loader: 'css-loader',
                 options: { sourceMap: false }
-            }, 
+            },
             { loader: 'sass-loader' }
         ];
         loaderInfo.use = [
@@ -48,7 +48,7 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
 
 export function createOmitCssLoaderRule(_opts?: SemiWebpackPluginOptions) {
     return {
-        test: /@douyinfe\/semi-[^/]+\/.+env\.js$/,
+        test: /@douyinfe(\/|\\)+semi-[^/]+(\/|\\)+.+env\.js$/,
         use: [{ loader: OMIT_CSS_LOADER }],
     };
 }
@@ -58,7 +58,7 @@ export function createPrefixLoaderRule(opts?: SemiWebpackPluginOptions) {
         replacers: { BASE_CLASS_PREFIX: opts.prefixCls },
     };
     return {
-        test: /@douyinfe\/semi-[^/]+\/.+env\.js$/,
+        test: /@douyinfe(\/|\\)+semi-[^/]+(\/|\\)+.+env\.js$/,
         use: [{ loader: PREFIX_LOADER, options }],
     };
 }


### PR DESCRIPTION
Fix: rspack plugin no effect on win32 platform, since win32 use \\ as system default sep.

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Rspack plugin 在 win32 平台不生效的问题

---

🇺🇸 English
- Fix: Fixed the issue that Rspack plugin does not work on win32 platform


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
