### PR TITLE
fix: Radio/RadioGroup 's value/defaultValue add boolean type support

### DIFF
--- a/packages/semi-ui/radio/radio.tsx
+++ b/packages/semi-ui/radio/radio.tsx
@@ -25,7 +25,7 @@ export type RadioProps = {
     checked?: boolean;
     children?: React.ReactNode;
     defaultChecked?: boolean;
-    value?: string | number;
+    value?: string | number | boolean;
     disabled?: boolean;
     prefixCls?: string;
     displayMode?: RadioDisplayMode;

--- a/packages/semi-ui/radio/radioGroup.tsx
+++ b/packages/semi-ui/radio/radioGroup.tsx
@@ -27,11 +27,11 @@ export interface OptionItem {
 export type Options = string[] | Array<OptionItem>;
 
 export type RadioGroupProps = {
-    defaultValue?: string | number;
+    defaultValue?: string | number | boolean;
     disabled?: boolean;
     name?: string;
     options?: Options;
-    value?: string | number;
+    value?: string | number | boolean;
     onChange?: (event: RadioChangeEvent) => void;
     className?: string;
     children?: React.ReactNode;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #137 

### Changelog
🇨🇳 Chinese
- Chore: Radio/RadioGroup 的 value/defaultValue 增加 boolean 类型

---

🇺🇸 English
- Chore: Add a boolean type to the value/defaultValue of Radio/RadioGroup.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
