### PR TITLE
fix: Fixed the problem of JS omitting calculation error when display …

### DIFF
--- a/packages/semi-ui/typography/util.tsx
+++ b/packages/semi-ui/typography/util.tsx
@@ -66,7 +66,7 @@ const getRenderText = (
     ellipsisContainer.style.left = '0';
     // 当 window.getComputedStyle 得到的 width 值为 auto 时，通过 getBoundingClientRect 得到准确宽度
     // When the width value obtained by window.getComputedStyle is auto, get the exact width through getBoundingClientRect
-    if (originStyle.getPropertyValue('width') === 'auto') {
+    if (originStyle.getPropertyValue('width') === 'auto' && originEle.offsetWidth) {
         ellipsisContainer.style.width = `${originEle.offsetWidth}px`;
     } 
     ellipsisContainer.style.height = 'auto';


### PR DESCRIPTION
…is none

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
在 #2591 问题修复中，为了获取到 width 为 auto 的容器的实际高度，使用了 offsetWidth，但是当 display 为 none 时候，offsetWidth 将为 0，会导致 JS 缩略计算错误。

复现版本 2.72.0。复现代码
```
import React from 'react';
import { Tabs, TabPane, Typography } from '@douyinfe/semi-ui';
() => (
    <div>
        <Tabs>
            <TabPane tab="文档" itemKey="1">
                <Typography.Text copyable ellipsis>文档</Typography.Text>
            </TabPane>
            <TabPane tab="快速起步" itemKey="2">
                <Typography.Text copyable ellipsis>快速起步</Typography.Text>
            </TabPane>
            <TabPane tab="帮助" itemKey="3">
                <Typography.Text copyable ellipsis>帮助</Typography.Text>
            </TabPane>
        </Tabs>
    </div>
);
```
上述问题我们通常是建议用户使用 tabs 的 keepDOM={false} 来保证正确性。
在#2591 修改之前 ，表现是虽然无法计算出合理的截断，会显示更多行的数据内容。在#2591 修改之后，会出现只显示...的情况。因此在 width 为auto 的情况下，此次的修改为仅当 offsetWidth 非0 时候，才会将 offsetWidth 作为计算缩略的容器的 width 值。



### Changelog
🇨🇳 Chinese
- Fix: 修复在 display 为 none 时，Typography 的JS 省略计算错误问题 

---

🇺🇸 English
- Fix: Fixed the problem of Typography’s JS omitting calculation error when display is none


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
