### PR TITLE
feat: [AIChatInput] The newly added keepSkillAfterSend API allows use…

### DIFF
--- a/packages/semi-ui/aiChatInput/_story/aiChatInput.stories.jsx
+++ b/packages/semi-ui/aiChatInput/_story/aiChatInput.stories.jsx
@@ -679,3 +679,37 @@ export const SetContent = () => {
       >点我查看富文本区域内容</Button>
   </>);
 }
+
+export const KeepSkill = () => {
+  const ref = useRef();
+  const [generating, setGenerating] = useState(false);
+
+  const onContentChange = useCallback((content) => {
+    console.log('onContentChange', content);
+  }, []);
+
+  const toggleGenerate = useCallback((props) => {
+    setGenerating(value => !value);
+  }, []);
+
+  return (<>
+      <AIChatInput
+          ref={ref}
+          generating={generating}
+          keepSkillAfterSend
+          defaultContent={`<skill-slot data-label="帮我写作" data-value="writing" data-template=true></skill-slot>帮我完成...`}
+          placeholder={'输入内容或者上传内容'} 
+          uploadProps={uploadProps}
+          onContentChange={onContentChange}
+          onMessageSend={toggleGenerate}
+          onStopGenerate={toggleGenerate}
+          style={outerStyle} 
+      />
+      <Button onClick={() => {
+        const html = ref.current.editor.getHTML();
+        const json = ref.current.editor.getJSON();
+        console.log('html', html);
+        console.log('json', json);
+      }}>点击获取</Button>
+  </>);
+}

--- a/packages/semi-ui/aiChatInput/index.tsx
+++ b/packages/semi-ui/aiChatInput/index.tsx
@@ -54,6 +54,7 @@ class AIChatInput extends BaseComponent<AIChatInputProps, AIChatInputState> {
         dropdownMatchTriggerWidth: true,
         round: true,
         topSlotPosition: 'top',
+        keepSkillAfterSend: false,
     }
 
     constructor(props: AIChatInputProps) {
@@ -203,14 +204,14 @@ class AIChatInput extends BaseComponent<AIChatInputProps, AIChatInputState> {
     }
 
     componentDidUpdate(prevProps: Readonly<AIChatInputProps>): void {
-        const { suggestions } = this.props;
+        const { suggestions, keepSkillAfterSend } = this.props;
         if (!isEqual(suggestions, prevProps.suggestions)) {
             const newVisible = (suggestions && suggestions.length > 0) ? true : false;
             newVisible ? this.foundation.showSuggestionPanel() :
                 this.foundation.hideSuggestionPanel();
         }
         if (this.props.generating && (this.props.generating !== prevProps.generating)) {
-            this.adapter.clearContent();
+            keepSkillAfterSend ? this.setContentWhileSaveTool('') : this.adapter.clearContent();
             this.adapter.clearAttachments();
         }
     }

--- a/packages/semi-ui/aiChatInput/interface.ts
+++ b/packages/semi-ui/aiChatInput/interface.ts
@@ -23,6 +23,7 @@ export interface AIChatInputState {
 
 export interface AIChatInputProps {
     dropdownMatchTriggerWidth?: boolean;
+    keepSkillAfterSend: boolean;
     className?: string;
     style?: React.CSSProperties;
     // Rich text editor related


### PR DESCRIPTION
…rs to set whether to delete the skill upon sending

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

用户提需，希望在有技能的时候，发送之后，不要删除技能

### Changelog
🇨🇳 Chinese
- Feat: AIChatInput 新增加 keepSkillAfterSend 用于设置是否在发送时候删除技能

---

🇺🇸 English
- Feat: AIChatInput now includes a new feature: keepSkillAfterSend, which allows you to set whether to delete skills when sending.


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
