### PR TITLE
fix: only collapsible tab in viewport trigger scroll into view

### DIFF
--- a/packages/semi-ui/tabs/_story/tabs.stories.jsx
+++ b/packages/semi-ui/tabs/_story/tabs.stories.jsx
@@ -1188,3 +1188,21 @@ export const CollapseScrollIntoViewDemo = () => {
     </div>
   )
 }
+
+export const DisplayHiddenTabBarOnCollapse = () => {
+  const [activeKey, setActiveKey] = useState('Tab-9');
+  return (
+    <div>
+      <div style={{ height: 1000, backgroundColor: 'lightPink' }}>
+        Tabs in the end of the page
+      </div>
+      <Tabs style={{ width: 500, margin: '20px' }} type="card" collapsible activeKey={activeKey} onChange={(e) => {
+          setActiveKey(e)
+        }}>
+      {[...Array(15).keys()].map(i => (
+        <TabPane tab={`Tab-${i}`} itemKey={`Tab-${i}`} key={i}>content of tab {i}</TabPane>
+      ))}
+    </Tabs>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2917

### Changelog
🇨🇳 Chinese
- Fix: 修复 collapsible Tabs 导致未在视口内触发的页面异常滚动行为

---

🇺🇸 English
- Fix: fix collapsible Tabs causing abnormal scrolling behavior of pages not triggered within the viewport


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
