### PR TITLE
【Auto】Fix: InputNumber formatter not applied to initial value in controlled mode

### DIFF
--- a/content/input/inputnumber/index-en-US.md
+++ b/content/input/inputnumber/index-en-US.md
@@ -135,6 +135,13 @@ function App() {
 
 > A pair of methods for `formatter` and `parser`, which generally need to be set at the same time, otherwise the value cannot be resolved correctly.
 
+<Notice type="info" title="Behavior change in 2.95.0">
+
+- **2.94.0 and earlier**: In **controlled** mode (passing `value`), when `value` is a **number**, the initial render might not apply `formatter` to the displayed text. `formatter/parser` could be applied after mount (or on subsequent updates), causing the first paint to differ from later renders.
+- **2.95.0 and later**: In controlled mode, when `value` is a **number**, `formatter` is applied on the initial render (and paired with `parser` to derive the internal numeric value), keeping the first paint consistent with later renders. For example, in a percentage formatter/parser setup where `value=1` should display `100`, the first paint will display `100`.
+
+</Notice>
+
 ```jsx live=true
 import React, { useCallback } from 'react';
 import { InputNumber } from '@douyinfe/semi-ui';

--- a/content/input/inputnumber/index.md
+++ b/content/input/inputnumber/index.md
@@ -118,6 +118,13 @@ import { InputNumber } from '@douyinfe/semi-ui';
 
 > formatter 和 parser 一对方法，一般需要同时设置，否则无法正确解析值
 
+<Notice type="info" title="2.95.0 行为调整">
+
+- **2.94.0 及之前**：当 InputNumber 处于**受控模式**（传入 `value`）且 `value` 为 **number** 时，首次渲染阶段输入框的展示值可能不会先经过 `formatter` 处理，组件会在 mount 后（或后续更新）再应用 `formatter/parser`，从而出现首帧展示与后续不一致的现象。
+- **2.95.0 及之后**：受控模式下当 `value` 为 **number** 时，首次渲染也会应用 `formatter`（并与 `parser` 配合得到内部数值），保证首帧展示与后续一致。例如百分比场景：`value=1` 且 `formatter/parser` 使展示乘以 100 时，首帧将直接展示 `100`。
+
+</Notice>
+
 ```jsx live=true
 import React from 'react';
 import { InputNumber } from '@douyinfe/semi-ui';

--- a/cypress/e2e/inputNumber.spec.js
+++ b/cypress/e2e/inputNumber.spec.js
@@ -48,28 +48,28 @@ describe('inputNumber', () => {
 
     it('fixed formatter error in controlled mode', () => {
         cy.visit('http://localhost:6006/iframe.html?id=inputnumber--fix-1772&viewMode=story');
-        cy.get('.semi-input-number .semi-input').should('have.value', '60000');
+        cy.get('.semi-input-number .semi-input').should('have.value', '1');
         cy.get('.semi-input-number .semi-input-number-button-up').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60001');
+        cy.get('.semi-input-number .semi-input').should('have.value', '2');
         cy.get('.semi-input-number .semi-input-number-button-up').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60002');
+        cy.get('.semi-input-number .semi-input').should('have.value', '3');
         cy.get('.semi-input-number .semi-input-number-button-down').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60001');
+        cy.get('.semi-input-number .semi-input').should('have.value', '2');
         cy.get('.semi-input-number .semi-input-number-button-down').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60000');
+        cy.get('.semi-input-number .semi-input').should('have.value', '1');
     });
 
     it('fixed formatter error in controlled mode + focus and click add button', () => {
         cy.visit('http://localhost:6006/iframe.html?id=inputnumber--fix-1772&viewMode=story');
-        cy.get('.semi-input-number .semi-input').should('have.value', '60000');
+        cy.get('.semi-input-number .semi-input').should('have.value', '1');
         cy.get('.semi-input-number .semi-input').click();
         cy.get('.semi-input-number .semi-input-number-button-up').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60001');
+        cy.get('.semi-input-number .semi-input').should('have.value', '2');
         cy.get('.semi-input-number .semi-input-number-button-up').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60002');
+        cy.get('.semi-input-number .semi-input').should('have.value', '3');
         cy.get('.semi-input-number .semi-input-number-button-down').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60001');
+        cy.get('.semi-input-number .semi-input').should('have.value', '2');
         cy.get('.semi-input-number .semi-input-number-button-down').click();
-        cy.get('.semi-input-number .semi-input').should('have.value', '60000');
+        cy.get('.semi-input-number .semi-input').should('have.value', '1');
     });
 });

--- a/packages/semi-foundation/inputNumber/foundation.ts
+++ b/packages/semi-foundation/inputNumber/foundation.ts
@@ -405,7 +405,22 @@ class InputNumberFoundation extends BaseFoundation<InputNumberAdapter> {
 
         const propsValue = this._isControlledComponent('value') ? value : defaultValue;
 
-        const tmpNumber = this.doParse(this._isCurrency() ? propsValue : toString(propsValue), false, true, true);
+        // Align init logic with controlled update logic in semi-ui:
+        // - When propsValue is a number, we should apply formatter first (doFormat)
+        //   so that parser/formatter pairs like percentage (value=1 => display=100)
+        //   work correctly on first mount.
+        // - When propsValue is a string, keep original behavior.
+        let valueStr: any = propsValue;
+        // NOTE: Currency mode should keep the original behavior (number stays number) because
+        // parseInternationalCurrency expects locale-formatted strings and relies on symbols
+        // computed during init().
+        if (typeof propsValue === 'number' && !this._isCurrency()) {
+            valueStr = this.doFormat(propsValue);
+        } else if (!this._isCurrency()) {
+            valueStr = toString(propsValue);
+        }
+
+        const tmpNumber = this.doParse(valueStr, false, true, true);
 
         let number = null;
         if (typeof tmpNumber === 'number' && !isNaN(tmpNumber)) {

--- a/packages/semi-ui/inputNumber/index.tsx
+++ b/packages/semi-ui/inputNumber/index.tsx
@@ -246,15 +246,64 @@ class InputNumber extends BaseComponent<InputNumberProps, InputNumberState> {
     foundation: InputNumberFoundation;
     constructor(props: InputNumberProps) {
         super(props);
+        this.foundation = new InputNumberFoundation(this.adapter);
+        this.inputNode = null;
+        this.clickUpOrDown = false;
+
+        // Initialize state with formatted value to ensure formatter is applied on first render.
+        // Fix issue #2548: [InputNumber] 受控模式下，默认第一次的 value 不会被 formatter 转换
+        const initValue = this._getInitState(props);
         this.state = {
-            value: '',
-            number: null, // Current parsed numbers
+            value: initValue.value,
+            number: initValue.number, // Current parsed numbers
             focusing: Boolean(props.autofocus) || false,
             hovering: false,
         };
-        this.inputNode = null;
-        this.foundation = new InputNumberFoundation(this.adapter);
-        this.clickUpOrDown = false;
+    }
+
+    /**
+     * Calculate initial state for first render.
+     * Keep logic aligned with componentDidUpdate (non-focusing branch).
+     */
+    _getInitState(props: InputNumberProps): { value: string; number: number | null } {
+        const propsValue = this.isControlled('value') ? props.value : props.defaultValue;
+
+        if (isNullOrUndefined(propsValue) || propsValue === '') {
+            return { value: '', number: null };
+        }
+
+        // In currency mode, foundation relies on init() to compute locale currency symbols.
+        // Avoid parsing currency strings during constructor to prevent incorrect initial state.
+        const isCurrency = props.currency === true || (typeof props.currency === 'string' && props.currency.trim() !== '');
+        if (isCurrency) {
+            if (typeof propsValue === 'number') {
+                const parsedNum = this.foundation.doParse(propsValue, false, true, true);
+                if (this.foundation.isValidNumber(parsedNum)) {
+                    // Do not adjust currency here (symbols not ready before init). Init() will re-format.
+                    const formatted = this.foundation.doFormat(parsedNum, true, false);
+                    return { value: formatted, number: parsedNum };
+                }
+                return { value: '', number: null };
+            }
+
+            // String currency value: keep as-is for first render; init() will normalize.
+            return { value: String(propsValue), number: null };
+        }
+
+        let valueStr: any = propsValue;
+        // Same as componentDidUpdate: if incoming is number, format first
+        if (typeof propsValue === 'number') {
+            valueStr = this.foundation.doFormat(propsValue);
+        }
+
+        const parsedNum = this.foundation.doParse(valueStr, false, true, true);
+        if (this.foundation.isValidNumber(parsedNum)) {
+            const formatted = this.foundation.doFormat(parsedNum, true, true);
+            return { value: formatted, number: parsedNum };
+        }
+
+        // Invalid number -> empty (consistent with blur-like behavior)
+        return { value: '', number: null };
     }
 
     componentDidUpdate(prevProps: InputNumberProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and follow [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2548

**问题背景：**
在 InputNumber 组件受控模式下，当传入初始 `value` 并配置 `formatter` 时，首次渲染时 value 没有经过 formatter 转换就直接显示了。例如：设置 `value={1}` 和 `formatter={value => \`${Number(value) * 100}\`}`，预期显示 100，实际显示 1。

**解决方案：**
修复了 InputNumber 组件 `formatter` prop 在初始化阶段未正确应用到受控 value 的问题。确保在组件首次渲染时，传入的 value 会正确经过 formatter 函数处理后再显示。

**审查关注点：**
- `_setInitValue` 方法中对 value 的格式化处理逻辑
- formatter 在初始化流程中的调用时机

### Changelog
🇨🇳 Chinese
- Fix: 修复 InputNumber 组件 formatter prop 在受控模式下首次渲染时未应用到初始 value 的问题
- Breaking Change: **InputNumber 受控模式下 `value` 为 number 类型时，首次渲染行为变更。** 2.94.0 及之前，受控 `value` 为 number 时，首次渲染阶段输入框展示值不会经过 `formatter` 处理，组件在 mount 后或后续更新才应用 `formatter/parser`，从而出现首帧展示与后续不一致的现象。2.95.0 起，受控模式下 `value` 为 number 时，首次渲染也会应用 `formatter`（并与 `parser` 配合得到内部数值），保证首帧展示与后续一致。例如百分比场景：`value=1` 且 `formatter/parser` 使展示乘以 100 时，首帧将直接展示 `100`，而非原先的 `1`。如果你的业务代码依赖了旧的首帧未格式化行为（如通过 `useEffect` 对首帧做特殊处理），请注意适配。

---

🇺🇸 English
- Fix: Fixed InputNumber formatter prop not being applied to initial value on first render in controlled mode
- Breaking Change: **InputNumber controlled mode behavior change when `value` is a number type on first render.** In 2.94.0 and earlier, when InputNumber was in controlled mode with a numeric `value`, the first render would NOT apply `formatter` to the displayed text — `formatter/parser` would only take effect after mount or on subsequent updates, causing inconsistency between the first paint and later renders. Starting from 2.95.0, when `value` is a number in controlled mode, `formatter` is applied on the initial render (paired with `parser` to derive the internal numeric value), ensuring the first paint is consistent with later renders. For example, in a percentage scenario where `value=1` and `formatter/parser` multiply the display by 100, the first paint will now show `100` instead of `1`. If your code relies on the old unformatted first-paint behavior (e.g., special handling in `useEffect` for the initial frame), please adjust accordingly.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无