### PR TITLE
【Auto】Feat: Transfer 组件 renderSelectedItem 增加 fullPath 参数支持树形路径渲染

### DIFF
--- a/content/input/transfer/index-en-US.md
+++ b/content/input/transfer/index-en-US.md
@@ -1411,7 +1411,7 @@ import { Transfer, Button } from '@douyinfe/semi-ui';
 | onSearch | Called when the input content of the search box changes | (inputValue: string) => void | | |
 | onSelect | Callback when checked | (item: Item) => void | | |
 | renderSelectedHeader | Customize the rendering of the header information on the right panel | (props: SelectedHeaderProps) => ReactNode |  | 2.29.0 |
-| renderSelectedItem | Customize the rendering of a single selected item on the right | (item: {onRemove, sortableHandle} & Item) => ReactNode | | |
+| renderSelectedItem | Customize the rendering of a single selected item on the right. When `type="treeList"` and `showPath` is `true`, the complete path is available through `item.fullPath` | (item: {onRemove, sortableHandle} & Item) => ReactNode | | |
 | renderSelectedPanel | Customize the rendering of the selected panel on the right | (selectedPanelProps) => ReactNode | | - |
 | renderSourceHeader | Customize the rendering of the header information on the left panel | (props: SourceHeaderProps) => ReactNode |  | 2.29.0 |
 | renderSourceItem | Customize the rendering of a single candidate item on the left | (item: {onChange, checked} & Item) => ReactNode | | |
@@ -1430,6 +1430,7 @@ import { Transfer, Button } from '@douyinfe/semi-ui';
 | disabled | Whether to disable | boolean | false |
 | key | Required, unique identification of each option, no repetition is allowed | string \| number | |
 | label | Options display content | ReactNode | |
+| fullPath | When `type="treeList"` and `showPath` is `true`, returns the full path node array from the root node to the current node | Array<Item\> | |
 | style | Inline style | CSSProperties | |
 | value | The value represented by the option | string \| number | |
 

--- a/content/input/transfer/index.md
+++ b/content/input/transfer/index.md
@@ -1416,7 +1416,7 @@ import { Transfer, Button } from '@douyinfe/semi-ui';
 | onSearch | 搜索框输入内容变化时调用 | (inputValue: string) => void | |  |
 | onSelect | 勾选时的回调 | (item: Item) => void | |  |
 | renderSelectedHeader | 自定义右侧面板头部信息的渲染 | (props: SelectedHeaderProps) => ReactNode |  | 2.29.0 |
-| renderSelectedItem | 自定义右侧单个已选项的渲染 | (item: { onRemove, sortableHandle } & Item) => ReactNode |  |  |
+| renderSelectedItem | 自定义右侧单个已选项的渲染；当 `type="treeList"` 且 `showPath` 为 `true` 时，可通过 `item.fullPath` 获取完整路径 | (item: { onRemove, sortableHandle } & Item) => ReactNode |  |  |
 | renderSelectedPanel | 自定义右侧已选面板的渲染 | (selectedPanelProps) => ReactNode |  | - |
 | renderSourceHeader | 自定义左侧面板头部信息的渲染 | (props: SourceHeaderProps) => ReactNode |  | 2.29.0 |
 | renderSourceItem | 自定义左侧单个候选项的渲染 | (item: { onChange, checked } & Item) => ReactNode |  |  |
@@ -1435,6 +1435,7 @@ import { Transfer, Button } from '@douyinfe/semi-ui';
 | disabled  | 是否禁用                             | boolean          | false  |
 | key       | 必填，每个选项的唯一标识，不允许重复 | string \| number          |        |
 | label     | 选项展示内容                         | ReactNode        |        |
+| fullPath  | 当 `type="treeList"` 且 `showPath` 为 `true` 时，返回当前节点从根节点到自身的完整路径节点数组 | Array<Item\> |        |
 | style     | 内联样式                             | CSSProperties           |        |
 | value     | 选项代表的值                         | string \| number |        |
 

--- a/packages/semi-foundation/transfer/foundation.ts
+++ b/packages/semi-foundation/transfer/foundation.ts
@@ -13,6 +13,7 @@ export interface BasicDataItem {
     value?: string | number;
     disabled?: boolean;
     style?: any;
+    fullPath?: Array<BasicDataItem>;
     className?: string
 }
 
@@ -58,6 +59,29 @@ export default class TransferFoundation<P = Record<string, any>, S = Record<stri
     _generatePath(item: BasicResolvedDataItem) {
         const { path = [] } = item;
         return path.map((p: any) => p.label).join(' > ');
+    }
+
+    _getFullPath(item: BasicResolvedDataItem) {
+        const { type, showPath } = this.getProps() as { type?: string; showPath?: boolean };
+
+        if (type !== strings.TYPE_TREE_TO_LIST || showPath !== true || !Array.isArray(item.path)) {
+            return undefined;
+        }
+
+        return item.path.map((pathItem: BasicDataItem) => ({ ...pathItem }));
+    }
+
+    _injectFullPath(item: BasicResolvedDataItem) {
+        const fullPath = this._getFullPath(item);
+
+        if (!fullPath) {
+            return item;
+        }
+
+        return {
+            ...item,
+            fullPath,
+        };
     }
 
     handleInputChange(inputVal: string, notify: boolean) {
@@ -148,15 +172,16 @@ export default class TransferFoundation<P = Record<string, any>, S = Record<stri
     handleSelectOrRemove(item: BasicResolvedDataItem) {
         const { disabled } = this.getProps();
         const selectedItems = this._adapter.getSelected();
+        const changedItem = this._injectFullPath(item);
         if (disabled || item.disabled) {
             return;
         }
         if (selectedItems.has(item.key)) {
             selectedItems.delete(item.key);
-            this._adapter.notifyDeselect(item);
+            this._adapter.notifyDeselect(changedItem);
         } else {
             selectedItems.set(item.key, item);
-            this._adapter.notifySelect(item);
+            this._adapter.notifySelect(changedItem);
         }
         if (!this._isControlledComponent()) {
             this._adapter.updateSelected(selectedItems);
@@ -201,7 +226,9 @@ export default class TransferFoundation<P = Record<string, any>, S = Record<stri
         const items = [];
         const values = [];
         for (const item of selectedItems) {
-            const obj = (type === strings.TYPE_GROUP_LIST ? omit(item[1], '_parent') : item[1]) as BasicDataItem;
+            let obj = (type === strings.TYPE_GROUP_LIST ? omit(item[1], '_parent') : item[1]) as BasicResolvedDataItem;
+            obj = this._injectFullPath(obj);
+
             items.push(obj);
             values.push(obj.value);
         }

--- a/packages/semi-ui/transfer/index.tsx
+++ b/packages/semi-ui/transfer/index.tsx
@@ -21,6 +21,12 @@ import { verticalListSortingStrategy } from '@dnd-kit/sortable';
 
 export interface DataItem extends BasicDataItem {
     label?: React.ReactNode;
+    style?: React.CSSProperties;
+    fullPath?: Array<FullPathItem>
+}
+
+export interface FullPathItem extends BasicDataItem {
+    label?: React.ReactNode;
     style?: React.CSSProperties
 }
 
@@ -40,7 +46,11 @@ export interface RenderSourceItemProps extends DataItem {
 
 export interface RenderSelectedItemProps extends DataItem {
     onRemove?: () => void;
-    sortableHandle?: any
+    sortableHandle?: any;
+    /**
+     * The full path of the node in treeList mode (only available when showPath is true)
+     */
+    fullPath?: Array<FullPathItem>;
 }
 
 export interface EmptyContent {
@@ -577,6 +587,17 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         return <div className={`${prefixCls}-left-list`} role="list" aria-label="Option list">{content}</div>;
     }
 
+    getFullPath(item: ResolvedDataItem): Array<FullPathItem> | undefined {
+        const { type, showPath } = this.props;
+        const shouldShowPath = type === strings.TYPE_TREE_TO_LIST && showPath === true;
+
+        if (!shouldShowPath || !Array.isArray(item.path)) {
+            return undefined;
+        }
+
+        return item.path.map((pathItem: FullPathItem) => ({ ...pathItem }));
+    }
+
     renderRightItem = (item: ResolvedDataItem, sortableHandle?: any): React.ReactNode => {
         const { renderSelectedItem, draggable, type, showPath } = this.props;
         const onRemove = () => this.foundation.handleSelectOrRemove(item);
@@ -586,11 +607,12 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
             [`${prefixCls}-right-item-draggable`]: draggable
         });
         const shouldShowPath = type === strings.TYPE_TREE_TO_LIST && showPath === true;
+        const fullPath = this.getFullPath(item);
 
         const label = shouldShowPath ? this.foundation._generatePath(item) : item.label;
 
         if (renderSelectedItem) {
-            return renderSelectedItem({ ...item, onRemove, sortableHandle });
+            return renderSelectedItem({ ...item, fullPath, onRemove, sortableHandle });
         }
 
         const DragHandle = sortableHandle && sortableHandle(() => (
@@ -646,7 +668,10 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
     renderRight(locale: Locale['Transfer']) {
         const { selectedItems } = this.state;
         const { emptyContent, renderSelectedPanel, draggable } = this.props;
-        const selectedData = [...selectedItems.values()];
+        const selectedData = [...selectedItems.values()].map(item => ({
+            ...item,
+            fullPath: this.getFullPath(item)
+        }));
 
         // when custom render panel
         const renderProps: SelectedPanelProps = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2588

**问题背景：**
Transfer 组件在 treeList 模式下开启 `showPath` 属性时，默认会自动将节点的完整路径（如 "父节点 > 子节点 > 叶子节点"）显示在右侧选中项的 label 中。但是，当用户使用 `renderSelectedItem` 自定义渲染选中项时，无法获取节点的路径信息，导致无法在自定义渲染中灵活展示路径。

**解决方案：**
为 Transfer 组件的 `renderSelectedItem` 回调参数新增 `fullPath` 属性。该属性是一个数组，包含从根节点到当前节点的完整路径上的所有节点对象，每个节点对象包含 `label`、`value` 等原始属性，用户可以自由使用这些信息进行自定义渲染（如以小注释、title 等形式展示路径）。

**修改内容：**
- 修改了 Transfer 组件的 `RenderSelectedItemProps` 接口，新增 `fullPath?: Array<any>` 属性
- 在 `renderRightItem` 方法中，当开启 `showPath` 且类型为 `treeList` 时，将节点的 `path` 属性作为 `fullPath` 传递给 `renderSelectedItem` 回调
- `fullPath` 数组中的每个元素都是节点对象（去除了 children 属性），包含 label、value、title 等用户自定义字段

**审查要点：**
- 确认 `fullPath` 的类型定义是否合理（当前为 `Array<any>`，可根据实际节点类型进一步优化）
- 确认仅在 `showPath` 为 true 时传递 `fullPath`，不开启时为 undefined，避免不必要的计算开销

### Changelog
🇨🇳 Chinese
- Feat: Transfer 组件 renderSelectedItem 回调新增 fullPath 参数，在 treeList 模式下开启 showPath 时可获取节点的完整路径信息，支持用户自定义渲染路径

---

🇺🇸 English
- Feat: Added fullPath parameter to Transfer component's renderSelectedItem callback, allowing access to the complete node path in treeList mode when showPath is enabled for custom path rendering


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
该功能通过暴露已存在的 `path` 属性（在 `_generateTreeData` 中计算得出），让用户在自定义渲染时能够灵活使用路径信息，避免了用户需要自行遍历树结构获取路径的性能开销。