### PR TITLE
fix: Remove resize event listening in non-display state of Tooltip

### DIFF
--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -108,7 +108,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
         const { triggerEventSet, portalEventSet } = this._generateEvent(trigger);
         this._bindTriggerEvent(triggerEventSet);
         this._bindPortalEvent(portalEventSet);
-        this._bindResizeEvent();
+        // this._bindResizeEvent();
     }
 
     unBindEvent() {
@@ -191,7 +191,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
         }
     }
 
-    updateStateIfCursorOnTrigger = (trigger: HTMLElement)=>{
+    updateStateIfCursorOnTrigger = (trigger: HTMLElement) => {
         if (trigger?.matches?.(":hover")) {
             const eventNames = this._adapter.getEventName();
             const triggerEventSet = this.getState("triggerEventSet");

--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -108,7 +108,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
         const { triggerEventSet, portalEventSet } = this._generateEvent(trigger);
         this._bindTriggerEvent(triggerEventSet);
         this._bindPortalEvent(portalEventSet);
-        // this._bindResizeEvent();
+        this._bindResizeEvent();
     }
 
     unBindEvent() {
@@ -284,6 +284,10 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
     onResize = () => {
         // this.log('resize');
         // rePosition when window resize
+        const visible = this.getState('visible');
+        if (!visible) {
+            return;
+        }
         this.calcPosition();
     };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 对于非展示状态的 Tooltip，页面尺寸变化时不做位置计算

---

🇺🇸 English
- Fix: For invisible Tooltips, position calculation is not performed when resizing


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
