### PR TITLE
style: add $color-button_disabled_outline_text-default for disabled o…

### DIFF
--- a/packages/semi-foundation/button/button.scss
+++ b/packages/semi-foundation/button/button.scss
@@ -251,13 +251,17 @@ $module: #{$prefix}-button;
         color: $color-button_disabled_solid-text-default;
         cursor: not-allowed;
 
-        &:not(.#{$module}-borderless):not(.#{$module}-light):hover {
+        &:not(.#{$module}-borderless):not(.#{$module}-light):not(.#{$module}-outline):hover {
             color: $color-button_disabled-text-hover;
         }
 
         &.#{$module}-light,
         &.#{$module}-borderless {
             color: $color-button_disabled-text-default;
+        }
+
+        &.#{$module}-outline {
+            color: $color-button_disabled_outline_text-default;
         }
     }
 

--- a/packages/semi-foundation/button/variables.scss
+++ b/packages/semi-foundation/button/variables.scss
@@ -80,10 +80,11 @@ $color-button_tertiary_outline-border-default: var(--semi-color-border); // 边�
 $color-button_tertiary_solid-text-default: var(--semi-color-text-1); // 浅色第三按钮文字颜色
 
 // disabled
-$color-button_disabled_solid-text-default: var(--semi-color-disabled-text); // 禁用按钮文字颜色
-$color-button_disabled-text-default: var(--semi-color-disabled-text); // 禁用按钮文字颜色
+$color-button_disabled_solid-text-default: var(--semi-color-disabled-text); // 禁用按钮文字颜色 - 深色主题
+$color-button_disabled-text-default: var(--semi-color-disabled-text); // 禁用按钮文字颜色 - 浅色主题或无背景
+$color-button_disabled_outline_text-default: var(--semi-color-disabled-text); // 禁用按钮文字颜色 - 边框模式
 $color-button_disabled-bg-default: var(--semi-color-disabled-bg); // 禁用按钮背景颜色
-$color-button_disabled-text-hover: $color-button_disabled-text-default; // 禁用按钮文字颜色 - 悬浮
+$color-button_disabled-text-hover: $color-button_disabled-text-default; // 禁用按钮文字颜色 - 深色主题 - 悬浮
 $color-button_disabled-bg-hover: var(--semi-color-disabled-bg); // 禁用按钮背景颜色 - 悬浮
 $color-button_disabled_primary-bg-default: $color-button_disabled-bg-default; // 禁用 primary 按钮背景颜色
 $color-button_disabled_secondary-bg-default: $color-button_disabled-bg-default; // 禁用 secondary 按钮背景颜色


### PR DESCRIPTION
…utline button

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2861 

### Changelog
🇨🇳 Chinese
- Style: 增加 $color-button_disabled_outline_text-default 用于设置边框模式的 Button 的禁用状态文字颜色 #2861 

---

🇺🇸 English
- Style: Add $color-button_disabled_outline_text-default to set the disabled state text color of Button in outline mode #2861 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
