### PR TITLE
fix: inputnumber plus calculate wrong cause by js precision

### DIFF
--- a/packages/semi-foundation/utils/number.ts
+++ b/packages/semi-foundation/utils/number.ts
@@ -10,7 +10,7 @@ export function plus(num1: number, num2: number) {
     const num1Digits = (num1.toString().split('.')[1] || '').length;
     const num2Digits = (num2.toString().split('.')[1] || '').length;
     const baseNum = Math.pow(10, Math.max(num1Digits, num2Digits));
-    return (num1 * baseNum + num2 * baseNum) / baseNum;
+    return (Math.round(num1 * baseNum + num2 * baseNum)) / baseNum;
 }
 
 export function minus(num1: number, num2: number) {

--- a/packages/semi-ui/inputNumber/__test__/inputNumber.test.js
+++ b/packages/semi-ui/inputNumber/__test__/inputNumber.test.js
@@ -563,5 +563,13 @@ describe(`InputNumber`, () => {
         expect(inputNumber.find('input').instance().value).toBe('123,456.78人民币');
     });
 
+    it('fix 2936, test js precision related calculation', () => {
+        const inputNumber = mount(<InputNumber step={0.01} max={0.08} min={0.01} defaultValue={0.07} />);
+        const btns = inputNumber.find(`.${BASE_CLASS_PREFIX}-input-number-suffix-btns .${BASE_CLASS_PREFIX}-input-number-button`);
+        const addBtn = btns.first();
+        addBtn.simulate('mousedown', { button: numbers.MOUSE_BUTTON_LEFT });
+        expect(inputNumber.find('input').instance().value).toBe('0.08');
+    });
+
 });
  

--- a/packages/semi-ui/inputNumber/_story/inputNumber.stories.jsx
+++ b/packages/semi-ui/inputNumber/_story/inputNumber.stories.jsx
@@ -969,3 +969,14 @@ export const TestInputNumber = () => {
   </div>
   )
 }
+
+
+export const Fix2936 = () => {
+  return (
+    <div style={{ width: 280 }}>
+        <label>点击增加按钮，值会变成 0.08 </label>
+        <InputNumber step={0.01} max={0.08} min={0.01} defaultValue={0.07} />
+        <br/><br/>
+    </div>
+  )
+}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2936

add 逻辑中需要通过 `Math.abs(numberMinus(max, curNum)) >= stepAbs` 计算 `curNum`
max = 0.08，step = 0.01，curNum = 0.07 时，numberMinus 通过 utils/number 下的 plus 计算 `numberMinus(max, curNum)`
<img width="1374" height="282" alt="image" src="https://github.com/user-attachments/assets/535cc76c-a393-4948-b72d-6f74c0c8c072" />
计算结果如下
<img width="786" height="172" alt="image" src="https://github.com/user-attachments/assets/0f912e52-92de-45e3-8fe7-3a3196196d0e" />
num1 * baseNum + num2 * baseNum 必定为整数，故加上一个四舍五入的计算即可得到正解


### Changelog
🇨🇳 Chinese
- Fix: 修复 InputNumber 因为 js 精度计算有误问题

---

🇺🇸 English
- Fix: fix the problem that InputNumber calculation is incorrect due to js precision


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
