### PR TITLE
fix: type define miss promise of formProps.validateFields

### DIFF
--- a/packages/semi-ui/form/_story/form.stories.tsx
+++ b/packages/semi-ui/form/_story/form.stories.tsx
@@ -167,6 +167,7 @@ class Demo extends React.Component<IProps, IState> {
     constructor(props:any) {
       super(props);
       this.state = { visible: false};
+      this.asyncValidateFields = this.asyncValidateFields.bind(this);
     }
 
     getFormApi(formApi) {
@@ -196,6 +197,20 @@ class Demo extends React.Component<IProps, IState> {
         let c = formApi.getValue('test4.notExist');
     }
 
+    asyncValidateFields(values) {
+        const sleep = ms => new Promise(resolve => setTimeout(resolve, ms));
+        return sleep(2000).then(() => {
+            let errors = {} as Record<string, any>;
+            if (values.name !== 'mike') {
+                errors.name = 'you must name mike';
+            }
+            if (values.sex !== 'female') {
+                errors.sex = 'sex not valid';
+            }
+            return errors;
+        });
+    }
+
     render() {
       const { visible } = this.state;
       return (
@@ -204,7 +219,8 @@ class Demo extends React.Component<IProps, IState> {
             getFormApi={this.getFormApi}
             onSubmit={values => console.log(values.test2)}
             onChange={formState => formState.values.test}
-            validateFields={values => ({ test4: 'test4 empty', test2: '' }) }
+            validateFields={this.asyncValidateFields}
+            // validateFields={values => ({ test4: 'test4 empty', test2: '', fieldNotExist: 'xx' }) }
         >
           </Form>
         </>

--- a/packages/semi-ui/form/interface.ts
+++ b/packages/semi-ui/form/interface.ts
@@ -97,6 +97,8 @@ export interface FormFCChild<K extends Record<string, any> = any> {
 }
 
 
+type BatchValidateResult<Values> = string | Partial<AllErrors<Values>>
+
 export interface BaseFormProps <Values extends Record<string, any> = any> extends Omit<React.FormHTMLAttributes<HTMLFormElement>, 'children' | 'onChange' | 'onSubmit' | 'onReset'> {
     'aria-label'?: React.AriaAttributes['aria-label'];
     onSubmit?: (values: Values, e?: React.FormEvent<HTMLFormElement>) => void;
@@ -106,7 +108,7 @@ export interface BaseFormProps <Values extends Record<string, any> = any> extend
     onErrorChange?: (errors: Record<keyof Values, FieldError>, changedError?: Partial<Record<keyof Values, FieldError>>) => void;
     onChange?: (formState: FormState<Values>) => void;
     allowEmpty?: boolean;
-    validateFields?: (values: Values) => string | Partial<AllErrors<Values>>;
+    validateFields?: (values: Values) => BatchValidateResult<Values> | Promise<BatchValidateResult<Values>>;
     /** Use this if you want to populate the form with initial values. */
     initValues?: Values;
     id?: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [ ] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description


### Changelog
🇨🇳 Chinese
- Fix: 修复 Form validateFields 类型定义不支持 promise 的问题

---

🇺🇸 English
- Fix: Fixed the problem that the type definition of Form validateFields does not support return promise.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
