### PR TITLE
【Auto】Feat: TextArea 组件增加行号支持 (Add line number support to TextArea component)

### DIFF
--- a/content/input/input/index-en-US.md
+++ b/content/input/input/index-en-US.md
@@ -289,6 +289,26 @@ import { TextArea } from '@douyinfe/semi-ui';
 );
 ```
 
+### Line Numbers
+
+Set `showLineNumber` to display line numbers. You can use `lineNumberStart` to set the starting line number, and customize the line number area via `lineNumberStyle`/`lineNumberClassName`.
+
+```jsx live=true
+import React from 'react';
+import { TextArea } from '@douyinfe/semi-ui';
+
+() => (
+    <TextArea
+        showLineNumber
+        lineNumberStart={1}
+        defaultValue={'Line 1\nLine 2\nThis is a long line to demonstrate soft wrap alignment with line numbers.\nLine 4\nLine 5'}
+        rows={5}
+        style={{ width: 420 }}
+        lineNumberStyle={{ color: 'var(--semi-color-text-2)' }}
+    />
+);
+```
+
 ### Line break by Shift + Enter
 By default, in a TextArea, both `Enter` and `Shift` + `Enter` can achieve line breaks.
 Through appropriate event listening and disabling the default behavior, you can achieve disabling line breaks with Enter and only allowing line breaks with Shift + Enter.
@@ -482,6 +502,10 @@ Answers to some questions:
 | preventScroll | Indicates whether the browser should scroll the document to display the newly focused element, acting on the focus method inside the component, excluding the component passed in by the user | boolean |  |  |
 | readonly          | Read-only, not editable                                                                                                | boolean                         | false   |
 | rows              | The number of visible text lines for the control.                                                                      | number                          | 4       |
+| showLineNumber     | Whether to display line numbers                                                                                        | boolean                         | false   |
+| lineNumberStart    | Starting line number                                                                                                   | number                          | 1       |
+| lineNumberClassName | ClassName for line number area                                                                                        | string                          | -       |
+| lineNumberStyle    | Style for line number area                                                                                              | CSSProperties                   | -       |
 | showClear         | Display the clear button when the input box has content and hover or focus                                                                                         | boolean                         | false   |
 | style             | Inline style                                                                                                           | CSSProperties                   | -       |
 | onBlur            | Callback invoked when input loses focus                                                                                | (e:event) => void               | -       |

--- a/content/input/input/index.md
+++ b/content/input/input/index.md
@@ -300,6 +300,26 @@ import { TextArea } from '@douyinfe/semi-ui';
 );
 ```
 
+### 行号
+
+通过设置 `showLineNumber` 展示行号。可用 `lineNumberStart` 设置起始行号，或通过 `lineNumberStyle`/`lineNumberClassName` 自定义行号区样式。
+
+```jsx live=true
+import React from 'react';
+import { TextArea } from '@douyinfe/semi-ui';
+
+() => (
+    <TextArea
+        showLineNumber
+        lineNumberStart={1}
+        defaultValue={'Line 1\nLine 2\n这是一行较长的文本，用来演示软换行时的行号对齐效果。\nLine 4\nLine 5'}
+        rows={5}
+        style={{ width: 420 }}
+        lineNumberStyle={{ color: 'var(--semi-color-text-2)' }}
+    />
+);
+```
+
 ### 使用 Shift + Enter 换行的多行输入框
 TextArea 默认情况下 Enter 回车与 Shift + Enter 均可实现换行  
 通过适当的事件监听与禁用默认行为，你可以实现禁用 Enter 换行，仅 Shift + Enter 才能换行
@@ -495,6 +515,10 @@ import { Input, Typography, Form, TextArea, Button } from '@douyinfe/semi-ui';
 | placeholder  | 当前的默认值                       | string                          | 无     |
 | readonly     | 只读                               | boolean                         | false  |
 | rows         | 默认行数                           | number                          | 4      |
+| showLineNumber | 是否展示行号 | boolean | false |
+| lineNumberStart | 行号起始值 | number | 1 |
+| lineNumberClassName | 行号区域 className | string | - |
+| lineNumberStyle | 行号区域样式 | CSSProperties | - |
 | showClear    | 支持清除               | boolean                         | false     |
 | style        | 样式                               | CSSProperties                   | -      |
 | onBlur       | 输入框失去焦点时的回调             |(e:event) => void               | -      |
@@ -558,4 +582,3 @@ import { Input, Typography, Form, TextArea, Button } from '@douyinfe/semi-ui';
 
 ## 相关物料
 <semi-material-list code="46"></semi-material-list>
-

--- a/packages/semi-foundation/input/textarea.scss
+++ b/packages/semi-foundation/input/textarea.scss
@@ -229,4 +229,56 @@ $module: #{$prefix}-input;
 
 }
 
+// Line number styles
+.#{$module}-textarea-wrapper-withLineNumber {
+    display: flex;
+    padding: 0;
+    align-items: flex-start;
+
+    .#{$module}-textarea-lineNumber {
+        flex-shrink: 0;
+        padding: $spacing-textarea-paddingY $spacing-textarea-paddingX;
+        background-color: var(--semi-color-fill-1);
+        border-right: 1px solid var(--semi-color-border);
+        color: var(--semi-color-text-2);
+        // Use common monospace font stack for better alignment
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+        font-size: inherit;
+        line-height: 1.5;
+        text-align: right;
+        user-select: none;
+        min-width: 36px;
+        border-radius: $radius-input_wrapper 0 0 $radius-input_wrapper;
+        // Allow scrolling but hide scrollbar
+        overflow-y: auto;
+        overflow-x: hidden;
+        scrollbar-width: none; // Firefox
+        -ms-overflow-style: none; // IE 10+
+        &::-webkit-scrollbar {
+            display: none; // Chrome, Safari, Edge
+        }
+    }
+
+    // Content wrapper for textarea to participate in flex layout
+    .#{$module}-textarea-content {
+        display: flex;
+        flex: 1;
+        min-width: 0;
+    }
+
+    .#{$module}-textarea-lineNumber-item {
+        display: flex;
+        // Align to the first visual line when soft-wrapping
+        align-items: flex-start;
+        justify-content: flex-end;
+        box-sizing: border-box;
+    }
+
+    .#{$module}-textarea {
+        border-radius: 0 $radius-input_wrapper $radius-input_wrapper 0;
+        line-height: 1.5;
+        flex: 1;
+    }
+}
+
 @import "./rtl.scss";

--- a/packages/semi-ui/input/textarea.tsx
+++ b/packages/semi-ui/input/textarea.tsx
@@ -9,6 +9,7 @@ import { noop, omit, isFunction, isUndefined, isObject, throttle } from 'lodash'
 import type { DebouncedFunc } from 'lodash';
 import { IconClear } from '@douyinfe/semi-icons';
 import ResizeObserver from '../resizeObserver';
+import type { CSSProperties } from 'react';
 
 const prefixCls = cssClasses.PREFIX;
 
@@ -61,7 +62,15 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
        Used to disable line breaks by pressing the enter key。
        Press enter + shift at the same time can start new line.
     */
-    disabledEnterStartNewLine?: boolean
+    disabledEnterStartNewLine?: boolean;
+    /** Whether to show line numbers */
+    showLineNumber?: boolean;
+    /** The starting line number, default is 1 */
+    lineNumberStart?: number;
+    /** Custom className for line number area */
+    lineNumberClassName?: string;
+    /** Custom style for line number area */
+    lineNumberStyle?: CSSProperties;
 }
 
 export interface TextAreaState {
@@ -70,7 +79,11 @@ export interface TextAreaState {
     isHover: boolean;
     height: number;
     minLength: number;
-    cachedValue?: string
+    cachedValue?: string;
+    // Used to trigger re-render of line numbers when textarea resizes
+    textareaWidth: number;
+    // Used to constrain line number panel height to textarea viewport
+    textareaHeight: number;
 }
 
 class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
@@ -94,6 +107,10 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         onCompositionUpdate: PropTypes.func,
         getValueLength: PropTypes.func,
         disabledEnterStartNewLine: PropTypes.bool,
+        showLineNumber: PropTypes.bool,
+        lineNumberStart: PropTypes.number,
+        lineNumberClassName: PropTypes.string,
+        lineNumberStyle: PropTypes.object,
         // TODO
         // resize: PropTypes.bool,
     };
@@ -115,6 +132,8 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         onCompositionStart: noop,
         onCompositionEnd: noop,
         onCompositionUpdate: noop,
+        showLineNumber: false,
+        lineNumberStart: 1,
         // resize: false,
     };
 
@@ -122,6 +141,8 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
     libRef: React.RefObject<HTMLInputElement>;
     foundation: TextAreaFoundation;
     throttledResizeTextarea: DebouncedFunc<typeof this.foundation.resizeTextarea>;
+    lineNumberRef: React.RefObject<HTMLDivElement>;
+    lineNumberResizeObserver: globalThis.ResizeObserver | null;
 
     constructor(props: TextAreaProps) {
         super(props);
@@ -133,11 +154,15 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             height: 0,
             minLength: props.minLength,
             cachedValue: props.value,
+            textareaWidth: 0,
+            textareaHeight: 0,
         };
         this.focusing = false;
         this.foundation = new TextAreaFoundation(this.adapter);
+        this.lineNumberResizeObserver = null;
 
         this.libRef = React.createRef<HTMLInputElement>();
+        this.lineNumberRef = React.createRef<HTMLDivElement>();
         this.throttledResizeTextarea = throttle(this.foundation.resizeTextarea, 10);
     }
 
@@ -187,10 +212,32 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         return willUpdateStates;
     }
 
+    componentDidMount(): void {
+        // Setup resize observer for line number recalculation
+        if (this.props.showLineNumber && this.libRef.current && typeof globalThis.ResizeObserver !== 'undefined') {
+            const textarea = this.libRef.current as unknown as HTMLTextAreaElement;
+            this.setState({ textareaWidth: textarea.clientWidth, textareaHeight: textarea.clientHeight });
+            
+            this.lineNumberResizeObserver = new globalThis.ResizeObserver((entries) => {
+                for (const entry of entries) {
+                    // contentRect does not include borders; align with textarea.clientHeight
+                    const nextWidth = entry.contentRect.width;
+                    const nextHeight = entry.contentRect.height;
+                    this.setState({ textareaWidth: nextWidth, textareaHeight: nextHeight });
+                }
+            });
+            this.lineNumberResizeObserver.observe(textarea);
+        }
+    }
+
     componentWillUnmount(): void {
         if (this.throttledResizeTextarea) {
             this.throttledResizeTextarea?.cancel?.();
             this.throttledResizeTextarea = null;
+        }
+        if (this.lineNumberResizeObserver) {
+            this.lineNumberResizeObserver.disconnect();
+            this.lineNumberResizeObserver = null;
         }
     }
 
@@ -200,6 +247,28 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             this.props.autosize
         ) {
             this.foundation.resizeTextarea();
+        }
+        
+        // Setup/cleanup resize observer when showLineNumber changes
+        if (this.props.showLineNumber !== prevProps.showLineNumber) {
+            if (this.props.showLineNumber && this.libRef.current && typeof globalThis.ResizeObserver !== 'undefined') {
+                const textarea = this.libRef.current as unknown as HTMLTextAreaElement;
+                this.setState({ textareaWidth: textarea.clientWidth, textareaHeight: textarea.clientHeight });
+                
+                if (!this.lineNumberResizeObserver) {
+                    this.lineNumberResizeObserver = new globalThis.ResizeObserver((entries) => {
+                        for (const entry of entries) {
+                            const nextWidth = entry.contentRect.width;
+                            const nextHeight = entry.contentRect.height;
+                            this.setState({ textareaWidth: nextWidth, textareaHeight: nextHeight });
+                        }
+                    });
+                }
+                this.lineNumberResizeObserver.observe(textarea);
+            } else if (this.lineNumberResizeObserver) {
+                this.lineNumberResizeObserver.disconnect();
+                this.lineNumberResizeObserver = null;
+            }
         }
     }
 
@@ -258,6 +327,109 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         }
     };
 
+    handleTextAreaScroll = (e: React.UIEvent<HTMLTextAreaElement>) => {
+        const { showLineNumber } = this.props;
+        if (showLineNumber && this.lineNumberRef.current) {
+            // Use rAF to avoid layout thrash
+            requestAnimationFrame(() => {
+                const panel = this.lineNumberRef.current;
+                if (panel) {
+                    panel.scrollTop = (e.target as HTMLTextAreaElement).scrollTop;
+                }
+            });
+        }
+    };
+
+    getTextareaLineHeightPx = (textarea: HTMLTextAreaElement): number => {
+        const computedStyle = window.getComputedStyle(textarea);
+        const lineHeightStr = computedStyle.lineHeight;
+        const fontSize = parseFloat(computedStyle.fontSize) || 14;
+        if (!lineHeightStr || lineHeightStr === 'normal') {
+            // Browsers typically use ~1.2, but Semi textarea visually closer to 1.5
+            return fontSize * 1.5;
+        }
+        const parsed = parseFloat(lineHeightStr);
+        return Number.isFinite(parsed) && parsed > 0 ? parsed : fontSize * 1.5;
+    };
+
+    // Calculate the number of wrapped lines for a given text line
+    calculateWrappedLines = (line: string, textarea: HTMLTextAreaElement): number => {
+        if (!line) return 1;
+        
+        const computedStyle = window.getComputedStyle(textarea);
+        const canvas = document.createElement('canvas');
+        const ctx = canvas.getContext('2d');
+        
+        if (!ctx) return 1;
+        
+        // Set font to match textarea
+        const fontSize = computedStyle.fontSize;
+        const fontFamily = computedStyle.fontFamily;
+        ctx.font = `${fontSize} ${fontFamily}`;
+        
+        // Calculate available width (excluding padding and scrollbar)
+        const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+        const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+        const textareaWidth = textarea.clientWidth - paddingLeft - paddingRight;
+        
+        if (textareaWidth <= 0) return 1;
+        
+        // Measure text width
+        const metrics = ctx.measureText(line);
+        const textWidth = metrics.width;
+        
+        // Calculate wrapped lines
+        const wrappedLines = Math.ceil(textWidth / textareaWidth);
+        return Math.max(1, wrappedLines);
+    };
+
+    renderLineNumbers() {
+        const { showLineNumber, lineNumberStart = 1, lineNumberClassName, lineNumberStyle } = this.props;
+        if (!showLineNumber) {
+            return null;
+        }
+        // Reference textareaWidth to trigger re-render when textarea resizes
+        const { value, textareaWidth, textareaHeight } = this.state;
+        const textarea = this.libRef.current as unknown as HTMLTextAreaElement;
+        const lines = value ? value.split('\n') : [''];
+        
+        const lineNumberCls = cls(`${prefixCls}-textarea-lineNumber`, lineNumberClassName);
+        const lineHeightPx = textarea ? this.getTextareaLineHeightPx(textarea) : 21;
+
+        // Constrain panel height to textarea viewport height to prevent expanding textarea
+        const mergedStyle: CSSProperties = {
+            ...(lineNumberStyle || {}),
+            height: textareaHeight ? `${textareaHeight}px` : undefined,
+            maxHeight: textareaHeight ? `${textareaHeight}px` : undefined,
+        };
+
+        return (
+            <div
+                ref={this.lineNumberRef}
+                className={lineNumberCls}
+                style={mergedStyle}
+            >
+                {lines.map((line, i) => {
+                    // Calculate wrapped lines for this line
+                    const wrappedLineCount = textarea ? this.calculateWrappedLines(line, textarea) : 1;
+                    
+                    return (
+                        <div 
+                            key={i} 
+                            className={`${prefixCls}-textarea-lineNumber-item`}
+                            style={{ 
+                                minHeight: `${wrappedLineCount * lineHeightPx}px`,
+                                lineHeight: `${lineHeightPx}px`
+                            }}
+                        >
+                            {lineNumberStart + i}
+                        </div>
+                    );
+                })}
+            </div>
+        );
+    }
+
     render() {
         const {
             autosize,
@@ -280,6 +452,10 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             showClear,
             borderless,
             autoFocus,
+            showLineNumber,
+            lineNumberStart,
+            lineNumberClassName,
+            lineNumberStyle,
             ...rest
         } = this.props;
         const { isFocus, value, minLength: stateMinLength } = this.state;
@@ -289,6 +465,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             [`${prefixCls}-textarea-wrapper-readonly`]: readonly,
             [`${prefixCls}-textarea-wrapper-${validateStatus}`]: Boolean(validateStatus),
             [`${prefixCls}-textarea-wrapper-focus`]: isFocus,
+            [`${prefixCls}-textarea-wrapper-withLineNumber`]: showLineNumber,
             // [`${prefixCls}-textarea-wrapper-resize`]: !autosize && resize,
         });
         // const ref = this.props.forwardRef || this.textAreaRef;
@@ -309,6 +486,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             onFocus: (e: React.FocusEvent<HTMLTextAreaElement>) => this.foundation.handleFocus(e),
             onBlur: (e: React.FocusEvent<HTMLTextAreaElement>) => this.foundation.handleBlur(e.nativeEvent),
             onKeyDown: (e: React.KeyboardEvent<HTMLTextAreaElement>) => this.foundation.handleKeyDown(e),
+            onScroll: this.handleTextAreaScroll,
             value: value === null || value === undefined ? '' : value,
             onCompositionStart: this.foundation.handleCompositionStart,
             onCompositionEnd: this.foundation.handleCompositionEnd,
@@ -328,7 +506,18 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
                 onMouseEnter={e => this.foundation.handleMouseEnter(e)}
                 onMouseLeave={e => this.foundation.handleMouseLeave(e)}
             >
-                {autosize ? (
+                {this.renderLineNumbers()}
+                {showLineNumber ? (
+                    <div className={`${prefixCls}-textarea-content`}>
+                        {autosize ? (
+                            <ResizeObserver onResize={this.throttledResizeTextarea}>
+                                <textarea {...itemProps} ref={this.setRef} />
+                            </ResizeObserver>
+                        ) : (
+                            <textarea {...itemProps} ref={this.setRef} />
+                        )}
+                    </div>
+                ) : autosize ? (
                     <ResizeObserver onResize={this.throttledResizeTextarea}>
                         <textarea {...itemProps} ref={this.setRef} />
                     </ResizeObserver>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20677,14 +20677,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20692,6 +20684,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23221,13 +23221,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23501,11 +23494,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
-  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24721,11 +24709,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2890

本 PR 为 TextArea 组件增加了行号支持功能。通过新增的 `showLineNumber` prop，用户可以在 TextArea 左侧显示行号区域。行号区域与 textarea 内容保持同步滚动，使用 `requestAnimationFrame` 确保滚动无延迟。

新增 Props 说明：
- **TextArea 组件新增 `showLineNumber` prop**：布尔值，控制是否显示行号区域，默认为 `false`
- **TextArea 组件新增 `lineNumberStart` prop**：数值，设置起始行号，默认为 `1`
- **TextArea 组件新增 `lineNumberClassName` prop**：字符串，用于自定义行号栏的类名
- **TextArea 组件新增 `lineNumberStyle` prop**：CSSProperties，用于自定义行号栏的内联样式

实现细节：
1. 使用 Canvas API 测量文本宽度，准确计算软换行（word wrap）产生的额外行数，确保行号与实际视觉行数一致
2. 通过 `ResizeObserver` 监听 textarea 大小变化，在容器宽度变化时重新计算行号
3. 使用 `requestAnimationFrame` 优化滚动同步性能，确保行号区域与 textarea 内容滚动保持同步

### Changelog
🇨🇳 Chinese
- Feat: TextArea 组件新增 `showLineNumber` prop，支持显示行号
- Feat: TextArea 组件新增 `lineNumberStart` prop，支持设置起始行号
- Feat: TextArea 组件新增 `lineNumberClassName` prop，支持自定义行号栏类名
- Feat: TextArea 组件新增 `lineNumberStyle` prop，支持自定义行号栏样式

---

🇺🇸 English
- Feat: Added `showLineNumber` prop to TextArea component to support displaying line numbers
- Feat: Added `lineNumberStart` prop to TextArea component to support setting the starting line number
- Feat: Added `lineNumberClassName` prop to TextArea component for customizing line number area className
- Feat: Added `lineNumberStyle` prop to TextArea component for customizing line number area styles


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
该功能参考了 CodeHighlight 组件的行号实现方式，并针对 TextArea 的编辑特性进行了优化。行号区域支持自动高度计算，可正确处理文本软换行情况。