### PR TITLE
fix: Modify the timing of getting position of container in tooltip to…

### DIFF
--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -92,7 +92,6 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
         this._mounted = true;
         this._bindEvent();
         this._shouldShow();
-        this._initContainerPosition();
         if (!wrapperId) {
             this._adapter.setId();
         }
@@ -316,6 +315,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
     };
 
     show = () => {
+        this._initContainerPosition();
         if (this._adapter.getAnimatingState()) {
             return;
         }
@@ -1134,6 +1134,9 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
     }
 
     _initContainerPosition() {
+        if (this._adapter.getContainerPosition() || !this._adapter.containerIsBody()) {
+            return;
+        }
         this._adapter.updateContainerPosition();
     }
 

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -431,6 +431,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             updateContainerPosition: () => {
                 const positionInBody = document.body.getAttribute('data-position');
                 if (positionInBody) {
+                    this.containerPosition = positionInBody;
                     return;
                 }
                 requestAnimationFrame(() => {

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -429,13 +429,20 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             },
             canMotion: () => Boolean(this.props.motion),
             updateContainerPosition: () => {
-                const container = this.getPopupContainer();
-                if (container && isHTMLElement(container)) {
-                    // getComputedStyle need first parameter is Element type
-                    const computedStyle = window.getComputedStyle(container);
-                    const position = computedStyle.getPropertyValue('position');
-                    this.containerPosition = position;
+                const positionInBody = document.body.getAttribute('data-position');
+                if (positionInBody) {
+                    return;
                 }
+                requestAnimationFrame(() => {
+                    const container = this.getPopupContainer();
+                    if (container && isHTMLElement(container)) {
+                        // getComputedStyle need first parameter is Element type
+                        const computedStyle = window.getComputedStyle(container);
+                        const position = computedStyle.getPropertyValue('position');
+                        document.body.setAttribute('data-position', position);
+                        this.containerPosition = position;
+                    }
+                });
             },
             getContainerPosition: () => this.containerPosition,
             getContainer: () => this.containerEl && this.containerEl.current,


### PR DESCRIPTION
… improve the performance of the style during initialization

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
**问题表现**
复杂页面，页面初始化时候，performance 性能面板上有 Tooltip 的 updateContainerPosition 有较长的 recalculate style 耗时。

**问题原因**
updateContainerPosition 中有 window.getComputedStyle 的调用，会触发样式的重新计算，如果在执行此语句之前后未更新的样式，则会执行较长时间。

**问题修改**
1. 时机从 init 节点移动到触发显示截断（foudation 的show 函数）
updateContainerPosition 是为了获取 container 的 position，用于弹出层的样式计算。因此可以将时机修改到 show 函数中

2. 在 foundation 的_initContainerPosition中增加容器是否为 body 的计算，如果不是，则无需调用 updateContainerPosition
因为保存 container 的 position 是为了解决容器为 body 时的一些特殊的case，因此，如果容器不是 body，则无需计算。

3. 在 updateContainerPosition 中将 position 的值保存到 body 的 data 属性中，让其他tooltip 的实例可通过data 属性获取 position， 无需通过 window.getComputedStyle 得到

### Changelog
🇨🇳 Chinese
- Fix: 修改 Tooltip 中获取 container 的 position 时机，提升组件初始化的性能

---

🇺🇸 English
- Fix: Modify the timing of getting the container's position in Tooltip to improve the performance of component initialization


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
