### PR TITLE
fix: Fixed where the border setting of the outer table affected the s…

### DIFF
--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -508,7 +508,7 @@ $module: #{$prefix}-table;
     }
 
     &-bordered {
-        .#{$module}-title {
+        & > .#{$module}-title {
             padding-left: $spacing-table_bordered_titler-paddingLeft;
             padding-right: $spacing-table_bordered_titler-paddingRight;
             border-top: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
@@ -516,37 +516,55 @@ $module: #{$prefix}-table;
             border-left: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
         }
 
-        .#{$module}-container {
+        & > .#{$module}-container {
             border: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
             border-right: 0;
             border-bottom: 0;
         }
 
-        .#{$module}-header {
-            &::-webkit-scrollbar {
+        :where(&) {
+            & > .#{$module}-container {
+                & >  .#{$module}-header {
+                    &::-webkit-scrollbar {
+                        border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
+                    }
+                }
+
+                & > .#{$module}-footer {
+                    border-left: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
+                    border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
+                    border-bottom: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
+                }
+            }
+        }
+
+        :where(& > .#{$module}-container) {
+            & > .#{$module}-body > .#{$module}-placeholder {
                 border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
             }
         }
 
-        .#{$module}-footer {
-            border-left: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
-            border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
-            border-bottom: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
-        }
+        :where(& > .#{$module}-container > .#{$module}-body) {
+            & > .#{$module} > .#{$module}-thead > .#{$module}-row > .#{$module}-row-head {
+                .react-resizable-handle {
+                    background-color: transparent;
+                }
+            }
 
-        .#{$module}-thead > .#{$module}-row > .#{$module}-row-head {
-            .react-resizable-handle {
-                background-color: transparent;
+            & > .#{$module} > .#{$module}-thead > .#{$module}-row > .#{$module}-row-head,
+            & > .#{$module} > .#{$module}-tbody > .#{$module}-row > .#{$module}-row-cell {
+                border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
             }
         }
 
-        .#{$module}-thead > .#{$module}-row > .#{$module}-row-head,
-        .#{$module}-tbody > .#{$module}-row > .#{$module}-row-cell {
-            border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
-        }
+        :where(& > .#{$module}-container > .#{$module}-header) {
+            & > .#{$module} > .#{$module}-thead > .#{$module}-row > .#{$module}-row-head {
+                border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
 
-        .#{$module}-placeholder {
-            border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
+                .react-resizable-handle {
+                    background-color: transparent;
+                }
+            }
         }
     }
 

--- a/packages/semi-ui/table/_story/borderedDoubleTable/index.jsx
+++ b/packages/semi-ui/table/_story/borderedDoubleTable/index.jsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { IconMore, IconTickCircle, IconComment, IconClear } from '@douyinfe/semi-icons';
+import { Avatar, Tag, Table } from '../../../index';
+
+const BorderedDoubleTable = () => {
+    const columns = [
+        {
+            title: '标题',
+            dataIndex: 'name',
+            render: (text, record, index) => {
+                return (
+                    <Table 
+                        bordered={false} 
+                        // title={"Child table header"}
+                        // footer={"child table footer"}
+                        columns={[{
+                            title: '标题',
+                            dataIndex: 'name',
+                            render: (text, record, index) => {
+                                return (
+                                    <div>
+                                        <Avatar
+                                            size="small"
+                                            shape="square"
+                                            src={record.nameIconSrc}
+                                            style={{ marginRight: 12 }}
+                                        ></Avatar>
+                                        {text}
+                                    </div>
+                                );
+                            },
+                        }]} 
+                        dataSource={data} 
+                        pagination={false}
+                    />
+                );
+            },
+        },
+        {
+            title: '大小',
+            dataIndex: 'size',
+        },
+        {
+            title: '交付状态',
+            dataIndex: 'status',
+            render: (text) => {
+                const tagConfig = {
+                    success: { color: 'green', prefixIcon: <IconTickCircle />, text: '已交付' },
+                    pending: { color: 'pink', prefixIcon: <IconClear />, text: '已延期' },
+                    wait: { color: 'cyan', prefixIcon: <IconComment />, text: '待评审' },
+                };
+                const tagProps = tagConfig[text];
+                return <Tag shape='circle' {...tagProps} style={{ userSelect: 'text' }}>{tagProps.text}</Tag>;
+            }
+        },
+        {
+            title: '所有者',
+            dataIndex: 'owner',
+            render: (text, record, index) => {
+                return (
+                    <div>
+                        <Avatar size="small" color={record.avatarBg} style={{ marginRight: 4 }}>
+                            {typeof text === 'string' && text.slice(0, 1)}
+                        </Avatar>
+                        {text}
+                    </div>
+                );
+            },
+        },
+        {
+            title: '更新日期',
+            dataIndex: 'updateTime',
+        },
+        {
+            title: '',
+            dataIndex: 'operate',
+            render: () => {
+                return <IconMore />;
+            },
+        },
+    ];
+    const data = [
+        {
+            key: '1',
+            name: 'Semi Design 设计稿.fig',
+            nameIconSrc: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/figma-icon.png',
+            size: '2M',
+            owner: '姜鹏志',
+            status: 'success',
+            updateTime: '2020-02-02 05:13',
+            avatarBg: 'grey',
+        },
+        {
+            key: '2',
+            name: 'Semi Design 分享演示文稿',
+            nameIconSrc: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/docs-icon.png',
+            size: '2M',
+            owner: '郝宣',
+            status: 'pending',
+            updateTime: '2020-01-17 05:31',
+            avatarBg: 'red',
+        },
+        {
+            key: '3',
+            name: '设计文档',
+            nameIconSrc: 'https://lf3-static.bytednsdoc.com/obj/eden-cn/ptlz_zlp/ljhwZthlaukjlkulzlp/docs-icon.png',
+            size: '34KB',
+            status: 'wait',
+            owner: 'Zoey Edwards',
+            updateTime: '2020-01-26 11:01',
+            avatarBg: 'light-blue',
+        },
+    ];
+    return <Table 
+        bordered 
+        columns={columns} 
+        dataSource={data} 
+        pagination={false} 
+        // title={"TestHeader"} 
+        // footer={"testFooter"}
+    />;
+};
+
+export default BorderedDoubleTable;
+

--- a/packages/semi-ui/table/_story/table.stories.jsx
+++ b/packages/semi-ui/table/_story/table.stories.jsx
@@ -50,6 +50,7 @@ import FixAllColumnsWithoutWidth from './FixAllColumnsWithoutWidth';
 import HugeData from "./HugeData"
 import RowSelectionRenderCell from './RowSelectionRenderCell';
 import RowBg from './RowBg';
+import BorderedDoubleTable from './borderedDoubleTable';
 
 export default {
   title: 'Table'
@@ -656,3 +657,5 @@ _RowSelectionRenderCell.story = {
 };
 
 export const RowBgDemo = () => <RowBg />;
+
+export const BorderedDoubleTableDemo = () => <BorderedDoubleTable />


### PR DESCRIPTION
…tyle of the inner table when multiple levels of table nesting were used

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3082 

***问题原因***
原来的样式选择器是通过空格实现的后代选择器，当两个 Table 嵌套时，外层设置 bordered 属性，会导致内层 table 中的对应元素也匹配上了相关的选择器。
***解决方案***
是通过 > 限制选择器只在直接子级生效 + :where 保证前后样式优先级一致。
***详情***
通过直接 > 符号限制只在直接子级生效，为了保证是直接子级，某些样式需要通过增加类名称来精准命中，但是增加类名称会影响整体选择器的优先级。因此需要使用了 [:where](https://developer.mozilla.org/zh-CN/docs/Web/CSS/Reference/Selectors/:where) 保证修改前后的优先级一致。
***为什么一定要保证修改前后的选择器优先级一致？***
因为在其他的地方也会设置相关选择器中设置的样式，比如 fixed 列，可resizable，在 resizing 时候，也会去设置semi-table-row-head层的 border-right。如果修改后的样式优先级过高，会导致其他原本可以生效的样式，在应当生效时下不生效

### Changelog
🇨🇳 Chinese
- Fix: 修复多层 Table 嵌套时候，外层 Table 的 bordered 设置为 true 导致内层 Table 也有边框问题 #3082

---

🇺🇸 English
- Fix: fixed an issue where setting the `bordered` property of the outer table to `true` caused the inner table to also have borders when dealing with nested tables. #3082 


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
