### PR TITLE
【Auto】Feat: Add clearContentOnGenerating prop to AIChatInput component

### DIFF
--- a/content/ai/aiChatInput/index-en-US.md
+++ b/content/ai/aiChatInput/index-en-US.md
@@ -1515,6 +1515,7 @@ render(<CustomRichTextExtension />);
 |------|-------------|------|---------|
 | canSend | Whether sending is allowed. If not set, sending depends on input, uploads, and references | boolean | true |
 | className | Custom class name | string | - |
+| clearContentOnGenerating | Whether to clear input content and attachments when generating changes from false to true. Set to false to retain input content (for infinite canvas and other non-chat scenarios) | boolean | true |
 | defaultContent | Default input content, supports html string or Tiptap content | TiptapContent | - |
 | dropdownMatchTriggerWidth | Should dropdown width match input? | boolean | true |
 | extensions | Custom editor extensions | Extension[] | - |

--- a/content/ai/aiChatInput/index.md
+++ b/content/ai/aiChatInput/index.md
@@ -1593,6 +1593,7 @@ render(<CustomRichTextExtension />);
 |------|----|------|-------|
 | canSend | 是否可以发送，未设置时，根据输入框内容，上传内容，引用内容决定是否可发送 | boolean | true |
 | className | 自定义类名 | string | - |
+| clearContentOnGenerating | 当 generating 从 false 变为 true 时，是否清空输入框内容和附件。设为 false 可保留输入内容（适用于无限画布等非对话场景） | boolean | true |
 | defaultContent | 输入框默认内容，支持 html string 以及 json 格式，同 Tiptap 的 Content | TiptapContent | - |
 | dropdownMatchTriggerWidth | 下拉弹出层是否是否与输入框宽度一致 | boolean | true |
 | extensions | 自定义扩展，类型同 tiptap 的 Extension 类型相同 | Extension[] | - |

--- a/packages/semi-ui/aiChatInput/index.tsx
+++ b/packages/semi-ui/aiChatInput/index.tsx
@@ -57,6 +57,7 @@ class AIChatInput extends BaseComponent<AIChatInputProps, AIChatInputState> {
         sendHotKey: strings.SEND_HOTKEY.ENTER,
         keepSkillAfterSend: false,
         showUploadButton: true,
+        clearContentOnGenerating: true,
     }
 
     constructor(props: AIChatInputProps) {
@@ -206,15 +207,17 @@ class AIChatInput extends BaseComponent<AIChatInputProps, AIChatInputState> {
     }
 
     componentDidUpdate(prevProps: Readonly<AIChatInputProps>): void {
-        const { suggestions, keepSkillAfterSend } = this.props;
+        const { suggestions, keepSkillAfterSend, clearContentOnGenerating } = this.props;
         if (!isEqual(suggestions, prevProps.suggestions)) {
             const newVisible = (suggestions && suggestions.length > 0) ? true : false;
             newVisible ? this.foundation.showSuggestionPanel() :
                 this.foundation.hideSuggestionPanel();
         }
         if (this.props.generating && (this.props.generating !== prevProps.generating)) {
-            keepSkillAfterSend ? this.setContentWhileSaveTool('') : this.adapter.clearContent();
-            this.adapter.clearAttachments();
+            if (clearContentOnGenerating !== false) {
+                keepSkillAfterSend ? this.setContentWhileSaveTool('') : this.adapter.clearContent();
+                this.adapter.clearAttachments();
+            }
         }
     }
 

--- a/packages/semi-ui/aiChatInput/interface.ts
+++ b/packages/semi-ui/aiChatInput/interface.ts
@@ -93,7 +93,12 @@ export interface AIChatInputProps {
     // Popover related
     popoverProps?: PopoverProps;
     sendHotKey?: 'enter' | 'shift+enter';
-    immediatelyRender?: boolean
+    immediatelyRender?: boolean;
+    /**
+     * Whether to clear input content when generating state changes from false to true
+     * @default true
+     */
+    clearContentOnGenerating?: boolean;
 }
 
 export interface RenderUploadButtonProps {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20677,14 +20677,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20692,6 +20684,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23221,13 +23221,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23501,11 +23494,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
-  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24721,11 +24709,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3166

在 AIChatInput 组件中新增 `clearContentOnGenerating` 属性，允许用户在 `generating` 状态变为 `true` 时控制是否清空输入框内容和附件。在传统的对话场景中，当消息发送后需要清空输入框；但在类似 Tapnow 的无限画布场景中，输入框是跟随节点的，内容不需要被清空。该属性默认值为 `true`，保持向后兼容，设置为 `false` 可禁用自动清空行为。

### Changelog
🇨🇳 Chinese
- Feat: AIChatInput 组件新增 `clearContentOnGenerating` 属性，支持在 generating 状态变化时控制是否自动清空输入框内容和附件

---

🇺🇸 English
- Feat: Added `clearContentOnGenerating` prop to AIChatInput component to control whether to clear input content and attachments when generating state changes


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- 变更文件：
  - `packages/semi-ui/aiChatInput/interface.ts`: 新增 `clearContentOnGenerating?: boolean` 属性定义
  - `packages/semi-ui/aiChatInput/index.tsx`: 添加默认值 `true`，并在 `componentDidUpdate` 中根据该属性决定是否清空内容
  - `content/ai/aiChatInput/index.md`: 更新中文文档，添加 `clearContentOnGenerating` API 说明
  - `content/ai/aiChatInput/index-en-US.md`: 更新英文文档，添加 `clearContentOnGenerating` API 说明