### PR TITLE
fix: MarkdownRender table duplicate column elements

### DIFF
--- a/packages/semi-ui/markdownRender/__test__/markdown.test.js
+++ b/packages/semi-ui/markdownRender/__test__/markdown.test.js
@@ -42,4 +42,62 @@ describe(`MarkdownRender`, () => {
         expect(render.exists(`.${BASE_CLASS_PREFIX}-table-thead`)).toEqual(true);
         expect(render.exists(`.${BASE_CLASS_PREFIX}-table-tbody`)).toEqual(true);
     });
+
+    it(`test table with bold header`, async () => {
+        const content = `
+        | Name | **Brand** | Count | **Price** |
+        | - | :- | -: | :-: |
+        | Book | Semi | 10 | ￥100 |
+        | Pen | Semi Design | 20 | ￥200 |
+        `;
+
+        const render = mount(
+            <MarkdownRender raw={content} />
+        );
+
+        // check if has table container
+        expect(render.exists(`.${BASE_CLASS_PREFIX}-table-container`)).toEqual(true);
+        // check if has table head & body
+        expect(render.exists(`.${BASE_CLASS_PREFIX}-table-thead`)).toEqual(true);
+        expect(render.exists(`.${BASE_CLASS_PREFIX}-table-tbody`)).toEqual(true);
+        // check has row is two
+        expect(render.find(`.${BASE_CLASS_PREFIX}-table-tbody .${BASE_CLASS_PREFIX}-table-row`).length).toBe(2);
+        // exist 'Semi Design' text
+        expect(render.contains('Semi Design')).toEqual(true);
+        // exist 'Semi' text
+        expect(render.contains('Semi')).toEqual(true);
+        // exist '￥100' text
+        expect(render.contains('￥100')).toEqual(true);
+        // exist '￥200' text
+        expect(render.contains('￥200')).toEqual(true);
+    });
+
+    it(`test table with bold and component header`, async () => {
+        const content = `
+        | Name | <h1>Brand</h1> | Count | **Price** |
+        | - | :- | -: | :-: |
+        | Book | Semi | 10 | ￥100 |
+        | Pen | Semi Design | 20 | ￥200 |
+        `;
+
+        const render = mount(
+            <MarkdownRender raw={content} format="mdx"/>
+        );
+
+        // check if has table container
+        expect(render.exists(`.${BASE_CLASS_PREFIX}-table-container`)).toEqual(true);
+        // check if has table head & body
+        expect(render.exists(`.${BASE_CLASS_PREFIX}-table-thead`)).toEqual(true);
+        expect(render.exists(`.${BASE_CLASS_PREFIX}-table-tbody`)).toEqual(true);
+        // check has row is two
+        expect(render.find(`.${BASE_CLASS_PREFIX}-table-tbody .${BASE_CLASS_PREFIX}-table-row`).length).toBe(2);
+        // exist 'Semi Design' text
+        expect(render.contains('Semi Design')).toEqual(true);
+        // exist 'Semi' text
+        expect(render.contains('Semi')).toEqual(true);
+        // exist '￥100' text
+        expect(render.contains('￥100')).toEqual(true);
+        // exist '￥200' text
+        expect(render.contains('￥200')).toEqual(true);
+    });
 });

--- a/packages/semi-ui/markdownRender/_story/markdownRender.stories.jsx
+++ b/packages/semi-ui/markdownRender/_story/markdownRender.stories.jsx
@@ -35,6 +35,39 @@ export const Table = ()=>{
     `} components={semiComponents}/>
 }
 
+export const TableWithBoldHeader = ()=>{
+    return <MarkdownRender raw={`
+| a | **b**  |  c |  **d**  |
+| - | :- | -: | :-: |
+| 1 | 2 | 3 | 4 |
+| 11 | 22 | 33 | 44 |
+| 111 | 222 | 333 | 444 |
+| 1111 | 2222 | 3333 | 4444 |
+    `} components={semiComponents}/>
+}
+
+export const TableWithComponentHeader = ()=>{
+    return <MarkdownRender raw={`
+| a | <h1>b</h1>  |  c |  **d**  |
+| - | :- | -: | :-: |
+| 1 | 2 | 3 | 4 |
+| 11 | 22 | 33 | 44 |
+| 111 | 222 | 333 | 444 |
+| 1111 | 2222 | 3333 | 4444 |
+    `} components={semiComponents} format="mdx"/>
+}
+
+export const TableWithComponent = ()=>{
+    return <MarkdownRender raw={`
+| a | <h1>b</h1>  |  c |  **d**  |
+| - | :- | -: | :-: |
+| 1 | 2 | 3 | 4 |
+| 11 | <h4>22</h4> | <h3>33</h3> | <h2>44</h2> |
+| <h3>111</h3> | ![Semi Design](https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/root-web-sites/colorful.jpg) | 333 | <h2>444</h2> |
+| 1111 | 2222 | 3333 | 4444 |
+    `} components={semiComponents} format="mdx"/>
+}
+
 export const WithSymbol = ()=>{
     return <MarkdownRender raw={`
 test \\\\{ cxode } test

--- a/packages/semi-ui/markdownRender/components/table.tsx
+++ b/packages/semi-ui/markdownRender/components/table.tsx
@@ -13,25 +13,24 @@ const table = (props: PropsWithChildren<TableProps>) => {
     const columnsFiber = toArray(get(children[0], 'props.children.props.children'));
     const dataFiber = toArray(get(children[1], 'props.children'));
 
-    const titles: string[] = columnsFiber.map(item => item?.props?.children || "");
+    const titlesColumns = columnsFiber.map((column, i) => {
+        return {
+            dataIndex: String(i),
+            title: column?.props?.children || ""
+        };
+    });
     const tableDataSource: any[] = [];
     for (let i = 0;i < dataFiber.length;i++) {
         let item: Record<string, string> = {
             key: String(i)
         };
         dataFiber[i]?.props.children?.forEach?.((child, index) => {
-            item[titles[index]] = child?.props?.children ?? "";
+            item[String(index)] = child?.props?.children ?? "";
         });
         tableDataSource.push(item);
     }
 
-
-    return <Table dataSource={tableDataSource} columns={titles.map(title => {
-        return {
-            title,
-            dataIndex: title
-        };
-    })} {...omit(props, 'children')}/>;
+    return <Table dataSource={tableDataSource} columns={titlesColumns} {...omit(props, 'children')}/>;
 };
 
 export default table;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [√] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # MarkdownRender table duplicate column elements

- when header containing more than two components or bold texts

### Changelog
🇨🇳 Chinese
- Fix: 修复了当MarkdownRender中的默认表格table，使用JSX组件的标题 或 标题使用加粗，数量≥2，会出现后面列覆盖前面列的情况。


---

🇺🇸 English
- Fix: fix MarkdownRender table duplicate column elements when header containing more than two components or bold texts


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

issue：https://github.com/DouyinFE/semi-design/issues/2716


问题分析解决见飞书文档：https://byte-lan.feishu.cn/docx/B6YPdkeTSoboxHxCzRucYlLFn3f


<!-- You can provide screenshot/video or some additional information -->
