### PR TITLE
fix: Fixed the issue that markdownRenderProps did not take effect whe…

### DIFF
--- a/packages/semi-ui/chat/chatBox/chatBoxContent.tsx
+++ b/packages/semi-ui/chat/chatBox/chatBoxContent.tsx
@@ -1,7 +1,7 @@
 import React, { ReactElement, ReactNode, useMemo } from 'react';
 import cls from 'classnames';
-import { Message, Metadata, RenderContentProps } from '../interface';
-import MarkdownRender, { MarkdownRenderProps } from '../../markdownRender';
+import { Message, Metadata, RenderContentProps, MarkdownRenderProps } from '../interface';
+import MarkdownRender from '../../markdownRender';
 import { cssClasses, strings } from '@douyinfe/semi-foundation/chat/constants';
 import { MDXProps } from 'mdx/types';
 import { FileAttachment, ImageAttachment } from '../attachment';
@@ -17,7 +17,7 @@ interface ChatBoxContentProps {
     role?: Metadata;
     message?: Message;
     customRenderFunc?: (props: RenderContentProps) => ReactNode;
-    markdownRenderProps?: MarkdownRenderProps;
+    markdownRenderProps?: MarkdownRenderProps
 }
 
 const ChatBoxContent = (props: ChatBoxContentProps) => {
@@ -64,6 +64,7 @@ const ChatBoxContent = (props: ChatBoxContentProps) => {
                             format='md'
                             raw={item.text}
                             components={markdownComponents as any}
+                            {...markdownRenderProps}
                         />;
                     } else if (item.type === 'image_url') {
                         return <ImageAttachment key={`index`} src={item.image_url.url} />;

--- a/packages/semi-ui/chat/interface.ts
+++ b/packages/semi-ui/chat/interface.ts
@@ -4,7 +4,9 @@ import { Upload } from '../index';
 import type { FileItem, UploadProps } from '../upload';
 import { EnableUploadProps, Message } from '@douyinfe/semi-foundation/chat/foundation';
 import type { TooltipProps } from '../tooltip';
-import { MarkdownRenderProps } from '../markdownRender';
+import { MarkdownRenderProps as OriginMarkdownRenderProps } from '../markdownRender';
+
+export type MarkdownRenderProps = Partial<OriginMarkdownRenderProps>;
 
 export { Message };
 export interface CommonChatsProps {


### PR DESCRIPTION
…n parsing text in Chat when the content of the message is an array

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 Chat 组件在解析消息的 content 为数组的文本内容时， markdownRenderProps 未生效问题

---

🇺🇸 English
- Fix: Fixed the issue that markdownRenderProps did not take effect when parsing text in Chat when the content of the message is an array


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
