### PR TITLE
fix: update regex patterns in loader rules to match 'semi-ui-19' scenario

### DIFF
--- a/packages/semi-rspack/src/rule.ts
+++ b/packages/semi-rspack/src/rule.ts
@@ -1,11 +1,11 @@
 import { RuleSetRule } from 'webpack';
-import { SOURCE_SUFFIX_LOADER, THEME_LOADER, OMIT_CSS_LOADER, PREFIX_LOADER, WEB_COMPONENT_LOADER, EXTRACT_CSS_LOADER } from './constants';
-import { SemiWebpackPluginOptions, SemiThemeOptions } from './types';
+import { EXTRACT_CSS_LOADER, OMIT_CSS_LOADER, PREFIX_LOADER, SOURCE_SUFFIX_LOADER, THEME_LOADER, WEB_COMPONENT_LOADER } from './constants';
+import { SemiThemeOptions, SemiWebpackPluginOptions } from './types';
 import { stringifyVariableRecord } from './utils';
 
 export function createSourceSuffixLoaderRule(_opts?: SemiWebpackPluginOptions) {
     return {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons)(\/|\\)+.+\.js$/,
+        test: /@douyinfe(\/|\\)+semi-(ui-19|ui|icons)(\/|\\)+.+\.js$/,
         use: [{ loader: SOURCE_SUFFIX_LOADER }],
     };
 }
@@ -27,7 +27,7 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
         cssLayer: opts.cssLayer
     };
     const loaderInfo = {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
+        test: /@douyinfe(\/|\\)+semi-(ui-19|ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
         use: [{ loader: THEME_LOADER, options }],
     };
     let commonLoader: any[] = [


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes #3113 

### Changelog
🇨🇳 Chinese
- Fix: 更新正则匹配规则，让其能匹配到 semi-ui-19 包，解决主题不生效的问题

---

🇺🇸 English
- Fix: update regex patterns in loader rules to match 'semi-ui-19' scenario


### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [ ] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
<!-- You can provide screenshot/video or some additional information -->
