### PR TITLE
fix: Fixed the display problem of cascader with single selection, con…

### DIFF
--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -242,7 +242,7 @@ export interface CascaderAdapter extends DefaultAdapter<BasicCascaderProps, Basi
     updateLoadedKeyRefValue: (keys: Set<string>) => void;
     getLoadedKeyRefValue: () => Set<string>;
     setEmptyContentMinWidth: (minWidth: number) => void;
-    getTriggerWidth: () => number;
+    getTriggerWidth: () => number
 }
 
 export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, BasicCascaderProps, BasicCascaderInnerData> {
@@ -521,7 +521,7 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
             }
             keyEntities[key] = optionNotExist as BasicEntity;
             // Fix: 1155, if the data is loaded asynchronously to update treeData, the emptying operation should not be done when entering the updateSelectedKey method
-        } else if (loading) {
+        } else if (loading || loadingKeys?.size) {
             // Use assign to avoid overwriting the'not-exist- * 'property of keyEntities after asynchronous loading
             // Overwriting'not-exist- * 'will cause selectionContent to be emptied unexpectedly when clicking on a dropDown item
             updateStates.keyEntities = assign(keyEntityState, keyEntities);

--- a/packages/semi-ui/cascader/_story/cascader.stories.jsx
+++ b/packages/semi-ui/cascader/_story/cascader.stories.jsx
@@ -2518,3 +2518,99 @@ export const PrefixSuffix = () => {
     </>
   )
 }
+
+export const Fixed2831 = () => {
+    const [value, setValue] = useState(undefined);
+    const [productAndBusinessData, setProductAndBusinessData] = useState([
+        {
+        label: 'TCS Manager',
+        value: 'TCS Manager',
+        children: [
+            {
+            label: '0',
+            value: '0',
+            },
+            {
+            label: '1',
+            value: '1',
+            },
+            {
+            label: '2',
+            value: '2',
+            },
+            {
+            label: '3',
+            value: '3',
+            },
+        ],
+        },
+        {
+        label: 'AAA Manager',
+        value: 'AAA Manager',
+        children: [
+            {
+            label: '4',
+            value: '4',
+            },
+            {
+            label: '5',
+            value: '5',
+            },
+            {
+            label: '6',
+            value: '6',
+            },
+            {
+            label: '7',
+            value: '7',
+            },
+        ],
+        },
+    ]);
+    return (
+        <Cascader
+            value={value}
+            field="ss"
+            placeholder={('tcs_manager_business_info')}
+            treeData={productAndBusinessData}
+            showNext="hover"
+            changeOnSelect
+            showClear
+            autoAdjustOverflow={false}
+            onChange={(value) => {setValue(value)}}
+            loadData={selectedOpt => {
+                if (!selectedOpt) {
+                return Promise.resolve();
+                }
+                const targetOpt = selectedOpt[selectedOpt.length - 1];
+                const { value } = targetOpt;
+                if (!value) {
+                return Promise.resolve();
+                }
+                return new Promise( (res) => {
+                    setTimeout(() => {
+                        setProductAndBusinessData(origin => {
+                        const newData = origin.map(i => {
+                        const children = (i.children || []).map((j, jIndex) => {
+                            if (j.children || j.value !== value) {
+                            return { ...j };
+                            }
+                            const subChildren = Array.from({ length: 5 }).map((i, index) => ({
+                            label: jIndex + '' + index,
+                            value: jIndex + '' + index,
+                            disabled: false,
+                            isLeaf: true,
+                            }));
+                            return { ...j, children: subChildren };
+                        });
+                        return { ...i, children };
+                        });
+                        return newData;
+                    });
+                        res();
+                    }, 2000);
+                });
+            }}
+            />
+    );
+}


### PR DESCRIPTION
…trolled value and value undefined, asynchronous loading, and showNext set to hover when loading multiple projects at the same time

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2831

问题分析：
在异步加载时候，在 foundation 中，会走 `collectOptions()` -> `updateSelectedKey()` ,由于同时加载多个，在第一个加载结束后， 先走 `updateSelectedKey()`, 此时 state 中的 loading 为 true，因此会走 loading 为 true 的条件。然后走 index.ts 中 `loading 为 false`的 设置。那么在第二个加载结束后，此时的 loading 为 false，因此会进入到最后一个条件中，清空了展开相关的 activeKeys

### Changelog
🇨🇳 Chinese
- Fix: 修复单选，受控 value且 value 为undefined，异步加载，showNext 为 hover 的 cascader 在同时加载多个项目时的显示问题 #2831 

---

🇺🇸 English
- Fix: Fixed the display problem of cascader with single selection, controlled value and value undefined, asynchronous loading, and showNext set to hover when loading multiple projects at the same time. #2831 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
