### PR TITLE
【Auto】fix(semi-next): 透传 semi-webpack-plugin 全量 options，避免 Tailwind 场景重复加载插件

### DIFF
--- a/packages/semi-next/README.md
+++ b/packages/semi-next/README.md
@@ -26,6 +26,9 @@ module.exports = semi({
 
 ## Options
 
+`@douyinfe/semi-next` passes its options through to `@douyinfe/semi-webpack-plugin`.
+So you can use all options supported by `SemiWebpackPluginOptions`.
+
 ### options.omitCss
 
 Type: `Boolean`

--- a/packages/semi-next/src/index.ts
+++ b/packages/semi-next/src/index.ts
@@ -1,20 +1,23 @@
 // import { NextConfig } from 'next';
-import SemiWebpackPlugin from '@douyinfe/semi-webpack-plugin';
+import SemiWebpackPlugin, { SemiWebpackPluginOptions } from '@douyinfe/semi-webpack-plugin';
 
-export interface SemiNextOptions {
-    omitCss?: boolean
-}
+export type SemiNextOptions = SemiWebpackPluginOptions;
 
 export default function(options: SemiNextOptions = {}) {
     return (nextConfig: any = {}) => {
         const actualConfig: any = {
             ...nextConfig,
             webpack(config: any, { isServer, webpack, ...rest }: any) {
+                const { omitCss = true, webpackContext, ...restOptions } = options;
                 config.plugins.push(new SemiWebpackPlugin({
-                    omitCss: options.omitCss === undefined ? true : options.omitCss,
+                    omitCss,
+                    ...restOptions,
+                    // Ensure SemiWebpackPlugin can access NormalModule under Next.
+                    // Keep backward compatible with user-provided webpackContext.
                     webpackContext: {
+                        ...webpackContext,
                         NormalModule: webpack.NormalModule
-                    }
+                    },
                 }));
                 if (isServer) {
                     if (


### PR DESCRIPTION

[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3115

`@douyinfe/semi-next` 目前仅暴露并处理了 `omitCss` 选项，未支持 `@douyinfe/semi-webpack-plugin` 的全部 options。导致在配合 TailwindCSS 等场景需要使用其它插件能力时，用户不得不额外再加载一次 `semi-webpack-plugin`，产生重复配置/重复加载的问题。

#### 问题根因

在 `packages/semi-next/src/index.ts` 中，`SemiNextOptions` 类型仅定义了 `omitCss` 一个字段：

```typescript
// 原代码
export interface SemiNextOptions {
    omitCss?: boolean
}
```

这导致用户无法使用 `@douyinfe/semi-webpack-plugin` 的其他配置项（如 `prefixCls`、`include`、`extractCss` 等），在需要这些功能时必须手动再加载一次插件。

#### 解决方案

1. **类型对齐**：`SemiNextOptions` 直接复用 `SemiWebpackPluginOptions` 类型
2. **全量透传**：除 `omitCss`（保持默认 `true`）外，其它字段全部透传给内部创建的 `SemiWebpackPlugin`
3. **合并 webpackContext**：保留用户传入字段，同时继续注入 Next.js 环境所需的上下文（`webpack.NormalModule`），确保兼容性

```typescript
// 修复后
export type SemiNextOptions = SemiWebpackPluginOptions;

// 透传所有选项，合并 webpackContext
const { omitCss = true, webpackContext, ...restOptions } = options;
config.plugins.push(new SemiWebpackPlugin({
    omitCss,
    ...restOptions,
    webpackContext: {
        ...webpackContext,
        NormalModule: webpack.NormalModule
    },
}));
```

#### 主要变更点

**packages/semi-next/src/index.ts**
- `SemiNextOptions` 类型改为复用 `SemiWebpackPluginOptions`
- 插件实例化时透传完整 options（`omitCss` 默认值保持 `true` 不变）
- 合并 `webpackContext`，避免覆盖 semi-next 必需注入的 `NormalModule`

**packages/semi-next/README.md**
- 更新 Options 文档：声明与 `@douyinfe/semi-webpack-plugin` options 一致
- 说明 `omitCss` 在 Next.js 场景下默认为 `true`

### Changelog
🇨🇳 Chinese
- Feature: `@douyinfe/semi-next` 支持透传 `@douyinfe/semi-webpack-plugin` 全量 options (#3115)

---

🇺🇸 English
- Feature: `@douyinfe/semi-next` now supports passing through all `@douyinfe/semi-webpack-plugin` options (#3115)

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

**使用示例：**
```javascript
// next.config.js
const semi = require('@douyinfe/semi-next').default;

module.exports = semi({
    // 现在可以使用所有 semi-webpack-plugin 的选项
    omitCss: true,  // 默认值，Next.js 场景必需
    prefixCls: 'my-prefix',
    include: '~@douyinfe/semi-ui/lib/.+\\.js$',
    // ... 其他 SemiWebpackPluginOptions
})({
    // Next.js config
});
```

**向后兼容性：**
- 现有使用 `omitCss` 的配置无需修改
- `omitCss` 默认值保持 `true`，符合 Next.js 场景需求
- `webpackContext` 合并处理，不会破坏 semi-next 的内部注入
