### PR TITLE
fix(datepicker): fixed chrome crashed bug by scrollList aria prop #2722

### DIFF
--- a/packages/semi-ui/scrollList/scrollItem.tsx
+++ b/packages/semi-ui/scrollList/scrollItem.tsx
@@ -446,8 +446,10 @@ export default class ScrollItem<T extends Item> extends BaseComponent<ScrollItem
                     key={prefixKey + index}
                     {...events}
                     className={cls}
+                    // eslint-disable-next-line jsx-a11y/role-has-required-aria-props
                     role="option"
-                    aria-selected={selected}
+                    // 
+                    // aria-selected={selected}
                     aria-disabled={item.disabled}
                 >
                     {text}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2722

### Changelog
🇨🇳 Chinese
- Fix: 修复 Chrome v133 版本无障碍 Bug 导致的点击 DatePicker 月份选择器后 Chrome 崩溃问题

---

🇺🇸 English
- Fix: Fixed the Chrome v133 accessibility bug that caused Chrome to crash after clicking the DatePicker month selector


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
