### PR TITLE
fix: to prevent the max-width setting of img in tailWindCSS from affe…

### DIFF
--- a/packages/semi-foundation/image/image.scss
+++ b/packages/semi-foundation/image/image.scss
@@ -10,6 +10,15 @@ $module: #{$prefix}-image;
     display: inline-block;
     overflow: hidden;
 
+    img {
+        /**
+            * In tailwind, the max-width of img/video is set to 100%, 
+            * which will affect the amplification effect of the picture.
+            * So we need to set max-width to none.
+        */ 
+        max-width: none;
+    }
+
     &-img {
         vertical-align: top;
         border-radius: inherit;
@@ -204,12 +213,6 @@ $module: #{$prefix}-image;
             // transition: transform $transition_duration-image_preview_image_img  $transition_delay-image_preview_image_img;
             z-index: 0;
             user-select: none;
-            /**
-             * In tailwind, the max-width of img/video is set to 100%, 
-             * which will affect the amplification effect of the picture.
-             * So we need to set max-width to none.
-            */
-            max-width: none;
         }
 
         &-spin {


### PR DESCRIPTION
…cting the img node in the Image component

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 设置 Image 中所有的 img 节点的 max-width 为none，避免同时使用 tailwind 时放大显示错误问题

---

🇺🇸 English
- Fix: set the max-width of all img nodes in the Image object to none to avoid display errors when using tailwind simultaneously.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
