### PR TITLE
style: [chat] start/end to flex-start/flex-end for align-items

### DIFF
--- a/packages/semi-foundation/chat/chat.scss
+++ b/packages/semi-foundation/chat/chat.scss
@@ -132,7 +132,7 @@ $module: #{$prefix}-chat;
             flex-direction: row-reverse;
 
             .#{$module}-chatBox-wrap {
-                align-items: end;
+                align-items: flex-end;
             }
         }
 
@@ -204,7 +204,7 @@ $module: #{$prefix}-chat;
         &-wrap {
             display: flex;
             flex-direction: column;
-            align-items: start;
+            align-items: flex-start;
             position: relative;
             row-gap: $spacing-chat_chatBox_wrap;
         }
@@ -431,7 +431,7 @@ $module: #{$prefix}-chat;
             border-radius: $radius-chat_inputBox_container;
             padding: $spacing-chat_inputBox_container-padding;
             border: $width-chat_inputBox_container-border solid $color-chat_inputBox_container-border;
-            align-items: end;
+            align-items: flex-end;
         }
             
         &-inputArea {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #


### Changelog
🇨🇳 Chinese
- Style: Chat 组件样式的 align-items 属性的 start/end 修改为 flex-start/flex-end

---

🇺🇸 English
- Style: The start/end of the align-items attribute of the Chat component style is modified to flex-start/flex-end


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
