### PR TITLE
fix: [JsonViewer] Fix the judgment condition for whether to re-init.

### DIFF
--- a/packages/semi-ui/jsonViewer/index.tsx
+++ b/packages/semi-ui/jsonViewer/index.tsx
@@ -20,6 +20,7 @@ import {
     IconWholeWord,
 } from '@douyinfe/semi-icons';
 import BaseComponent, { BaseProps } from '../_base/baseComponent';
+import {isEqual} from "lodash";
 const prefixCls = cssClasses.PREFIX;
 
 export type { JsonViewerOptions };
@@ -81,7 +82,7 @@ class JsonViewerCom extends BaseComponent<JsonViewerProps, JsonViewerState> {
     }
 
     componentDidUpdate(prevProps: JsonViewerProps): void {
-        if (prevProps.options !== this.props.options) {
+        if (!isEqual(prevProps.options, this.props.options) || this.props.value !== prevProps.value) {
             this.foundation.jsonViewer.dispose();
             this.foundation.init();
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
prevProps.options !== this.props.options 这一行通常会返回 true，除非 options 属性引用的是同一个对象
加上value更新时重新init。
之前写法，恰好当其他属性比如value属性改变是也会重新init。

### Changelog
🇨🇳 Chinese
- Fix:  修复JsonViewer 是否重新init的判断条件

---

🇺🇸 English
- Fix: Fix JsonViewer the judgment condition for whether to re-init.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
