### PR TITLE
【Auto】Fix: TagInput renderTagItem onClose automatically prevents Tag's internal close when passed to Tag component

### DIFF
--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -425,7 +425,13 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         });
         const DragHandle = sortableHandle && sortableHandle(() => <IconHandle className={`${prefixCls}-drag-handler`}></IconHandle>);
         const elementKey = showIconHandler ? value : `${index}${value}`;
-        const onClose = () => {
+        const onClose = (...args: any[]) => {
+            // args[1] is the event object from Tag component's close method
+            // We need to call preventDefault to prevent Tag's internal setVisible(false)
+            // when the user passes this onClose to a Tag component
+            if (args[1] && typeof args[1].preventDefault === 'function') {
+                args[1].preventDefault();
+            }
             !disabled && this.handleTagClose(index);
         };
         if (isFunction(renderTagItem)) {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DoucinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3212

**问题背景：**
当用户在 TagInput 的 renderTagItem 中使用 Tag 组件，并将 TagInput 提供的 onClose 回调直接传递给 Tag 的 onClose prop 时，会出现一次关闭两个 tag 的问题。这是因为 Tag 组件在触发 onClose 后，内部还会执行 setVisible(false)，导致双重关闭效果。

**解决方案：**
修改 TagInput 组件的 renderTagItem 回调参数 `onClose` 的行为：
- onClose 现在可以接收 Tag 组件传递的参数（value 和 event 对象）
- 当检测到第二个参数（事件对象）存在时，自动调用 preventDefault() 来阻止 Tag 组件内部的 setVisible(false) 逻辑
- 这样用户无需手动调用 preventDefault，直接传递 onClose 即可正常工作

**审查要点：**
- 重点关注 `packages/semi-ui/tagInput/index.tsx` 中 onClose 函数的修改
- 该修改向后兼容，不影响现有用法
- 用户不再需要使用 workaround（手动调用 e.preventDefault()）

### Changelog
🇨🇳 Chinese
- Fix: 修复 TagInput 组件的 renderTagItem 回调参数 onClose 在传递给 Tag 组件时自动阻止双重关闭的问题

---

🇺🇸 English
- Fix: Fixed TagInput renderTagItem's onClose callback automatically preventing double close when passed to Tag component


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
修复前，用户需要手动在 onClose 中调用 preventDefault：
```js
<Tag onClose={(_, e) => {
    e.preventDefault();
    onClose();
}} />
```

修复后，用户可以直接传递 onClose，无需额外处理：
```js
<Tag onClose={onClose} />
```