### PR TITLE
fix: fix custom.scss selector problem in theme loader

### DIFF
--- a/packages/semi-rspack/src/loaders/semi-theme-loader.ts
+++ b/packages/semi-rspack/src/loaders/semi-theme-loader.ts
@@ -73,7 +73,8 @@ export default function SemiThemeLoader(this: LoaderContext<SemiThemeLoaderOptio
                 }
                 const resolved = require.resolve(`${theme}/scss/custom.scss`);
                 const customFileContent = fs.readFileSync(resolved, 'utf-8');
-                if (customFileContent.includes('body {')) {
+                const regex = /body\s*\{/;
+                if (regex.test(customFileContent)) {
                     addBodySelector = false;
                 }
                 const collectAllVariablesPath: string[] = [

--- a/packages/semi-webpack/src/semi-theme-loader.ts
+++ b/packages/semi-webpack/src/semi-theme-loader.ts
@@ -71,7 +71,8 @@ export default function SemiThemeLoader(source: string) {
                 }
                 const resolved = require.resolve(`${theme}/scss/custom.scss`);
                 const customFileContent = fs.readFileSync(resolved, 'utf-8');
-                if (customFileContent.includes('body {')) {
+                const regex = /body\s*\{/;
+                if (regex.test(customFileContent)) {
                     addBodySelector = false;
                 }
                 const collectAllVariablesPath: string[] = [


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #

### Changelog
🇨🇳 Chinese
- Fix: 修复 semi-theme-loader 在用户自定义主题的 custom.css 中有 body 选择器时，custom.css 中的内容未生效问题

---

🇺🇸 English
- Fix: Fixed an issue where semi-theme-loader prevented content in custom.css from taking effect when there was a body selector in the custom.css file of a user-defined theme.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
