### PR TITLE
style: [ScrollList] add overflow hidden for the outer layer

### DIFF
--- a/packages/semi-foundation/scrollList/scrollList.scss
+++ b/packages/semi-foundation/scrollList/scrollList.scss
@@ -12,7 +12,7 @@ $module: #{$prefix}-scrolllist;
     background: $color-scrollList-bg;
     box-shadow: $shadow-scrollList;
     border-radius: $radius-scrollList;
-
+    overflow: hidden;
     @include font-size-regular;
     user-select: none;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

<strong>问题</strong>
用户反馈在主题配置的时候，有以下问题：
当 timePicker 下拉面板中的 x 方向的 padding 为 0 时候，被选中的/hover 的块在边缘会有颜色透出
![image](https://github.com/user-attachments/assets/f644c8ff-4671-4e21-aa78-0c7463fca458)

<strong>原因</strong>
TimePicker 的下拉面板中的内容使用的是 scrollList， scrollList 的的最外层有设置 border-radius，但是无 overflow 相关的设置，因此添加 overflow: hidden 放置内容透出。

<strong>影响面考虑</strong>
对于 scrollList 来说，结构是 header，body， footer，从使用上来说，是希望三者不需要通过滚动条来调节是否显示，滚动区域应该只出现在 body 部分。因此认为增加 overflow：hidden 是合理的



### Changelog
🇨🇳 Chinese
- Style: ScrollList 最外层增加 overflow: hidden 的样式设置

---

🇺🇸 English
- Fix: Add overflow: hidden style setting to the outermost layer of ScrollList


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
