### PR TITLE
【Auto】Fix: Table resizable drag issues on Windows Chrome/Edge

### DIFF
--- a/packages/semi-ui/table/ResizableTable.tsx
+++ b/packages/semi-ui/table/ResizableTable.tsx
@@ -98,6 +98,16 @@ const ResizableTable = (props: TableProps = {}, ref: React.MutableRefObject<Tabl
     };
 
     const handleResizeStart = (column: ColumnProps<any>) => (e: React.MouseEvent) => {
+        // Fix: Clear text selection to prevent drag issues on Windows Chrome/Edge
+        // Related issue: https://github.com/DouyinFE/semi-design/issues/2962
+        // Reference: https://github.com/ant-design/ant-design/issues/56356
+        if (typeof window !== 'undefined') {
+            const selection = window.getSelection();
+            if (selection) {
+                selection.removeAllRanges();
+            }
+        }
+
         const nextColumns = cloneDeep(columns);
 
         const curColumn: ColumnProps = findColumn(nextColumns, column, childrenColumnName);


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2962

**问题背景：**
Table 组件的 resizable 功能在 Windows 平台的 Chrome/Edge 浏览器上存在拖动异常问题，具体表现为：
1. 按住鼠标来回拖动后松开，拖动模块依然保持点击状态，移动鼠标时表格列会跟随移动
2. 点击标题栏后无法正常拖动，但移动鼠标时标题栏会跟着移动
3. 拖动时表格列的变化方向和鼠标拖动方向相反

**根本原因：**
在 Windows Chrome/Edge 浏览器上，用户在拖动操作前可能会误选中表格内的文本，导致浏览器的文本选择行为与拖动事件产生冲突，从而引发各种拖动异常。

**解决方案：**
在 ResizableTable 组件的 `handleResizeStart` 函数中，于拖动开始时调用 `window.getSelection().removeAllRanges()` 清除所有文本选择，确保拖动操作不会受到文本选择的影响。此方案参考了 ant-design 的类似问题修复（ant-design/ant-design#56356）。

**审查要点：**
- 关注 `handleResizeStart` 函数中新增的文本选择清除逻辑
- 确认该修复不影响其他平台的正常使用
- 参考 issue 和 ant-design 的相关问题进行验证

### Changelog
🇨🇳 Chinese
- Fix: 修复 Table 组件 resizable 在 Windows Chrome/Edge 浏览器上拖动异常的问题，拖动开始时清除文本选择以避免事件冲突

---

🇺🇸 English
- Fix: Fixed Table component resizable drag issues on Windows Chrome/Edge by clearing text selection at drag start to prevent event conflicts

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此修复参考了 ant-design 的类似问题：https://github.com/ant-design/ant-design/issues/56356