### PR TITLE
【Auto】Feat: Chat component avatar prop supports ReactNode (vector icons)

### DIFF
--- a/content/plus/chat/index-en-US.md
+++ b/content/plus/chat/index-en-US.md
@@ -1656,7 +1656,7 @@ render(DefaultChat);
 | PROPERTIES | INSTRUCTIONS | TYPE | DEFAULT |
 |------|--------|-------|-------|
 | name | name | string | - |
-| avatar | avatar | string | - |
+| avatar | avatar, supports image URL or ReactNode (such as Semi icons) | ReactNode \| string | - |
 | color | Avatar background color, same as the color parameter of Avatar component, support `amber`、 `blue`、 `cyan`、 `green`、 `grey`、 `indigo`、 `light-blue`、 `light-green`、 `lime`、 `orange`、 `pink`、 `purple`、 `red`、 `teal`、 `violet`、 `yellow` | string | `grey` |
 
 #### Message

--- a/content/plus/chat/index.md
+++ b/content/plus/chat/index.md
@@ -1659,7 +1659,7 @@ render(DefaultChat);
 | 属性  | 说明   | 类型   | 默认值 |
 |------|--------|-------|-------|
 | name | 名称 | string | - |
-| avatar | 头像 | string | - |
+| avatar | 头像，支持图片 URL 或 ReactNode（如 Semi 图标） | ReactNode \| string | - |
 | color | 头像背景色，同 Avatar 组件的 color 参数, 支持 `amber`、 `blue`、 `cyan`、 `green`、 `grey`、 `indigo`、 `light-blue`、 `light-green`、 `lime`、 `orange`、 `pink`、 `purple`、 `red`、 `teal`、 `violet`、 `yellow` | string | `grey` |
 
 #### Message

--- a/packages/semi-ui/chat/chatBox/chatBoxAvatar.tsx
+++ b/packages/semi-ui/chat/chatBox/chatBoxAvatar.tsx
@@ -19,14 +19,16 @@ const ChatBoxAvatar = React.memo((props: ChatBoxAvatarProps) => {
 
     const node = useMemo(() => {
         const { avatar, color } = role;
+        const isAvatarString = typeof avatar === 'string';
         return (<Avatar
             className={cls(`${PREFIX_CHAT_BOX}-avatar`,
                 {
                     [`${PREFIX_CHAT_BOX}-avatar-hidden`]: continueSend
                 })}
-            src={avatar}
+            src={isAvatarString ? avatar : undefined}
             size="extra-small"
         >
+            {!isAvatarString ? avatar : null}
         </Avatar>);
     }, [role]);
 

--- a/packages/semi-ui/chat/interface.ts
+++ b/packages/semi-ui/chat/interface.ts
@@ -133,7 +133,7 @@ export interface RoleConfig {
 
 export interface Metadata {
     name?: string;
-    avatar?: string;
+    avatar?: ReactNode | string;
     color?: string;
     [x: string]: any
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20677,14 +20677,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20692,6 +20684,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23221,13 +23221,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.4.tgz#6fac6bd96f7db477d966c7ec17c1a2b1ad8e6591"
-  integrity sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23501,11 +23494,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.4"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.4.tgz#438e57baa19b77cb23aab516cf635cd0579ee09a"
-  integrity sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24721,11 +24709,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3152

本次 PR 为 Chat 组件的 `roleConfig` 配置中的 `avatar` 属性增加了对 ReactNode（矢量图标）的支持。

**问题背景**：之前的 `avatar` 属性只支持字符串类型的图片 URL，用户无法直接使用 React 图标组件（如 `@gravity-ui/icons` 或 Semi Design 的 Icon 组件）作为头像。

**解决方案**：
1. 修改 `Metadata` 接口中的 `avatar` 类型定义，从 `string` 扩展为 `ReactNode | string`
2. 在 `ChatBoxAvatar` 组件中通过类型判断处理不同格式的 avatar：
   - 当 avatar 为字符串时，作为图片 URL 通过 `src` 属性传递给 Avatar 组件
   - 当 avatar 为 ReactNode 时，作为 Avatar 组件的子元素渲染
3. 更新了中英文文档，说明 `avatar` 属性支持图片 URL 或 ReactNode（如 Semi 图标）

**审查关注点**：请重点关注类型定义的兼容性，以及 ChatBoxAvatar 组件中条件渲染逻辑的正确性。

### Changelog
🇨🇳 Chinese
- Feat: Chat 组件 roleConfig 配置中的 avatar 属性类型扩展为 ReactNode | string，支持传入矢量图标组件作为头像

---

🇺🇸 English
- Feat: Extended Chat component's avatar prop type in roleConfig to ReactNode | string, supporting vector icon components as avatars


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
使用示例：
```jsx
import { IconBell } from '@douyinfe/semi-icons';

const roleConfig = {
  user: {
    name: 'User',
    avatar: <IconBell />,  // 现在支持传入 React 图标组件
  },
  assistant: {
    name: 'Assistant',
    avatar: 'https://example.com/avatar.png',  // 仍然支持图片 URL
  },
}
```