### PR TITLE
fix: fix iconButton lost keyframe when no spin component exist

### DIFF
--- a/packages/semi-foundation/button/iconButton.scss
+++ b/packages/semi-foundation/button/iconButton.scss
@@ -4,6 +4,14 @@
 $module: #{$prefix}-button;
 
 .#{$module} {
+    @keyframes #{$prefix}-animation-rotate {
+        from {
+            transform: rotate(0);
+        }
+        to {
+            transform: rotate(360deg);
+        }
+    }
     &.#{$module}-with-icon {
         display: inline-flex;
         align-items: center;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [X] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [X] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Button 在项目内不存在 Spin 组件时 Loading 的显示问题

---

🇺🇸 English
- Fix: Fixed the display problem of Loading when there is no Spin component in the Button project


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
