### PR TITLE
【Auto】fix(semi-webpack/semi-rspack): 正则支持匹配 `@douyinfe/semi-ui-19` 等带数字后缀包名

### DIFF
--- a/packages/semi-rspack/README.md
+++ b/packages/semi-rspack/README.md
@@ -5,6 +5,9 @@ The plugin is designed for Semi Design, support rspack, provides two major abili
 - Custom theme
 - Replace prefix of CSS selector 
 
+> Note: The plugin detects Semi related dependencies by package path. It supports both
+> `@douyinfe/semi-ui` and version-suffixed packages like `@douyinfe/semi-ui-19` (also for `semi-icons`).
+
 ## Usage 
 
 ### Install 

--- a/packages/semi-rspack/src/rule.ts
+++ b/packages/semi-rspack/src/rule.ts
@@ -5,7 +5,8 @@ import { stringifyVariableRecord } from './utils';
 
 export function createSourceSuffixLoaderRule(_opts?: SemiWebpackPluginOptions) {
     return {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons)(\/|\\)+.+\.js$/,
+        // Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-icons-19
+        test: /@douyinfe(\/|\\)+semi-(ui|icons)(-\d+)?(\/|\\)+.+\.js$/,
         use: [{ loader: SOURCE_SUFFIX_LOADER }],
     };
 }
@@ -27,7 +28,8 @@ export function createThemeLoaderRule(opts?: SemiWebpackPluginOptions) {
         cssLayer: opts.cssLayer
     };
     const loaderInfo = {
-        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(\/|\\)+lib(\/|\\)+.+\.scss$/,
+        // Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-foundation-19
+        test: /@douyinfe(\/|\\)+semi-(ui|icons|foundation)(-\d+)?(\/|\\)+lib(\/|\\)+.+\.scss$/,
         use: [{ loader: THEME_LOADER, options }],
     };
     let commonLoader: any[] = [

--- a/packages/semi-webpack/README.md
+++ b/packages/semi-webpack/README.md
@@ -5,6 +5,9 @@ The plugin is designed for Semi Design, support webpack4 and webpack5, provides 
 - Custom theme
 - Replace prefix of CSS selector 
 
+> Note: The plugin detects Semi related dependencies by package path. It supports both
+> `@douyinfe/semi-ui` and version-suffixed packages like `@douyinfe/semi-ui-19` (also for `semi-icons`).
+
 ## Usage 
 
 ### Install 

--- a/packages/semi-webpack/src/semi-webpack-plugin.ts
+++ b/packages/semi-webpack/src/semi-webpack-plugin.ts
@@ -29,6 +29,11 @@ export interface SemiThemeOptions {
     name?: string
 }
 
+// Support packages like @douyinfe/semi-ui-19, @douyinfe/semi-icons-19
+// Only allow numeric suffix to avoid over-matching non-Semi packages.
+const SEMI_LIB_JS_RE = /@douyinfe\/semi-(ui|icons)(-\d+)?\/lib\/.+\.js$/;
+const SEMI_LIB_SCSS_RE = /@douyinfe\/semi-(ui|icons|foundation)(-\d+)?\/lib\/.+\.scss$/;
+
 export default class SemiWebpackPlugin {
 
     options: SemiWebpackPluginOptions;
@@ -92,7 +97,7 @@ export default class SemiWebpackPlugin {
 
     omitCss(module: any) {
         const compatiblePath = transformPath(module.resource);
-        if (/@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/.test(compatiblePath)) {
+        if (SEMI_LIB_JS_RE.test(compatiblePath)) {
             module.loaders = module.loaders || [];
             module.loaders.push({
                 loader: path.join(__dirname, 'semi-omit-css-loader')
@@ -102,13 +107,13 @@ export default class SemiWebpackPlugin {
 
     customTheme(module: any) {
         const compatiblePath = transformPath(module.resource);
-        if (/@douyinfe\/semi-(ui|icons)\/lib\/.+\.js$/.test(compatiblePath)) {
+        if (SEMI_LIB_JS_RE.test(compatiblePath)) {
             module.loaders = module.loaders || [];
             module.loaders.push({
                 loader: path.join(__dirname, 'semi-source-suffix-loader')
             });
         }
-        if (/@douyinfe\/semi-(ui|icons|foundation)\/lib\/.+\.scss$/.test(compatiblePath)) {
+        if (SEMI_LIB_SCSS_RE.test(compatiblePath)) {
             const scssLoader = require.resolve('sass-loader');
             const cssLoader = require.resolve('css-loader');
             const styleLoader = require.resolve('style-loader');
@@ -199,4 +204,3 @@ export default class SemiWebpackPlugin {
         }, '');
     }
 }
-


### PR DESCRIPTION
关联 Issue: #3116

### 问题概述
`@douyinfe/semi-webpack-plugin`（以及对应的 `semi-rspack` 规则）在判断 `module.resource` 路径时，包名匹配正则仅覆盖 `@douyinfe/semi-ui`/`semi-icons`/`semi-foundation`，未包含 `@douyinfe/semi-ui-19` 这类“带数字后缀”的包名，导致相关 loader/rule 不生效。

### 解决方案
将 Semi 相关依赖的包名匹配逻辑扩展为支持可选的 `-数字` 后缀（例如 `-19`），并保持原有包名/路径匹配边界，避免误匹配。

### 主要变更点
- 更新 `packages/semi-webpack/src/semi-webpack-plugin.ts`：扩展匹配正则以覆盖 `@douyinfe/semi-ui-19` 等变体，并提取/复用匹配常量以减少重复与维护成本。
- 更新 `packages/semi-webpack/README.md`：补充说明支持带数字后缀的 Semi 包名形态。
- 更新 `packages/semi-rspack/src/rule.ts`：同步修复 rspack 侧同类路径匹配规则。
- 更新 `packages/semi-rspack/README.md`：同步补充文档说明。

### 测试说明
- 未新增自动化测试（该包当前缺少就绪的测试基础设施）。
- 通过对典型 `module.resource` 路径用例进行人工校验，确认 `@douyinfe/semi-ui-19/lib/...` 能命中对应规则且不影响原有 `@douyinfe/semi-ui/lib/...` 等匹配路径。