### PR TITLE
Style - select placeholder inactive

### DIFF
--- a/cypress/e2e/select.spec.js
+++ b/cypress/e2e/select.spec.js
@@ -217,7 +217,7 @@ describe('Select', () => {
         cy.get('[data-cy=option-8]').should('have.class', 'custom-option-render-focused');
     });
 
-    it.only('Fixed PR-2465', () => {
+    it('Fixed PR-2465', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?path=/story/select--fix-2465');
         cy.get('.semi-select').eq(0).click();
         cy.get('button').contains('single close').eq(0).click();

--- a/packages/semi-foundation/select/foundation.ts
+++ b/packages/semi-foundation/select/foundation.ts
@@ -1113,10 +1113,12 @@ export default class SelectFoundation extends BaseFoundation<SelectAdapter> {
 
     handleInputBlur(e: any) {
         const { filter, autoFocus } = this.getProps();
+        const { showInput } = this.getStates();
         const isMultiple = this._isMultiple();
-        if (autoFocus && filter && !isMultiple ) {
-            // under this condition, when input blur, hide the input
-            this.toggle2SearchInput(false);
+        if (filter && !isMultiple ) {
+            if (showInput || autoFocus) {
+                this.toggle2SearchInput(false);
+            }
         }
     }
 

--- a/packages/semi-foundation/select/select.scss
+++ b/packages/semi-foundation/select/select.scss
@@ -183,7 +183,8 @@ $overflowList: #{$prefix}-overflow-list;
         }
 
         &-placeholder {
-            color: $color-select_input_placeholder-text;
+            // color: $color-select_input_placeholder-text;
+            color: red
         }
 
         .#{$prefix}-tag {

--- a/packages/semi-foundation/select/select.scss
+++ b/packages/semi-foundation/select/select.scss
@@ -183,8 +183,7 @@ $overflowList: #{$prefix}-overflow-list;
         }
 
         &-placeholder {
-            // color: $color-select_input_placeholder-text;
-            color: red
+            color: $color-select_input_placeholder-text;
         }
 
         .#{$prefix}-tag {

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -790,6 +790,7 @@ export const SelectFilterSingle = () => (
       }}
       showClear
       autoFocus
+      placeholder='singe filter select'
       onSearch={(val) => console.log(`onSearch:${val}`)}
       onFocus={() => console.log('onFocus')}
       onBlur={() => console.log('onBlur')}
@@ -2217,6 +2218,7 @@ class OptionGroupDemo extends React.Component {
             width: 180,
           }}
           filter
+          showClear
         >
           {groups.map((group, index) => this.renderGroup(group, index))}
         </Select>
@@ -2227,6 +2229,7 @@ class OptionGroupDemo extends React.Component {
               let sug = sugInput.toUpperCase();
               return label.includes(sug);
           }}
+          showClear
           id='without-key'
           style={{ width: "180px" }}
           placeholder="without key"
@@ -2255,10 +2258,6 @@ class OptionGroupDemo extends React.Component {
 }
 
 export const SelectOptionGroup = () => <OptionGroupDemo />;
-
-SelectOptionGroup.story = {
-  name: 'Select OptionGroup',
-};
 
 const BlurDemo = () => {
   const onBlur = (value, e) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
如下 Demo，点击选项然后点击 clearIcon后，state中的 showInput状态不正确，导致 placeholder 的 text 依然激活了 .semi-select-selection-text-inactive样式，opactiy为0.4，没有正确恢复到点击前的状态。
Ps：为了更明显观测到现象，这里覆盖了一下样式。
![image](https://github.com/user-attachments/assets/afeaf389-a0e1-490f-a77f-2d2751f68103)
![20241028155827_rec_](https://github.com/user-attachments/assets/d8bd255d-17ff-492d-9f1e-3e45cb751c99)

```
import React from 'react';
import { Select } from '@douyinfe/semi-ui';
() => {
  const data = [
    {
      label: 'Asia',
      children: [
        { value: 'a-1', label: 'China' },
        { value: 'a-2', label: 'Koera' },
      ]
    },
    {
      label: 'Europe',
      children: [
        { value: 'b-1', label: 'Germany' },
        { value: 'b-2', label: 'France' },
      ]
    },
    {
      label: 'South America',
      children: [
        { value: 'c-1', label: 'Peru' },
      ]
    }
  ];
  return (
    <> 
    <Select showClear placeholder="请选择" style={{ width: 180 }} filter>
      {
        data.map((group, index) => (
          <Select.OptGroup label={group.label} key={`${index}-${group.label}`}>
            {
              group.children.map((option, index2) => (
                <Select.Option value={option.value} key={`${index2}-${group.label}`}>
                  {option.label}
                </Select.Option>
              ))
            }
          </Select.OptGroup>
        ))
      }
    </Select>
    </>
  );
};
```


### Changelog
🇨🇳 Chinese
- Style: 修复 Select 在 filter、showClear 开启，点击 clearIcon 且失焦后，placeholder 透明度不正确的问题

---

🇺🇸 English
- Style: Fix the issue where the placeholder transparency of Select is incorrect after filter and showClear are enabled, clearIcon is clicked, and the input loses focus.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
