### PR TITLE
Fix/2967

### DIFF
--- a/cypress/e2e/tagInput.spec.js
+++ b/cypress/e2e/tagInput.spec.js
@@ -6,4 +6,10 @@ describe('tag', () => {
         cy.get('.semi-icon-close').click();
         cy.get('.semi-icon-close').should('not.exist');
     });
+
+    it('sortable item long text', () => {
+        cy.visit('http://127.0.0.1:6006/iframe.html?id=taginput--long-text-item-draggable&args=&viewMode=story');
+        cy.get('.semi-tagInput-wrapper').click();
+        cy.get('.semi-tag').eq(0).should('have.css', 'width').and('eq', '290px');
+    });
 });

--- a/packages/semi-foundation/tagInput/tagInput.scss
+++ b/packages/semi-foundation/tagInput/tagInput.scss
@@ -44,6 +44,7 @@ $module: #{$prefix}-tagInput;
 
     &-sortable-item {
         position: relative;
+        max-width: 100%;
         &-over {
             overflow: visible;
             &::before {
@@ -139,6 +140,7 @@ $module: #{$prefix}-tagInput;
         &-tag {
             margin-right: $spacing-extra-tight;
             white-space: pre;
+            max-width: 100%;
 
             &-size {
                 &-small {

--- a/packages/semi-ui/cascader/_story/cascader.stories.jsx
+++ b/packages/semi-ui/cascader/_story/cascader.stories.jsx
@@ -2614,3 +2614,19 @@ export const Fixed2831 = () => {
             />
     );
 }
+
+export const Fixed2967 = () => {
+  const data = [
+    { label: '这是一个超长的用于测试的选项', value: '1' },
+  ]
+  return (
+    <Cascader
+      multiple
+      filterTreeNode
+      defaultValue={['1']}
+      style={{ width: 200 }}
+      treeData={data}
+      placeholder="请选择所在地区"
+    />
+  )
+}

--- a/packages/semi-ui/tagInput/_story/tagInput.stories.jsx
+++ b/packages/semi-ui/tagInput/_story/tagInput.stories.jsx
@@ -581,3 +581,14 @@ export const testMaxLength = () => (
   </>
 );
 
+export const longTextItemDraggable = () => {
+  return (
+    <TagInput 
+      draggable
+      aria-label='input tag' 
+      defaultValue={['抖音抖音抖音抖音抖音抖音抖音抖音抖音音抖音抖音音抖音抖音音抖音抖音', '火山', '西瓜视频']} 
+      placeholder="请输入..." 
+      style={{ width: 300 }} 
+    />
+  )
+}

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -428,10 +428,16 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             !disabled && this.handleTagClose(index);
         };
         if (isFunction(renderTagItem)) {
-            return (<div className={itemWrapperCls} key={elementKey}>
-                {showIconHandler && sortableHandle ? <DragHandle /> : null}
-                {renderTagItem(value, index, onClose)}
-            </div>);
+            if (showIconHandler && sortableHandle) {
+                return (
+                    <div className={itemWrapperCls} key={elementKey}>
+                        <DragHandle />
+                        {renderTagItem(value, index, onClose)}
+                    </div>
+                );
+            } else {
+                return renderTagItem(value, index, onClose);
+            }
         } else {
             return (
                 <Tag


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #2967 

### Changelog
🇨🇳 Chinese
- Fix: 修复多选，可搜索的 Cascader 在内容太长时，内容未正确缩略问题  #2967 
- Fix: 修复 TagInput 中可拖拽的 tag 在内容太长时，内容未正确缩略问题

---

🇺🇸 English
- Fix: Fixed an issue where the content of a multi-select, searchable Cascader was not correctly ellipsised when the content was too long (#2967)
- Fix: Fixed an issue where the content of a draggable tag in a TagInput was not correctly ellipsised when the content was too long


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
