### PR TITLE
fix: list dataSouce is empty and loading show empty state

### DIFF
--- a/packages/semi-ui/list/__test__/list.test.js
+++ b/packages/semi-ui/list/__test__/list.test.js
@@ -261,4 +261,15 @@ describe('List', () => {
         ).toEqual('尾部');
         list.unmount();
     });
+
+
+    it('List show empty div when loading and dataSource is empty', () => {
+        const list = renderList({
+            dataSource: [],
+            loading: true
+        });
+        expect(list.exists(`.${BASE_CLASS_PREFIX}-list-empty`)).toEqual(true);
+        expect(list.exists(`.${BASE_CLASS_PREFIX}-spin-large`)).toEqual(true);
+        list.unmount();
+    });
 });

--- a/packages/semi-ui/list/index.tsx
+++ b/packages/semi-ui/list/index.tsx
@@ -152,8 +152,10 @@ class List<T = any> extends BaseComponent<ListProps<T>> {
                     })
                 );
             });
-        } else if (!children && !loading) {
-            childrenList = this.renderEmpty();
+        } else if (!children) {
+            childrenList = <Spin spinning={loading} size="large">
+                {this.renderEmpty()}
+            </Spin>;
         }
         return (
             <div className={wrapperCls} style={style} {...this.getDataAttr(rest)}>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes https://github.com/DouyinFE/semi-design/issues/2683

### Changelog
🇨🇳 Chinese
- Fix: 修复 List 组件 dataSource 为空时被 Spin 组件遮挡问题

---

🇺🇸 English
- Fix: Fix the issue where the List component's dataSource is empty and it is covered by the Spin component.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
