### PR TITLE
style: [AIChatInput] Set the box-sizing of inputSlot to content-box

### DIFF
--- a/packages/semi-foundation/aiChatInput/aiChatInput.scss
+++ b/packages/semi-foundation/aiChatInput/aiChatInput.scss
@@ -523,6 +523,7 @@ $module: #{$prefix}-aiChatInput;
     
             .input-slot {
                 display: inline-block;
+                box-sizing: content-box;
                 background-color: $color-aiChatInput_rich_text-input_slot-bg;
                 border-radius: $radius-aiChatInput_rich_text-input_slot;
                 padding: $spacing-aiChatInput_rich_text-input_slot-paddingY $spacing-aiChatInput_rich_text-input_slot-paddingX;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [x] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3094 

### Changelog
🇨🇳 Chinese
- Style: AIChatInput 的 input-slot 显式设置 box-sizing 为 content-box，避免用户项目中 tailwindCss 引入，或者其他全局样式设置的影响 #3094 

---

🇺🇸 English
- Style: The input-slot of AIChatInput explicitly sets box-sizing to content-box to avoid the introduction of tailwindCss in user projects or the influence of other global style settings. #3094 


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
