### PR TITLE
fix: Fixed the placeHolder of TreeSelect is blocked when the search b…

### DIFF
--- a/packages/semi-foundation/treeSelect/treeSelect.scss
+++ b/packages/semi-foundation/treeSelect/treeSelect.scss
@@ -165,13 +165,16 @@ $module: #{$prefix}-tree-select;
             
             &-placeholder {
                 opacity: .6;
-                z-index: -1;
             }
 
             &-disabled {
                 cursor: not-allowed;
                 color: $color-treeSelect_selection_TriggerSearchItem_disabled-text-default;
             }
+        }
+
+        .#{$module}-triggerSingleSearch-upper {
+            z-index: 1;
         }
 
         .#{$module}-triggerSingleSearch-wrapper{

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -494,7 +494,7 @@ Searchable.story = {
 };
 
 export const SearchPosition = () => (
-  <>
+  <div style={{ background: 'var(--semi-color-bg-0)'}}>
     <TreeSelect
       searchPosition="trigger"
       style={{ width: 300 }}
@@ -540,7 +540,7 @@ export const SearchPosition = () => (
       maxTagCount={1}
       placeholder="maxTagCount=1"
     />
-  </>
+  </div>
 );
 
 SearchPosition.story = {

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -1288,12 +1288,12 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             disabled,
             preventScroll,
         } = this.props;
+        const { inputValue, inputTriggerFocus } = this.state;
         const isDropdownPositionSearch = searchPosition === strings.SEARCH_POSITION_DROPDOWN;
         const inputcls = cls({
             [`${prefixTree}-input`]: isDropdownPositionSearch,
             [`${prefixcls}-inputTrigger`]: !isDropdownPositionSearch
         });
-        const { inputValue } = this.state;
         const baseInputProps = {
             value: inputValue,
             className: inputcls,
@@ -1314,6 +1314,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const wrapperCls = cls({
             [`${prefixTree}-search-wrapper`]: isDropdownPositionSearch,
             [`${prefixcls}-triggerSingleSearch-wrapper`]: !isDropdownPositionSearch && !multiple,
+            [`${prefixcls}-triggerSingleSearch-upper`]: !isDropdownPositionSearch && inputTriggerFocus,
         });
         const useCusSearch = typeof searchRender === 'function' || typeof searchRender === 'boolean';
         if (useCusSearch && !searchRender) {


### PR DESCRIPTION
…ox is in trigger, single selection

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

<strong> 问题原因：</strong>
修复 #2292 时候，引入负值的 z-index 。负值的 z-index 会处于层叠上下文的下方，原来在 placeholder 层设置了  z-index 为 -1， 预期是想要实现
1. 当 input 没有被 focus 时，placeholder 层位于 input 框的上层，这样能够保证 ReactNode 类型的 label 的一些 hover功能正常触发（比如被 tooltip 包裹）。
2. 当 input 被 focus 后，input 无输入文本时，placeholder 位于 input 框的下层，hover input 框不会导致 placeholder 的 hover 功能被触发。

<strong>为什么在开发阶段没有发现这个问题？</strong>
有 cypress 测试用例覆盖，TreeSelect 的 search Position 用例，但由于 storybook 中背景没有设置颜色，因此即使负值的 z-index 位于层叠上下文的下方，仍然能够显示出来，而官网中，用例区域有背景色（-semi- color-bg-0），遮挡住了负值 z-index 的文本。因此两者的表现不同。

<strong>修复方式</strong>
去掉 placeholder 文本层的负值的 z-index，当 searchPosition 在 trigger中并且 focus 的状态下，设置 input 的wrapper 层的 z-index 为 1，保证此时 input 在 文本上方

### Changelog
🇨🇳 Chinese
- Fix: 修复当单选，搜索框在 trigger 时，TreeSelect 的 placeholder被遮挡问题

---

🇺🇸 English
- Fix: Fix the problem that the placeholder of TreeSelect is blocked when single selection and search box are in trigger


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
