### PR TITLE
fix(PinCode): fix Chinese IME input issue

### DIFF
--- a/packages/semi-ui/pincode/index.tsx
+++ b/packages/semi-ui/pincode/index.tsx
@@ -113,7 +113,13 @@ class PinCode extends BaseComponent<PinCodeProps, PinCodeState> {
             onKeyDown={e => {
                 this.foundation.handleKeyDownOnSingleInput(e.nativeEvent, index);
             }}
-            onChange={v => {
+            onChange={(v, e) => {
+                // 检查是否在输入法组合状态（中文输入法等）
+                // 原生 InputEvent 有 isComposing 属性，表示是否处于组合输入中
+                const nativeEvent = e.nativeEvent;
+                if (nativeEvent && 'isComposing' in nativeEvent && (nativeEvent as InputEvent).isComposing) {
+                    return;
+                }
                 const userInputChar = v[v.length - 1];
                 if (this.foundation.validateValue(userInputChar)) {
                     this.foundation.completeSingleInput(index, userInputChar);


### PR DESCRIPTION
- Check native InputEvent.isComposing to detect IME composition state
- Ignore onChange events during composition to prevent multiple character input
- Use native event property for simpler and more reliable implementation

<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
在中文输入法状态下，PinCode 组件输入一个字符会在验证码输入框中跳出多个字符。

   **问题原因**：中文输入法在输入拼音时会多次触发 `onChange` 事件，每次按键都被当作有效输入处理。

   **解决方案**：
   - 检查原生 `InputEvent.isComposing` 属性来检测输入法组合状态
   - 在组合过程中忽略 `onChange` 事件，防止多个字符被输入
   - 使用原生事件属性实现更简洁可靠

### Changelog
🇨🇳 Chinese
 - Fix: 修复 PinCode 组件在中文输入法状态下输入一个字符会跳出多个字符的问题

---

🇺🇸 English
- Fix: fix PinCode component inputting multiple characters when using Chinese IME


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

测试步骤：
   1. 打开 PinCode 组件
   2. 切换到中文输入法
   3. 输入拼音不会触发输入
   4. 切换回英文输入法，确认正常输入
before:

https://github.com/user-attachments/assets/06f4e36e-a07e-490f-8ce1-af174360303b


after:

https://github.com/user-attachments/assets/84ecde63-04e9-4157-b71d-8c6abe4dcf77



