### PR TITLE
【Auto】Feat: Add renderUploadButton to AIChatInput

### DIFF
--- a/content/ai/aiChatInput/index-en-US.md
+++ b/content/ai/aiChatInput/index-en-US.md
@@ -421,6 +421,46 @@ function ActionArea() {
 render(<ActionArea />);
 ```
 
+### Custom Upload Button
+
+By default, an upload button is rendered on the left side of the footer action area. Use `renderUploadButton` for **UI-only** customization (e.g. icon-only button, tooltip, etc.).
+
+Note: This does not affect upload / paste-upload behavior (`Upload` is still managed internally). `openFileDialog` triggers the internal Upload file chooser.
+
+```jsx live=true dir="column" noInline=true
+import React from 'react';
+import { AIChatInput } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+const uploadProps = { action: "https://api.semi.design/upload" };
+const outerStyle = { margin: 12 };
+
+function CustomUploadButton() {
+    return (
+        <AIChatInput
+            placeholder={'Custom upload button UI (paste-upload still works)'}
+            uploadProps={uploadProps}
+            renderUploadButton={({ openFileDialog, disabled }) => (
+                <button
+                    type="button"
+                    disabled={disabled}
+                    className="semi-button semi-button-borderless"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        openFileDialog();
+                    }}
+                >
+                    <IconUpload />
+                </button>
+            )}
+            style={outerStyle}
+        />
+    );
+}
+
+render(<CustomUploadButton />);
+```
+
 ### Button Shape
 
 You can use the `round` API to configure the button shape at the bottom. The default is `true` (rounded). Set it to `false` for square buttons.
@@ -1488,6 +1528,7 @@ render(<CustomRichTextExtension />);
 | onSuggestClick | Callback for clicking a suggestion | (suggestion: Suggestion) => void | - |
 | onTemplateVisibleChange | Callback for template's visibility change | (visible: boolean) => void | - |
 | onUploadChange | Callback for file upload | (props: OnChangeProps) => void | - |
+| renderUploadButton | Customize upload button UI in the footer action area (Upload is still managed internally; built-in upload/paste-upload logic is preserved) | (props: <ApiType detail='{ defaultNode: React.ReactNode; openFileDialog: () => void; disabled: boolean; attachments: Attachment[] }'>RenderUploadButtonProps</ApiType>) => React.ReactNode | - |
 | popoverProps | Popup configuration | PopoverProps | - |
 | placeholder | Input placeholder | string \| (props: <ApiType detail='{ editor: Editor; node: Node; pos: number; hasAnchor: boolean }'>PlaceholderProps</ApiType>) => string | - |
 | references | Reference list | Reference[] | - |

--- a/content/ai/aiChatInput/index.md
+++ b/content/ai/aiChatInput/index.md
@@ -482,6 +482,46 @@ function ActionArea() {
 render(<ActionArea />);
 ```
 
+### 自定义上传按钮
+
+底部操作区左侧默认会渲染上传按钮。你可以通过 `renderUploadButton` **仅自定义按钮 UI**（例如改成图标按钮、加 Tooltip 等）。
+
+注意：这不会影响上传/粘贴上传逻辑（`Upload` 仍由组件内部托管），`openFileDialog` 会触发内部 Upload 的文件选择。
+
+```jsx live=true dir="column" noInline=true
+import React from 'react';
+import { AIChatInput } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+const uploadProps = { action: "https://api.semi.design/upload" };
+const outerStyle = { margin: 12 };
+
+function CustomUploadButton() {
+    return (
+        <AIChatInput
+            placeholder={'自定义上传按钮（仍支持粘贴上传）'}
+            uploadProps={uploadProps}
+            renderUploadButton={({ openFileDialog, disabled }) => (
+                <button
+                    type="button"
+                    disabled={disabled}
+                    className="semi-button semi-button-borderless"
+                    onClick={(e) => {
+                        e.stopPropagation();
+                        openFileDialog();
+                    }}
+                >
+                    <IconUpload />
+                </button>
+            )}
+            style={outerStyle}
+        />
+    );
+}
+
+render(<CustomUploadButton />);
+```
+
 ### 底部按钮形状
 
 用户可以通过 `round` API 配置底部按钮的形状，默认是 `true`，是圆角按钮， 可以设置为 `false` 来配置为方形按钮。
@@ -1566,6 +1606,7 @@ render(<CustomRichTextExtension />);
 | onSuggestClick | 建议点击回调 | (suggestion: Suggestion) => void | - |
 | onTemplateVisibleChange | 模板弹出层可见性变化回调 | (visible: boolean) => void | - |
 | onUploadChange | 上传文件相关回调 | (props: OnChangeProps) => void | - |
+| renderUploadButton | 自定义底部操作区上传按钮 UI（Upload 仍由组件内部托管，保留内置上传/粘贴上传逻辑） | (props: <ApiType detail='{ defaultNode: React.ReactNode; openFileDialog: () => void; disabled: boolean; attachments: Attachment[] }'>RenderUploadButtonProps</ApiType>) => React.ReactNode | - |
 | popoverProps | 下拉弹出层的配置参数 | PopoverProps | - |
 | placeholder | 输入框占位符 | string \| (props: <ApiType detail='{ editor: Editor; node: Node; pos: number; hasAnchor: boolean }'>PlaceholderProps</ApiType>) => string | - |
 | references | 输入框引用列表 | Reference[] | - |
@@ -1628,5 +1669,4 @@ render(<CustomRichTextExtension />);
 
 ## 设计变量
 <DesignToken/>
-
 

--- a/packages/semi-ui/aiChatInput/_story/aiChatInput.stories.tsx
+++ b/packages/semi-ui/aiChatInput/_story/aiChatInput.stories.tsx
@@ -3,6 +3,7 @@ import { AIChatInput } from '../../index';
 import { storiesOf } from '@storybook/react';
 import { uploadProps } from './constant';
 import ReferSlot from './referSlot';
+import { IconUpload } from '@douyinfe/semi-icons';
 
 const stories = storiesOf('AIChatInput', module);
 
@@ -36,4 +37,37 @@ stories.add('default', () => {
         onStopGenerate={toggleGenerate}
       />
     );
+});
+
+stories.add('renderUploadButton', () => {
+  const [generating, setGenerating] = useState(false);
+  const toggleGenerate = useCallback(() => {
+    setGenerating(value => !value);
+  }, []);
+
+  return (
+    <AIChatInput
+      extensions={[ReferSlot]}
+      generating={generating}
+      defaultContent={''}
+      placeholder={'自定义上传按钮 UI（仍保留粘贴上传能力）'}
+      uploadProps={uploadProps}
+      renderUploadButton={({ openFileDialog, disabled }) => (
+        <button
+          type="button"
+          disabled={disabled}
+          className="semi-button semi-button-borderless"
+          onClick={(e) => {
+            e.stopPropagation();
+            openFileDialog();
+          }}
+        >
+          <IconUpload />
+        </button>
+      )}
+      style={outerStyle}
+      onMessageSend={toggleGenerate}
+      onStopGenerate={toggleGenerate}
+    />
+  );
 });

--- a/packages/semi-ui/aiChatInput/index.tsx
+++ b/packages/semi-ui/aiChatInput/index.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable jsx-a11y/no-static-element-interactions */
 import React from 'react';
 import BaseComponent from '../_base/baseComponent';
-import { AIChatInputProps, AIChatInputState, Skill, Attachment, Reference, Content, LeftMenuChangeProps } from './interface';
+import { AIChatInputProps, AIChatInputState, Skill, Attachment, Reference, Content, LeftMenuChangeProps, RenderUploadButtonProps } from './interface';
 import { noop, isEqual } from 'lodash';
 import { cssClasses, numbers, strings } from '@douyinfe/semi-foundation/aiChatInput/constants';
 import { Popover, Tooltip, Upload, Progress } from '../index';
@@ -512,25 +512,45 @@ class AIChatInput extends BaseComponent<AIChatInputProps, AIChatInputState> {
         </LocaleConsumer>;
     }
 
-    renderUploadButton = () => {
-        const { uploadTipProps, uploadProps } = this.props;
+    renderUploadNode = () => {
+        const { uploadTipProps, uploadProps, renderUploadButton } = this.props;
         const { attachments } = this.state;
-        const { className, onChange, renderFileItem, children, ...rest } = uploadProps ?? {};
+        const { children, ...rest } = uploadProps ?? {};
         const realUploadProps = {
             ...rest,
             onChange: this.foundation.onUploadChange,
         };
-        const uploadNode = <Upload
-            ref={this.uploadRef}
-            fileList={attachments}
-            listType="none" 
-            {...realUploadProps}
-            key='upload'
-        >
-            <button className={`${prefixCls}-footer-action-button ${prefixCls}-footer-action-upload`} >
+
+        const defaultButtonNode = (
+            <button className={`${prefixCls}-footer-action-button ${prefixCls}-footer-action-upload`}>
                 <IconPaperclip />
             </button>
-        </Upload>;
+        );
+
+        const openFileDialog = () => {
+            this.uploadRef.current?.openFileDialog?.();
+        };
+
+        const renderProps: RenderUploadButtonProps = {
+            defaultNode: children ?? defaultButtonNode,
+            openFileDialog,
+            disabled: Boolean(uploadProps?.disabled),
+            attachments: attachments ?? [],
+        };
+
+        const uploadChild = renderUploadButton ? renderUploadButton(renderProps) : renderProps.defaultNode;
+
+        const uploadNode = (
+            <Upload
+                ref={this.uploadRef}
+                fileList={attachments}
+                listType="none"
+                {...realUploadProps}
+                key='upload'
+            >
+                {uploadChild}
+            </Upload>
+        );
 
         return uploadTipProps ? <Tooltip {...uploadTipProps} key='upload'><span>{uploadNode}</span></Tooltip> : uploadNode;
     }
@@ -555,7 +575,7 @@ class AIChatInput extends BaseComponent<AIChatInputProps, AIChatInputState> {
         const { renderActionArea, showUploadButton } = this.props;
         const actionCls = `${prefixCls}-footer-action`;
         const actionNode = [
-            showUploadButton && this.renderUploadButton(),
+            showUploadButton && this.renderUploadNode(),
             this.renderSendButton(),
         ].filter(Boolean);
         if (renderActionArea) {

--- a/packages/semi-ui/aiChatInput/interface.ts
+++ b/packages/semi-ui/aiChatInput/interface.ts
@@ -44,6 +44,11 @@ export interface AIChatInputProps {
     // Upload related
     uploadProps?: UploadProps;
     onUploadChange?: (props: OnChangeProps) => void;
+    /**
+     * Customize upload button UI in footer action area,
+     * while keeping built-in upload / paste-upload logic.
+     */
+    renderUploadButton?: (props: RenderUploadButtonProps) => ReactNode;
     // TopSlot related
     renderTopSlot?: (props: RenderTopSlotProps) => ReactNode;
     topSlotPosition?: 'top' | 'middle' | 'bottom';
@@ -83,6 +88,22 @@ export interface AIChatInputProps {
     popoverProps?: PopoverProps;
     sendHotKey?: 'enter' | 'shift+enter';
     immediatelyRender?: boolean
+}
+
+export interface RenderUploadButtonProps {
+    /**
+     * Default upload button node rendered by AIChatInput.
+     * You can wrap/clone it or return a completely custom node.
+     */
+    defaultNode: ReactNode;
+    /**
+     * Open file selector dialog.
+     * Note: Upload wrapper will also open dialog on click by default,
+     * but you can use this when you stop propagation in your custom node.
+     */
+    openFileDialog: () => void;
+    disabled: boolean;
+    attachments: Attachment[];
 }
 
 export interface RenderSuggestionItemProps {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3087

AIChatInput 目前上传按钮的 UI 无法定制，用户如果想完全自定义上传按钮，需要自己处理粘贴上传触发、上传流程复用以及附件渲染等逻辑，接入成本较高。

本次新增 `renderUploadButton` API：允许仅自定义上传按钮的展示 UI，但上传/粘贴上传仍复用组件内部的 Upload 实例与既有逻辑，不需要用户额外接管上传与粘贴上传链路。

请重点关注：自定义渲染仅影响按钮节点渲染，不影响 `uploadProps/onUploadChange` 的行为；默认渲染保持不变；粘贴文件上传仍可正常走内部 `manualUpload` 逻辑。

### Changelog
🇨🇳 Chinese
- Feat: AIChatInput 支持通过 renderUploadButton 自定义上传按钮 UI，上传与粘贴上传逻辑保持内置复用

---

🇺🇸 English
- Feat: Add renderUploadButton to AIChatInput to customize upload button UI while keeping built-in upload and paste-upload logic

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information