### PR TITLE
style: Fixed the style error when hovering the table header that can …

### DIFF
--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -145,7 +145,8 @@ $module: #{$prefix}-table;
                 &.#{$module}-row-head-clickSort {
                     cursor: pointer;
                     &:hover {
-                        background: $color-table_th-clickSort-bg-hover;
+                        background-image: linear-gradient(0deg, $color-table_th-clickSort-bg-hover, $color-table_th-clickSort-bg-hover);
+                        background-color: $color-table_cell-bg-hover;
                         
                         &.#{$module}-cell-fixed {
                             &-left,


### PR DESCRIPTION
…be clicked to trigger sorting

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
在 #2413 的 PR 中，对于支持点击表头触发排序的表头，添加了hover 时候的背景色，设置的颜色 token 是带有透明度的，当改列同时为固定列时候，则被固定列遮挡的内容会被透出来
![image](https://github.com/user-attachments/assets/b51acc80-c4e1-4cbb-b8cb-7bf8205ca83b)
修复后
![img_v3_02go_40a4e767-d8dd-46f9-8c2c-ccd293ab568g](https://github.com/user-attachments/assets/a2e10734-5567-4159-8aad-7e3f9f1ed0d7)
![img_v3_02go_713d1b12-d146-4784-8670-62d932f3142g](https://github.com/user-attachments/assets/79a909af-5802-4af4-9e9d-fcd7029089b5)




### Changelog
🇨🇳 Chinese
- Fix:  修复点击触发排序的表头会透出被遮盖的内容问题，影响版本 2.65.0-2.69.1

---

🇺🇸 English
- Fix: Fixed the problem that the covered content will be revealed in the table header that can be clicked to trigger sorting，Affected versions 2.65.0-2.69.1


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
