### PR TITLE
fix: Fixed when TreeSelect is disabled, clicking on the trigger would…

### DIFF
--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -225,5 +225,12 @@ describe('treeSelect', () => {
         cy.get('.semi-tree-option-expand-icon').eq(0).trigger('click');
         cy.get('.semi-tree-option-label-text').eq(0).contains('Asia');
     })
+
+    it.only('disabled treeSelect can have focus border', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--fixed-2968');
+        cy.get('.semi-tree-select').focus();
+        // semi-tree-select 层级的元素的 border 应该存在，并且 border color 应该是 transparent
+        cy.get('.semi-tree-select').should('have.css', 'border-color', 'rgba(0, 0, 0, 0)');  
+    })
 });
 

--- a/cypress/e2e/treeSelect.spec.js
+++ b/cypress/e2e/treeSelect.spec.js
@@ -226,7 +226,7 @@ describe('treeSelect', () => {
         cy.get('.semi-tree-option-label-text').eq(0).contains('Asia');
     })
 
-    it.only('disabled treeSelect can have focus border', () => {
+    it('disabled treeSelect can have focus border', () => {
         cy.visit('http://127.0.0.1:6006/iframe.html?id=treeselect--fixed-2968');
         cy.get('.semi-tree-select').focus();
         // semi-tree-select 层级的元素的 border 应该存在，并且 border color 应该是 transparent

--- a/packages/semi-foundation/treeSelect/treeSelect.scss
+++ b/packages/semi-foundation/treeSelect/treeSelect.scss
@@ -22,11 +22,11 @@ $module: #{$prefix}-tree-select;
         border: $width-treeSelect_hover-border solid $color-treeSelect_default-border-hover;
     }
 
-    &:focus {
-        border: $width-treeSelect_focus-border solid $color-treeSelect_default-border-focus;
-        background-color: $color-treeSelect_default-bg-focus;
-        outline: 0;
-    }
+    // &:focus {
+    //     border: $width-treeSelect_focus-border solid $color-treeSelect_default-border-focus;
+    //     background-color: $color-treeSelect_default-bg-focus;
+    //     outline: 0;
+    // }
 
     &:active{
         background-color: $color-treeSelect_default-bg-active;

--- a/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
+++ b/packages/semi-ui/treeSelect/_story/treeSelect.stories.jsx
@@ -2995,3 +2995,17 @@ export const CustomExpandIcon = () => {
     </>
   );
 }
+
+export const Fixed2968 = () => {
+    return ( 
+        <>
+        <TreeSelect
+            disabled
+            style={{ width: 300 }}
+            dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+            treeData={treeData1}
+            placeholder="请选择"
+        />
+        </>
+    );
+}


### PR DESCRIPTION
… cause unexpected focus styles

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2968 

TreeSelect 的聚焦样式已经可以通过 state 中的 isFocus 变量决定，样式也可以通过 .semi-tree-select-focus 来处理，因此无需通过 .semi-tree-select:hover 来控制。

### Changelog
🇨🇳 Chinese
- Fix: 修复 TreeSelect 在 disabled 情况下，点击会有意外的聚焦样式问题 #2968 

---

🇺🇸 English
- Fix: Fixed the issue where clicking on TreeSelect when it is disabled would cause unexpected focus style issues #2968 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
