### PR TITLE
【Auto】Fix: JsonViewer selection lost when scrolling

### DIFF
--- a/packages/semi-json-viewer-core/src/model/selectionModel.ts
+++ b/packages/semi-json-viewer-core/src/model/selectionModel.ts
@@ -132,54 +132,193 @@ export class SelectionModel {
     public toViewPosition() {
         const selection = window.getSelection();
         if (!selection) return;
-        const range = new Range();
 
         if (this.isSelectedAll) {
-            range.setStartBefore(this._view.scrollDom.firstChild!);
-            range.setEndAfter(this._view.scrollDom.lastChild!);
+            const firstChild = this._view.scrollDom.firstChild;
+            const lastChild = this._view.scrollDom.lastChild;
+
+            if (!firstChild || !lastChild) {
+                selection.removeAllRanges();
+                return;
+            }
+
+            const range = new Range();
+            range.setStartBefore(firstChild);
+            range.setEndAfter(lastChild);
             selection.removeAllRanges();
             selection.addRange(range);
             return;
         }
 
+        // Handle multi-selection (non-collapsed selection)
+        if (!this.isCollapsed) {
+            this._restoreMultiSelection(selection);
+            return;
+        }
+
         const row = this._jsonModel.lastChangeBufferPos.lineNumber;
         const col = this._jsonModel.lastChangeBufferPos.column - 1;
+        const firstVisibleLineElement = this._view.scrollDom.firstElementChild as HTMLElement | null;
+        const lastVisibleLineElement = this._view.scrollDom.lastElementChild as HTMLElement | null;
 
-        if (this.isSelecting) {
-            
+        if (!firstVisibleLineElement || !lastVisibleLineElement) {
+            selection.removeAllRanges();
+            return;
         }
 
         const lineElement = this._view.getLineElement(row);
-        
-        if (!lineElement) return;
-        
-        if (col === 0) {
-            range.setStart(lineElement, 0);
-            range.setEnd(lineElement, 0);
-        } else {
-            const walker = document.createTreeWalker(
-                lineElement,
-                NodeFilter.SHOW_TEXT,
-                null
-            );
 
-            let node: Text | null = walker.nextNode() as Text;
-            let currentOffset = 0;
-            
-            while (node) {
-                const nodeLength = node.length;
-                if (currentOffset + nodeLength >= col) {
-                    range.setStart(node, col - currentOffset);
-                    range.setEnd(node, col - currentOffset);
-                    break;
-                }
-                currentOffset += nodeLength;
-                node = walker.nextNode() as Text;
+        const range = new Range();
+
+        if (!lineElement) {
+            const firstVisibleLineNumber = Number(firstVisibleLineElement.dataset.lineNumber || 0);
+            const lastVisibleLineNumber = Number(lastVisibleLineElement.dataset.lineNumber || 0);
+
+            if (row < firstVisibleLineNumber) {
+                range.setStartBefore(firstVisibleLineElement);
+                range.setEndBefore(firstVisibleLineElement);
+            } else if (row > lastVisibleLineNumber) {
+                range.setStartAfter(lastVisibleLineElement);
+                range.setEndAfter(lastVisibleLineElement);
+            } else {
+                selection.removeAllRanges();
+                return;
+            }
+        } else {
+            const position = this._findPositionInLine(lineElement, col);
+
+            if (position) {
+                range.setStart(position.node, position.offset);
+                range.setEnd(position.node, position.offset);
+            } else {
+                range.setStart(lineElement, 0);
+                range.setEnd(lineElement, 0);
             }
         }
 
         selection.removeAllRanges();
         selection.addRange(range);
+    }
+
+    /**
+     * Restore multi-selection (non-collapsed selection) after DOM re-render
+     */
+    private _restoreMultiSelection(selection: Selection) {
+        const firstVisibleLineElement = this._view.scrollDom.firstElementChild as HTMLElement | null;
+        const lastVisibleLineElement = this._view.scrollDom.lastElementChild as HTMLElement | null;
+
+        if (!firstVisibleLineElement || !lastVisibleLineElement) {
+            selection.removeAllRanges();
+            return;
+        }
+
+        const startLineElement = this._view.getLineElement(this.startRow);
+        const endLineElement = this._view.getLineElement(this.endRow);
+        const firstVisibleLineNumber = Number(firstVisibleLineElement.dataset.lineNumber || 0);
+        const lastVisibleLineNumber = Number(lastVisibleLineElement.dataset.lineNumber || 0);
+
+        const isSelectionAboveViewport = this.endRow < firstVisibleLineNumber;
+        const isSelectionBelowViewport = this.startRow > lastVisibleLineNumber;
+
+        // Entire selection is above the viewport, keep browser selection constrained inside JsonViewer.
+        if (isSelectionAboveViewport) {
+            const range = new Range();
+            range.setStartBefore(firstVisibleLineElement);
+            range.setEndBefore(firstVisibleLineElement);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            return;
+        }
+
+        // Entire selection is below the viewport, keep browser selection constrained inside JsonViewer.
+        if (isSelectionBelowViewport) {
+            const range = new Range();
+            range.setStartAfter(lastVisibleLineElement);
+            range.setEndAfter(lastVisibleLineElement);
+            selection.removeAllRanges();
+            selection.addRange(range);
+            return;
+        }
+
+        const range = new Range();
+
+        // Set start position
+        if (startLineElement) {
+            const startPos = this._findPositionInLine(startLineElement, this.startCol - 1);
+            if (startPos) {
+                range.setStart(startPos.node, startPos.offset);
+            } else {
+                // Fallback: set to start of line
+                range.setStart(startLineElement, 0);
+            }
+        } else {
+            // Start line is not visible (scrolled above), extend selection to the beginning of scrollDom
+            range.setStartBefore(firstVisibleLineElement);
+        }
+
+        // Set end position
+        if (endLineElement) {
+            const endPos = this._findPositionInLine(endLineElement, this.endCol - 1);
+            if (endPos) {
+                range.setEnd(endPos.node, endPos.offset);
+            } else {
+                // Fallback: set to end of line
+                const lastChild = endLineElement.lastChild;
+                if (lastChild) {
+                    if (lastChild.nodeType === Node.TEXT_NODE) {
+                        range.setEnd(lastChild, lastChild.textContent?.length || 0);
+                    } else {
+                        range.setEnd(endLineElement, endLineElement.childNodes.length);
+                    }
+                }
+            }
+        } else {
+            // End line is not visible (scrolled below), extend selection to the end of scrollDom
+            range.setEndAfter(lastVisibleLineElement);
+        }
+
+        selection.removeAllRanges();
+        selection.addRange(range);
+    }
+
+    /**
+     * Find the text node and offset for a given column position in a line element
+     */
+    private _findPositionInLine(lineElement: HTMLElement, col: number): { node: Text; offset: number } | null {
+        if (col === 0) {
+            // Find the first text node
+            const walker = document.createTreeWalker(lineElement, NodeFilter.SHOW_TEXT, null);
+            const firstNode = walker.nextNode() as Text;
+            if (firstNode) {
+                return { node: firstNode, offset: 0 };
+            }
+            return null;
+        }
+
+        const walker = document.createTreeWalker(lineElement, NodeFilter.SHOW_TEXT, null);
+        let node: Text | null = walker.nextNode() as Text;
+        let currentOffset = 0;
+
+        while (node) {
+            const nodeLength = node.length;
+            if (currentOffset + nodeLength >= col) {
+                return { node, offset: col - currentOffset };
+            }
+            currentOffset += nodeLength;
+            node = walker.nextNode() as Text;
+        }
+
+        // If col is beyond the line, return the end of the last text node
+        walker.currentNode = lineElement;
+        let lastNode: Text | null = null;
+        while (walker.nextNode()) {
+            lastNode = walker.currentNode as Text;
+        }
+        if (lastNode) {
+            return { node: lastNode, offset: lastNode.length };
+        }
+
+        return null;
     }
 
     public toLastPosition() {
@@ -262,4 +401,3 @@ export class SelectionModel {
     }
     
 }
-


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2976

**问题背景：**
JsonViewer 组件在虚拟滚动场景下存在选区丢失的问题。当用户使用光标进行多选操作后滚动视图，DOM 会重新渲染导致之前的选择区域丢失。

**原因分析：**
`selectionModel.ts` 中的 `toViewPosition()` 方法只处理了全选（`isSelectedAll`）和折叠选区（`isCollapsed === true`，即光标位置）两种情况，但没有处理非折叠的多选情况（`isCollapsed === false`）。当滚动触发 DOM 重新渲染后，多选区域无法被正确恢复。

**解决方案：**
1. 在 `toViewPosition()` 方法中新增对多选情况的处理，当检测到非折叠选区时调用 `_restoreMultiSelection()` 方法恢复选区
2. 新增 `_restoreMultiSelection()` 私有方法，根据保存的 `startRow/startCol` 和 `endRow/endCol` 重新定位 DOM 选区
3. 新增 `_findPositionInLine()` 辅助方法，在行元素中查找指定列位置对应的文本节点和偏移量

**审查关注点：**
- 多选恢复逻辑是否完整覆盖了边界情况（起始行/结束行不可见等）
- 文本节点定位算法的正确性

### Changelog
🇨🇳 Chinese
- Fix: 修复 JsonViewer 组件滚动时多选区域丢失的问题

---

🇺🇸 English
- Fix: Fixed JsonViewer multi-selection lost when scrolling

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
该修复主要针对虚拟滚动场景下的选区持久化问题，通过保存和恢复选区位置信息来确保滚动后选区不丢失。