### PR TITLE
【Auto】Feat: Table 组件新增 filterConfirmMode 属性，支持筛选确认模式

### DIFF
--- a/packages/semi-ui/table/ColumnFilter.tsx
+++ b/packages/semi-ui/table/ColumnFilter.tsx
@@ -8,11 +8,14 @@ import { cssClasses } from '@douyinfe/semi-foundation/table/constants';
 import Dropdown, { DropdownProps } from '../dropdown';
 import { Radio } from '../radio';
 import { Checkbox } from '../checkbox';
+import Button from '../button';
+import Space from '../space';
 import {
     FilterIcon,
     Filter,
     OnFilterDropdownVisibleChange,
-    RenderFilterDropdownItem
+    RenderFilterDropdownItem,
+    FilterConfirmMode
 } from './interface';
 
 function renderDropdown(props: RenderDropdownProps, nestedElem: React.ReactNode = null, level = 0) {
@@ -27,7 +30,18 @@ function renderDropdown(props: RenderDropdownProps, nestedElem: React.ReactNode 
         position = 'bottom',
         renderFilterDropdown,
         renderFilterDropdownItem,
+        filterConfirmMode = 'immediate',
+        tempFilteredValue,
+        setTempFilteredValue,
+        confirm,
+        clear,
+        close,
+        reset,
     } = props ?? {};
+
+    // Determine which value to use for displaying checked state
+    // In confirm mode, use tempFilteredValue; otherwise use filteredValue
+    const displayValue = filterConfirmMode === 'confirm' ? (tempFilteredValue ?? []) : filteredValue;
 
     const renderFilterDropdownProps: RenderFilterDropdownProps = pick(props, ['tempFilteredValue', 'setTempFilteredValue', 'confirm', 'clear', 'close', 'filters']);
     const render = typeof renderFilterDropdown === 'function' ? renderFilterDropdown(renderFilterDropdownProps) : (
@@ -44,27 +58,48 @@ function renderDropdown(props: RenderDropdownProps, nestedElem: React.ReactNode 
                             domEvent.stopPropagation();
                             domEvent.preventDefault();
                         }
-                        let values = [...filteredValue];
 
-                        const included = values.includes(filter.value);
-                        const idx = values.indexOf(filter.value);
+                        // In confirm mode, update tempFilteredValue instead of calling onSelect
+                        if (filterConfirmMode === 'confirm') {
+                            const currentTempValue = tempFilteredValue ?? [...filteredValue];
+                            let values = [...currentTempValue];
 
-                        if (idx > -1) {
-                            values.splice(idx, 1);
-                        } else if (filterMultiple) {
-                            values.push(filter.value);
+                            const included = values.includes(filter.value);
+                            const idx = values.indexOf(filter.value);
+
+                            if (idx > -1) {
+                                values.splice(idx, 1);
+                            } else if (filterMultiple) {
+                                values.push(filter.value);
+                            } else {
+                                values = [filter.value];
+                            }
+                            
+                            setTempFilteredValue?.(values);
                         } else {
-                            values = [filter.value];
+                            // Immediate mode: original behavior
+                            let values = [...filteredValue];
+
+                            const included = values.includes(filter.value);
+                            const idx = values.indexOf(filter.value);
+
+                            if (idx > -1) {
+                                values.splice(idx, 1);
+                            } else if (filterMultiple) {
+                                values.push(filter.value);
+                            } else {
+                                values = [filter.value];
+                            }
+                            return onSelect({
+                                value: filter.value,
+                                filteredValue: values,
+                                included: !included,
+                                domEvent,
+                            });
                         }
-                        return onSelect({
-                            value: filter.value,
-                            filteredValue: values,
-                            included: !included,
-                            domEvent,
-                        });
                     };
 
-                    const checked = filteredValue.includes(filter.value);
+                    const checked = displayValue.includes(filter.value);
                     const { text } = filter;
                     const { value } = filter;
                     const key = `${level}_${index}`;
@@ -77,7 +112,7 @@ function renderDropdown(props: RenderDropdownProps, nestedElem: React.ReactNode 
                                 value,
                                 text,
                                 checked,
-                                filteredValue,
+                                filteredValue: displayValue,
                                 level,
                             }) :
                             null;
@@ -109,17 +144,42 @@ function renderDropdown(props: RenderDropdownProps, nestedElem: React.ReactNode 
                     }
                     return item;
                 })}
+            {/* Show confirm and reset buttons in confirm mode */}
+            {filterConfirmMode === 'confirm' && level === 0 && (
+                <div style={{ padding: '8px 12px', borderTop: '1px solid var(--semi-color-border)', display: 'flex', justifyContent: 'flex-end' }}>
+                    <Space>
+                        <Button 
+                            size="small" 
+                            onClick={() => reset?.()}
+                        >
+                            重置
+                        </Button>
+                        <Button 
+                            size="small" 
+                            theme="solid" 
+                            onClick={() => confirm?.({ closeDropdown: true })}
+                        >
+                            确定
+                        </Button>
+                    </Space>
+                </div>
+            )}
         </Dropdown.Menu>
     );
 
+    // Extract filterDropdownVisible to avoid passing it twice
+    const { filterDropdownVisible: _, ...restProps } = props;
+    
     const dropdownProps: DropdownProps = {
-        ...props,
-        onVisibleChange: (visible: boolean) => onFilterDropdownVisibleChange(visible),
+        ...restProps,
         trigger,
         position,
         render,
+        onVisibleChange: (visible: boolean) => onFilterDropdownVisibleChange(visible),
     };
 
+    // Only set visible when it's controlled (not null/undefined)
+    // This is important for confirm mode to work correctly
     if (filterDropdownVisible != null) {
         dropdownProps.visible = filterDropdownVisible;
     }
@@ -140,7 +200,8 @@ export default function ColumnFilter(props: ColumnFilterProps = {}): React.React
         onSelect,
         filterDropdownVisible,
         renderFilterDropdown,
-        onFilterDropdownVisibleChange
+        onFilterDropdownVisibleChange,
+        filterConfirmMode = 'immediate'
     } = props;
     let { filterDropdown = null } = props;
 
@@ -148,8 +209,11 @@ export default function ColumnFilter(props: ColumnFilterProps = {}): React.React
     // custom filter related status
     const isFilterDropdownVisibleControlled = typeof filterDropdownVisible !== 'undefined';
     const isCustomFilterDropdown = typeof renderFilterDropdown === 'function';
-    const isCustomDropdownVisible = !isFilterDropdownVisibleControlled && isCustomFilterDropdown;
+    // In confirm mode, we also need to control the dropdown visible state
+    const isCustomDropdownVisible = !isFilterDropdownVisibleControlled && (isCustomFilterDropdown || filterConfirmMode === 'confirm');
     const [tempFilteredValue, setTempFilteredValue] = useState<any[]>(filteredValue);
+    // Store the initial filtered value when dropdown opens (for reset functionality)
+    const [initialFilteredValue, setInitialFilteredValue] = useState<any[]>(filteredValue);
     const dropdownVisibleInitValue = isCustomDropdownVisible ? false : filterDropdownVisible;
     const [dropdownVisible, setDropdownVisible] = useState<boolean | undefined>(dropdownVisibleInitValue);
 
@@ -185,9 +249,18 @@ export default function ColumnFilter(props: ColumnFilterProps = {}): React.React
         setDropdownVisible(false);
     };
 
+    const reset: RenderFilterDropdownProps['reset'] = () => {
+        setTempFilteredValue(initialFilteredValue);
+    };
+
     const handleFilterDropdownVisibleChange = (visible: boolean) => {
         if (isCustomDropdownVisible) {
             setDropdownVisible(visible);
+        }
+        // When dropdown opens in confirm mode, save the initial filtered value for reset
+        if (visible && filterConfirmMode === 'confirm') {
+            setInitialFilteredValue(filteredValue);
+            setTempFilteredValue(filteredValue);
         }
         onFilterDropdownVisibleChange(visible);
     };
@@ -197,7 +270,9 @@ export default function ColumnFilter(props: ColumnFilterProps = {}): React.React
         setTempFilteredValue,
         confirm,
         clear,
-        close
+        close,
+        reset,
+        filters: props.filters
     };
 
     const finalCls = cls(`${prefixCls}-column-filter`, {
@@ -257,7 +332,8 @@ export interface RenderDropdownProps extends FilterDropdownProps, RenderFilterDr
     onSelect?: (data: OnSelectData) => void;
     onFilterDropdownVisibleChange?: OnFilterDropdownVisibleChange;
     renderFilterDropdown?: (props: RenderFilterDropdownProps) => React.ReactNode;
-    renderFilterDropdownItem?: RenderFilterDropdownItem
+    renderFilterDropdownItem?: RenderFilterDropdownItem;
+    filterConfirmMode?: FilterConfirmMode;
 }
 
 export interface FilterDropdownProps extends Omit<DropdownProps, 'render' | 'onVisibleChange'> {}
@@ -281,6 +357,8 @@ export interface RenderFilterDropdownProps {
     clear: (props?: { closeDropdown?: boolean }) => void;
     /** close dropdown  */
     close: () => void;
+    /** reset tempFilteredValue to initial value when dropdown opened  */
+    reset?: () => void;
     /** column filters  */
     filters?: RenderDropdownProps['filters']
 }

--- a/packages/semi-ui/table/interface.ts
+++ b/packages/semi-ui/table/interface.ts
@@ -95,6 +95,8 @@ export interface ColumnProps<RecordType extends Record<string, any> = any> {
     filterDropdownVisible?: boolean;
     filterIcon?: FilterIcon;
     filterMultiple?: boolean;
+    /** filter confirm mode, 'immediate' means filter immediately when clicking option, 'confirm' means filter after clicking confirm button */
+    filterConfirmMode?: FilterConfirmMode;
     filteredValue?: any[];
     /** `filters` is not required if you use `renderFilterDropdown`  */
     filters?: Filter[];
@@ -129,6 +131,7 @@ export type Align = BaseAlign;
 export type SortOrder = BaseSortOrder;
 export type SortIcon = (props: { sortOrder: SortOrder }) => ReactNode;
 export type FilterIcon = boolean | React.ReactNode | FilterIconRenderFunction;
+export type FilterConfirmMode = 'immediate' | 'confirm';
 export interface Filter extends BaseFilter {
     value?: any;
     text?: React.ReactNode;

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20677,14 +20677,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20692,6 +20684,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23221,13 +23221,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23501,11 +23494,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
-  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24721,11 +24709,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2892

**问题背景：**
Table 组件的多选筛选功能存在用户体验问题：点击筛选选项后筛选立即生效，用户无法在应用筛选前预览多个筛选条件，也无法一键重置到初始状态。

**解决方案：**
为 Table 组件新增 `filterConfirmMode` 属性，支持两种筛选确认模式：
- `immediate`（默认值）：点击筛选选项后立即生效，保持原有行为，向后兼容
- `confirm`：点击筛选选项后仅更新临时状态，需点击"确定"按钮才应用筛选，同时提供"重置"按钮恢复到打开下拉框时的状态

**Props 变更：**
- Table 组件新增 `filterConfirmMode` prop（类型：`'immediate' | 'confirm'`，默认值：`'immediate'`）
- `RenderFilterDropdownProps` 接口新增 `reset` 方法，用于自定义筛选下拉框时重置临时筛选值

**审查关注点：**
1. `ColumnFilter.tsx` 中 confirm 模式下的状态管理逻辑
2. 重置按钮功能：重置到打开下拉框时的初始值，而非清空所有筛选
3. 向后兼容性：默认值为 `immediate`，不影响现有代码

### Changelog
🇨🇳 Chinese
- Feat: Table 组件新增 `filterConfirmMode` 属性，支持筛选确认模式。设置 `filterConfirmMode='confirm'` 时，筛选下拉框底部会显示"确定"和"重置"按钮，点击确定后才应用筛选，点击重置恢复到打开时的状态

---

🇺🇸 English
- Feat: Added `filterConfirmMode` prop to Table component for filter confirmation mode. When set to `filterConfirmMode='confirm'`, the filter dropdown shows "Confirm" and "Reset" buttons at the bottom, applying filters only after clicking confirm, and reset restores to the state when dropdown opened


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
该功能通过 playground 测试验证，confirm 模式下筛选选项点击后表格数据不变，点击确定后才应用筛选，重置按钮可恢复到打开下拉框时的状态。