### PR TITLE
fix: [Collapsible] remove useless isEqual compare in componentDidUpdate

### DIFF
--- a/packages/semi-ui/collapsible/index.tsx
+++ b/packages/semi-ui/collapsible/index.tsx
@@ -9,7 +9,7 @@ import BaseComponent from "../_base/baseComponent";
 import PropTypes from "prop-types";
 import cls from "classnames";
 import { cssClasses } from "@douyinfe/semi-foundation/collapsible/constants";
-import { isEqual } from "lodash";
+import { isEqual, omit, pick } from "lodash";
 import "@douyinfe/semi-foundation/collapsible/collapsible.scss";
 import { getDefaultPropsFromGlobalConfig } from "../_utils";
 
@@ -123,8 +123,8 @@ class Collapsible extends BaseComponent<CollapsibleProps, CollapsibleState> {
     }
 
     componentDidUpdate(prevProps: Readonly<CollapsibleProps>, prevState: Readonly<CollapsibleState>, snapshot?: any) {
-        const changedPropKeys = Object.keys(this.props).filter(key => !isEqual(this.props[key], prevProps[key]));
-        const changedStateKeys = Object.keys(this.state).filter(key => !isEqual(this.state[key], prevState[key]));
+        const changedPropKeys = Object.keys(pick(this.props, ['reCalcKey', "isOpen"])).filter(key => !isEqual(this.props[key], prevProps[key]));
+        const changedStateKeys = Object.keys(pick(this.state, ['domInRenderTree'])).filter(key => !isEqual(this.state[key], prevState[key]));
         if (changedPropKeys.includes("reCalcKey")) {
             this.foundation.updateDOMHeight(this.domRef.current.scrollHeight);
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 去除 Collapsible 组件更新时多余的属性前后是否变化对比

---

🇺🇸 English
- Fix: Remove redundant calculations to determine whether the properties have changed when the Collapsible component is updated.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
