### PR TITLE
style: Adjust the height of the input-wrapper layer in the range type…

### DIFF
--- a/packages/semi-foundation/datePicker/datePicker.scss
+++ b/packages/semi-foundation/datePicker/datePicker.scss
@@ -934,6 +934,7 @@ $module-list: #{$prefix}-scrolllist;
 
                 .#{$prefix}-input-wrapper {
                     background-color: transparent;
+                    height: fit-content;
                     border: none;
                 }
 


### PR DESCRIPTION
… DatePicker

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #
***问题表现***
设计反馈，range 类型的 DatePicker 文本没有居中，
![image](https://github.com/user-attachments/assets/eccd3217-b308-4341-8bf9-7ecb2331fb64)

***问题原因***
range 类型的 DatePicker 的中的 input 的尺寸都是 small 尺寸的 Input 组件
input 元素层的高度是 22（18 height + 2 padding-top + 2 padding- bottom）
input-wrapper 层的高度受到input 层的元素控制，设置是 24，在 Input 组件中可以通过  input 元素高度 + 上 border + 下 border = 22 + 1 + 1 = 24，和高度设置一致，让元素居中，但在 DatePicker 中border被设置为了 none，因此高度上多出 2px，内容没有居中。

***修复思路***
input-wrapper 层级的高度设置为 fit-content，和内部的 input 元素保持一致，因为 input-wrapper的外层为 flex 布局，垂直方向居中，因此可以保证内容居中

修改后：
![image](https://github.com/user-attachments/assets/6be02a5d-61f3-424e-ab0d-43b04574d4d7)




### Changelog
🇨🇳 Chinese
- Style: 调整 range 类型的DatePicker 中 input-wrapper 层的高度, 让内容居中

---

🇺🇸 English
- Style: Adjust the height of the input-wrapper layer in the range type DatePicker to center the content


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
