### PR TITLE
fix: Fixed the issue where the inputSlot format was not displayed whe…

### DIFF
--- a/packages/semi-ui/aiChatInput/extension/plugins.ts
+++ b/packages/semi-ui/aiChatInput/extension/plugins.ts
@@ -1,4 +1,4 @@
-import { EditorState, Plugin, PluginKey, TextSelection, Transaction } from 'prosemirror-state';
+import { EditorState, Plugin, PluginKey, TextSelection, Transaction, Selection } from 'prosemirror-state';
 import { strings } from '@douyinfe/semi-foundation/aiChatInput/constants';
 import { EditorView } from '@tiptap/pm/view';
 /**
@@ -414,7 +414,7 @@ export function handlePasteLogic(view: EditorView, event: ClipboardEvent) {
     let tr = state.tr;
     const parentNode = $from.parent;
     if (parentNode.type.name === 'inputSlot') {
-        return specialPasteLogicForInputSlot(event, $from, tr, dispatch);
+        return specialPasteLogicForInputSlot(event, $from, tr, dispatch, state.selection);
     }
     removeZeroWidthChar($from, tr);
     tr.setMeta(strings.DELETABLE, true);
@@ -423,18 +423,26 @@ export function handlePasteLogic(view: EditorView, event: ClipboardEvent) {
 }
 
 /**
- * 如果是 parentNode 是 input-slot，当里面内容仅为零宽字符时候
- * 直接去掉零宽字符会导致 input-slot 消失，
+ * specialPasteLogicForInputSlot 处理两种情况
+ * 1. 如果是 parentNode 是 input-slot，当里面内容仅为零宽字符时候
+ * 直接去掉零宽字符会导致 input-slot 消失， 
  * 因此将此行为处理成获取文字部分，将零宽字符替换为文字内容
- * If the parentNode is input-slot, and the content inside is only zero-width characters...
+ * 2. 如果 parentNode 是 input-slot，选中 input-slot 中的所有文字并粘贴
+ * 会导致 input-slot 被删除，因此需要处理成使用复制内容替换原有内容的
+ * The `specialPasteLogicForInputSlot` function handles two cases.
+ * 1. If the parentNode is input-slot, and its content consists of only zero-width characters...
  * Removing zero-width characters directly will cause the input slot to disappear.
- * Therefore, this paste behavior is processed to retrieve the text portion and replace the zero-width characters with the text content.
+ * Therefore, this behavior is processed by retrieving the text portion and replacing the zero-width characters with the text content.
+ * 2. If the parentNode is input-slot, select all the text in the input-slot and paste it.
+ * This will cause the input slot to be deleted, so it needs to be handled by replacing the original content with copied content.
  */
-export function specialPasteLogicForInputSlot(event: ClipboardEvent, $from: any, tr: Transaction, dispatch: (tr: Transaction) => void) {
+export function specialPasteLogicForInputSlot(event: ClipboardEvent, $from: any, tr: Transaction, dispatch: (tr: Transaction) => void, selection: Selection) {
     const parentNode = $from.parent;
     const nodeText = parentNode.textContent;
     const isOnlyZeroWidth = nodeText && nodeText === strings.ZERO_WIDTH_CHAR;
-    if (isOnlyZeroWidth) {
+    const isAllTextSelected = !selection.empty && 
+        selection.from === $from.start() && selection.to === $from.end();
+    if (isOnlyZeroWidth || isAllTextSelected) {
         const pastedText = event.clipboardData?.getData('text/plain') || '';
         if (pastedText) {
             const pos = $from.start();


### PR DESCRIPTION
…n pasting content into an empty inputSlot

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3049 

### Changelog
🇨🇳 Chinese
- Fix: 修复向空的 inputSlot 中粘贴内容时候，仅粘贴了文本，无 inputSlot 样式问题 #3049 
- Fix: 修复当选中 inputSlot 中的所有内容并粘贴内容时候，仅粘贴了文本，无 inputSlot 样式问题  #3049

---

🇺🇸 English
- Fix: Fixed an issue where pasting content into an empty inputSlot resulted in only text being pasted without displaying the inputSlot style #3049 
- Fix: Fixed an issue where, when pasting content after selecting all text in an inputSlot, the inputSlot would disappear. #3049 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
