### PR TITLE
fix: add react19-adapter to package.json exports and fix build

### DIFF
--- a/content/ecosystem/changelog/index-en-US.md
+++ b/content/ecosystem/changelog/index-en-US.md
@@ -16,6 +16,11 @@ Version：Major.Minor.Patch (follow the **Semver** specification)
 
 ---
 
+#### 🎉 2.92.2 (2026-03-04)
+- 【Fix】
+    - Fix `@douyinfe/semi-ui/react19-adapter` import failure due to missing exports declaration in package.json
+    - Fix compilation failure caused by missing `@douyinfe/semi-illustrations` path mapping in `packages/semi-ui/tsconfig.json`
+
 #### 🎉 2.92.1 (2026-03-04)
 - 【Fix】
     - Align AIChatDialogue PropTypes with TypeScript interface definition [#3141](https://github.com/DouyinFE/semi-design/pull/3141)

--- a/content/ecosystem/changelog/index.md
+++ b/content/ecosystem/changelog/index.md
@@ -14,6 +14,11 @@ Semi 版本号遵循 **Semver** 规范（主版本号 - 次版本号 - 修订版
 -   不同版本间的详细关系，可查阅 [FAQ](/zh-CN/start/faq)
 
 
+#### 🎉 2.92.2 (2026-03-04)
+- 【Fix】
+    - 修复 `@douyinfe/semi-ui/react19-adapter` 因 package.json exports 缺少声明导致无法导入的问题
+    - 修复 `packages/semi-ui/tsconfig.json` 缺少 `@douyinfe/semi-illustrations` 路径映射导致编译失败的问题
+
 #### 🎉 2.92.1 (2026-03-04)
 - 【Fix】
     - 修复 AIChatDialogue PropTypes 与 TypeScript 类型定义不一致的问题 [#3141](https://github.com/DouyinFE/semi-design/pull/3141)

--- a/packages/semi-ui/package.json
+++ b/packages/semi-ui/package.json
@@ -56,6 +56,10 @@
                 "lib/es/_utils/index.d.ts",
                 "lib/es/_utils/index"
             ],
+            "lib/es/_utils/reactRender": [
+                "lib/es/_utils/reactRender.d.ts",
+                "lib/es/_utils/reactRender"
+            ],
             "lib/es/_utils/semi-global": [
                 "lib/es/_utils/semi-global.d.ts",
                 "lib/es/_utils/semi-global"
@@ -1488,6 +1492,10 @@
                 "lib/es/rating/item.d.ts",
                 "lib/es/rating/item"
             ],
+            "lib/es/react19-adapter": [
+                "lib/es/react19-adapter.d.ts",
+                "lib/es/react19-adapter"
+            ],
             "lib/es/resizable": [
                 "lib/es/resizable/index.d.ts",
                 "lib/es/resizable/index"
@@ -1563,6 +1571,70 @@
             "lib/es/select/virtualRow": [
                 "lib/es/select/virtualRow.d.ts",
                 "lib/es/select/virtualRow"
+            ],
+            "lib/es/sideBar": [
+                "lib/es/sideBar/index.d.ts",
+                "lib/es/sideBar/index"
+            ],
+            "lib/es/sideBar/annotation": [
+                "lib/es/sideBar/annotation/index.d.ts",
+                "lib/es/sideBar/annotation/index"
+            ],
+            "lib/es/sideBar/annotation/content": [
+                "lib/es/sideBar/annotation/content.d.ts",
+                "lib/es/sideBar/annotation/content"
+            ],
+            "lib/es/sideBar/annotation/index": [
+                "lib/es/sideBar/annotation/index.d.ts",
+                "lib/es/sideBar/annotation/index"
+            ],
+            "lib/es/sideBar/annotation/item": [
+                "lib/es/sideBar/annotation/item.d.ts",
+                "lib/es/sideBar/annotation/item"
+            ],
+            "lib/es/sideBar/container": [
+                "lib/es/sideBar/container/index.d.ts",
+                "lib/es/sideBar/container/index"
+            ],
+            "lib/es/sideBar/container/index": [
+                "lib/es/sideBar/container/index.d.ts",
+                "lib/es/sideBar/container/index"
+            ],
+            "lib/es/sideBar/index": [
+                "lib/es/sideBar/index.d.ts",
+                "lib/es/sideBar/index"
+            ],
+            "lib/es/sideBar/interface": [
+                "lib/es/sideBar/interface.d.ts",
+                "lib/es/sideBar/interface"
+            ],
+            "lib/es/sideBar/mcpConfigure": [
+                "lib/es/sideBar/mcpConfigure/index.d.ts",
+                "lib/es/sideBar/mcpConfigure/index"
+            ],
+            "lib/es/sideBar/mcpConfigure/content": [
+                "lib/es/sideBar/mcpConfigure/content.d.ts",
+                "lib/es/sideBar/mcpConfigure/content"
+            ],
+            "lib/es/sideBar/mcpConfigure/index": [
+                "lib/es/sideBar/mcpConfigure/index.d.ts",
+                "lib/es/sideBar/mcpConfigure/index"
+            ],
+            "lib/es/sideBar/options": [
+                "lib/es/sideBar/options.d.ts",
+                "lib/es/sideBar/options"
+            ],
+            "lib/es/sideBar/widget/code": [
+                "lib/es/sideBar/widget/code.d.ts",
+                "lib/es/sideBar/widget/code"
+            ],
+            "lib/es/sideBar/widget/file": [
+                "lib/es/sideBar/widget/file.d.ts",
+                "lib/es/sideBar/widget/file"
+            ],
+            "lib/es/sideBar/widget/imageSlot": [
+                "lib/es/sideBar/widget/imageSlot.d.ts",
+                "lib/es/sideBar/widget/imageSlot"
             ],
             "lib/es/sideSheet": [
                 "lib/es/sideSheet/index.d.ts",
@@ -2098,6 +2170,11 @@
             "import": "./lib/es/index.js",
             "require": "./lib/cjs/index.js"
         },
+        "./react19-adapter": {
+            "types": "./lib/es/react19-adapter.d.ts",
+            "import": "./lib/es/react19-adapter.js",
+            "require": "./lib/cjs/react19-adapter.js"
+        },
         "./lib/es/_base/base.css": {
             "import": "./lib/es/_base/base.css",
             "require": "./lib/cjs/_base/base.css",
@@ -2222,6 +2299,18 @@
             "import": "./lib/es/_utils/index.js",
             "require": "./lib/cjs/_utils/index.js",
             "default": "./lib/es/_utils/index.js"
+        },
+        "./lib/es/_utils/reactRender.js": {
+            "types": "./lib/es/_utils/reactRender.d.ts",
+            "import": "./lib/es/_utils/reactRender.js",
+            "require": "./lib/cjs/_utils/reactRender.js",
+            "default": "./lib/es/_utils/reactRender.js"
+        },
+        "./lib/es/_utils/reactRender": {
+            "types": "./lib/es/_utils/reactRender.d.ts",
+            "import": "./lib/es/_utils/reactRender.js",
+            "require": "./lib/cjs/_utils/reactRender.js",
+            "default": "./lib/es/_utils/reactRender.js"
         },
         "./lib/es/_utils/semi-global.js": {
             "types": "./lib/es/_utils/semi-global.d.ts",
@@ -6099,6 +6188,18 @@
             "require": "./lib/cjs/rating/item.js",
             "default": "./lib/es/rating/item.js"
         },
+        "./lib/es/react19-adapter.js": {
+            "types": "./lib/es/react19-adapter.d.ts",
+            "import": "./lib/es/react19-adapter.js",
+            "require": "./lib/cjs/react19-adapter.js",
+            "default": "./lib/es/react19-adapter.js"
+        },
+        "./lib/es/react19-adapter": {
+            "types": "./lib/es/react19-adapter.d.ts",
+            "import": "./lib/es/react19-adapter.js",
+            "require": "./lib/cjs/react19-adapter.js",
+            "default": "./lib/es/react19-adapter.js"
+        },
         "./lib/es/resizable": {
             "types": "./lib/es/resizable/index.d.ts",
             "import": "./lib/es/resizable/index.js",
@@ -6302,6 +6403,174 @@
             "import": "./lib/es/select/virtualRow.js",
             "require": "./lib/cjs/select/virtualRow.js",
             "default": "./lib/es/select/virtualRow.js"
+        },
+        "./lib/es/sideBar": {
+            "types": "./lib/es/sideBar/index.d.ts",
+            "import": "./lib/es/sideBar/index.js",
+            "require": "./lib/cjs/sideBar/index.js",
+            "default": "./lib/es/sideBar/index.js"
+        },
+        "./lib/es/sideBar/annotation": {
+            "types": "./lib/es/sideBar/annotation/index.d.ts",
+            "import": "./lib/es/sideBar/annotation/index.js",
+            "require": "./lib/cjs/sideBar/annotation/index.js",
+            "default": "./lib/es/sideBar/annotation/index.js"
+        },
+        "./lib/es/sideBar/annotation/content.js": {
+            "types": "./lib/es/sideBar/annotation/content.d.ts",
+            "import": "./lib/es/sideBar/annotation/content.js",
+            "require": "./lib/cjs/sideBar/annotation/content.js",
+            "default": "./lib/es/sideBar/annotation/content.js"
+        },
+        "./lib/es/sideBar/annotation/content": {
+            "types": "./lib/es/sideBar/annotation/content.d.ts",
+            "import": "./lib/es/sideBar/annotation/content.js",
+            "require": "./lib/cjs/sideBar/annotation/content.js",
+            "default": "./lib/es/sideBar/annotation/content.js"
+        },
+        "./lib/es/sideBar/annotation/index.js": {
+            "types": "./lib/es/sideBar/annotation/index.d.ts",
+            "import": "./lib/es/sideBar/annotation/index.js",
+            "require": "./lib/cjs/sideBar/annotation/index.js",
+            "default": "./lib/es/sideBar/annotation/index.js"
+        },
+        "./lib/es/sideBar/annotation/index": {
+            "types": "./lib/es/sideBar/annotation/index.d.ts",
+            "import": "./lib/es/sideBar/annotation/index.js",
+            "require": "./lib/cjs/sideBar/annotation/index.js",
+            "default": "./lib/es/sideBar/annotation/index.js"
+        },
+        "./lib/es/sideBar/annotation/item.js": {
+            "types": "./lib/es/sideBar/annotation/item.d.ts",
+            "import": "./lib/es/sideBar/annotation/item.js",
+            "require": "./lib/cjs/sideBar/annotation/item.js",
+            "default": "./lib/es/sideBar/annotation/item.js"
+        },
+        "./lib/es/sideBar/annotation/item": {
+            "types": "./lib/es/sideBar/annotation/item.d.ts",
+            "import": "./lib/es/sideBar/annotation/item.js",
+            "require": "./lib/cjs/sideBar/annotation/item.js",
+            "default": "./lib/es/sideBar/annotation/item.js"
+        },
+        "./lib/es/sideBar/container": {
+            "types": "./lib/es/sideBar/container/index.d.ts",
+            "import": "./lib/es/sideBar/container/index.js",
+            "require": "./lib/cjs/sideBar/container/index.js",
+            "default": "./lib/es/sideBar/container/index.js"
+        },
+        "./lib/es/sideBar/container/index.js": {
+            "types": "./lib/es/sideBar/container/index.d.ts",
+            "import": "./lib/es/sideBar/container/index.js",
+            "require": "./lib/cjs/sideBar/container/index.js",
+            "default": "./lib/es/sideBar/container/index.js"
+        },
+        "./lib/es/sideBar/container/index": {
+            "types": "./lib/es/sideBar/container/index.d.ts",
+            "import": "./lib/es/sideBar/container/index.js",
+            "require": "./lib/cjs/sideBar/container/index.js",
+            "default": "./lib/es/sideBar/container/index.js"
+        },
+        "./lib/es/sideBar/index.js": {
+            "types": "./lib/es/sideBar/index.d.ts",
+            "import": "./lib/es/sideBar/index.js",
+            "require": "./lib/cjs/sideBar/index.js",
+            "default": "./lib/es/sideBar/index.js"
+        },
+        "./lib/es/sideBar/index": {
+            "types": "./lib/es/sideBar/index.d.ts",
+            "import": "./lib/es/sideBar/index.js",
+            "require": "./lib/cjs/sideBar/index.js",
+            "default": "./lib/es/sideBar/index.js"
+        },
+        "./lib/es/sideBar/interface.js": {
+            "types": "./lib/es/sideBar/interface.d.ts",
+            "import": "./lib/es/sideBar/interface.js",
+            "require": "./lib/cjs/sideBar/interface.js",
+            "default": "./lib/es/sideBar/interface.js"
+        },
+        "./lib/es/sideBar/interface": {
+            "types": "./lib/es/sideBar/interface.d.ts",
+            "import": "./lib/es/sideBar/interface.js",
+            "require": "./lib/cjs/sideBar/interface.js",
+            "default": "./lib/es/sideBar/interface.js"
+        },
+        "./lib/es/sideBar/mcpConfigure": {
+            "types": "./lib/es/sideBar/mcpConfigure/index.d.ts",
+            "import": "./lib/es/sideBar/mcpConfigure/index.js",
+            "require": "./lib/cjs/sideBar/mcpConfigure/index.js",
+            "default": "./lib/es/sideBar/mcpConfigure/index.js"
+        },
+        "./lib/es/sideBar/mcpConfigure/content.js": {
+            "types": "./lib/es/sideBar/mcpConfigure/content.d.ts",
+            "import": "./lib/es/sideBar/mcpConfigure/content.js",
+            "require": "./lib/cjs/sideBar/mcpConfigure/content.js",
+            "default": "./lib/es/sideBar/mcpConfigure/content.js"
+        },
+        "./lib/es/sideBar/mcpConfigure/content": {
+            "types": "./lib/es/sideBar/mcpConfigure/content.d.ts",
+            "import": "./lib/es/sideBar/mcpConfigure/content.js",
+            "require": "./lib/cjs/sideBar/mcpConfigure/content.js",
+            "default": "./lib/es/sideBar/mcpConfigure/content.js"
+        },
+        "./lib/es/sideBar/mcpConfigure/index.js": {
+            "types": "./lib/es/sideBar/mcpConfigure/index.d.ts",
+            "import": "./lib/es/sideBar/mcpConfigure/index.js",
+            "require": "./lib/cjs/sideBar/mcpConfigure/index.js",
+            "default": "./lib/es/sideBar/mcpConfigure/index.js"
+        },
+        "./lib/es/sideBar/mcpConfigure/index": {
+            "types": "./lib/es/sideBar/mcpConfigure/index.d.ts",
+            "import": "./lib/es/sideBar/mcpConfigure/index.js",
+            "require": "./lib/cjs/sideBar/mcpConfigure/index.js",
+            "default": "./lib/es/sideBar/mcpConfigure/index.js"
+        },
+        "./lib/es/sideBar/options.js": {
+            "types": "./lib/es/sideBar/options.d.ts",
+            "import": "./lib/es/sideBar/options.js",
+            "require": "./lib/cjs/sideBar/options.js",
+            "default": "./lib/es/sideBar/options.js"
+        },
+        "./lib/es/sideBar/options": {
+            "types": "./lib/es/sideBar/options.d.ts",
+            "import": "./lib/es/sideBar/options.js",
+            "require": "./lib/cjs/sideBar/options.js",
+            "default": "./lib/es/sideBar/options.js"
+        },
+        "./lib/es/sideBar/widget/code.js": {
+            "types": "./lib/es/sideBar/widget/code.d.ts",
+            "import": "./lib/es/sideBar/widget/code.js",
+            "require": "./lib/cjs/sideBar/widget/code.js",
+            "default": "./lib/es/sideBar/widget/code.js"
+        },
+        "./lib/es/sideBar/widget/code": {
+            "types": "./lib/es/sideBar/widget/code.d.ts",
+            "import": "./lib/es/sideBar/widget/code.js",
+            "require": "./lib/cjs/sideBar/widget/code.js",
+            "default": "./lib/es/sideBar/widget/code.js"
+        },
+        "./lib/es/sideBar/widget/file.js": {
+            "types": "./lib/es/sideBar/widget/file.d.ts",
+            "import": "./lib/es/sideBar/widget/file.js",
+            "require": "./lib/cjs/sideBar/widget/file.js",
+            "default": "./lib/es/sideBar/widget/file.js"
+        },
+        "./lib/es/sideBar/widget/file": {
+            "types": "./lib/es/sideBar/widget/file.d.ts",
+            "import": "./lib/es/sideBar/widget/file.js",
+            "require": "./lib/cjs/sideBar/widget/file.js",
+            "default": "./lib/es/sideBar/widget/file.js"
+        },
+        "./lib/es/sideBar/widget/imageSlot.js": {
+            "types": "./lib/es/sideBar/widget/imageSlot.d.ts",
+            "import": "./lib/es/sideBar/widget/imageSlot.js",
+            "require": "./lib/cjs/sideBar/widget/imageSlot.js",
+            "default": "./lib/es/sideBar/widget/imageSlot.js"
+        },
+        "./lib/es/sideBar/widget/imageSlot": {
+            "types": "./lib/es/sideBar/widget/imageSlot.d.ts",
+            "import": "./lib/es/sideBar/widget/imageSlot.js",
+            "require": "./lib/cjs/sideBar/widget/imageSlot.js",
+            "default": "./lib/es/sideBar/widget/imageSlot.js"
         },
         "./lib/es/sideSheet": {
             "types": "./lib/es/sideSheet/index.d.ts",

--- a/packages/semi-ui/scripts/generateExports.js
+++ b/packages/semi-ui/scripts/generateExports.js
@@ -127,9 +127,21 @@ function generateExports() {
         }
     };
 
+    // 添加顶层快捷导出（如 react19-adapter）
+    const shortcutExports = {};
+    const react19AdapterJs = path.join(libEsPath, 'react19-adapter.js');
+    if (fs.existsSync(react19AdapterJs)) {
+        shortcutExports['./react19-adapter'] = {
+            types: './lib/es/react19-adapter.d.ts',
+            import: './lib/es/react19-adapter.js',
+            require: './lib/cjs/react19-adapter.js'
+        };
+    }
+
     // 合并所有 exports
     const allExports = {
         ...mainExports,
+        ...shortcutExports,
         ...exports,
         ...cssExports
     };

--- a/packages/semi-ui/tsconfig.json
+++ b/packages/semi-ui/tsconfig.json
@@ -14,7 +14,8 @@
             "@douyinfe/semi-foundation/*": ["../semi-foundation/*"],
             "@douyinfe/semi-ui/*": ["../semi-ui/*"],
             "@douyinfe/semi-theme-default/*": ["../semi-theme-default/*"],
-            "@douyinfe/semi-icons": ["../semi-icons/src"]
+            "@douyinfe/semi-icons": ["../semi-icons/src"],
+            "@douyinfe/semi-illustrations": ["../semi-illustrations/src"]
         },
         "forceConsistentCasingInFileNames": true,
         "allowSyntheticDefaultImports": true,


### PR DESCRIPTION

[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [x] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

修复两个构建相关的问题：

#### 1. `@douyinfe/semi-ui/react19-adapter` 无法导入

用户按照 [React 19 适配文档](https://semi.bytedance.net/zh-CN/ecosystem/react19) 使用 `import '@douyinfe/semi-ui/react19-adapter'` 时，会报错：

```
Package subpath './react19-adapter' is not defined by "exports" in package.json
```

**原因**：`react19-adapter.ts` 源文件存在，`sideEffects` 中也已声明，但 `package.json` 的 `exports` 字段中缺少 `"./react19-adapter"` 的导出条目。

**修复**：
- 在 `exports` 中添加 `"./react19-adapter"` 条目
- 更新 `generateExports.js` 脚本，使其在扫描 `lib/es` 时自动生成该快捷导出路径

#### 2. `packages/semi-ui/tsconfig.json` 缺少 `@douyinfe/semi-illustrations` 路径映射

`sideBar/mcpConfigure/content.tsx` 引用了 `@douyinfe/semi-illustrations`，但 `packages/semi-ui/tsconfig.json` 的 `paths` 中未配置该映射（根目录 `tsconfig.json` 有，但 build 时使用的是包级别的 tsconfig），导致 `build:lib` 编译失败。

**修复**：在 `packages/semi-ui/tsconfig.json` 的 `paths` 中添加 `"@douyinfe/semi-illustrations": ["../semi-illustrations/src"]`。

### Changelog
🇨🇳 Chinese
- Fix: 修复 `@douyinfe/semi-ui/react19-adapter` 因 package.json exports 缺少声明导致无法导入的问题
- Fix: 修复 `packages/semi-ui/tsconfig.json` 缺少 `@douyinfe/semi-illustrations` 路径映射导致编译失败的问题

---

🇺🇸 English
- Fix: Fix `@douyinfe/semi-ui/react19-adapter` import failure due to missing exports declaration in package.json
- Fix: Fix compilation failure caused by missing `@douyinfe/semi-illustrations` path mapping in `packages/semi-ui/tsconfig.json`

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

