### PR TITLE
Feat: support grouped Options in Virtualized Select #2643

### DIFF
--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -3743,11 +3743,11 @@ export const FilterVirtualizedOptGroupSelect = () => {
       defaultOpen
       value={value}
       onChange={val => setValue(val)}
-      // virtualize={{
-      //   height: 300,
-      //   width: '100%',
-      //   itemSize: 36,
-      // }}
+      virtualize={{
+        height: 300,
+        width: '100%',
+        itemSize: 36,
+      }}
     >
       <Select.OptGroup label="Asia" virtualize>
         {asiaOptions.map(option => (

--- a/packages/semi-ui/select/_story/select.stories.jsx
+++ b/packages/semi-ui/select/_story/select.stories.jsx
@@ -2796,7 +2796,13 @@ const FilterDefaultOpen = () => {
         filter
         defaultOpen
       >
-        <Select.OptGroup label="Asia">
+        <Select.OptGroup label="Asia" virtualize={
+          {
+            height: 270,
+            width: '100%',
+            itemSize: 36,
+          }
+        }>
           <Select.Option value="a-1">China</Select.Option>
           <Select.Option value="a-2">Korea</Select.Option>
         </Select.OptGroup>
@@ -3710,3 +3716,70 @@ export const fix2465 = () => {
         </div>
     );
 }
+
+export const FilterVirtualizedOptGroupSelect = () => {
+  const [value, setValue] = useState('a-1');
+  
+  const asiaOptions = Array.from({ length: 50 }, (_, index) => ({
+    value: `a-${index + 1}`,
+    label: `Asia Country ${index + 1}`
+  }));
+
+  const europeOptions = Array.from({ length: 50 }, (_, index) => ({
+    value: `b-${index + 1}`,
+    label: `Europe Country ${index + 1}`
+  }));
+
+  const africaOptions = Array.from({ length: 50 }, (_, index) => ({
+    value: `c-${index + 1}`,
+    label: `Africa Country ${index + 1}`
+  }));
+
+  return (
+    <Select
+      placeholder="Select a country"
+      style={{ width: 300 }}
+      filter
+      defaultOpen
+      value={value}
+      onChange={val => setValue(val)}
+      // virtualize={{
+      //   height: 300,
+      //   width: '100%',
+      //   itemSize: 36,
+      // }}
+    >
+      <Select.OptGroup label="Asia" virtualize>
+        {asiaOptions.map(option => (
+          <Select.Option key={option.value} value={option.value}>
+            {option.label}
+          </Select.Option>
+        ))}
+      </Select.OptGroup>
+      <Select.OptGroup label="Europe" virtualize>
+        {europeOptions.map(option => (
+          <Select.Option key={option.value} value={option.value}>
+            {option.label}
+          </Select.Option>
+        ))}
+      </Select.OptGroup>
+      <Select.OptGroup label="Africa" virtualize> 
+        {africaOptions.map(option => (
+          <Select.Option key={option.value} value={option.value}>
+            {option.label}
+          </Select.Option>
+        ))}
+      </Select.OptGroup>
+    </Select>
+  );
+};
+
+FilterVirtualizedOptGroupSelect.story = {
+  name: '分组选择器虚拟化（1000个选项）',
+  parameters: {
+    info: {
+      title: '分组选择器虚拟化',
+      description: '测试OptGroup是否支持虚拟化'
+    }
+  }
+};

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -946,7 +946,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
             <List
                 ref={this.virtualizeListRef}
                 height={height || numbers.LIST_HEIGHT}
-                itemCount={visibleOptions.length}
+                itemCount={content.length}
                 itemSize={itemSize}
                 width={width || '100%'}
                 style={{ direction }}

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -182,14 +182,14 @@ export type SelectProps = {
     showRestTagsPopover?: boolean;
     restTagsPopoverProps?: PopoverProps
 } & Pick<
-TooltipProps,
-| 'spacing'
-| 'getPopupContainer'
-| 'motion'
-| 'autoAdjustOverflow'
-| 'mouseLeaveDelay'
-| 'mouseEnterDelay'
-| 'stopPropagation'
+    TooltipProps,
+    | 'spacing'
+    | 'getPopupContainer'
+    | 'motion'
+    | 'autoAdjustOverflow'
+    | 'mouseLeaveDelay'
+    | 'mouseEnterDelay'
+    | 'stopPropagation'
 > & React.RefAttributes<any>;
 
 export interface SelectState {
@@ -316,7 +316,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
     };
 
     static __SemiComponentName__ = "Select";
-    
+
     static defaultProps: Partial<SelectProps> = getDefaultPropsFromGlobalConfig(Select.__SemiComponentName__, {
         stopPropagation: true,
         motion: true,
@@ -751,7 +751,7 @@ class Select extends BaseComponent<SelectProps, SelectState> {
              * When searchPosition is trigger, the keyboard events are bound to the outer trigger div, so there is no need to listen in input.
              * When searchPosition is dropdown, the popup and the outer trigger div are not parent- child relationships,
              * and bubbles cannot occur, so onKeydown needs to be listened in input.
-             *  */ 
+             *  */
             onKeyDown: (e) => this.foundation._handleKeyDown(e)
         };
 
@@ -924,15 +924,47 @@ class Select extends BaseComponent<SelectProps, SelectState> {
         const { direction } = this.context;
         const { height, width, itemSize } = virtualize;
 
+        const content: any[] = [];
+
+        visibleOptions.forEach((option) => {
+            if (option._parentGroup && !content.some(item =>
+                item.type === OptionGroup &&
+                item.props.label === option._parentGroup.label
+            )) {
+                content.push(
+                    <OptionGroup
+                        key={`group-${option._parentGroup.label}`}
+                        {...option._parentGroup}
+                    />
+                );
+            }
+
+            content.push(option);
+        });
+
         return (
             <List
                 ref={this.virtualizeListRef}
                 height={height || numbers.LIST_HEIGHT}
                 itemCount={visibleOptions.length}
                 itemSize={itemSize}
-                itemData={{ visibleOptions, renderOption: this.renderOption }}
                 width={width || '100%'}
                 style={{ direction }}
+                itemData={{
+                    visibleOptions: content,
+                    renderOption: (option, index, style) => {
+                        if (option.type === OptionGroup) {
+                            return React.cloneElement(option, { style });
+                        }
+                        return this.renderOption(option, index, style);
+                    }
+                }}
+                itemKey={(index, data) => {
+                    const option = data.visibleOptions[index];
+                    return option.type === OptionGroup
+                        ? `group-${option.props.label}`
+                        : option.value;
+                }}
             >
                 {VirtualRow}
             </List>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
阅读了相关源码我认为问题本质是虚拟滚动和分组渲染的实现方式不兼容，我尝试修改了虚拟列表渲染的逻辑，增加了对于分组情况的支持。


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
