### PR TITLE
【Auto】Fix: Trigger uploadProps onRemove in AIChatInput

### DIFF
--- a/content/ai/aiChatInput/index-en-US.md
+++ b/content/ai/aiChatInput/index-en-US.md
@@ -29,6 +29,7 @@ Supports text input and file upload. You can configure the following parameters 
 
 - `uploadProps`: Configure parameters related to file upload. See [UploadProps](/en-US/plus/upload#API)
 - `onUploadChange`: Callback when file upload changes
+- When deleting uploaded files, `uploadProps.onRemove` will be triggered, and `uploadProps.beforeRemove` will be respected (Promise supported)
 - `placeholder`: Placeholder for the input box
 - `defaultContent`: Default content for the input box
 - `onContentChange`: Callback when the content of the input box changes; the parameter is the current content

--- a/content/ai/aiChatInput/index.md
+++ b/content/ai/aiChatInput/index.md
@@ -29,6 +29,7 @@ import { AIChatInput } from '@douyinfe/semi-ui';
 
 - `uploadProps` 配置文件上传相关的参数，详见 [UploadProps](/zh-CN/plus/upload#API)
 - `onUploadChange` 获取文件上传变化
+- 删除上传文件时，会触发 `uploadProps.onRemove`，并遵循 `uploadProps.beforeRemove`（支持 Promise）
 - `placeholder` 输入框的占位符
 - `defaultContent` 输入框的默认内容
 - `onContentChange` 输入框内容变化时的回调函数，参数为当前输入框的内容
@@ -1628,5 +1629,4 @@ render(<CustomRichTextExtension />);
 
 ## 设计变量
 <DesignToken/>
-
 

--- a/packages/semi-foundation/aiChatInput/foundation.ts
+++ b/packages/semi-foundation/aiChatInput/foundation.ts
@@ -90,12 +90,50 @@ export default class AIChatInputFoundation extends BaseFoundation<AIChatInputAda
         this._adapter.focusEditor();
     }
 
+    /**
+     * Delete uploaded file item.
+     * Notes:
+     * - AIChatInput uses custom upload list UI, so we need to align remove behavior with Upload:
+     *   1) respect uploadProps.beforeRemove (support Promise)
+     *   2) call uploadProps.onRemove with (currentFile, nextFileList, currentFileItem)
+     *   3) still trigger onUploadChange/uploadProps.onChange for fileList update
+     */
     handleUploadFileDelete = (attachment: Attachment) => {
-        const { attachments } = this.getStates();
-        const newAttachments = attachments.filter(item => item.uid !== attachment.uid);
-        this.onUploadChange({
-            currentFile: attachment,
-            fileList: newAttachments
+        const { uploadProps } = this.getProps();
+        const { attachments: attachmentsFromState } = this.getStates();
+        const attachments = Array.isArray(attachmentsFromState) ? attachmentsFromState : [];
+
+        // Keep consistent with Upload: disabled means no-op
+        if (uploadProps?.disabled) {
+            return;
+        }
+
+        const index = attachments.findIndex(item => item.uid === attachment.uid);
+        if (index < 0) {
+            return;
+        }
+
+        const beforeRemove = uploadProps?.beforeRemove;
+        Promise.resolve(beforeRemove?.(attachment, attachments) ?? true).then(res => {
+            // prevent remove while user return false
+            if (res === false) {
+                return;
+            }
+
+            const newAttachments = attachments.slice();
+            newAttachments.splice(index, 1);
+
+            // Align Upload onRemove signature: (File, nextFileList, currentFileItem)
+            // currentFile: use original File instance when available
+            uploadProps?.onRemove?.(attachment.fileInstance as any, newAttachments as any, attachment as any);
+
+            // keep existing behavior: update state + notify upload change
+            this.onUploadChange({
+                currentFile: attachment,
+                fileList: newAttachments
+            });
+        }).catch(() => {
+            // if user pass reject promise, no need to do anything
         });
     }
 

--- a/packages/semi-ui/aiChatInput/__test__/aiChatInputFoundation.test.js
+++ b/packages/semi-ui/aiChatInput/__test__/aiChatInputFoundation.test.js
@@ -1,0 +1,163 @@
+import sinon from 'sinon';
+import AIChatInputFoundation from '@douyinfe/semi-foundation/aiChatInput/foundation';
+
+describe('AIChatInputFoundation', () => {
+    it('should trigger uploadProps.onRemove when deleting uploaded file', async () => {
+        const attachment = {
+            uid: '1',
+            name: 'a.png',
+            size: '1KB',
+            status: 'success',
+            fileInstance: { name: 'a.png' },
+        };
+
+        const attachments = [attachment];
+        const spyOnRemove = sinon.spy();
+        const spyOnUploadChange = sinon.spy();
+        const spyUploadOnChange = sinon.spy();
+
+        const adapter = {
+            getProps: () => ({
+                onUploadChange: spyOnUploadChange,
+                uploadProps: {
+                    action: 'https://semi.test/upload',
+                    onRemove: spyOnRemove,
+                    onChange: spyUploadOnChange,
+                },
+            }),
+            getStates: () => ({ attachments }),
+            setState: () => {},
+        };
+
+        const foundation = new AIChatInputFoundation(adapter);
+        foundation.handleUploadFileDelete(attachment);
+
+        // wait for Promise.resolve().then
+        await Promise.resolve();
+
+        expect(spyOnRemove.callCount).toEqual(1);
+        expect(spyOnRemove.firstCall.args[0]).toEqual(attachment.fileInstance);
+        expect(Array.isArray(spyOnRemove.firstCall.args[1])).toEqual(true);
+        expect(spyOnRemove.firstCall.args[1].length).toEqual(0);
+        expect(spyOnRemove.firstCall.args[2].uid).toEqual('1');
+
+        // still trigger onUploadChange + uploadProps.onChange via onUploadChange
+        expect(spyOnUploadChange.callCount).toEqual(1);
+        expect(spyUploadOnChange.callCount).toEqual(1);
+        expect(spyOnUploadChange.firstCall.args[0].fileList.length).toEqual(0);
+    });
+
+    it('should respect uploadProps.beforeRemove returning false', async () => {
+        const attachment = {
+            uid: '1',
+            name: 'a.png',
+            size: '1KB',
+            status: 'success',
+        };
+        const attachments = [attachment];
+
+        const spyOnRemove = sinon.spy();
+        const spyOnUploadChange = sinon.spy();
+        const spyUploadOnChange = sinon.spy();
+        const spyBeforeRemove = sinon.spy(() => false);
+
+        const adapter = {
+            getProps: () => ({
+                onUploadChange: spyOnUploadChange,
+                uploadProps: {
+                    action: 'https://semi.test/upload',
+                    beforeRemove: spyBeforeRemove,
+                    onRemove: spyOnRemove,
+                    onChange: spyUploadOnChange,
+                },
+            }),
+            getStates: () => ({ attachments }),
+            setState: () => {},
+        };
+
+        const foundation = new AIChatInputFoundation(adapter);
+        foundation.handleUploadFileDelete(attachment);
+
+        await Promise.resolve();
+
+        expect(spyBeforeRemove.callCount).toEqual(1);
+        expect(spyOnRemove.callCount).toEqual(0);
+        expect(spyOnUploadChange.callCount).toEqual(0);
+        expect(spyUploadOnChange.callCount).toEqual(0);
+    });
+
+    it('should support uploadProps.beforeRemove returning Promise', async () => {
+        const attachment = {
+            uid: '1',
+            name: 'a.png',
+            size: '1KB',
+            status: 'success',
+        };
+        const attachments = [attachment];
+
+        const spyOnRemove = sinon.spy();
+        const spyOnUploadChange = sinon.spy();
+        const spyBeforeRemove = sinon.spy(() => Promise.resolve(true));
+
+        const adapter = {
+            getProps: () => ({
+                onUploadChange: spyOnUploadChange,
+                uploadProps: {
+                    action: 'https://semi.test/upload',
+                    beforeRemove: spyBeforeRemove,
+                    onRemove: spyOnRemove,
+                },
+            }),
+            getStates: () => ({ attachments }),
+            setState: () => {},
+        };
+
+        const foundation = new AIChatInputFoundation(adapter);
+        foundation.handleUploadFileDelete(attachment);
+
+        // flush both: outer Promise.resolve and beforeRemove Promise.resolve(true)
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(spyBeforeRemove.callCount).toEqual(1);
+        expect(spyOnRemove.callCount).toEqual(1);
+        expect(spyOnUploadChange.callCount).toEqual(1);
+    });
+
+    it('should do nothing when deleting non-existent uid', async () => {
+        const attachment = {
+            uid: 'not-exist',
+            name: 'a.png',
+            size: '1KB',
+            status: 'success',
+            fileInstance: { name: 'a.png' },
+        };
+        const attachments = [{ ...attachment, uid: '1' }];
+
+        const spyOnRemove = sinon.spy();
+        const spyOnUploadChange = sinon.spy();
+        const spyUploadOnChange = sinon.spy();
+
+        const adapter = {
+            getProps: () => ({
+                onUploadChange: spyOnUploadChange,
+                uploadProps: {
+                    action: 'https://semi.test/upload',
+                    onRemove: spyOnRemove,
+                    onChange: spyUploadOnChange,
+                },
+            }),
+            getStates: () => ({ attachments }),
+            setState: () => {},
+        };
+
+        const foundation = new AIChatInputFoundation(adapter);
+        foundation.handleUploadFileDelete(attachment);
+
+        await Promise.resolve();
+
+        expect(spyOnRemove.callCount).toEqual(0);
+        expect(spyOnUploadChange.callCount).toEqual(0);
+        expect(spyUploadOnChange.callCount).toEqual(0);
+    });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1585,36 +1585,15 @@
     "@douyinfe/semi-animation-styled" "2.65.0"
     classnames "^2.2.6"
 
-"@douyinfe/semi-animation-react@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-react/-/semi-animation-react-2.90.13.tgz#a12f651c8a8626bd93743a66140e79428f547e7e"
-  integrity sha512-OWAvznz6fGdO17fYoDIzgSGKj6awqOPeC0N13OzfPtZ7ofZNozdhWqFHRVMiZgRe2MiJ3W63cHw9OLEdLNYsQA==
-  dependencies:
-    "@douyinfe/semi-animation" "2.90.13"
-    "@douyinfe/semi-animation-styled" "2.90.13"
-    classnames "^2.2.6"
-
 "@douyinfe/semi-animation-styled@2.65.0":
   version "2.65.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.65.0.tgz#8c56047a5704a45b05cc9809a2a126cc24526ea1"
   integrity sha512-YFF8Ptcz/jwS0phm28XZV7ROqMQ233sjVR0Uy33FImCITr6EAPe5wcCeEmzVZoYS7x3tUFR30SF+0hSO01rQUg==
 
-"@douyinfe/semi-animation-styled@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation-styled/-/semi-animation-styled-2.90.13.tgz#ace70a229b7e188f543f17b63fd6310869dc0a7e"
-  integrity sha512-h0m97jF341yo7bV+pS/vDck4GAtE0VUbvrcZT1Ku7yjntHqicqLc4BGJGVs/RdSEcZo/zZJ3N2UDj0Qc+Pk58A==
-
 "@douyinfe/semi-animation@2.65.0":
   version "2.65.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation/-/semi-animation-2.65.0.tgz#f544a6b420c3e948c09836019e6b63f1382cd12c"
   integrity sha512-NXgRJVOcz+cpyu5H5MRzhELlUAJaBgUOSgZAoJM3r8jxV08FJSCNgo3zTZzQ6AwgRg8fmWRsxykGaE/RKtm7Uw==
-  dependencies:
-    bezier-easing "^2.1.0"
-
-"@douyinfe/semi-animation@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-animation/-/semi-animation-2.90.13.tgz#d0d514ece0c3b87893f9c9207ea9dc75c8441033"
-  integrity sha512-qHMn8whglNbziNsNBIyrL5/jDDf4pvlJwPelGDH1orG9rryuNpLGalX9mBY7z4OKaXjrp2tfQc0mADRKVht0fA==
   dependencies:
     bezier-easing "^2.1.0"
 
@@ -1637,26 +1616,6 @@
     remark-gfm "^4.0.0"
     scroll-into-view-if-needed "^2.2.24"
 
-"@douyinfe/semi-foundation@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-foundation/-/semi-foundation-2.90.13.tgz#dd5c4ba1fd83717bcb927947a59e104f67f790a0"
-  integrity sha512-sTQVfk2UdF79VffSFy3DwPtT4qGHp9LkaFPeeW7mGUu8c3el6fKd6WSYJXNyE8Iba5bnqzxWAyfjtCxUYA+sfQ==
-  dependencies:
-    "@douyinfe/semi-animation" "2.90.13"
-    "@douyinfe/semi-json-viewer-core" "2.90.13"
-    "@mdx-js/mdx" "^3.0.1"
-    async-validator "^3.5.0"
-    classnames "^2.2.6"
-    date-fns "^2.29.3"
-    date-fns-tz "^1.3.8"
-    fast-copy "^3.0.1 "
-    lodash "^4.17.21"
-    lottie-web "^5.12.2"
-    memoize-one "^5.2.1"
-    prismjs "^1.29.0"
-    remark-gfm "^4.0.0"
-    scroll-into-view-if-needed "^2.2.24"
-
 "@douyinfe/semi-icons@2.65.0", "@douyinfe/semi-icons@latest":
   version "2.65.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.65.0.tgz#af39cbd5431ebccedcf7d9ce689646e54bebc432"
@@ -1664,29 +1623,10 @@
   dependencies:
     classnames "^2.2.6"
 
-"@douyinfe/semi-icons@2.90.13", "@douyinfe/semi-icons@^2.0.0":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-icons/-/semi-icons-2.90.13.tgz#69253e0ba40b3e2255868b169959b2c89cd73a94"
-  integrity sha512-9OiKvleOMB+t0h+Vbq/6Tz90JJPANJDvW5g3XtVWmIwIgScgy/N52fMhWXDf6Avr6wi9MDPcQZ6SYPO2S7m4sQ==
-  dependencies:
-    classnames "^2.2.6"
-
 "@douyinfe/semi-illustrations@2.65.0":
   version "2.65.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.65.0.tgz#9916c540c91222a1d9f48cd34a941d28b8a05d2f"
   integrity sha512-1IhOztyBYiSu8WrcvN+oWWtcJTC9+x6zbnYtufx4ToISs5UO1te1PQofABpkDzIJYFtW9yYLxg4uoL4wGjqYMA==
-
-"@douyinfe/semi-illustrations@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-illustrations/-/semi-illustrations-2.90.13.tgz#56c6f01411aa49178f382118564a8a12e17b33f5"
-  integrity sha512-8gdonacMEw9Q9y3Y34gg1pHa7N5aURVv2qoE3hkPGpmW0RjIET1uaKaKZmGNQiXbgv6jPZ80LV4gxEw3ez4YWg==
-
-"@douyinfe/semi-json-viewer-core@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-json-viewer-core/-/semi-json-viewer-core-2.90.13.tgz#b39bc4419af64c13443651e58407717790a5e1fa"
-  integrity sha512-QwRe4MtB7SH/IjdcgqsuY2NgkXcxFTSRwYpslGNNVkEPHpxyXEqR3WIr1tMaU8Hjel8Pldc6E3F22+XZl8Gd1g==
-  dependencies:
-    jsonc-parser "^3.3.1"
 
 "@douyinfe/semi-scss-compile@2.23.2":
   version "2.23.2"
@@ -1758,49 +1698,6 @@
   version "2.61.0"
   resolved "https://registry.yarnpkg.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.61.0.tgz#a7e9bf9534721c12af1d0eeb5d5a2de615896a23"
   integrity sha512-obn/DOw4vZyKFAlWvZxHTpBLAK9FO9kygTSm2GROgvi+UDB2PPU6l20cuUCsdGUNWJRSqYlTTVZ1tNYIyFZ5Sg==
-
-"@douyinfe/semi-theme-default@2.90.13":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-theme-default/-/semi-theme-default-2.90.13.tgz#8d2ac6675c6854a5acfea75de7e574b277ec8b04"
-  integrity sha512-8f4j7NVw7w1IFFTEpTe/RkK3TW4DZWrUngV6CK3XXSCQKSVVyG/cXI5xgK9jkFiuES5S+d+ZlvL2sTA4+x8HWw==
-
-"@douyinfe/semi-ui@^2.0.0":
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/@douyinfe/semi-ui/-/semi-ui-2.90.13.tgz#50ab890a557baf8560ef9bf9865b6ccf23396f41"
-  integrity sha512-6mD2Q8aQOXah7nNSxpdvjbFI3PgI/TYez9/yBEq7+0CbEn3BGJsjl1dcRoE0JJ30IUIdCCJRTB0q3JQWH2Bvsw==
-  dependencies:
-    "@dnd-kit/core" "^6.0.8"
-    "@dnd-kit/sortable" "^7.0.2"
-    "@dnd-kit/utilities" "^3.2.1"
-    "@douyinfe/semi-animation" "2.90.13"
-    "@douyinfe/semi-animation-react" "2.90.13"
-    "@douyinfe/semi-foundation" "2.90.13"
-    "@douyinfe/semi-icons" "2.90.13"
-    "@douyinfe/semi-illustrations" "2.90.13"
-    "@douyinfe/semi-theme-default" "2.90.13"
-    "@tiptap/core" "^3.10.7"
-    "@tiptap/extension-document" "^3.10.7"
-    "@tiptap/extension-hard-break" "^3.10.7"
-    "@tiptap/extension-mention" "^3.10.7"
-    "@tiptap/extension-paragraph" "^3.10.7"
-    "@tiptap/extension-text" "^3.10.7"
-    "@tiptap/extensions" "^3.10.7"
-    "@tiptap/pm" "^3.10.7"
-    "@tiptap/react" "^3.10.7"
-    async-validator "^3.5.0"
-    classnames "^2.2.6"
-    copy-text-to-clipboard "^2.1.1"
-    date-fns "^2.29.3"
-    date-fns-tz "^1.3.8"
-    fast-copy "^3.0.1 "
-    jsonc-parser "^3.3.1"
-    lodash "^4.17.21"
-    prop-types "^15.7.2"
-    prosemirror-state "^1.4.3"
-    react-resizable "^3.0.5"
-    react-window "^1.8.2"
-    scroll-into-view-if-needed "^2.2.24"
-    utility-types "^3.10.0"
 
 "@douyinfe/semi-ui@latest":
   version "2.65.0"
@@ -6252,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6297,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -12439,11 +12336,6 @@ eslint-plugin-react@^7.20.6, eslint-plugin-react@^7.24.0:
     semver "^6.3.1"
     string.prototype.matchall "^4.0.11"
     string.prototype.repeat "^1.0.0"
-
-eslint-plugin-semi-design@^2.33.0:
-  version "2.90.13"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-semi-design/-/eslint-plugin-semi-design-2.90.13.tgz#ed6e94a1758824835945410eb7a3c5375e76861b"
-  integrity sha512-CLFEuJUWWe//DGOUUiuFmyTaHlIc5L3AwHQRfiYZEsiqxAf3YvFfr261dzwctwKQiq1owvNGoo8Eg1VxUqYJKg==
 
 eslint-rule-composer@^0.3.0:
   version "0.3.0"
@@ -20785,14 +20677,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20800,6 +20684,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23329,13 +23221,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23609,11 +23494,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
-  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24829,11 +24709,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [x] Test Case
 - [ ] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3100

AIChatInput 的附件删除按钮是自定义实现，删除时仅更新内部附件状态并触发 onChange，但没有走 Upload 的移除流程，导致传入的 `uploadProps.onRemove`（以及 `beforeRemove` 的拦截逻辑）不会生效。

本次修复在 foundation 的删除逻辑中补齐与 Upload 一致的 remove 事件链路：删除前执行 `uploadProps.beforeRemove`（支持 Promise，返回 false/resolve false 则阻止删除），删除后触发 `uploadProps.onRemove` 并同步相关变更回调。

同时补充了 foundation 级别回归测试覆盖 onRemove 触发与 beforeRemove 阻断场景，并更新组件文档说明相关回调行为，方便使用者正确接入。

### Changelog
🇨🇳 Chinese
- Fix: 修复 AIChatInput 删除附件时未触发 uploadProps.onRemove，且 beforeRemove 无法阻断的问题

---

🇺🇸 English
- Fix: Fix AIChatInput attachment removal not triggering uploadProps.onRemove and not honoring beforeRemove

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
新增测试位于 `packages/semi-ui/aiChatInput/__test__/aiChatInputFoundation.test.js`，覆盖 `beforeRemove`（含 Promise）返回 false 时不删除，以及删除后触发 `onRemove` 的行为。