### PR TITLE
fix(select): avoid ellipsisTrigger flicker in react 18

### DIFF
--- a/packages/semi-ui/overflowList/__test__/overflowList.test.js
+++ b/packages/semi-ui/overflowList/__test__/overflowList.test.js
@@ -28,4 +28,29 @@ describe('OverflowList', () => {
         expect(node.find(`.${BASE_CLASS_PREFIX}-overflow-list-scroll-wrapper`).exists()).toEqual(true);
         node.unmount();
     });
+
+    it('keeps collapse content visible when items update after first measurement', () => {
+        const node = mount(
+            <OverflowList
+                items={[{ key: 'alarm' }, { key: 'bookmark' }]}
+                visibleItemRenderer={item => <div>{item.key}</div>}
+                overflowRenderer={() => null}
+            />
+        );
+
+        node.setState({
+            overflowStatus: 'normal',
+            pivot: 1,
+            visible: [{ key: 'alarm' }, { key: 'bookmark' }],
+            overflow: [],
+        });
+
+        node.setProps({
+            items: [{ key: 'alarm' }, { key: 'bookmark' }, { key: 'camera' }],
+        });
+        node.update();
+
+        expect(node.find(`.${BASE_CLASS_PREFIX}-overflow-list`).prop('style').visibility).toEqual('visible');
+        node.unmount();
+    });
 });

--- a/packages/semi-ui/overflowList/index.tsx
+++ b/packages/semi-ui/overflowList/index.tsx
@@ -141,7 +141,6 @@ class OverflowList extends BaseComponent<OverflowListProps, OverflowListState> {
                 newState.overflow = overflow;
                 newState.maxCount = maxCount;
             }
-            newState.pivot = -1;
             newState.overflowStatus = "calculating";
         }
         return newState;
@@ -180,17 +179,17 @@ class OverflowList extends BaseComponent<OverflowListProps, OverflowListState> {
     };
 
     componentDidUpdate(prevProps: OverflowListProps, prevState: OverflowListState): void {
-
-        const prevItemsKeys = prevProps.items.map((item) =>
-            item.key
+        const prevItemsKeys = prevProps.items.map((item, index) =>
+            this.getItemKey(item, index)
         );
-        const nowItemsKeys = this.props.items.map((item) =>
-            item.key
+        const nowItemsKeys = this.props.items.map((item, index) =>
+            this.getItemKey(item, index)
         );
 
         // Determine whether to update by comparing key values
         if (!isEqual(prevItemsKeys, nowItemsKeys)) {
             this.itemRefs = {};
+            this.itemSizeMap = new Map();
             this.setState({ visibleState: new Map() });
         }
 
@@ -300,7 +299,7 @@ class OverflowList extends BaseComponent<OverflowListProps, OverflowListState> {
                 [
                     collapseFrom === Boundary.START ? overflow : null,
                     visible.map((item, idx) => {
-                        const { key } = item;
+                        const key = this.getItemKey(item, idx);
                         const element = visibleItemRenderer(item, idx);
                         const child = React.cloneElement(element);
                         return (
@@ -325,7 +324,7 @@ class OverflowList extends BaseComponent<OverflowListProps, OverflowListState> {
                     ...style,
                     ...(renderMode === RenderMode.COLLAPSE ? {
                         maxWidth: '100%',
-                        visibility: overflowStatus === "calculating" ? "hidden" : "visible",
+                        visibility: overflowStatus === "calculating" && this.state.pivot < 0 ? "hidden" : "visible",
                     } : null)
                 },
             },

--- a/packages/semi-ui/select/__test__/select.test.js
+++ b/packages/semi-ui/select/__test__/select.test.js
@@ -4202,6 +4202,27 @@ describe('Select', () => {
         expect(select.exists(`.${BASE_CLASS_PREFIX}-select-content-wrapper-collapse`)).toBe(true);
     });
 
+    it('ellipsisTrigger keeps OverflowList mounted when selections update', async () => {
+        const props = {
+            multiple: true,
+            ellipsisTrigger: true,
+            maxTagCount: 2,
+            defaultValue: ['abc', 'hotsoon', 'pipixia'],
+            optionList: defaultList,
+            motion: false,
+            style: { width: 200 },
+        };
+        const select = getSelect(props);
+        await sleep(200);
+        const overflowList = select.find('OverflowList').instance();
+        const nextSelections = new Map(select.state().selections);
+        nextSelections.set(defaultList[3].label, defaultList[3]);
+        select.setState({ selections: nextSelections });
+        await sleep(50);
+        select.update();
+        expect(select.find('OverflowList').instance()).toBe(overflowList);
+    });
+
     it('ellipsisTrigger with handleOverflow callback', async () => {
         const props = {
             multiple: true,

--- a/packages/semi-ui/select/index.tsx
+++ b/packages/semi-ui/select/index.tsx
@@ -1198,7 +1198,7 @@ class Select<T = BasicSelectValue> extends BaseComponent<SelectProps<T>, SelectS
             <div className={`${prefixcls}-content-wrapper-collapse`}>
                 <OverflowList
                     items={normalTags}
-                    key={String(selections.length)}
+                    itemKey={item => item?.[1]?.value}
                     overflowRenderer={overflowItems => this.renderOverflow(overflowItems as [React.ReactNode, any][], length - 1)}
                     onOverflow={overflowItems => this.handleOverflow(overflowItems as [React.ReactNode, any][])}
                     visibleItemRenderer={(item, index) => this.renderTag(item as [React.ReactNode, any], index)}


### PR DESCRIPTION
## Summary
- keep collapsed select content visible while overflow layout recalculates after the first measurement
- let OverflowList track item changes with stable item keys instead of remounting on selection length changes
- add regression tests for OverflowList visibility and Select ellipsisTrigger updates

## Testing
- NODE_ENV=test ./node_modules/.bin/jest packages/semi-ui/overflowList/__test__/overflowList.test.js --runInBand
- NODE_ENV=test ./node_modules/.bin/jest packages/semi-ui/select/__test__/select.test.js --runInBand

Closes #3004