### PR TITLE
修复 semi-webpack/semi-rspack：支持匹配 @douyinfe/semi-ui-19 等带数字后缀包名

### DIFF
--- a/packages/semi-rspack/README.md
+++ b/packages/semi-rspack/README.md
@@ -5,6 +5,9 @@ The plugin is designed for Semi Design, support rspack, provides two major abili
 - Custom theme
 - Replace prefix of CSS selector 
 
+> Note: The plugin detects Semi related dependencies by package path. It supports both
+> `@douyinfe/semi-ui` and version-suffixed packages like `@douyinfe/semi-ui-19` (also for `semi-icons`).
+
 ## Usage 
 
 ### Install 

--- a/packages/semi-rspack/src/rule.ts
+++ b/packages/semi-rspack/src/rule.ts
@@ -5,7 +5,8 @@ import { stringifyVariableRecord } from './utils';
 
 export function createSourceSuffixLoaderRule(_opts?: SemiWebpackPluginOptions) {
     return {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons)(\/|\\)+.+\.js$/,
+        // Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-icons-19
+        test: /@douyinfe(\/|\\)+semi-(ui|icons)(-\d+)?(\/|\\)+.+\.js$/,
         use: [{ loader: SOURCE_SUFFIX_LOADER }],
     };
 }
@@ -27,7 +28,8 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
         cssLayer: opts.cssLayer
     };
     const loaderInfo = {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
+        // Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-foundation-19
+        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(-\d+)?(\/|\\)+lib(\/|\\)+.+\.scss$/,
         use: [{ loader: THEME_LOADER, options }],
     };
     let commonLoader: any[] = [

--- a/packages/semi-webpack/README.md
+++ b/packages/semi-webpack/README.md
@@ -5,6 +5,9 @@ The plugin is designed for Semi Design, support webpack4 and webpack5, provides 
 - Custom theme
 - Replace prefix of CSS selector 
 
+> Note: The plugin detects Semi related dependencies by package path. It supports both
+> `@douyinfe/semi-ui` and version-suffixed packages like `@douyinfe/semi-ui-19` (also for `semi-icons`).
+
 ## Usage 
 
 ### Install 

--- a/packages/semi-webpack/src/semi-webpack-plugin.ts
+++ b/packages/semi-webpack/src/semi-webpack-plugin.ts
@@ -29,6 +29,11 @@ export interface SemiThemeOptions {
     name?: string
 }
 
+// Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-icons-19
+// Only allow numeric suffix to avoid over-matching non-Semi packages.
+const SEMI_LIB_JS_RE = /@douyinfe\/semi-(ui|icons)(-\d+)?\/lib\/.+\.js$/;
+const SEMI_LIB_SCSS_RE = /@douyinfe\/semi-(ui|icons|foundation)(-\d+)?\/lib\/.+\.scss$/;
+
 export default class SemiWebpackPlugin {
 
     options: SemiWebpackPluginOptions;
@@ -92,7 +97,7 @@ export default class SemiWebpackPlugin {
 
     omitCss(module: any) {
         const compatiblePath = transformPath(module.resource);
-        if (/@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/.test(compatiblePath)) {
+        if (SEMI_LIB_JS_RE.test(compatiblePath)) {
             module.loaders = module.loaders || [];
             module.loaders.push({
                 loader: path.join(__dirname, 'semi-omit-css-loader')
@@ -102,13 +107,13 @@ export default class SemiWebpackPlugin {
 
     customTheme(module: any) {
         const compatiblePath = transformPath(module.resource);
-        if (/@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/.test(compatiblePath)) {
+        if (SEMI_LIB_JS_RE.test(compatiblePath)) {
             module.loaders = module.loaders || [];
             module.loaders.push({
                 loader: path.join(__dirname, 'semi-source-suffix-loader')
             });
         }
-        if (/@douyinfe\/semi-(ui|icons|foundation)\/lib\/.+\.scss$/.test(compatiblePath)) {
+        if (SEMI_LIB_SCSS_RE.test(compatiblePath)) {
             const scssLoader = require.resolve('sass-loader');
             const cssLoader = require.resolve('css-loader');
             const styleLoader = require.resolve('style-loader');
@@ -199,4 +204,3 @@ export default class SemiWebpackPlugin {
         }, '');
     }
 }
-


### PR DESCRIPTION
关联 Issue: #3116（`@douyinfe/semi-webpack-plugin` 正则未匹配 `@douyinfe/semi-ui-19`）

### 问题概述
现有规则/正则仅匹配 `@douyinfe/semi-(ui|icons|foundation)` 的固定包名形态，导致当依赖包名为 `@douyinfe/semi-ui-19`（或类似带数字后缀）时无法命中，从而插件对应 loader/rule 不生效。

### 解决方案
将 Semi 相关依赖的识别正则扩展为“可选数字后缀”形式（例如 `semi-ui(-19)?`），确保 `@douyinfe/semi-ui` 与 `@douyinfe/semi-ui-19` 均能被正确匹配，同时保持对 `semi-icons`、`semi-foundation` 的兼容。

### 主要变更点
- `packages/semi-webpack/src/semi-webpack-plugin.ts`：更新并复用匹配正则，支持 `@douyinfe/semi-ui-19` 等形态
- `packages/semi-webpack/README.md`：补充说明支持带数字后缀的 Semi 包名
- `packages/semi-rspack/src/rule.ts`：同步修复 rspack 侧的匹配规则，保持行为一致
- `packages/semi-rspack/README.md`：同步更新文档说明

### 测试说明
- 本次未新增自动化测试用例；通过典型依赖路径（`@douyinfe/semi-ui` / `@douyinfe/semi-ui-19`）进行匹配逻辑手工校验，确保规则可命中并不影响原有包名匹配。