### PR TITLE
fix: Modify the way to clear ellipsisContainer and removDDe the obsol…

### DIFF
--- a/packages/semi-ui/typography/util.tsx
+++ b/packages/semi-ui/typography/util.tsx
@@ -78,11 +78,8 @@ const getRenderText = (
     ellipsisContainer.style.textOverflow = 'clip';
     ellipsisContainer.style.webkitLineClamp = 'none';
 
-    // Render fake container
-    ReactDOM.render(
-        <></>,
-        ellipsisContainer
-    );
+    // Clear container content
+    ellipsisContainer.innerHTML = '';
 
     // Check if ellipsis in measure div is enough for content
     function inRange() {


### PR DESCRIPTION
…ete use of ReactDOM.render()

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2699 

### Changelog
🇨🇳 Chinese
- Fix: 去除 Typography 中过时 React 语法ReactDOM.render() 的使用，改为其他方式清空用于测试合适省略长度的容器 #2699 

---

🇺🇸 English
- Fix: Remove the use of the outdated React syntax ReactDOM.render() in Typography and use other methods to clear the container for testing the appropriate omitted length. #2699 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
