### PR TITLE
style: In range DatePicker, increase input priority on hover/active s…

### DIFF
--- a/packages/semi-foundation/datePicker/datePicker.scss
+++ b/packages/semi-foundation/datePicker/datePicker.scss
@@ -936,6 +936,14 @@ $module-list: #{$prefix}-scrolllist;
                     background-color: transparent;
                     height: fit-content;
                     border: none;
+
+                    &:active  {
+                        background-color: transparent;
+                    }
+
+                    &:hover {
+                        background-color: transparent;
+                    }
                 }
 
                 &-focus {


### PR DESCRIPTION
…tate

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

***问题原因***
范围类型的 DatePicker，使用了 Input 元素做为输入，在 hover/active 状态下，和背景色相关的两组选择器：
.semi-datepicker-range-input-wrapper .semi-input-wrapper （在 datePicker.scss 中）
.semi-input-wrapper-focus:active 或者 .semi-input-wrapper:hover 在 input.scss中）
优先级一致，因此生效会和顺序有关系
![image](https://github.com/user-attachments/assets/a20a1c84-4d3f-4f44-9287-2ecbcdf2ce12)
用户页面中编译后的顺序不同，导致样式不符合预期
![image](https://github.com/user-attachments/assets/6a219174-6b0e-49a1-884e-1c82b023c78c)

***修复思路***
在 datePicker 中增加 :hover, :active 时候的颜色设置

### Changelog
🇨🇳 Chinese
- Style: 对于范围类型的 DatePicker，增加其中设置的 hover/active 状态下的 input 背景色的优先级

---

🇺🇸 English
- Style: For range-type DatePicker, increase the priority of the input background color set in the hover/active state


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
