### PR TITLE
fix: [Typography] fix uncorrectly js truncation problem when width is…

### DIFF
--- a/packages/semi-ui/typography/_story/typography.stories.jsx
+++ b/packages/semi-ui/typography/_story/typography.stories.jsx
@@ -224,6 +224,20 @@ export const EllipsisSingle = () => (
       Web 应用。 区别于其他的设计系统而言，Semi Design
       以用户中心、内容优先、设计人性化为设计理念，具有四大优势。
     </Paragraph>
+    <br />
+    <div style={{ width: 300}} >
+      <Typography.Text
+        copyable={true}
+        link={{ href: '---' }}
+        ellipsis={{
+          showTooltip: {
+            opts: { content: '我是一个超长超长超长超长超长超长超长超长超长的链接' },
+          },
+        }}
+      >
+      我是一个超长超长超长超长超长超长超长超长超长的链接我是一个超长超长超长超长超长超长超长超长超长的链接
+      </Typography.Text>
+    </div>
   </div>
 );
 

--- a/packages/semi-ui/typography/util.tsx
+++ b/packages/semi-ui/typography/util.tsx
@@ -64,6 +64,11 @@ const getRenderText = (
     ellipsisContainer.setAttribute('style', originCSS);
     ellipsisContainer.style.position = 'fixed';
     ellipsisContainer.style.left = '0';
+    // 当 window.getComputedStyle 得到的 width 值为 auto 时，通过 getBoundingClientRect 得到准确宽度
+    // When the width value obtained by window.getComputedStyle is auto, get the exact width through getBoundingClientRect
+    if (originStyle.getPropertyValue('width') === 'auto') {
+        ellipsisContainer.style.width = `${originEle.offsetWidth}px`;
+    } 
     ellipsisContainer.style.height = 'auto';
     ellipsisContainer.style.top = '-999999px';
     ellipsisContainer.style.zIndex = '-1000';


### PR DESCRIPTION
… auto

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2591 

### Changelog
🇨🇳 Chinese
- Fix: 修复 js 省略 的Typography 未设置宽度时，省略计算错误问题 #2591 

---

🇺🇸 English
- Fix: Fixed the problem that the Typography component ellipsis calculation errors when it is in JS truncate and does not set the width #2591 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
