### PR TITLE
【Auto】Feat: Input and TextArea support composition mode for IME input

### DIFF
--- a/content/input/input/index-en-US.md
+++ b/content/input/input/index-en-US.md
@@ -457,6 +457,62 @@ Answers to some questions:
 
 > Why not modify maxLength dynamically? Modify maxLength dynamically after the input operation is completed, calculate the remaining character length that can be entered. If the maxLength is set to 1, you want to enter a '💖' with a length of 2, but due to the limitation of input maxLength, you can't enter it at all here, and you can't update maxLength.
 
+### IME Input Mode
+
+By setting the `composition` property to `true`, you can enable IME input mode. In this mode, when using an IME (e.g., Chinese pinyin input), `onChange` will not be triggered during IME confirmation (e.g., while pinyin is being typed), and will only be triggered once after the IME confirms the input. This is useful for real-time search scenarios to avoid unnecessary requests during pinyin input.
+
+Both Input and TextArea support this property.
+
+```jsx live=true
+import React, { useState } from 'react';
+import { Input, TextArea } from '@douyinfe/semi-ui';
+
+() => {
+    const [inputValue, setInputValue] = useState('');
+    const [textAreaValue, setTextAreaValue] = useState('');
+    const [inputLogs, setInputLogs] = useState([]);
+    const [textAreaLogs, setTextAreaLogs] = useState([]);
+
+    const handleInputChange = (value) => {
+        setInputValue(value);
+        setInputLogs(prev => [...prev, value]);
+    };
+
+    const handleTextAreaChange = (value) => {
+        setTextAreaValue(value);
+        setTextAreaLogs(prev => [...prev, value]);
+    };
+
+    return (
+        <div>
+            <h4>Input with composition</h4>
+            <Input
+                composition
+                value={inputValue}
+                onChange={handleInputChange}
+                placeholder="With composition, onChange is not triggered during IME input"
+                style={{ width: 300 }}
+            />
+            <div style={{ marginTop: 8, color: 'var(--semi-color-text-2)', fontSize: 12 }}>
+                onChange trigger count: {inputLogs.length}
+            </div>
+            <br/><br/>
+            <h4>TextArea with composition</h4>
+            <TextArea
+                composition
+                value={textAreaValue}
+                onChange={handleTextAreaChange}
+                placeholder="With composition, onChange is not triggered during IME input"
+                style={{ width: 300 }}
+            />
+            <div style={{ marginTop: 8, color: 'var(--semi-color-text-2)', fontSize: 12 }}>
+                onChange trigger count: {textAreaLogs.length}
+            </div>
+        </div>
+    );
+};
+```
+
 
 ## API Reference
 
@@ -477,6 +533,7 @@ Answers to some questions:
 | borderless        | borderless mode  >=2.33.0                                                                                                                                                                     | boolean                         |           |
 | className         | Class name                                                                                                                                                                                    | string                          |           |
 | clearIcon         | Can be used to customize the clear button, valid when showClear is true  **>=2.25**                                                                                                           | ReactNode                       |           |
+| composition       | Whether to enable IME composition input mode. When enabled, `onChange` will not be triggered during IME composition (e.g., Chinese pinyin input), and will only be triggered once after composition ends | boolean                         | false     |
 | defaultValue      | Default value                                                                                                                                                                                 | ReactText                       |           |
 | disabled          | Toggle whether to disable input                                                                                                                                                               | boolean                         | false     |
 | getValueLength    | Custom calculated character string length                                                                                                                                                     | (value: string) => number       |           |
@@ -518,6 +575,7 @@ Answers to some questions:
 | borderless        | borderless mode  >=2.33.0                                                                                                                                                                     | boolean                         |           |
 | className         | Class name                                                                                                             | string                          | -       |
 | cols              | The visible width of the text control, in average character widths. If it is specified, it must be a positive integer. | number                          | -       |
+| composition       | Whether to enable IME composition input mode. When enabled, `onChange` will not be triggered during IME composition (e.g., Chinese pinyin input), and will only be triggered once after composition ends | boolean                         | false     |
 | disabled          | Disabled                                                                                                               | boolean                         | false   |
 | getValueLength    | Custom calculated character string length                                                                              | (value: string) => number       |         |
 | maxCount          | The maximum number of characters and display count                                                                     | number                          | -       |

--- a/content/input/input/index.md
+++ b/content/input/input/index.md
@@ -472,6 +472,62 @@ import { Input, Typography, Form, TextArea, Button } from '@douyinfe/semi-ui';
 
 > 为何不动态修改 maxLength？动态修改 maxLength 在输入操作完成以后，计算剩余可以输入的字符长度。 如 maxLength 设置为 1，想输入一个 length 为 2 的 '💖'，但是由于 input maxLength 的限制，这里根本就输入不进去，也就无法更新 maxLength。
 
+### 输入法模式
+
+通过设置 `composition` 属性为 `true`，可以开启输入法模式。在该模式下，使用输入法（如中文拼音）输入时，`onChange` 不会在输入法未确认（如拼音过程中）触发，而是在输入法确认后触发一次。适用于实时搜索等场景，避免在拼音输入过程中触发不必要的请求。
+
+Input 和 TextArea 均支持该属性。
+
+```jsx live=true
+import React, { useState } from 'react';
+import { Input, TextArea } from '@douyinfe/semi-ui';
+
+() => {
+    const [inputValue, setInputValue] = useState('');
+    const [textAreaValue, setTextAreaValue] = useState('');
+    const [inputLogs, setInputLogs] = useState([]);
+    const [textAreaLogs, setTextAreaLogs] = useState([]);
+
+    const handleInputChange = (value) => {
+        setInputValue(value);
+        setInputLogs(prev => [...prev, value]);
+    };
+
+    const handleTextAreaChange = (value) => {
+        setTextAreaValue(value);
+        setTextAreaLogs(prev => [...prev, value]);
+    };
+
+    return (
+        <div>
+            <h4>Input with composition</h4>
+            <Input
+                composition
+                value={inputValue}
+                onChange={handleInputChange}
+                placeholder="开启 composition，拼音输入时不会触发 onChange"
+                style={{ width: 300 }}
+            />
+            <div style={{ marginTop: 8, color: 'var(--semi-color-text-2)', fontSize: 12 }}>
+                onChange 触发次数: {inputLogs.length}
+            </div>
+            <br/><br/>
+            <h4>TextArea with composition</h4>
+            <TextArea
+                composition
+                value={textAreaValue}
+                onChange={handleTextAreaChange}
+                placeholder="开启 composition，拼音输入时不会触发 onChange"
+                style={{ width: 300 }}
+            />
+            <div style={{ marginTop: 8, color: 'var(--semi-color-text-2)', fontSize: 12 }}>
+                onChange 触发次数: {textAreaLogs.length}
+            </div>
+        </div>
+    );
+};
+```
+
 ## API 参考
 
 ### Input
@@ -490,6 +546,7 @@ import { Input, Typography, Form, TextArea, Button } from '@douyinfe/semi-ui';
 | borderless        | 无边框模式  >=2.33.0                                | boolean                         |           |
 | className         | 类名                                             | string                          |           |
 | clearIcon         | 可用于自定义清除按钮, showClear为true时有效 **>=2.25.0**     | ReactNode                       |  |
+| composition       | 是否开启输入法模式，开启后输入法未确认期间不会触发 onChange，输入法确认后触发一次 onChange | boolean                         | false     |
 | defaultValue      | 输入框内容默认值                                       | ReactText                       |           |
 | disabled          | 是否禁用，默认为false                                  | boolean                         | false     |
 | getValueLength    | 自定义计算字符串长度                                     | (value: string) => number       |      |
@@ -532,6 +589,7 @@ import { Input, Typography, Form, TextArea, Button } from '@douyinfe/semi-ui';
 | borderless        | 无边框模式  >=2.33.0                                 | boolean                         |           |
 | className    | 类名                               | string                          | -      |
 | cols         | 默认列数                           | number                          | 无     |
+| composition  | 是否开启输入法模式，开启后输入法未确认期间不会触发 onChange，输入法确认后触发一次 onChange | boolean                         | false     |
 | disabled     | 禁用状态                           | boolean                         | false  |
 | getValueLength| 自定义计算字符串长度                                            | (value: string) => number        |      |
 | maxCount     | 设置字数限制并显示字数统计         | number                          | 无     |

--- a/packages/semi-foundation/input/foundation.ts
+++ b/packages/semi-foundation/input/foundation.ts
@@ -59,7 +59,15 @@ class InputFoundation extends BaseFoundation<InputAdapter> {
     }
 
     handleChange(value: any, e: any) {
+        const { composition } = this._adapter.getProps();
         let nextValue = value;
+        // When composition is enabled and in IME composing, only update internal state without triggering onChange
+        // We still need to update internal state for both controlled and uncontrolled components,
+        // so that the input can correctly display the composing text
+        if (composition && this.compositionEnter) {
+            this._adapter.setValue(nextValue);
+            return;
+        }
         if (!this.compositionEnter) {
             nextValue = this.getNextValue(nextValue);
         }
@@ -101,9 +109,16 @@ class InputFoundation extends BaseFoundation<InputAdapter> {
     }
 
     handleCompositionEnd = (e: any) => {
+        const { composition } = this._adapter.getProps();
         const value = e.target.value;
         this.compositionEnter = false;
-        this._adapter.notifyCompositionEnd(e); 
+        this._adapter.notifyCompositionEnd(e);
+        // When composition is enabled, trigger onChange after IME composition ends
+        if (composition) {
+            const nextValue = this.getNextValue(value);
+            this.changeInput(nextValue, e);
+            return;
+        }
         const { getValueLength, maxLength, minLength } = this.getProps();
         if (!isFunction(getValueLength)) {
             return;

--- a/packages/semi-foundation/input/textareaFoundation.ts
+++ b/packages/semi-foundation/input/textareaFoundation.ts
@@ -63,8 +63,15 @@ export default class TextAreaFoundation extends BaseFoundation<TextAreaAdapter> 
     }
 
     handleChange(value: string, e: any) {
-        const { maxLength, minLength, getValueLength } = this._adapter.getProps();
+        const { composition } = this._adapter.getProps();
         let nextValue = value;
+        // When composition is enabled and in IME composing, only update internal state without triggering onChange
+        // We still need to update internal state for both controlled and uncontrolled components,
+        // so that the textarea can correctly display the composing text
+        if (composition && this.compositionEnter) {
+            this._adapter.setValue(nextValue);
+            return;
+        }
         if (!this.compositionEnter) {
             nextValue = this.getNextValue(nextValue);
         }
@@ -100,20 +107,27 @@ export default class TextAreaFoundation extends BaseFoundation<TextAreaAdapter> 
     }
 
     handleCompositionEnd = (e: any) => {
+        const { composition } = this._adapter.getProps();
+        const value = e.target.value;
         this.compositionEnter = false;
-        this._adapter.notifyCompositionEnd(e); 
+        this._adapter.notifyCompositionEnd(e);
+        // When composition is enabled, trigger onChange after IME composition ends
+        if (composition) {
+            const nextValue = this.getNextValue(value);
+            this._changeValue(nextValue, e);
+            return;
+        }
         const { getValueLength, maxLength, minLength } = this.getProps();
         if (!isFunction(getValueLength)) {
             return;
         }
-        const value = e.target.value;
         if (maxLength) {
             const nextValue = this.handleVisibleMaxLength(value);
             nextValue !== value && this._changeValue(nextValue, e);
         }
         if (minLength) {
             this.handleVisibleMinLength(value);
-        } 
+        }
     }
     
     handleCompositionUpdate = (e) => {

--- a/packages/semi-ui/input/index.tsx
+++ b/packages/semi-ui/input/index.tsx
@@ -67,7 +67,9 @@ export interface InputProps extends
     preventScroll?: boolean;
     /** internal prop, DatePicker use it */
     showClearIgnoreDisabled?: boolean;
-    onlyBorder?: number
+    onlyBorder?: number;
+    /** Whether to enable composition mode. When enabled, onChange will not be triggered during IME composition, and will only be triggered once after composition ends */
+    composition?: boolean;
 }
 
 export interface InputState {
@@ -126,6 +128,7 @@ class Input extends BaseComponent<InputProps, InputState> {
         getValueLength: PropTypes.func,
         preventScroll: PropTypes.bool,
         borderless: PropTypes.bool,
+        composition: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -154,6 +157,7 @@ class Input extends BaseComponent<InputProps, InputState> {
         onCompositionUpdate: noop,
         validateStatus: 'default',
         borderless: false,
+        composition: false,
     };
 
     inputRef!: React.RefObject<HTMLInputElement>;
@@ -462,6 +466,7 @@ class Input extends BaseComponent<InputProps, InputState> {
             borderless,
             showClearIgnoreDisabled,
             onlyBorder,
+            composition,
             ...rest
         } = this.props;
         const { value, isFocus, minLength: stateMinLength } = this.state;

--- a/packages/semi-ui/input/textarea.tsx
+++ b/packages/semi-ui/input/textarea.tsx
@@ -73,6 +73,8 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
     lineNumberStyle?: CSSProperties;
     /** The style of textarea element */
     textareaStyle?: CSSProperties;
+    /** Whether to enable composition mode. When enabled, onChange will not be triggered during IME composition, and will only be triggered once after composition ends */
+    composition?: boolean;
 }
 
 export interface TextAreaState {
@@ -110,6 +112,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         onCompositionUpdate: PropTypes.func,
         getValueLength: PropTypes.func,
         disabledEnterStartNewLine: PropTypes.bool,
+        composition: PropTypes.bool,
         showLineNumber: PropTypes.bool,
         lineNumberStart: PropTypes.number,
         lineNumberClassName: PropTypes.string,
@@ -135,6 +138,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         onCompositionStart: noop,
         onCompositionEnd: noop,
         onCompositionUpdate: noop,
+        composition: false,
         showLineNumber: false,
         lineNumberStart: 1,
         // resize: false,
@@ -473,6 +477,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             lineNumberStart,
             lineNumberClassName,
             lineNumberStyle,
+            composition,
             ...rest
         } = this.props;
         const { isFocus, value, minLength: stateMinLength } = this.state;
@@ -493,7 +498,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             [`${prefixCls}-textarea-showClear`]: showClear,
         });
         const itemProps = {
-            ...omit(rest, 'insetLabel', 'insetLabelId', 'getValueLength', 'onClear', 'showClear', 'disabledEnterStartNewLine'),
+            ...omit(rest, 'insetLabel', 'insetLabelId', 'getValueLength', 'onClear', 'showClear', 'disabledEnterStartNewLine', 'composition'),
             style: textareaStyle,
             autoFocus: autoFocus || this.props['autofocus'],
             className: itemCls,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2134

为 Input 和 TextArea 组件新增 `composition` prop，支持输入法组合模式。当开启此模式时，使用中文输入法等 IME 输入时，`onChange` 不会在拼音输入阶段频繁触发，而是在输入法确认后触发一次。这解决了实时搜索等场景中，拼音输入时频繁触发 onChange 导致的搜索结果异常和无意义请求问题。

**实现方案：**
- 在 `handleChange` 中，当 `composition` 为 true 且处于 IME 组合状态时，只更新内部状态而不触发 onChange
- 在 `handleCompositionEnd` 中，当 `composition` 为 true 时，在组合输入结束后触发一次 onChange
- 同时在 InputFoundation 和 TextAreaFoundation 中实现了该逻辑，确保两个组件行为一致

**审查者应关注：**
- composition prop 的默认值为 false，不影响现有使用
- 实现中正确处理了 maxLength、minLength 等边界情况
- 文档中已添加示例和 API 说明

### Changelog
🇨🇳 Chinese
- Feat: Input 和 TextArea 组件新增 `composition` prop，开启后输入法未确认期间不会触发 onChange，输入法确认后触发一次 onChange，适用于实时搜索等场景

---

🇺🇸 English
- Feat: Added `composition` prop to Input and TextArea components, when enabled onChange won't trigger during IME composition and only triggers once after composition ends, suitable for real-time search scenarios


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无