### PR TITLE
fix: update semi-extract-css-content-loader

### DIFF
--- a/packages/semi-rspack/src/loaders/semi-extract-css-content-loader.ts
+++ b/packages/semi-rspack/src/loaders/semi-extract-css-content-loader.ts
@@ -7,19 +7,19 @@ import { LoaderContext } from 'webpack';
  * @description 
  * 此 loader 用于从 css-loader 处理后的 js 代码中获取纯 css 样式字符串
  * source 是经过 css-loader 处理后的 js 代码。要获取其中的  css 样式字符串，需经过如下操作：
- * 1. 通过识别module.id, "做为开头，", ""]);作为结尾拿到中间的 css 代码
+ * 1. 通过识别module.id, "或者module.id, `做为开头，", ""]);或者`, ""]);做为结尾拿到中间的 css 代码
  * 2. 将 文本中的 \n 替换为空字符串
  */
 export default function semiExtractCssContentLoader(this: LoaderContext<void>, source: string) {
-    const beginContent = 'module.id, "';
-    const endContent = '", ""]);';
+    const beginContent = 'module.id, ';
+    const endContent = ', ""]);';
     let begInIndex = source.indexOf(beginContent);
     let endIndex = source.length;
     let result = source;
     if (begInIndex !== -1) {
         endIndex = source.lastIndexOf(endContent);
         if (endIndex !== -1) {
-            result = source.slice(begInIndex + beginContent.length, endIndex);
+            result = source.slice(begInIndex + beginContent.length + 1, endIndex - 1);
             result = result.replace(/\\n/g, "");
         }
     }

--- a/packages/semi-webpack/src/semi-extract-css-content-loader.ts
+++ b/packages/semi-webpack/src/semi-extract-css-content-loader.ts
@@ -5,20 +5,20 @@
  * @description 
  * 此 loader 用于从 css-loader 处理后的 js 代码中获取纯 css 样式字符串
  * source 是经过 css-loader 处理后的 js 代码。要获取其中的  css 样式字符串，需经过如下操作：
- * 1. 通过识别module.id, "做为开头，", ""]);作为结尾拿到中间的 css 代码
+ * 1. 通过识别module.id, "或者module.id, `做为开头，", ""]);或者`, ""]);做为结尾拿到中间的 css 代码
  * 2. 将 文本中的 \n 替换为空字符串
  */
 
 export default function semiExtractCssContentLoader(source: string) {
-    const beginContent = 'module.id, "';
-    const endContent = '", ""]);';
+    const beginContent = 'module.id, ';
+    const endContent = ', ""]);';
     let begInIndex = source.indexOf(beginContent);
     let endIndex = source.length;
     let result = source;
     if (begInIndex !== -1) {
         endIndex = source.lastIndexOf(endContent);
         if (endIndex !== -1) {
-            result = source.slice(begInIndex + beginContent.length, endIndex);
+            result = source.slice(begInIndex + beginContent.length + 1, endIndex - 1);
             result = result.replace(/\\n/g, "");
         }
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

从 css-loader 的产物中提取纯  css 字符串，原来的方式是匹配module.id, "到", ""]);之间的内容，后发现，也可能是module.id, `到`, ""]);之间的内容，及css 的开头和结尾的字符串标识可能是 “”，也可能是 ``


### Changelog
🇨🇳 Chinese
- Fix: 完善 semi-extract-css-content-loader 中的纯 css 内容抽取逻辑

---

🇺🇸 English
- Fix: Improve the pure CSS content extraction logic in semi-extract-css-content-loader


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
