### PR TITLE
style: Fixed the issue where the timeline width is set to 100% and pa…

### DIFF
--- a/packages/semi-foundation/timeline/timeline.scss
+++ b/packages/semi-foundation/timeline/timeline.scss
@@ -7,6 +7,7 @@ $module: #{$prefix}-timeline;
     padding: $spacing-timeline-padding;
     width: $width-timeline;
     list-style: none;
+    box-sizing: border-box;
 
     &-item {
         position: relative;


### PR DESCRIPTION
…dding is set, causing the width to exceed the container

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
![image](https://github.com/user-attachments/assets/6cc9d14a-dfe4-4e30-8b45-63d740f879c0)


修复此问题有两种方法：
1. 删除 width: 100%的设置
2. 设置 box-sizing: border-box

选择解法 2 而不是解法 1 的原因是因为 width 的 token 已经提供给用户，允许设置

### Changelog
🇨🇳 Chinese
- Style: 修复 Timeline 因为宽度设置为 100% ，且有 padding ，导致宽度超出容器问题

---

🇺🇸 English
- Style: Fix the problem that the width of Timeline exceeds the container because the width is set to 100% and there is padding


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
