### PR TITLE
fix: [Cascader] fix icon width error in option list pannel

### DIFF
--- a/packages/semi-foundation/cascader/cascader.scss
+++ b/packages/semi-foundation/cascader/cascader.scss
@@ -436,7 +436,7 @@ $module: #{$prefix}-cascader;
         &-icon {
             display: inline-flex;
             flex-shrink: 0;
-            width: $width-cascader-icon;
+            width:$width-cascader-option-icon;
             color: $color-cascader_option-icon-default;
 
             &-active,
@@ -450,13 +450,13 @@ $module: #{$prefix}-cascader;
         }
 
         &-spin-icon {
-            width: $width-cascader-icon;
-            height: $width-cascader-icon;
+            width: $width-cascader-option-icon;
+            height: $width-cascader-option-icon;
             line-height: 0;
 
             & svg {
-                width: $width-cascader-icon;
-                height: $width-cascader-icon;
+                width: $width-cascader-option-icon;
+                height: $width-cascader-option-icon;
             }
         }
 

--- a/packages/semi-foundation/cascader/variables.scss
+++ b/packages/semi-foundation/cascader/variables.scss
@@ -92,7 +92,8 @@ $height-cascader_large: $height-control-large; // 级联选择触发器高度 - 
 $width-cascader_hover-border: $width-cascader-border; // 级联选择触发器描边宽度 - 悬浮
 $width-cascader_focus-border: $border-thickness-control-focus; // 级联选择触发器描边宽度 - 选中态
 $width-cascader_search-border: 1px; // 级联选择触搜索描边宽度
-$width-cascader-icon: 32px; // 级联选择图标尺寸
+$width-cascader-icon: 32px; // 级联选择触发器图标尺寸
+$width-cascader-option-icon: 16px; // 级联选择选项面板图标尺寸
 $width-cascader_option:  150px; // 级联选择各级菜单宽度
 $height-cascader_option_list: 180px; // 级联选择菜单高度
 $height-cascader_selection_tagInput_wrapper_small: 22px;  //级联选择多选搜索时搜索框最小高度 - 小尺寸


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
PR [2472](https://github.com/DouyinFE/semi-design/pull/2475) 对 icon 宽度做了修改，影响到了面板中的 icon 宽度。

修复方式：
新增加 token 用于表示面板中的 icon 的 token

修复前
![image](https://github.com/user-attachments/assets/8b2da7d7-bd7a-4d66-b70c-1494303e7e39)

修复后
![image](https://github.com/user-attachments/assets/36c60826-2286-4711-ac25-b69ea81d24c2)



### Changelog
🇨🇳 Chinese
- Fix: 修复 Cascader 面板 icon 宽度错误问题，影响版本2.67.0～2.67.1
- Style: 新增加 $width-cascader-option-icon 用于表示面板中的 icon 的宽度

---

🇺🇸 English
- Fix: Fixed the issue of incorrect width of Cascader panel icon, affecting versions 2.67.0～2.67.1
- Style: Newly added $width-cascader-option-icon is used to represent the width of the icon in the panel


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
