### PR TITLE
fix(pagination): prevent infinite render loop in React 18

### DIFF
--- a/packages/semi-foundation/pagination/foundation.ts
+++ b/packages/semi-foundation/pagination/foundation.ts
@@ -64,7 +64,10 @@ class PaginationFoundation<P = Record<string, any>, S = Record<string, any>> ext
             prevIsDisabled = false;
             nextIsDisabled = true;
         }
-        this._adapter.setDisabled(prevIsDisabled, nextIsDisabled);
+        const { prevDisabled: currentPrevDisabled, nextDisabled: currentNextDisabled } = this.getStates();
+        if (prevIsDisabled !== currentPrevDisabled || nextIsDisabled !== currentNextDisabled) {
+            this._adapter.setDisabled(prevIsDisabled, nextIsDisabled);
+        }
     }
 
     goPage(targetPageIndex: number | '...') {
@@ -98,9 +101,17 @@ class PaginationFoundation<P = Record<string, any>, S = Record<string, any>> ext
         }
         this._updateDisabled({ currentPage: targetPageIndex, total, pageSize });
         this._updatePageList({ currentPage: targetPageIndex, total, pageSize });
-        this._adapter.updateTotal(total);
-        this._adapter.setCurrentPage(targetPageIndex);
-        this._adapter.updatePageSize(pageSize);
+        // Only call setState when value actually changed to avoid unnecessary re-renders
+        // that can cause infinite loops in React 18's concurrent batching
+        if (total !== this.getState('total')) {
+            this._adapter.updateTotal(total);
+        }
+        if (targetPageIndex !== this.getState('currentPage')) {
+            this._adapter.setCurrentPage(targetPageIndex);
+        }
+        if (pageSize !== this.getState('pageSize')) {
+            this._adapter.updatePageSize(pageSize);
+        }
     }
 
     updateAllPageNumbers(total: number, pageSize: number) {


### PR DESCRIPTION
## Summary

- Pagination's `componentDidUpdate` → `foundation.updatePage()` unconditionally fires multiple `setState` calls (`updateTotal`, `setCurrentPage`, `updatePageSize`, `setDisabled`) even when values haven't changed
- In React 18's concurrent batching, these redundant `setState` calls trigger another `componentDidUpdate` cycle → infinite loop → crash with **"Maximum update depth exceeded"** (React error #185)
- Added equality checks before each `setState` call so only actual value changes trigger re-renders

## How to reproduce

1. Use React 18 with `createRoot` (concurrent mode)
2. Use `<Table>` with controlled `pagination` config object that gets recreated on each render (e.g. inline object in JSX)
3. Have an async data source that updates `total` (e.g. 0 → real value)
4. The pagination `componentDidUpdate` detects prop change → calls `updatePage` → fires 5× `setState` → triggers another `componentDidUpdate` → infinite loop

## Fix

Add state comparison guards before calling `setState` in `updatePage()` and `_updateDisabled()`:

```typescript
// Before:
this._adapter.updateTotal(total);
this._adapter.setCurrentPage(targetPageIndex);
this._adapter.updatePageSize(pageSize);

// After:
if (total !== this.getState('total')) {
    this._adapter.updateTotal(total);
}
if (targetPageIndex !== this.getState('currentPage')) {
    this._adapter.setCurrentPage(targetPageIndex);
}
if (pageSize !== this.getState('pageSize')) {
    this._adapter.updatePageSize(pageSize);
}
```

Same pattern applied to `_updateDisabled()` for `prevDisabled`/`nextDisabled`.

## Test plan

- [x] Existing pagination tests still pass (no behavioral change when values actually differ)
- [ ] Verify no infinite loop with controlled Pagination + React 18 `createRoot`
- [ ] Verify page navigation still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)