### PR TITLE
fix: nav hover will lost open state in collapse mode, close #2558

### DIFF
--- a/packages/semi-ui/navigation/SubNav.tsx
+++ b/packages/semi-ui/navigation/SubNav.tsx
@@ -137,8 +137,6 @@ export default class SubNav extends BaseComponent<SubNavProps, SubNavState> {
             getOpenKeys: () => this.context && this.context.openKeys,
             getOpenKeysIsControlled: () => this.context && this.context.openKeysIsControlled,
             getCanUpdateOpenKeys: () => this.context && this.context.canUpdateOpenKeys,
-            updateOpen: isOpen =>
-                this._invokeContextFunc(isOpen ? 'addOpenKeys' : 'removeOpenKeys', this.props.itemKey),
             notifyGlobalOpenChange: (...args) => this._invokeContextFunc('onOpenChange', ...args),
             notifyGlobalOnSelect: (...args) => this._invokeContextFunc('onSelect', ...args),
             notifyGlobalOnClick: (...args) => this._invokeContextFunc('onClick', ...args),
@@ -146,7 +144,8 @@ export default class SubNav extends BaseComponent<SubNavProps, SubNavState> {
             getIsOpen: () => {
                 const { itemKey } = this.props;
                 return Boolean(this.context && this.context.openKeys && this.context.openKeys.includes(this.props.itemKey));
-            }
+            },
+            updateOpenKeys: (newOpenKeys) => { this.context.updateOpenKeys(newOpenKeys); }
         };
     }
 

--- a/packages/semi-ui/navigation/nav-context.ts
+++ b/packages/semi-ui/navigation/nav-context.ts
@@ -24,7 +24,10 @@ export interface NavContextType {
     renderWrapper?: NavProps['renderWrapper'];
     getPopupContainer?: DropdownProps['getPopupContainer'];
     tooltipShowDelay?: number;
-    tooltipHideDelay?: number
+    tooltipHideDelay?: number;
+    updateOpenKeys?: (openKeys: ItemKey[]) => void;
+    addOpenKeys?: (itemKey: ItemKey) => void;
+    removeOpenKeys?: (itemKey: ItemKey) => void
 }
 
 const NavContext = React.createContext<NavContextType>({


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
- 修复 #2558 存在的问题
- 修改说明：
1. Sub 移除 updateOpen的 adapter，直接换成  updateOpenKeys
原有的 SubNav 中，将 openKeys的更新耦合在了两个操作中: updateOpen时，判断 dropdown的 visible决定是 addOpenKeys，还是 removeOpenKeys。 
foundation 中 调用 updateOpen时，无法直接决定 newOpenKeys。但是实际上在两处仅有的 updateOpen调用中，它的前一步骤已经把最新的 newOpenKeys算出来了，没有必要再在 updateOpen adapter中重新计算。此处应该信赖直接更新即可


2. nax-context 补充类型声明，实际上在 nav /index.tsx中已经通过 context往下传了 updateOpenKeys、addOpenKeys、removeOpenKeys三个操作函数，但因为之前代码中是通过 `this._invokeContextFunc(isOpen ? 'addOpenKeys' : 'removeOpenKeys', this.props.itemKey` 这种方式调用的，绕过了类型检测，所以并没有检测出类型缺失。

3. subNavFoundation中增加检测，如果hover时，这个 item已经是open状态，无论dropdown 由 show -> hide还是由 hide -> show，都不再修改 openKeys，解决 #2558 的问题


### Changelog
🇨🇳 Chinese
- Fix: 修复 Nav 折叠态下，hover subNav可能导致展开状态丢失的问题 #2558 

---

🇺🇸 English
- Fix: Fixed the issue where hovering over subNav in the collapsed state of Nav may cause the expanded state to be lost. #2558


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
