### PR TITLE
docs: Fixed the problem that when Select is in multiple/small size, i…

### DIFF
--- a/packages/semi-foundation/select/select.scss
+++ b/packages/semi-foundation/select/select.scss
@@ -245,7 +245,7 @@ $overflowList: #{$prefix}-overflow-list;
 
         .#{$module}-content-wrapper {
             width: 100%;
-            min-height: $height-select_multiple_content_wrapper-minHeight;
+            min-height: $height-select_default - 2 * $width-select-border ;
             flex-wrap: wrap;
 
             &-empty {
@@ -276,13 +276,13 @@ $overflowList: #{$prefix}-overflow-list;
 
     &-multiple.#{$module}-large {
         .#{$module}-content-wrapper {
-            min-height: $height-select_large - 2;
+            min-height: $height-select_large - 2 * $width-select-border;
         }
     }
 
     &-multiple.#{$module}-small {
         .#{$module}-content-wrapper {
-            min-height: $height-select_small - 2;
+            min-height: $height-select_small - 2 * $width-select-border;
         }
     }
 

--- a/packages/semi-foundation/select/variables.scss
+++ b/packages/semi-foundation/select/variables.scss
@@ -71,7 +71,6 @@ $width-select_arrow: 32px; // 选择器输入框下拉箭头宽度
 $width-select_arrow_empty: 12px; // 选择器输入框下拉箭头为空时（有suffix icon）宽度
 $width-select_clear-icon: 32px; // 选择器输入框清空按钮宽度
 $width-select_group_top-border: $border-thickness-control; // 选择器菜单分组标题描边宽度
-$height-select_multiple_content_wrapper-minHeight: $height-select_default - 2px; // 多项选择器标签组最小高度
 
 $height-select_multiple_input_small: 20px; // 小尺寸多项选择器输入框Input框高度
 $height-select_multiple_input_default: 24px; // 默认多项选择器输入框Input框高度


### PR DESCRIPTION
…f the token of border is not set to 1, the minimum height will be incorrect

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2877 

### Changelog
🇨🇳 Chinese
- Style: 修复 Select 在 multiple/small 尺寸时候，如果 border 的 token 设置不为 1， 则最小高度会不正确问题。 废弃默认尺寸最小宽度设置 token $height-select_multiple_content_wrapper-minHeight  #2877 

---

🇺🇸 English
- Style: Fixed the problem that when Select is in multiple/small size, if the token of border is not set to 1, the minimum height will be incorrect. Abandon the default size minimum width setting token $height-select_multiple_content_wrapper-minHeight #2877 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
