### PR TITLE
fix: Fixed the issue in DragMove that after setting the handler, Drag…

### DIFF
--- a/packages/semi-foundation/dragMove/foundation.ts
+++ b/packages/semi-foundation/dragMove/foundation.ts
@@ -46,9 +46,21 @@ export default class DragMoveFoundation<P = Record<string, any>, S = Record<stri
         this.element = element;
         this.element.style.position = 'absolute';
         this.handler.style.cursor = 'move';
+        this._registerStartEvent();
+    }
+
+    _registerStartEvent = () => {
+        this.handler.addEventListener('mousedown', this.onMouseDown);
+        this.handler.addEventListener('touchstart', this.onTouchStart);
+    }
+
+    _unRegisterStartEvent = () => {
+        this.handler.removeEventListener('mousedown', this.onMouseDown);
+        this.handler.removeEventListener('touchstart', this.onTouchStart);
     }
 
     destroy() {
+        this._unRegisterStartEvent();
         this._unRegisterEvent();
     }
 

--- a/packages/semi-ui/dragMove/index.ts
+++ b/packages/semi-ui/dragMove/index.ts
@@ -130,20 +130,6 @@ export default class DragMove extends BaseComponent<DragMoveProps, null> {
                     ref.current = node;
                 }
             },
-            onMouseDown: (e: MouseEvent) => {
-                this.foundation.onMouseDown(e);
-                const { onMouseDown } = children.props;
-                if (typeof onMouseDown === 'function') {
-                    onMouseDown(e);
-                }
-            },
-            onTouchStart: (e: TouchEvent) => {
-                this.foundation.onTouchStart(e);
-                const { onMouseMove } = children.props;
-                if (typeof onMouseMove === 'function') {
-                    onMouseMove(e);
-                }
-            },
         });
         return newChildren;
     }


### PR DESCRIPTION
…Move child elements can still be dragged

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2661 

### Changelog
🇨🇳 Chinese
- Fix: 修复 DragMove 中设置 handler 后，DragMove 的子元素仍然可以被拖动问题 #2661 

---

🇺🇸 English
- Fix: Fixed the problem that after setting the handler in DragMove, the child elements of DragMove can still be dragged. #2661 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
