### PR TITLE
fix: Update the display logic of months in different years under type monthRange

### DIFF
--- a/cypress/e2e/datePicker.spec.js
+++ b/cypress/e2e/datePicker.spec.js
@@ -821,9 +821,9 @@ describe('DatePicker', () => {
         cy.get('.semi-datepicker .semi-input').eq(-1).click();
         cy.get('.semi-datepicker .semi-input-clearbtn').click();
         cy.get('.semi-scrolllist-item-sel').eq(0).contains(`${year}年`);
-        cy.get('.semi-scrolllist-item-sel').eq(2).contains(`${year}年`);
+        cy.get('.semi-scrolllist-item-sel').eq(2).contains(`${month+1 <= 12 ? year : year + 1}年`);
         cy.get('.semi-scrolllist-item-sel').eq(1).contains(`${month}月`);
-        cy.get('.semi-scrolllist-item-sel').eq(3).contains(`${month+1}月`);
+        cy.get('.semi-scrolllist-item-sel').eq(3).contains(`${month+1 <= 12 ? month+1 : 1}月`);
     });
 
     it('test split first inset input + dateTimeRange', () => {

--- a/packages/semi-foundation/datePicker/_utils/getYearAndMonth.ts
+++ b/packages/semi-foundation/datePicker/_utils/getYearAndMonth.ts
@@ -1,0 +1,12 @@
+export default function getYearAndMonth(year: { left: number; right: number }, month: { left: number; right: number }) {
+    const nowYear = new Date().getFullYear();
+    const nowMonth = new Date().getMonth();
+
+    const rightMonth = month.right || (nowMonth + 2);
+    const rightYear = year.right || (rightMonth <= 12 ? nowYear : nowYear + 1);
+
+    return {
+        year: { left: year.left || nowYear, right: rightYear },
+        month: { left: month.left || nowMonth + 1, right: rightMonth <= 12 ? rightMonth : 1 },
+    };
+}

--- a/packages/semi-foundation/datePicker/_utils/index.ts
+++ b/packages/semi-foundation/datePicker/_utils/index.ts
@@ -11,6 +11,7 @@ import getDefaultFormatToken from './getDefaultFormatToken';
 import getYears from './getYears';
 import getMonthsInYear from './getMonthsInYear';
 import getFullDateOffset from './getFullDateOffset';
+import getYearAndMonth from './getYearAndMonth';
 
 export {
     isAfter,
@@ -24,5 +25,6 @@ export {
     getDefaultFormatToken,
     getYears,
     getMonthsInYear,
-    getFullDateOffset
+    getFullDateOffset,
+    getYearAndMonth
 };

--- a/packages/semi-ui/datePicker/yearAndMonth.tsx
+++ b/packages/semi-ui/datePicker/yearAndMonth.tsx
@@ -63,6 +63,9 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
 
         let { currentYear, currentMonth } = props;
 
+        const rightMonth = currentMonth.right || (now.getMonth() + 2);
+        const rightYear = currentYear.right || (rightMonth <= 12 ? now.getFullYear() : now.getFullYear() + 1);
+
         this.state = {
             years: getYears(props.startYear, props.endYear).map(year => ({
                 value: year,
@@ -74,8 +77,10 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
                     value: idx + 1,
                     month: idx + 1,
                 })),
-            currentYear: { left: currentYear.left || now.getFullYear(), right: currentYear.right || now.getFullYear() },
-            currentMonth: { left: currentMonth.left || now.getMonth() + 1, right: currentMonth.right || now.getMonth() + 2 },
+            currentYear: { left: currentYear.left || now.getFullYear(), right: rightYear },
+            currentMonth: {
+                left: currentMonth.left || now.getMonth() + 1, right: rightMonth <= 12 ? rightMonth : 1
+            },
         };
 
         this.yearRef = React.createRef();
@@ -112,15 +117,18 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
 
     static getDerivedStateFromProps(props: YearAndMonthProps, state: YearAndMonthState) {
         const willUpdateStates: Partial<YearAndMonthState> = {};
+        const nowYear = new Date().getFullYear();
+        const nowMonth = new Date().getMonth();
+
+        const rightMonth = props.currentMonth.right || (nowMonth + 2);
+        const rightYear = props.currentYear.right || (rightMonth <= 12 ? nowYear : nowYear + 1);
 
         if (!isEqual(props.currentYear, state.currentYear)) {
-            const nowYear = new Date().getFullYear();
-            willUpdateStates.currentYear = { left: props.currentYear.left || nowYear, right: props.currentYear.right || nowYear };
+            willUpdateStates.currentYear = { left: props.currentYear.left || nowYear, right: rightYear };
         }
 
         if (!isEqual(props.currentMonth, state.currentMonth)) {
-            const nowMonth = new Date().getMonth();
-            willUpdateStates.currentMonth = { left: props.currentMonth.left || nowMonth + 1, right: props.currentMonth.right || nowMonth + 2 };
+            willUpdateStates.currentMonth = { left: props.currentMonth.left || nowMonth + 1, right: rightMonth <= 12 ? rightMonth : 1 };
         }
 
         return willUpdateStates;

--- a/packages/semi-ui/datePicker/yearAndMonth.tsx
+++ b/packages/semi-ui/datePicker/yearAndMonth.tsx
@@ -4,7 +4,7 @@ import YearAndMonthFoundation, { MonthScrollItem, YearAndMonthAdapter, YearAndMo
 import BaseComponent, { BaseProps } from '../_base/baseComponent';
 import ScrollList from '../scrollList/index';
 import ScrollItem from '../scrollList/scrollItem';
-import { getYears } from '@douyinfe/semi-foundation/datePicker/_utils/index';
+import { getYearAndMonth, getYears } from '@douyinfe/semi-foundation/datePicker/_utils/index';
 
 import IconButton from '../iconButton';
 import { IconChevronLeft } from '@douyinfe/semi-icons';
@@ -63,8 +63,7 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
 
         let { currentYear, currentMonth } = props;
 
-        const rightMonth = currentMonth.right || (now.getMonth() + 2);
-        const rightYear = currentYear.right || (rightMonth <= 12 ? now.getFullYear() : now.getFullYear() + 1);
+        const { year, month } = getYearAndMonth(currentYear, currentMonth);
 
         this.state = {
             years: getYears(props.startYear, props.endYear).map(year => ({
@@ -77,10 +76,8 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
                     value: idx + 1,
                     month: idx + 1,
                 })),
-            currentYear: { left: currentYear.left || now.getFullYear(), right: rightYear },
-            currentMonth: {
-                left: currentMonth.left || now.getMonth() + 1, right: rightMonth <= 12 ? rightMonth : 1
-            },
+            currentYear: year,
+            currentMonth: month,
         };
 
         this.yearRef = React.createRef();
@@ -117,18 +114,14 @@ class YearAndMonth extends BaseComponent<YearAndMonthProps, YearAndMonthState> {
 
     static getDerivedStateFromProps(props: YearAndMonthProps, state: YearAndMonthState) {
         const willUpdateStates: Partial<YearAndMonthState> = {};
-        const nowYear = new Date().getFullYear();
-        const nowMonth = new Date().getMonth();
-
-        const rightMonth = props.currentMonth.right || (nowMonth + 2);
-        const rightYear = props.currentYear.right || (rightMonth <= 12 ? nowYear : nowYear + 1);
+        const { year, month } = getYearAndMonth(props.currentYear, props.currentMonth);
 
         if (!isEqual(props.currentYear, state.currentYear)) {
-            willUpdateStates.currentYear = { left: props.currentYear.left || nowYear, right: rightYear };
+            willUpdateStates.currentYear = year;
         }
 
         if (!isEqual(props.currentMonth, state.currentMonth)) {
-            willUpdateStates.currentMonth = { left: props.currentMonth.left || nowMonth + 1, right: rightMonth <= 12 ? rightMonth : 1 };
+            willUpdateStates.currentMonth = month;
         }
 
         return willUpdateStates;


### PR DESCRIPTION


<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Datepicker 类型为 monthRange 时，面板默认选中的年月无法选中跨年情况

---

🇺🇸 English
- Fix: Fixed the issue that when the Datepicker type is monthRange, the default selected year and month in the panel cannot be selected across the year


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
