### PR TITLE
fix: add Math.round to inputnumber calculate to avoid js precision calculation problem

### DIFF
--- a/packages/semi-foundation/inputNumber/foundation.ts
+++ b/packages/semi-foundation/inputNumber/foundation.ts
@@ -440,11 +440,11 @@ class InputNumberFoundation extends BaseFoundation<InputNumberAdapter> {
         if (step < 0) {
             // Js accuracy problem
             if (Math.abs(numberMinus(min, curNum)) >= stepAbs) {
-                curNum = (curNum * scale + step * scale) / scale;
+                curNum = (Math.round(curNum * scale + step * scale)) / scale;
             }
         } else if (step > 0) {
             if (Math.abs(numberMinus(max, curNum)) >= stepAbs) {
-                curNum = (curNum * scale + step * scale) / scale;
+                curNum = (Math.round(curNum * scale + step * scale)) / scale;
             }
         }
         if (typeof min === 'number' && min > curNum) {

--- a/packages/semi-ui/inputNumber/_story/inputNumber.stories.jsx
+++ b/packages/semi-ui/inputNumber/_story/inputNumber.stories.jsx
@@ -991,3 +991,15 @@ export const FormInputNumberDemo = () => {
   </Form>
   )
 }
+
+export const Fix3025 = () => {
+  return (
+    <div style={{ width: 280 }}>
+       <label>设置了步长 step=0.01 </label>
+       <InputNumber step={0.01} defaultValue={0.14}/> 
+       <br/><br/>
+       <label>设置了步长 step=0.02 </label>
+       <InputNumber step={0.02} defaultValue={0.01}/> 
+  </div>
+  )
+}


### PR DESCRIPTION


<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3025 
问题类似于 #2936 ，修复方法参考 #2937 

### Changelog
🇨🇳 Chinese
- Fix: 修复 InputNumber 在设置小数步长时，进退位计算精度不正确问题

---

🇺🇸 English
- Fix: fixed an issue where carry-over/borrowing precision was incorrect when setting the decimal step size for InputNumber.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
