### PR TITLE
style: add $color-tagInput_disabled-bg for disabled Taginput background

### DIFF
--- a/packages/semi-foundation/tagInput/tagInput.scss
+++ b/packages/semi-foundation/tagInput/tagInput.scss
@@ -104,6 +104,7 @@ $module: #{$prefix}-tagInput;
     }
 
     &-disabled {
+        background-color: $color-tagInput_disabled-bg;
         cursor: not-allowed;
 
         .#{$module}-clearBtn,

--- a/packages/semi-foundation/tagInput/variables.scss
+++ b/packages/semi-foundation/tagInput/variables.scss
@@ -2,6 +2,7 @@ $color-tagInput-icon-default: var(--semi-color-text-2); // 标签输入框图标
 $color-tagInput-maxTagCount-default: var(--semi-color-text-0); // 标签输入框限制标签展示数量文字颜色
 $color-tagInput-icon-hover: var(--semi-color-primary-hover); // 标签输入框图标颜色 - 悬浮
 $color-tagInput_disabled-text-default: var(--semi-color-disabled-text); // 标签输入框禁用文字颜色
+$color-tagInput_disabled-bg: var(--semi-color-disabled-fill); // 标签输入框禁用背景色
 $color-tagInput_default-bg-focus: var(--semi-color-fill-0); // 标签输入框背景颜色 - 选中态
 
 $color-tagInput-border-default: transparent; // 标签输入框描边颜色 - 默认


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Style: 增加禁用态的 TagInput 的背景色 token，$color-tagInput_disabled-bg

---

🇺🇸 English
- Style: Add a background color token for disabled TagInput, $color-tagInput_disabled-bg


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
