### PR TITLE
修复 semi-webpack/semi-rspack：支持匹配 `@douyinfe/semi-ui-19` 等带数字后缀包名

### DIFF
--- a/packages/semi-rspack/README.md
+++ b/packages/semi-rspack/README.md
@@ -5,6 +5,9 @@ The plugin is designed for Semi Design, support rspack, provides two major abili
 - Custom theme
 - Replace prefix of CSS selector 
 
+> Note: The plugin detects Semi related dependencies by package path. It supports both
+> `@douyinfe/semi-ui` and version-suffixed packages like `@douyinfe/semi-ui-19` (also for `semi-icons`).
+
 ## Usage 
 
 ### Install 

--- a/packages/semi-rspack/src/rule.ts
+++ b/packages/semi-rspack/src/rule.ts
@@ -5,7 +5,8 @@ import { stringifyVariableRecord } from './utils';
 
 export function createSourceSuffixLoaderRule(_opts?: SemiWebpackPluginOptions) {
     return {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons)(\/|\\)+.+\.js$/,
+        // Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-icons-19
+        test: /@douyinfe(\/|\\)+semi-(ui|icons)(-\d+)?(\/|\\)+.+\.js$/,
         use: [{ loader: SOURCE_SUFFIX_LOADER }],
     };
 }
@@ -27,7 +28,8 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
         cssLayer: opts.cssLayer
     };
     const loaderInfo = {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
+        // Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-foundation-19
+        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(-\d+)?(\/|\\)+lib(\/|\\)+.+\.scss$/,
         use: [{ loader: THEME_LOADER, options }],
     };
     let commonLoader: any[] = [

--- a/packages/semi-webpack/README.md
+++ b/packages/semi-webpack/README.md
@@ -5,6 +5,9 @@ The plugin is designed for Semi Design, support webpack4 and webpack5, provides 
 - Custom theme
 - Replace prefix of CSS selector 
 
+> Note: The plugin detects Semi related dependencies by package path. It supports both
+> `@douyinfe/semi-ui` and version-suffixed packages like `@douyinfe/semi-ui-19` (also for `semi-icons`).
+
 ## Usage 
 
 ### Install 

--- a/packages/semi-webpack/src/semi-webpack-plugin.ts
+++ b/packages/semi-webpack/src/semi-webpack-plugin.ts
@@ -29,6 +29,11 @@ export interface SemiThemeOptions {
     name?: string
 }
 
+// Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-icons-19
+// Only allow numeric suffix to avoid over-matching non-Semi packages.
+const SEMI_LIB_JS_RE = /@douyinfe\/semi-(ui|icons)(-\d+)?\/lib\/.+\.js$/;
+const SEMI_LIB_SCSS_RE = /@douyinfe\/semi-(ui|icons|foundation)(-\d+)?\/lib\/.+\.scss$/;
+
 export default class SemiWebpackPlugin {
 
     options: SemiWebpackPluginOptions;
@@ -92,7 +97,7 @@ export default class SemiWebpackPlugin {
 
     omitCss(module: any) {
         const compatiblePath = transformPath(module.resource);
-        if (/@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/.test(compatiblePath)) {
+        if (SEMI_LIB_JS_RE.test(compatiblePath)) {
             module.loaders = module.loaders || [];
             module.loaders.push({
                 loader: path.join(__dirname, 'semi-omit-css-loader')
@@ -102,13 +107,13 @@ export default class SemiWebpackPlugin {
 
     customTheme(module: any) {
         const compatiblePath = transformPath(module.resource);
-        if (/@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/.test(compatiblePath)) {
+        if (SEMI_LIB_JS_RE.test(compatiblePath)) {
             module.loaders = module.loaders || [];
             module.loaders.push({
                 loader: path.join(__dirname, 'semi-source-suffix-loader')
             });
         }
-        if (/@douyinfe\/semi-(ui|icons|foundation)\/lib\/.+\.scss$/.test(compatiblePath)) {
+        if (SEMI_LIB_SCSS_RE.test(compatiblePath)) {
             const scssLoader = require.resolve('sass-loader');
             const cssLoader = require.resolve('css-loader');
             const styleLoader = require.resolve('style-loader');
@@ -199,4 +204,3 @@ export default class SemiWebpackPlugin {
         }, '');
     }
 }
-


### PR DESCRIPTION
修复 Issue #3116：`@douyinfe/semi-webpack-plugin`（以及对应的 `semi-rspack` 规则）在通过 `module.resource` 路径正则识别 Semi 相关依赖时，仅匹配 `@douyinfe/semi-(ui|icons|foundation)`，导致 `@douyinfe/semi-ui-19/lib/...` 这类带数字后缀的包名无法命中，从而相关 loader/规则不生效。

### 解决方案
将依赖识别正则扩展为支持可选的 `-数字` 后缀（如 `semi-ui-19`），并保持对原有 `semi-ui` / `semi-icons` / `semi-foundation` 的兼容；同时在 `semi-rspack` 中对齐相同的匹配逻辑。

### 主要变更点
- 更新 `packages/semi-webpack/src/semi-webpack-plugin.ts`：扩展 Semi 依赖路径匹配正则，覆盖 `@douyinfe/semi-ui-<number>` 形态
- 更新 `packages/semi-webpack/README.md`：补充说明支持带数字后缀的 Semi 包名
- 更新 `packages/semi-rspack/src/rule.ts`：对齐相同的包名匹配规则，避免 rspack 场景同类问题
- 更新 `packages/semi-rspack/README.md`：同步文档说明

### 测试说明
- 本次修改为匹配逻辑与文档更新；仓库内该包未见现成自动化用例覆盖该正则场景
- 建议在项目中分别引入 `@douyinfe/semi-ui` 与 `@douyinfe/semi-ui-19` 验证对应规则/loader 是否均能生效（webpack 与 rspack 场景各验证一次）