### PR TITLE
【Auto】Feat: JsonViewer support customizing search button rendering via renderSearchButton prop

### DIFF
--- a/content/plus/jsonviewer/index-en-US.md
+++ b/content/plus/jsonviewer/index-en-US.md
@@ -216,6 +216,46 @@ function CustomRenderJsonComponent() {
 render(CustomRenderJsonComponent);
 ```
 
+### Custom Search Button
+
+Use the `renderSearchButton` property to customize the rendering of the search button, enabling fixed positioning, custom styles, and more.
+
+```jsx live=true dir="column" noInline=true
+import React from 'react';
+import { JsonViewer, Button } from '@douyinfe/semi-ui';
+import { IconSearch } from '@douyinfe/semi-icons';
+
+const data = `{
+    "name": "Semi",
+    "version": "0.0.0"
+}`;
+
+function CustomSearchButtonDemo() {
+    return (
+        <div style={{ marginBottom: 16 }}>
+            <JsonViewer 
+                height={200} 
+                width={700} 
+                value={data}
+                renderSearchButton={(defaultButton, controls) => (
+                    <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 10 }}>
+                        {!controls.showSearchBar ? (
+                            <Button icon={<IconSearch />} onClick={controls.onToggleSearchBar}>
+                                Search
+                            </Button>
+                        ) : (
+                            defaultButton
+                        )}
+                    </div>
+                )}
+            />
+        </div>
+    );
+}
+
+render(CustomSearchButtonDemo);
+```
+
 ## API Reference
 
 ### JsonViewer
@@ -229,6 +269,7 @@ render(CustomRenderJsonComponent);
 | style | InlineStyle of wrapper DOM | object | - |
 | showSearch | Whether to show search icon | boolean | true |
 | limitSearchButtonBounds | Whether to limit the search button drag bounds within the container **>=2.94.0** | boolean | false |
+| renderSearchButton | Custom render search button **>=2.95.0** | (defaultButton: ReactNode, controls: SearchControls) => ReactNode | - |
 | options | Formatting configuration | JsonViewerOptions | - |
 | onChange | Callback for content change | (value: string) => void | - |
 
@@ -256,6 +297,20 @@ render(CustomRenderJsonComponent);
 | --- | --- | --- | --- |
 | match | Matching rule | string \| RegExp \| (value: string, path: string) => boolean | - |
 | render | Render function | (content: string) => React.ReactNode | - |
+
+### SearchControls
+
+When using `renderSearchButton`, the second parameter `controls` contains the following properties:
+
+| Attribute | Description | Type |
+| --- | --- | --- |
+| showSearchBar | Whether the search bar is currently visible | boolean |
+| onToggleSearchBar | Toggle search bar visibility | () => void |
+| onSearch | Execute search | (text: string, caseSensitive?: boolean, wholeWord?: boolean, regex?: boolean) => void |
+| onPrevSearch | Navigate to previous search result | () => void |
+| onNextSearch | Navigate to next search result | () => void |
+| onReplace | Replace current search match | (text: string) => void |
+| onReplaceAll | Replace all search matches | (text: string) => void |
 
 ## Methods
 

--- a/content/plus/jsonviewer/index.md
+++ b/content/plus/jsonviewer/index.md
@@ -214,6 +214,46 @@ function CustomRenderJsonComponent() {
 render(CustomRenderJsonComponent);
 ```
 
+### 自定义搜索按钮
+
+通过 `renderSearchButton` 属性，你可以自定义搜索按钮的渲染方式，实现固定位置、自定义样式等需求。
+
+```jsx live=true dir="column" noInline=true
+import React from 'react';
+import { JsonViewer, Button } from '@douyinfe/semi-ui';
+import { IconSearch } from '@douyinfe/semi-icons';
+
+const data = `{
+    "name": "Semi",
+    "version": "0.0.0"
+}`;
+
+function CustomSearchButtonDemo() {
+    return (
+        <div style={{ marginBottom: 16 }}>
+            <JsonViewer 
+                height={200} 
+                width={700} 
+                value={data}
+                renderSearchButton={(defaultButton, controls) => (
+                    <div style={{ position: 'absolute', top: 10, right: 10, zIndex: 10 }}>
+                        {!controls.showSearchBar ? (
+                            <Button icon={<IconSearch />} onClick={controls.onToggleSearchBar}>
+                                搜索
+                            </Button>
+                        ) : (
+                            defaultButton
+                        )}
+                    </div>
+                )}
+            />
+        </div>
+    );
+}
+
+render(CustomSearchButtonDemo);
+```
+
 
 ## API 参考
 
@@ -228,6 +268,7 @@ render(CustomRenderJsonComponent);
 | style             | 内联样式                           | object                                  | -   |
 | showSearch        | 是否显示搜索Icon                           | boolean                                  | true   |
 | limitSearchButtonBounds | 是否限制搜索按钮拖动范围在容器内 **>=2.94.0**                          | boolean                                  | false   |
+| renderSearchButton | 自定义渲染搜索按钮 **>=2.95.0** | (defaultButton: ReactNode, controls: SearchControls) => ReactNode | - |
 | options           | 编辑器配置                                | JsonViewerOptions                       | -   |
 | onChange          | 内容变化回调                           | (value: string) => void                  | -   |
 
@@ -254,6 +295,20 @@ render(CustomRenderJsonComponent);
 | tabSize           | 缩进大小                                 | number                          | 4  |
 | insertSpaces      | 是否使用空格进行缩进                       | boolean                         | true  |
 | eol               | 换行符                                   | string                          | '\n'  |
+
+### SearchControls
+
+当使用 `renderSearchButton` 时，第二个参数 `controls` 包含以下属性：
+
+| 属性                | 说明                                          | 类型                              |
+|-------------------|------------------------------------------------|---------------------------------|
+| showSearchBar     | 当前是否显示搜索栏                            | boolean                         |
+| onToggleSearchBar | 切换搜索栏显示/隐藏                           | () => void                      |
+| onSearch          | 执行搜索                                      | (text: string, caseSensitive?: boolean, wholeWord?: boolean, regex?: boolean) => void |
+| onPrevSearch      | 跳转到上一个搜索结果                          | () => void                      |
+| onNextSearch      | 跳转到下一个搜索结果                          | () => void                      |
+| onReplace         | 替换当前搜索结果                              | (text: string) => void          |
+| onReplaceAll      | 替换所有搜索结果                              | (text: string) => void          |
 
 ## Methods
 

--- a/packages/semi-ui/jsonViewer/index.tsx
+++ b/packages/semi-ui/jsonViewer/index.tsx
@@ -43,6 +43,23 @@ export interface JsonViewerProps extends BaseProps {
      * @default false
      */
     limitSearchButtonBounds?: boolean;
+    /**
+     * Custom render search button
+     * @param defaultSearchButton - Default search button React node
+     * @param searchControls - Search related controls and methods
+     */
+    renderSearchButton?: (
+        defaultSearchButton: React.ReactNode,
+        searchControls: {
+            showSearchBar: boolean;
+            onToggleSearchBar: () => void;
+            onSearch: (text: string, caseSensitive?: boolean, wholeWord?: boolean, regex?: boolean) => void;
+            onPrevSearch: () => void;
+            onNextSearch: () => void;
+            onReplace: (text: string) => void;
+            onReplaceAll: (text: string) => void;
+        }
+    ) => React.ReactNode;
 }
 
 export interface JsonViewerState {
@@ -332,7 +349,55 @@ class JsonViewerCom extends BaseComponent<JsonViewerProps, JsonViewerState> {
     }
     render() {
         let isDragging = false;
-        const { width, className, style, showSearch = true, limitSearchButtonBounds, ...rest } = this.props;
+        const { width, className, style, showSearch = true, limitSearchButtonBounds, renderSearchButton, ...rest } = this.props;
+        
+        // Default search button
+        const defaultSearchButton = (
+            <DragMove
+                constrainer={limitSearchButtonBounds ? 'parent' as any : undefined}
+                onMouseDown={() => {
+                    isDragging = false;
+                }}
+                onMouseMove={() => {
+                    isDragging = true;
+                }}
+            >
+                <div style={{ position: 'absolute', top: 0, left: width }}>
+                    {!this.state.showSearchBar ? (
+                        <Button
+                            className={`${prefixCls}-search-bar-trigger`}
+                            onClick={e => {
+                                e.preventDefault();
+                                if (isDragging) {
+                                    e.stopPropagation();
+                                    e.preventDefault();
+                                    return;
+                                }
+                                this.foundation.showSearchBar();
+                            }}
+                            icon={<IconSearch />}
+                            style={{ position: 'absolute', top: 20, right: 20 }}
+                        />
+                    ) : (
+                        this.renderSearchBox()
+                    )}
+                </div>
+            </DragMove>
+        );
+
+        // Search controls for custom render
+        const searchControls = {
+            showSearchBar: this.state.showSearchBar,
+            onToggleSearchBar: () => this.foundation.showSearchBar(),
+            onSearch: (text: string, caseSensitive?: boolean, wholeWord?: boolean, regex?: boolean) => {
+                this.foundation.search(text, caseSensitive, wholeWord, regex);
+            },
+            onPrevSearch: () => this.foundation.prevSearch(),
+            onNextSearch: () => this.foundation.nextSearch(),
+            onReplace: (text: string) => this.foundation.replace(text),
+            onReplaceAll: (text: string) => this.foundation.replaceAll(text),
+        };
+
         return (
             <>
                 <div style={{ ...this.getStyle(), position: 'relative', ...style }} className={className} {...this.getDataAttr(rest)}>
@@ -342,36 +407,9 @@ class JsonViewerCom extends BaseComponent<JsonViewerProps, JsonViewerState> {
                         className={classNames(prefixCls, `${prefixCls}-background`)}
                     ></div>
                     {showSearch && (
-                        <DragMove
-                            constrainer={limitSearchButtonBounds ? 'parent' as any : undefined}
-                            onMouseDown={() => {
-                                isDragging = false;
-                            }}
-                            onMouseMove={() => {
-                                isDragging = true;
-                            }}
-                        >
-                            <div style={{ position: 'absolute', top: 0, left: width }}>
-                                {!this.state.showSearchBar ? (
-                                    <Button
-                                        className={`${prefixCls}-search-bar-trigger`}
-                                        onClick={e => {
-                                            e.preventDefault();
-                                            if (isDragging) {
-                                                e.stopPropagation();
-                                                e.preventDefault();
-                                                return;
-                                            }
-                                            this.foundation.showSearchBar();
-                                        }}
-                                        icon={<IconSearch />}
-                                        style={{ position: 'absolute', top: 20, right: 20 }}
-                                    />
-                                ) : (
-                                    this.renderSearchBox()
-                                )}
-                            </div>
-                        </DragMove>
+                        renderSearchButton 
+                            ? renderSearchButton(defaultSearchButton, searchControls)
+                            : defaultSearchButton
                     )}
                 </div>
                 {Array.from(this.state.customRenderMap.entries()).map(([key, value]) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2838

**问题背景：**
Issue #2838 要求 JsonView 组件的搜索按钮支持样式设置，可以选择固定在顶部，不拖动。目前搜索按钮可以通过 DragMove 组件拖动，但用户希望能够自定义搜索按钮的渲染方式，例如固定位置或限制在特定区域内。

**解决方案：**
为 JsonViewer 组件新增了 `renderSearchButton` prop，允许用户完全自定义搜索按钮的渲染。该 prop 接收一个渲染函数，参数包括：
1. `defaultSearchButton` - 默认的搜索按钮 React 节点（包含完整的拖动功能和搜索栏）
2. `searchControls` - 搜索相关的控制方法和状态

用户可以通过这个 API 实现：
- 固定搜索按钮位置（不使用 DragMove）
- 自定义搜索按钮的样式和布局
- 限制搜索按钮的拖动范围
- 完全自定义搜索交互逻辑

**审查要点：**
- 新增的 `renderSearchButton` prop 的类型定义是否清晰完整
- `searchControls` 对象提供的方法是否满足自定义渲染的需求
- 默认行为是否保持向后兼容（未提供 `renderSearchButton` 时使用原有逻辑）
- 文档示例是否清晰展示了使用场景

### Changelog
🇨🇳 Chinese
- Feat: JsonViewer 组件新增 `renderSearchButton` prop，支持自定义搜索按钮的渲染，可实现固定位置、限制拖动范围等需求

---

🇺🇸 English
- Feat: Added `renderSearchButton` prop to JsonViewer component, allowing custom rendering of search button for fixed position, constrained dragging, etc.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
`renderSearchButton` prop 接收两个参数：
1. `defaultSearchButton` (ReactNode): 默认的搜索按钮，包含完整的拖动和搜索功能
2. `searchControls` (object): 包含搜索控制方法和状态
   - `showSearchBar` (boolean): 当前搜索栏是否显示
   - `onToggleSearchBar` (): 切换搜索栏显示/隐藏
   - `onSearch(text, caseSensitive?, wholeWord?, regex?)`: 执行搜索
   - `onPrevSearch()`: 跳转到上一个搜索结果
   - `onNextSearch()`: 跳转到下一个搜索结果
   - `onReplace(text)`: 替换当前搜索结果
   - `onReplaceAll(text)`: 替换所有搜索结果