### PR TITLE
fix: [TreeSelect] Fixed option text displays incorrectly when the exp…

### DIFF
--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -217,5 +217,13 @@ describe('treeSelect', () => {
         cy.get('.semi-tree-select').trigger('click');
         cy.get('.semi-tree-option').should('have.length', 2);
     })
+
+    it('keyMaps + search', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--filter-and-key-maps');
+        cy.get('.semi-tree-select').trigger('click');
+        cy.get('.semi-input').type('1');
+        cy.get('.semi-tree-option-expand-icon').eq(0).trigger('click');
+        cy.get('.semi-tree-option-label-text').eq(0).contains('Asia');
+    })
 });
 

--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -776,7 +776,8 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
         return !allChecked;
     }
     handleNodeExpandInSearch(e: any, treeNode: BasicTreeNodeProps) {
-        const { treeData, filteredShownKeys, keyEntities, keyMaps } = this.getStates();
+        const { treeData, filteredShownKeys, keyEntities } = this.getStates();
+        const { keyMaps } = this.getProps();
         const showFilteredOnly = this._showFilteredOnly();
         // clone otherwise will be modified unexpectedly
         const filteredExpandedKeys = new Set(this.getState('filteredExpandedKeys')) as Set<string>;

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2889,3 +2889,75 @@ export const EmptyContent = () => {
       </>
   );
 }
+
+export const filterAndKeyMaps = () => {
+  const treeData = [
+    {
+        name: 'Asia',
+        value: 'Asia',
+        key: '0',
+        children: [
+            {
+                name: 'China',
+                value: 'China',
+                key: '0-0',
+                children: [
+                    {
+                        name: 'Beijing',
+                        value: 'Beijing',
+                        key: '0-0-0',
+                    },
+                    {
+                        name: 'Shanghai',
+                        value: 'Shanghai',
+                        key: '0-0-1',
+                    },
+                ],
+            },
+            {
+                name: 'Japan',
+                value: 'Japan',
+                key: '0-1',
+                children: [
+                    {
+                        name: 'Osaka',
+                        value: 'Osaka',
+                        key: '0-1-0'
+                    }
+                ]
+            },
+        ],
+    },
+    {
+        name: 'North America',
+        value: 'North America',
+        key: '1',
+        children: [
+            {
+                name: 'United States',
+                value: 'United States',
+                key: '1-0'
+            },
+            {
+                name: 'Canada',
+                value: 'Canada',
+                key: '1-1'
+            }
+          ]
+      }
+  ];
+  return (
+    <TreeSelect
+      style={{ width: 300 }}
+      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+      treeData={treeData}
+      filterTreeNode
+      keyMaps={{
+        key: 'key',
+        value: 'value',
+        label: 'name',
+      }}
+      placeholder="单选可搜索的"
+    />
+  )
+}


### PR DESCRIPTION
…and button is clicked after searching for TreeSelect with keyMaps set

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
问题原因：
在搜索状态下，计算展开的可见选项需要用到的 keyMaps 取值错误（错误从 state 中取，实际应当从 props 中取）。

修复问题同时增加测试用例

复现代码
```
 () => {
  const treeData = [
    {
        name: 'Asia',
        value: 'Asia',
        key: '0',
        children: [
            {
                name: 'China',
                value: 'China',
                key: '0-0',
                children: [
                    {
                        name: 'Beijing',
                        value: 'Beijing',
                        key: '0-0-0',
                    },
                    {
                        name: 'Shanghai',
                        value: 'Shanghai',
                        key: '0-0-1',
                    },
                ],
            },
            {
                name: 'Japan',
                value: 'Japan',
                key: '0-1',
                children: [
                    {
                        name: 'Osaka',
                        value: 'Osaka',
                        key: '0-1-0'
                    }
                ]
            },
        ],
    },
    {
        name: 'North America',
        value: 'North America',
        key: '1',
        children: [
            {
                name: 'United States',
                value: 'United States',
                key: '1-0'
            },
            {
                name: 'Canada',
                value: 'Canada',
                key: '1-1'
            }
          ]
      }
  ];
  return (
    <TreeSelect
      style={{ width: 300 }}
      dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
      treeData={treeData}
      filterTreeNode
      keyMaps={{
        key: 'key',
        value: 'value',
        label: 'name',
      }}
      placeholder="单选可搜索的"
    />
  )
}
```
复现步骤：
1. 点击trigger 展开选项列表
2. 在搜索框中输入1
3. 点击展开按钮

会发现 label 未展示
![image](https://github.com/user-attachments/assets/ff8b56e0-694f-43f5-8f07-cb139d3f315f)


### Changelog
🇨🇳 Chinese
- Fix: 修复设置了 keyMaps 的 TreeSelect 在搜索状态中，点击展开按钮后，选项文本展示错误问题

---

🇺🇸 English
- Fix: Fixed the issue that the option text is displayed incorrectly when clicking the expand button in the search state of TreeSelect with keyMaps set


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
