### PR TITLE
fix: pinCode number format IME issue in iOS

### DIFF
--- a/packages/semi-ui/pincode/index.tsx
+++ b/packages/semi-ui/pincode/index.tsx
@@ -103,13 +103,14 @@ class PinCode extends BaseComponent<PinCodeProps, PinCodeState> {
             ref={dom => this.inputDOMList[index] = dom}
             key={`input-${index}`}
             autoFocus={this.props.autoFocus && index === 0}
+            inputMode={this.props.format === "number" ? "numeric" : "text"}
             value={this.state.valueList[index]}
             size={this.props.size}
             disabled={this.props.disabled}
-            onBlur={()=>this.foundation.handleCurrentActiveIndexChange(index, "blur")}
-            onFocus={()=>this.foundation.handleCurrentActiveIndexChange(index, "focus")}
-            onPaste={e=>this.foundation.handlePaste(e.nativeEvent, index)}
-            onKeyDown={e=>{
+            onBlur={() => this.foundation.handleCurrentActiveIndexChange(index, "blur")}
+            onFocus={() => this.foundation.handleCurrentActiveIndexChange(index, "focus")}
+            onPaste={e => this.foundation.handlePaste(e.nativeEvent, index)}
+            onKeyDown={e => {
                 this.foundation.handleKeyDownOnSingleInput(e.nativeEvent, index);
             }}
             onChange={v => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 PinCode 组件 format='number' 情况下，iOS端输入被打断问题（输入一个数字后，自动从数字/字符键盘切换到字母键盘）

---

🇺🇸 English
- Fix: fix iOS input interruption in PinCode component with format='number' (switches from number/character to letter keyboard after input a digit)


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
Before:
![ScreenRecording_02-12-2025 00-55-32_1](https://github.com/user-attachments/assets/89723025-aad4-4e8f-a086-7c9f202ed9d8)

After:
![ScreenRecording_02-12-2025 00-56-27_1](https://github.com/user-attachments/assets/3f9d217f-f232-4c7c-9caa-a9d3318eb026)

