### PR TITLE
fix: [TreeSelect] Fix the typeError when closing the panel when searc…

### DIFF
--- a/packages/semi-foundation/tree/treeUtil.ts
+++ b/packages/semi-foundation/tree/treeUtil.ts
@@ -53,6 +53,9 @@ export function flattenTreeData(treeNodeList: any[], expandedKeys: Set<string>, 
     const filterSearch = Boolean(filteredShownKeys);
     const realKeyName = get(keyMaps, 'key', 'key');
     const realChildrenName = get(keyMaps, 'children', 'children');
+    if (isUndefined(treeNodeList)) {
+        return [];
+    }
     function flatten(list: any[], parent: any = null) {
         return list.map((treeNode, index) => {
             const pos = getPosition(parent ? parent.pos : '0', index);


### PR DESCRIPTION
…h is enabled and treeData is undefined

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #


### Changelog
🇨🇳 Chinese
- Fix: 修复 TreeSelect 在开启搜索并且 treeData 为 undefined 时，关闭面板时候的 TypeError

---

🇺🇸 English
- Fix: Fix the TypeError when closing the panel of the TreeSelect component when search is enabled and treeData is undefined


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
