### PR TITLE
fix: When all items except the disabled item in the left panel of tra…

### DIFF
--- a/packages/semi-foundation/transfer/transfer.scss
+++ b/packages/semi-foundation/transfer/transfer.scss
@@ -53,6 +53,7 @@ $module: #{$prefix}-transfer;
         margin-bottom: $spacing-transfer_header-marginBottom;
         margin-left: $spacing-transfer_header-marginLeft;
         color: $color-transfer_header-text;
+        flex-shrink: 0;
 
         &-all {
             font-weight: $font-transfer_header_all-fontWeight;

--- a/packages/semi-ui/transfer/index.tsx
+++ b/packages/semi-ui/transfer/index.tsx
@@ -409,7 +409,17 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         // For example, the filtered data on the left is 1, 3, 4;
         // The selected option is 1,2,3,4, it is true
         // The selected option is 2,3,4, then it is false
-        const leftContainesNotInSelected = Boolean(filterData.find(f => !selectedItems.has(f.key)));
+        let filterDataAllDisabled = true;
+        const leftContainesNotInSelected = Boolean(filterData.find(f => {
+            if (f.disabled) {
+                return false;
+            } else {
+                if (filterDataAllDisabled) {
+                    filterDataAllDisabled = false;
+                }
+                return !selectedItems.has(f.key);
+            }
+        }));
 
         const totalText = totalToken.replace('${total}', `${showNumber}`);
 
@@ -418,7 +428,7 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
             allContent: leftContainesNotInSelected ? locale.selectAll : locale.clearSelectAll,
             onAllClick: () => this.foundation.handleAll(leftContainesNotInSelected),
             type: 'left',
-            showButton: type !== strings.TYPE_TREE_TO_LIST,
+            showButton: type !== strings.TYPE_TREE_TO_LIST && !filterDataAllDisabled,
             num: showNumber,
             allChecked: !leftContainesNotInSelected
         };
@@ -638,12 +648,13 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         }
         const selectedToken = locale.selected;
         const selectedText = selectedToken.replace('${total}', `${selectedData.length}`);
+        const hasValidSelected = selectedData.findIndex(item => !item.disabled) !== -1;
         const headerConfig = {
             totalContent: selectedText,
             allContent: locale.clear,
             onAllClick: () => this.foundation.handleClear(),
             type: 'right',
-            showButton: Boolean(selectedData.length),
+            showButton: Boolean(selectedData.length) && hasValidSelected,
             num: selectedData.length,
         };
         const headerCom = this.renderHeader(headerConfig);

--- a/packages/semi-ui/transfer/index.tsx
+++ b/packages/semi-ui/transfer/index.tsx
@@ -410,7 +410,7 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         // The selected option is 1,2,3,4, it is true
         // The selected option is 2,3,4, then it is false
         let filterDataAllDisabled = true;
-        const leftContainesNotInSelected = Boolean(filterData.find(f => {
+        const leftContainsNotInSelected = Boolean(filterData.find(f => {
             if (f.disabled) {
                 return false;
             } else {
@@ -425,12 +425,12 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
 
         const headerConfig: HeaderConfig = {
             totalContent: totalText,
-            allContent: leftContainesNotInSelected ? locale.selectAll : locale.clearSelectAll,
-            onAllClick: () => this.foundation.handleAll(leftContainesNotInSelected),
+            allContent: leftContainsNotInSelected ? locale.selectAll : locale.clearSelectAll,
+            onAllClick: () => this.foundation.handleAll(leftContainsNotInSelected),
             type: 'left',
             showButton: type !== strings.TYPE_TREE_TO_LIST && !filterDataAllDisabled,
             num: showNumber,
-            allChecked: !leftContainesNotInSelected
+            allChecked: !leftContainsNotInSelected
         };
         const inputCom = this.renderFilter(locale);
         const headerCom = this.renderHeader(headerConfig);
@@ -482,13 +482,13 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
             filterData,
             sourceData: data,
             propsDataSource: dataSource,
-            allChecked: !leftContainesNotInSelected,
+            allChecked: !leftContainsNotInSelected,
             showNumber,
             inputValue,
             selectedItems,
             value: values,
             onSelect: this.foundation.handleSelect.bind(this.foundation),
-            onAllClick: () => this.foundation.handleAll(leftContainesNotInSelected),
+            onAllClick: () => this.foundation.handleAll(leftContainsNotInSelected),
             onSearch: this.onInputChange,
             onSelectOrRemove: (item: ResolvedDataItem) => this.onSelectOrRemove(item),
         };


### PR DESCRIPTION
…nsfer are selected, the operation button should display Cancel all selections

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2575 
修改前：
![image](https://github.com/user-attachments/assets/94c8e6bd-7160-4c90-ac88-88aaf7e4ff6d)
修改后：
![image](https://github.com/user-attachments/assets/2baa8742-9c92-4c3e-8286-6783ab661423)

本PR修改带来的其他变化：
1. 当左侧全部为 disabled 时，左侧不会当显示全选/非全选按钮（因为disabled项目不可以通过操作选中）
2. 当右侧有选项，但是都为 disabled 时，右侧不会显示清空按钮（因为disable的项目无法被清空）

### Changelog
🇨🇳 Chinese
- Fix: 当 Transfer 的左侧面板中除去被禁用项外的其他项目都被选中时，操作按钮应当显示取消全选 #2575 

---

🇺🇸 English
- Fix: When all items except the disabled item in the left panel of transfer are selected, the operation button should display Cancel all selections #2575 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
