### PR TITLE
【Auto】Fix: Upgrade lottie-web to ^5.13.0 to fix SSR crash on Node 21+

### DIFF
--- a/packages/semi-foundation/package.json
+++ b/packages/semi-foundation/package.json
@@ -14189,7 +14189,7 @@
         "date-fns-tz": "^1.3.8",
         "fast-copy": "^3.0.1 ",
         "lodash": "^4.17.21",
-        "lottie-web": "^5.12.2",
+        "lottie-web": "^5.13.0",
         "memoize-one": "^5.2.1",
         "prismjs": "^1.29.0",
         "remark-gfm": "^4.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18253,6 +18253,11 @@ lottie-web@^5.12.2:
   resolved "https://registry.yarnpkg.com/lottie-web/-/lottie-web-5.12.2.tgz#579ca9fe6d3fd9e352571edd3c0be162492f68e5"
   integrity sha512-uvhvYPC8kGPjXT3MyKMrL3JitEAmDMp30lVkuq/590Mw9ok6pWcFCwXJveo0t5uqYw1UREQHofD+jVpdjBv8wg==
 
+lottie-web@^5.13.0:
+  version "5.13.0"
+  resolved "https://registry.npmjs.org/lottie-web/-/lottie-web-5.13.0.tgz#441d3df217cc8ba302338c3f168e1a3af0f221d3"
+  integrity sha512-+gfBXl6sxXMPe8tKQm7qzLnUy5DUPJPKIyRHwtpCpyUEYjHYRJC/5gjUvdkuO2c3JllrPtHXH5UJJK8LRYl5yQ==
+
 lower-case-first@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/lower-case-first/-/lower-case-first-1.0.2.tgz#e5da7c26f29a7073be02d52bac9980e5922adfa1"


### PR DESCRIPTION

[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3175

升级 `lottie-web` 从 `^5.12.2` 到 `^5.13.0`，修复在 Node 21+ 环境下从 `@douyinfe/semi-ui` 根入口导入时触发的 SSR 崩溃问题。

**问题背景**：`lottie-web@5.12.2` 使用 `typeof navigator !== "undefined"` 作为环境检测，但 Node 21+ 提供了全局 `navigator` 对象，导致 SSR 阶段进入浏览器代码路径，调用 `document.createElement()` 触发 `ReferenceError: document is not defined`。

**解决方案**：`lottie-web@5.13.0` 更新了 rollup 配置，防止 lottie-web 在 SSR 上下文中运行，从根本上解决了此问题。

**变更范围**：
- `packages/semi-foundation/package.json`: `lottie-web` 版本从 `^5.12.2` 更新为 `^5.13.0`
- `yarn.lock`: 新增 `lottie-web@5.13.0` 解析条目

**风险评估**：低风险
- `lottie-web` 5.13.0 无任何 Breaking Change，全部为 bug fix + 性能优化
- Semi 仅使用了 `lottie.loadAnimation()` 和 `animation.destroy()` 两个核心 API，这两个 API 在 5.13.0 中无变更

### Changelog
🇨🇳 Chinese
- Fix: 升级 lottie-web 至 ^5.13.0，修复 Node 21+ 环境下 SSR 崩溃问题（`ReferenceError: document is not defined`）

---

🇺🇸 English
- Fix: Upgrade lottie-web to ^5.13.0 to fix SSR crash (`ReferenceError: document is not defined`) on Node 21+ environments


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- lottie-web 5.13.0 CHANGELOG: https://github.com/airbnb/lottie-web/blob/master/CHANGELOG.md
- Key fix in 5.13.0: "rollup config updated to prevent lottie-web from running in Server-Side Rendering contexts"
- Reproduction repo from issue reporter: https://github.com/X-W-W/semi-ssr-reproduce