### PR TITLE
【Auto】Fix: Add textareaStyle prop to TextArea component for styling inner textarea element

### DIFF
--- a/content/input/input/index-en-US.md
+++ b/content/input/input/index-en-US.md
@@ -289,6 +289,29 @@ import { TextArea } from '@douyinfe/semi-ui';
 );
 ```
 
+### Setting TextArea Height
+
+You can set the style of the internal textarea element through `textareaStyle`, such as height, background color, etc.
+
+```jsx live=true
+import React from 'react';
+import { TextArea } from '@douyinfe/semi-ui';
+
+() => (
+    <div>
+        <TextArea textareaStyle={{ height: 120 }} placeholder="Height 120px" />
+        <br/><br/>
+        <TextArea textareaStyle={{ height: 200, backgroundColor: '#f9f9f9' }} placeholder="Height 200px with gray background" />
+        <br/><br/>
+        <TextArea 
+            style={{ border: '2px solid var(--semi-color-primary)' }} 
+            textareaStyle={{ height: 150 }} 
+            placeholder="style controls outer container, textareaStyle controls textarea" 
+        />
+    </div>
+);
+```
+
 ### Line Numbers
 
 Set `showLineNumber` to display line numbers. You can use `lineNumberStart` to set the starting line number, and customize the line number area via `lineNumberStyle`/`lineNumberClassName`.
@@ -507,7 +530,8 @@ Answers to some questions:
 | lineNumberClassName | ClassName for line number area                                                                                        | string                          | -       |
 | lineNumberStyle    | Style for line number area                                                                                              | CSSProperties                   | -       |
 | showClear         | Display the clear button when the input box has content and hover or focus                                                                                         | boolean                         | false   |
-| style             | Inline style                                                                                                           | CSSProperties                   | -       |
+| style             | Inline style for the outer container                                                                                                           | CSSProperties                   | -       |
+| textareaStyle     | Style for the textarea element, can be used to set height, background color, etc. **>=2.94.0** | CSSProperties | - |
 | onBlur            | Callback invoked when input loses focus                                                                                | (e:event) => void               | -       |
 | onChange          | Callback invoked when input value changes                                                                              | (value:string, e:event) => void |         |
 | onClear           | Callback invoked when clicking clear icon                                                                | (e:event) => void               |         |

--- a/content/input/input/index.md
+++ b/content/input/input/index.md
@@ -300,6 +300,29 @@ import { TextArea } from '@douyinfe/semi-ui';
 );
 ```
 
+### 设置 TextArea 高度
+
+通过 `textareaStyle` 可以设置内部 textarea 元素的样式，如高度、背景色等。
+
+```jsx live=true
+import React from 'react';
+import { TextArea } from '@douyinfe/semi-ui';
+
+() => (
+    <div>
+        <TextArea textareaStyle={{ height: 120 }} placeholder="高度 120px" />
+        <br/><br/>
+        <TextArea textareaStyle={{ height: 200, backgroundColor: '#f9f9f9' }} placeholder="高度 200px，灰色背景" />
+        <br/><br/>
+        <TextArea 
+            style={{ border: '2px solid var(--semi-color-primary)' }} 
+            textareaStyle={{ height: 150 }} 
+            placeholder="style 控制外层容器，textareaStyle 控制 textarea" 
+        />
+    </div>
+);
+```
+
 ### 行号
 
 通过设置 `showLineNumber` 展示行号。可用 `lineNumberStart` 设置起始行号，或通过 `lineNumberStyle`/`lineNumberClassName` 自定义行号区样式。
@@ -520,7 +543,8 @@ import { Input, Typography, Form, TextArea, Button } from '@douyinfe/semi-ui';
 | lineNumberClassName | 行号区域 className | string | - |
 | lineNumberStyle | 行号区域样式 | CSSProperties | - |
 | showClear    | 支持清除               | boolean                         | false     |
-| style        | 样式                               | CSSProperties                   | -      |
+| style        | 外层容器样式                               | CSSProperties                   | -      |
+| textareaStyle | textarea 元素的样式，可用于设置 textarea 的高度等样式 **>=2.94.0** | CSSProperties | - |
 | onBlur       | 输入框失去焦点时的回调             |(e:event) => void               | -      |
 | onChange     | 输入框内容变化时的回调             | (value:string, e:event) => void |        |
 | onClear      | 点击清除按钮时的回调 | (e:event) => void                         | -       |

--- a/packages/semi-ui/input/textarea.tsx
+++ b/packages/semi-ui/input/textarea.tsx
@@ -61,7 +61,7 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
     /* Inner params for TextArea, Chat use it, 。
        Used to disable line breaks by pressing the enter key。
        Press enter + shift at the same time can start new line.
-    */
+     */
     disabledEnterStartNewLine?: boolean;
     /** Whether to show line numbers */
     showLineNumber?: boolean;
@@ -71,6 +71,8 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
     lineNumberClassName?: string;
     /** Custom style for line number area */
     lineNumberStyle?: CSSProperties;
+    /** The style of textarea element */
+    textareaStyle?: CSSProperties;
 }
 
 export interface TextAreaState {
@@ -99,6 +101,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         validateStatus: PropTypes.string,
         className: PropTypes.string,
         style: PropTypes.object,
+        textareaStyle: PropTypes.object,
         showClear: PropTypes.bool,
         onClear: PropTypes.func,
         onResize: PropTypes.func,
@@ -458,6 +461,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             maxCount,
             defaultValue,
             style,
+            textareaStyle,
             forwardRef,
             getValueLength,
             maxLength,
@@ -490,6 +494,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         });
         const itemProps = {
             ...omit(rest, 'insetLabel', 'insetLabelId', 'getValueLength', 'onClear', 'showClear', 'disabledEnterStartNewLine'),
+            style: textareaStyle,
             autoFocus: autoFocus || this.props['autofocus'],
             className: itemCls,
             disabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #965

在 TextArea 组件中，`style` 属性被应用到外层 wrapper div 而不是内部的 textarea 元素，导致用户通过 `style={{ height: 300 }}` 设置的高度无法实际生效。参考 Input 组件的 `inputStyle` 实现，本 PR 为 TextArea 组件新增 `textareaStyle` prop，使用户能够直接为内部 textarea 元素设置样式（如 height、minHeight、maxHeight 等），从而解决高度设置不生效的问题。

主要修改内容：
- 在 `TextAreaProps` 接口中新增 `textareaStyle?: CSSProperties` 属性定义
- 在 `propTypes` 中添加 `textareaStyle: PropTypes.object` 类型校验
- 在 render 方法中将 `textareaStyle` 应用到内部 textarea 元素的 style 属性上

### Changelog
🇨🇳 Chinese
- Fix: 修复 TextArea 组件 style 设置高度不生效的问题，新增 textareaStyle prop 用于直接设置内部 textarea 元素的样式

---

🇺🇸 English
- Fix: Fixed TextArea style height not taking effect issue by adding textareaStyle prop to directly style the inner textarea element


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

此修复方案与 Input 组件的 `inputStyle` prop 设计保持一致，提供了对内部元素样式的直接控制能力。用户现在可以通过 `textareaStyle` 属性设置 textarea 的高度、最小高度、最大高度等样式属性。