### PR TITLE
fix: Set the max-width of the img node of the image preview to none t…

### DIFF
--- a/packages/semi-foundation/image/image.scss
+++ b/packages/semi-foundation/image/image.scss
@@ -204,6 +204,12 @@ $module: #{$prefix}-image;
             // transition: transform $transition_duration-image_preview_image_img  $transition_delay-image_preview_image_img;
             z-index: 0;
             user-select: none;
+            /**
+             * In tailwind, the max-width of img/video is set to 100%, 
+             * which will affect the amplification effect of the picture.
+             * So we need to set max-width to none.
+            */
+            max-width: none;
         }
 
         &-spin {


### PR DESCRIPTION
…o avoid the influence of tailwind

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
![img_v3_02hf_ad508555-8f22-4917-8e31-66b67e229c5g](https://github.com/user-attachments/assets/2c166f7a-f85f-44ee-8072-b127207cca97)


### Changelog
🇨🇳 Chinese
- Fix: 设置图片预览的 img 节点的 max-width 为none，避免同时使用 tailwind 时放大显示错误问题

---

🇺🇸 English
- Fix: Set the max-width of the img node of the image preview to none to avoid enlargement display errors when using tailwind at the same time.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
