### PR TITLE
feat: webpack and rspack plugin add built-in silenceDeprecations in sass-loader

### DIFF
--- a/packages/semi-rspack/src/rule.ts
+++ b/packages/semi-rspack/src/rule.ts
@@ -12,6 +12,8 @@ export function createSourceSuffixLoaderRule(_opts?: SemiWebpackPluginOptions) {
 
 export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
     const themeOptions: SemiThemeOptions = {};
+    const scssLoader = require.resolve('sass-loader');
+
     if (typeof opts.theme === 'object') {
         Object.assign(themeOptions, opts.theme);
     } else {
@@ -28,21 +30,31 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
         test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
         use: [{ loader: THEME_LOADER, options }],
     };
+    let commonLoader: any[] = [
+        { 
+            loader: scssLoader,
+            options: {
+                sassOptions: {
+                    silenceDeprecations: ['import', 'legacy-js-api', 'global-builtin'],
+                },
+            }
+        }
+    ];
     if (opts.webComponentPath) {
-        const commonLoader = [
+        commonLoader = [
             { loader: "raw-loader" },
             { loader: EXTRACT_CSS_LOADER },
             {
                 loader: 'css-loader',
                 options: { sourceMap: false }
             },
-            { loader: 'sass-loader' }
-        ];
-        loaderInfo.use = [
             ...commonLoader,
-            ...loaderInfo.use
-        ] as any;
-    }
+        ];
+    } 
+    loaderInfo.use = [
+        ...commonLoader,
+        ...loaderInfo.use
+    ] as any;
     return loaderInfo;
 }
 

--- a/packages/semi-webpack/src/semi-webpack-plugin.ts
+++ b/packages/semi-webpack/src/semi-webpack-plugin.ts
@@ -133,14 +133,19 @@ export default class SemiWebpackPlugin {
                         loader: extraCssLoader
                     }
                 ];
-                const commonLoaderList = [
+                const commonLoaderList: any[] = [
                     {
                         loader: cssLoader,
                         options: {
                             sourceMap: false,
                         }
                     }, {
-                        loader: scssLoader
+                        loader: scssLoader,
+                        options: {
+                            sassOptions: {
+                                silenceDeprecations: ['import', 'legacy-js-api', 'global-builtin'],
+                            },
+                        }
                     },
                     {
                         loader: path.join(__dirname, 'semi-theme-loader'),


### PR DESCRIPTION

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
针对 /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/ 下的文件进行 sass-loader 配置，静默 sass 弃用警告

### Changelog
🇨🇳 Chinese
- Feat: semi webpack 和 rspack 插件在 sass-loader 中添加内置 silenceDeprecations 选项（'import', 'legacy-js-api', 'global-builtin'）静默 sass 相关的弃用警告

---

🇺🇸 English
- Feat: webpack and rspack plugins in semi add built-in silenceDeprecations options ('import', 'legacy-js-api', 'global-builtin') to sass-loader to silence sass-related deprecation warnings


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
