### PR TITLE
fix: fix Dragmove cannot be used as a JSX componen

### DIFF
--- a/packages/semi-ui/dragMove/index.ts
+++ b/packages/semi-ui/dragMove/index.ts
@@ -26,7 +26,7 @@ export interface DragMoveProps {
     customMove?: (e: HTMLElement, top: number, left: number) => void
 }
 
-export default class DragMove extends BaseComponent<DragMoveProps, null> {
+export default class DragMove extends BaseComponent<DragMoveProps> {
     
     static propTypes = {
         children: PropTypes.node,
@@ -57,7 +57,7 @@ export default class DragMove extends BaseComponent<DragMoveProps, null> {
     elementRef: React.RefObject<unknown>;
     foundation: DragMoveFoundation;
 
-    get adapter(): DragMoveAdapter<DragMoveProps, null> {
+    get adapter(): DragMoveAdapter<DragMoveProps> {
         return {
             ...super.adapter,
             getDragElement: () => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3022 

### Changelog
🇨🇳 Chinese
- Chore: 修复 DragMove 类型定义错误问题 #3022 

---

🇺🇸 English
- Chore: Fixed an issue with the DragMove type definition being incorrect #3022 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
