### PR TITLE
style: [Cropper] To prevent the max-Width setting of img in tailwindC…

### DIFF
--- a/packages/semi-foundation/cropper/cropper.scss
+++ b/packages/semi-foundation/cropper/cropper.scss
@@ -6,6 +6,11 @@ $half_corner_width: calc($width-cropper_box_corner / 2);
 .#{$module} {
     position: relative;
 
+    & img {
+      // To avoid the `max-Width` setting of `img` to 100% in `tailwindCSS` affecting the style of img in Cropper.
+      max-width: none;
+    }
+
     &-img {
       position: absolute;
       user-select: none;


### PR DESCRIPTION
…SS from affecting the styles of img in Cropper

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3010 

### Changelog
🇨🇳 Chinese
- Style: 设置 Cropper 中的 img 的 max-width 为 none，避免 tailwindCSS 中对 img 的 max-width 设置影响 Cropper 样式 #3010 

---

🇺🇸 English
- Style: set the max-width of the img element in the Cropper to none to prevent the max-width setting of the img element in tailwindCSS from affecting the Cropper's style. #3010 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [x] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
