### PR TITLE
style: For Tree/TreeSelect with showLine set to true, when the top no…

### DIFF
--- a/packages/semi-ui/tree/_story/tree.stories.jsx
+++ b/packages/semi-ui/tree/_story/tree.stories.jsx
@@ -207,6 +207,17 @@ const treeDataWithIcon = [
   },
 ];
 
+const OneLevelData = [
+  {
+    label: '亚洲',
+    key: 'yazhou',
+  },
+  {
+    label: '北美洲',
+    key: 'beimeizhou',
+  },
+]
+
 let opts = {
   content: 'Hi, Bytedance dance dance',
   duration: 3,
@@ -3077,6 +3088,14 @@ export const ShowLine = () => {
       multiple
       defaultExpandAll
       disableStrictly
+    />
+    <>单选，单层节点</>
+    <Tree
+      showLine={showLine}
+      treeData={OneLevelData}
+      // value="meiguo"
+      defaultExpandAll
+      onChange={(...args) => console.log(args)}
     />
   </div>
   )

--- a/packages/semi-ui/tree/treeNode.tsx
+++ b/packages/semi-ui/tree/treeNode.tsx
@@ -203,7 +203,7 @@ export default class TreeNode extends PureComponent<TreeNodeProps, TreeNodeState
 
     renderArrow() {
         const showIcon = !this.isLeaf();
-        const { loading, expanded, showLine } = this.props;
+        const { loading, expanded, showLine, level } = this.props;
         if (loading) {
             return <Spin wrapperClassName={`${prefixcls}-spin-icon`} />;
         }
@@ -218,7 +218,8 @@ export default class TreeNode extends PureComponent<TreeNodeProps, TreeNodeState
                 />
             );
         }
-        if (showLine) {
+        // when leaf node 's level is 0, no switcher
+        if (showLine && level) {
             return this.renderSwitcher();
         }
         return (


### PR DESCRIPTION
…de is a leaf node, there should be no line in front of the top node

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
关联问题 #1801 

对于 showLine 为 true 的 Tree/TreeSelect，当顶层节点为叶子节点时，顶层节点前不应该有线条
#### 修改前
![image](https://github.com/user-attachments/assets/a104402b-5b30-48ec-bb7e-3b53640183a7)
#### 修改后
![image](https://github.com/user-attachments/assets/b1203cd1-eb96-4a31-92b6-ae25da1146e6)

#### 其他
增加 storybook 用例，检测顶层节点为叶子节点的UI表现


### Changelog
🇨🇳 Chinese
- Style: 对于 showLine 为 true 的 Tree/TreeSelect，当顶层节点为叶子节点时，顶层节点前不应该有线条

---

🇺🇸 English
- Style: For Tree/TreeSelect with showLine set to true, when the top node is a leaf node, there should be no line in front of the top node.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
