### PR TITLE
fix: Fix the problem that the height of modal does not cover the scre…

### DIFF
--- a/cypress/e2e/modal.spec.js
+++ b/cypress/e2e/modal.spec.js
@@ -51,4 +51,17 @@ describe('modal', () => {
         // cy.get('button[aria-label=close]').tab({ shift: true });
         // cy.contains('确定').should('be.focused');
     });
+
+    it('Full screen', () => {
+        cy.visit("http://localhost:6006/iframe.html?id=modal--full-screen&viewMode=story");
+        // 测试 classname 为 .semi-modal-content-fullScreen 的高度和 classname 为 .semi-modal-mask 高度一致
+        cy.get(".semi-button").click();
+        cy.get('.semi-modal-content-fullScreen').then($content => {
+            const contentHeight = $content[0].getBoundingClientRect().height;
+            cy.get('.semi-modal-mask').then($mask => {
+                const maskHeight = $mask[0].getBoundingClientRect().height;
+                expect(contentHeight).to.be.equal(maskHeight); 
+            });
+        });
+    });
 });

--- a/packages/semi-foundation/modal/modal.scss
+++ b/packages/semi-foundation/modal/modal.scss
@@ -80,6 +80,7 @@ $module: #{$prefix}-modal;
     &-content-fullScreen {
         border-radius: $radius-modal_content_fullscreen;
         border: none;
+        height: 100%;
         top: $spacing-modal_content_fullscreen-top;
     }
 

--- a/packages/semi-ui/modal/_story/modal.stories.jsx
+++ b/packages/semi-ui/modal/_story/modal.stories.jsx
@@ -362,7 +362,26 @@ export const DraggableModal = () => {
     );
 };
 
-
 DraggableModal.story = {
     name: 'draggable modal',
 };
+
+export const FullScreen = () => {
+   const [visible, setVisible] = useState(false);
+    return (
+        <div>
+            <Button onClick={() => setVisible(true)}>Open Modal</Button>
+            <Modal
+                title="可拖拽Modal"
+                visible={visible}
+                fullScreen
+                // motion 为 false 是为了保证 e2e 取高度值的时候，拿到的不是动画中的值
+                motion={false}
+                onCancel={() => setVisible(false)}
+            >
+                <p>This is the content of a basic sidesheet.</p>
+                <p>Here is more content...</p>
+            </Modal>
+        </div>
+    );
+}


### PR DESCRIPTION
…en when fullScreen is set, since 2.82.0

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2880 

### Changelog
🇨🇳 Chinese
- Style: 修复 Modal 在 fullScreen 为 true 时候，并没有铺满整个屏幕问题。影响版本：v2.82.0 #2880 

---

🇺🇸 English
- Style: Fix the problem that Modal does not cover the entire screen when fullScreen is true. Affected version: v2.82.0 #2880 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
