### PR TITLE
fix: convert item.value to item.month to ensure that the datepicker can compare the correct numbers instead of letters in monthRange

### DIFF
--- a/packages/semi-foundation/datePicker/yearAndMonthFoundation.ts
+++ b/packages/semi-foundation/datePicker/yearAndMonthFoundation.ts
@@ -106,7 +106,7 @@ export default class YearAndMonthFoundation extends BaseFoundation<YearAndMonthA
         month[panelType] = item.month;
 
         // Make sure the time on the right panel is always greater than or equal to the time on the left panel
-        if (type === 'monthRange' && panelType === left && currentYear[left] === currentYear[right] && item.value > month[right]) {
+        if (type === 'monthRange' && panelType === left && currentYear[left] === currentYear[right] && item.month > month[right]) {
             month[right] = item.month ;
         } 
 

--- a/packages/semi-ui/locale/_story/locale.stories.jsx
+++ b/packages/semi-ui/locale/_story/locale.stories.jsx
@@ -174,6 +174,9 @@ const I18nComponent = () => {
                 <p>More content...</p>
             </Modal>
             <div>
+                <DatePicker type="monthRange" onChange={(date, dateString) => console.log(dateString)} />
+            </div>
+            <div>
               <DatePicker style={{ ...style, width: 200 }} open defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
               <DatePicker style={{ ...style,marginLeft:120, width: 250 }} open type="dateTime" presets={presets} presetPosition="left" defaultPickerValue={[new Date('2024-09-08 00:00'), new Date('2024-09-09 12:00')]} />
               {/* <DatePicker style={{ ...style, width: 250 }} type="dateRange" /> */}


### PR DESCRIPTION

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2870 
预期是比较 8 和 7 这两个月份的数字位去判断要不要自动滚动，但是在英文情况下 item.value 值为 August ，和数字比较导致判断错误。将 item.value 改成 item.month 即可

### Changelog
🇨🇳 Chinese
- Fix: 修复 DatePicker 在 monthRange 且多语言情况下，点击月份无法自动滚动到非禁用项问题 #2870 

---

🇺🇸 English
- Fix: fix the issue that DatePicker cannot automatically scroll to non-disabled items when clicking on the month in monthRange and multi-language #2870 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
