### PR TITLE
style: Fixed the closeIcon color error of solid and white tags

### DIFF
--- a/packages/semi-foundation/tag/tag.scss
+++ b/packages/semi-foundation/tag/tag.scss
@@ -155,6 +155,19 @@ $types: "ghost", "solid", "light";
             height: $width-tag_avatar_circle_large;
         }
     }
+
+    .#{$module}-close {
+        color: $color-tag_close-icon_deep-default;
+        opacity: .8;
+
+        &:hover {
+            opacity: 1.0;
+        }
+
+        &:active {
+            opacity: .9;
+        }
+    }
 }
 
 .#{$module}-group {
@@ -222,21 +235,6 @@ $types: "ghost", "solid", "light";
     background-color: $color-tag_avatar-bg-default;
     border: $width-tag_avatar-border solid $color-tag_avatar-border-default;
     color: $color-tag_avatar-text-default;
-}
-
-.#{$module}-solid {
-    .#{$module}-close {
-        color: $color-tag_close-icon_deep-default;
-        opacity: .8;
-
-        &:hover {
-            opacity: 1.0;
-        }
-
-        &:active {
-            opacity: .9;
-        }
-    }
 }
 
 @import './rtl.scss';

--- a/packages/semi-foundation/tag/tag.scss
+++ b/packages/semi-foundation/tag/tag.scss
@@ -156,16 +156,18 @@ $types: "ghost", "solid", "light";
         }
     }
 
-    .#{$module}-close {
-        color: $color-tag_close-icon_deep-default;
-        opacity: .8;
+    &-solid {
+        .#{$module}-close {
+            color: $color-tag_close-icon_deep-default;
+            opacity: .8;
 
-        &:hover {
-            opacity: 1.0;
-        }
+            &:hover {
+                opacity: 1.0;
+            }
 
-        &:active {
-            opacity: .9;
+            &:active {
+                opacity: .9;
+            }
         }
     }
 }

--- a/packages/semi-ui/tag/_story/tag.stories.jsx
+++ b/packages/semi-ui/tag/_story/tag.stories.jsx
@@ -385,7 +385,7 @@ export const maxWidth = () => {
   </>
 )}
 
-export const Solid = () => (
+export const Type = () => (
     <Space wrap>
       {['solid', 'light', 'ghost'].map(type => {
         return <div>

--- a/packages/semi-ui/tag/_story/tag.stories.jsx
+++ b/packages/semi-ui/tag/_story/tag.stories.jsx
@@ -387,12 +387,18 @@ export const maxWidth = () => {
 
 export const Solid = () => (
     <Space wrap>
-        {[false, true].map(close => {
-          return <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }} >{['amber', 'blue', 'cyan', 'green', 'grey', 'indigo',  
-                'light-blue', 'light-green', 'lime', 'orange', 'pink',  
-                'purple', 'red', 'teal', 'violet', 'yellow', 'white'
-            ].map(item => (<Tag type="solid" color={item} key={item} closable={close}> {item} </Tag>))}</div>
-          ;
-        })}
+      {['solid', 'light', 'ghost'].map(type => {
+        return <div>
+          <p>type = {type}</p>
+          {[false, true].map(close => {
+            return <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap', marginBottom: 10 }} >
+              {['amber', 'blue', 'cyan', 'green', 'grey', 'indigo',  
+                  'light-blue', 'light-green', 'lime', 'orange', 'pink',  
+                  'purple', 'red', 'teal', 'violet', 'yellow', 'white'
+              ].map(item => (<Tag type={type} color={item} key={item} closable={close}> {item} </Tag>))}
+            </div>
+          })}
+        </div>;
+      })}
     </Space>
 )

--- a/packages/semi-ui/tag/_story/tag.stories.jsx
+++ b/packages/semi-ui/tag/_story/tag.stories.jsx
@@ -384,3 +384,15 @@ export const maxWidth = () => {
     </Tag>
   </>
 )}
+
+export const Solid = () => (
+    <Space wrap>
+        {[false, true].map(close => {
+          return <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }} >{['amber', 'blue', 'cyan', 'green', 'grey', 'indigo',  
+                'light-blue', 'light-green', 'lime', 'orange', 'pink',  
+                'purple', 'red', 'teal', 'violet', 'yellow', 'white'
+            ].map(item => (<Tag type="solid" color={item} key={item} closable={close}> {item} </Tag>))}</div>
+          ;
+        })}
+    </Space>
+)


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:
 
修复前：
<img width="1706" height="290" alt="image" src="https://github.com/user-attachments/assets/4bf0f8cb-f70c-4bf0-ab2d-91e418008464" />

修复后：
<img width="1702" height="312" alt="image" src="https://github.com/user-attachments/assets/d8b52311-3403-466a-88f5-474148915b5e" />

增加 storybook 用例， cypress 监测


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style: 修复 type 为 solid，color 为 white 的 Tag 的关闭图标颜色错误问题

---

🇺🇸 English
- Style: Fixed the issue that the close icon of a tag with type solid and color white has incorrect color


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
