### PR TITLE
【Auto】Feat: Table onRow callback now provides disabled and selected status

### DIFF
--- a/content/show/table/index-en-US.md
+++ b/content/show/table/index-en-US.md
@@ -5410,7 +5410,7 @@ render(App);
 | onExpandedRowsChange | Triggers when unfolding row changes                                                                                       | (rows: RecordType[]) => void |  |
 | onGroupedRow | Similar to onRow, but this parameter is used to define the row attribute of the grouping header alone                     | (record: RecordType, index: number) => object |  | - |
 | onHeaderRow | Set the header row property, and the returned object is merged to the header line                                         | (columns: Column[], index: number) => object |  |
-| onRow | Set the row property, and the returned object is merged to the table row                                                  | (record: RecordType, index: number) => object |  |
+| onRow | Set the row property, and the returned object is merged to the table row | (record: RecordType, index: number, rowStatus?: { disabled?: boolean; selected?: boolean }) => object |  | - |
 
 Some of the type definitions used above:
 
@@ -5481,15 +5481,25 @@ function App() {
 
 > Also in `column.onCell` `column.onHeaderCell` Properties or events supported by td / th can also be returned.
 
+The third parameter `rowStatus` of `onRow` can get the current row's status information, including `disabled` and `selected` properties (supported in v2.61.0). This is useful when you need to execute different logic based on the row's selected or disabled state, for example, determining whether to allow selection when clicking a row.
+
 ```jsx noInline=true
 import React from 'react';
 import { Table } from '@douyinfe/semi-ui';
 
 () => (
     <Table
-        onRow={(record, index) => {
+        onRow={(record, index, rowStatus) => {
             return {
-                onClick: event => {},
+                onClick: event => {
+                    // rowStatus.disabled indicates whether the current row is disabled
+                    // rowStatus.selected indicates whether the current row is selected
+                    if (rowStatus?.disabled) {
+                        console.log('This row is disabled');
+                        return;
+                    }
+                    console.log('Clicked row', index, rowStatus);
+                },
                 onMouseEnter: event => {},
                 onMouseLeave: event => {},
                 className: '',

--- a/content/show/table/index.md
+++ b/content/show/table/index.md
@@ -5797,7 +5797,7 @@ render(App);
 | onExpandedRowsChange | 展开的行变化时触发                                                           | (rows: RecordType[]) => void |  |
 | onGroupedRow | 类似于 onRow，不过这个参数单独用于定义分组表头的行属性                                      | (record: RecordType, index: number) => object |  | - |
 | onHeaderRow | 设置头部行属性，返回的对象会被合并传给表头行                                              | (columns: Column[], index: number) => object |  |
-| onRow | 设置行属性，返回的对象会被合并传给表格行                                                | (record: RecordType, index: number) => object |  |
+| onRow | 设置行属性，返回的对象会被合并传给表格行 | (record: RecordType, index: number, rowStatus?: { disabled?: boolean; selected?: boolean }) => object |  | - |
 
 一些上面用到的类型定义：
 
@@ -5874,15 +5874,25 @@ function App() {
 
 `onHeaderRow` 中可以返回 th 支持的属性或者事件 `onRow` 中可以返回 tr 支持的属性或者事件
 
+`onRow` 的第三个参数 `rowStatus` 可以获取当前行的状态信息，包括 `disabled` 和 `selected` 属性（v2.61.0 支持）。这在需要根据行的选中或禁用状态执行不同逻辑时非常有用，例如点击行时判断是否允许选中。
+
 ```jsx
 import React from 'react';
 import { Table } from '@douyinfe/semi-ui';
 
 () => (
     <Table
-        onRow={(record, index) => {
+        onRow={(record, index, rowStatus) => {
             return {
-                onClick: event => {}, // 点击行
+                onClick: event => {
+                    // rowStatus.disabled 表示当前行是否被禁用
+                    // rowStatus.selected 表示当前行是否被选中
+                    if (rowStatus?.disabled) {
+                        console.log('该行已被禁用');
+                        return;
+                    }
+                    console.log('点击行', index, rowStatus);
+                }, // 点击行
                 onMouseEnter: event => {}, // 鼠标移入行
                 onMouseLeave: event => {}, // 鼠标移出行
                 className: '',

--- a/packages/semi-ui/table/Body/BaseRow.tsx
+++ b/packages/semi-ui/table/Body/BaseRow.tsx
@@ -168,10 +168,12 @@ export default class TableRow extends BaseComponent<BaseRowProps, Record<string,
             onRow,
             index,
             record,
+            disabled,
+            selected,
         } = this.props;
         const customRowProps = this.adapter.getCache('customRowProps');
         if (typeof customRowProps === 'undefined') {
-            const { className: customClassName, style: customStyle, ...rowProps } = onRow(record, index) || {};
+            const { className: customClassName, style: customStyle, ...rowProps } = onRow(record, index, { disabled, selected }) || {};
             this.adapter.setCache('customRowProps', { ...rowProps });
         }
     }
@@ -342,6 +344,7 @@ export default class TableRow extends BaseComponent<BaseRowProps, Record<string,
             components,
             prefixCls,
             selected,
+            disabled,
             onRow,
             index,
             className,
@@ -359,7 +362,7 @@ export default class TableRow extends BaseComponent<BaseRowProps, Record<string,
 
         const BodyRow = components.body.row;
 
-        const { className: customClassName, style: customStyle, ...rowProps } = onRow(record, index) || {};
+        const { className: customClassName, style: customStyle, ...rowProps } = onRow(record, index, { disabled, selected }) || {};
 
         this.adapter.setCache('customRowProps', { ...rowProps });
 

--- a/packages/semi-ui/table/interface.ts
+++ b/packages/semi-ui/table/interface.ts
@@ -340,7 +340,7 @@ export interface ChangeInfo<RecordType> {
     extra?: OnChangeExtra
 }
 export type OnChange<RecordType> = (changeInfo: ChangeInfo<RecordType>) => void;
-export type OnRow<RecordType> = (record?: RecordType, index?: number) => OnRowReturnObject;
+export type OnRow<RecordType> = (record?: RecordType, index?: number, rowStatus?: { disabled?: boolean; selected?: boolean }) => OnRowReturnObject;
 export type OnGroupedRow<RecordType> = (record?: RecordType, index?: number) => OnGroupedRowReturnObject;
 export type OnHeaderRow<RecordType> = (columns?: ColumnProps<RecordType>[], index?: number) => OnHeaderRowReturnObject;
 export type OnExpandedRowsChange<RecordType> = (expandedRows?: IncludeGroupRecord<RecordType>[]) => void;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2462

**问题背景：**
用户在使用 Table 组件时，通过 `rowSelection.getCheckboxProps` 配置行的 disabled 状态，但在 `onRow.onClick` 回调中无法直接获取这个状态。用户不得不手动调用 `getCheckboxProps` 来判断行是否被禁用，这增加了代码复杂度。

**解决方案：**
修改了 Table 组件的 `onRow` 回调函数签名，增加了第三个参数 `rowStatus`，包含当前行的 `disabled` 和 `selected` 状态。这样用户可以在 `onRow` 回调中直接判断行的禁用状态，无需额外调用 `getCheckboxProps`。

**变更内容：**
- 修改了 Table 组件的 `onRow` prop，增加了第三个参数 `{ disabled?: boolean; selected?: boolean }`
- 此变更是向后兼容的，现有代码无需修改

**审查者应关注：**
- `OnRow` 类型定义的变更是否合理
- `BaseRow.tsx` 中调用 `onRow` 时传递 `disabled` 和 `selected` 的逻辑是否正确

### Changelog
🇨🇳 Chinese
- Feat: Table 组件 onRow 回调新增第三个参数 rowStatus，包含 disabled 和 selected 状态，方便在行事件中获取当前行的禁用和选中状态

---

🇺🇸 English
- Feat: Added third parameter rowStatus to Table onRow callback, containing disabled and selected status for easy access to row state in row events


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
**使用示例：**
```tsx
<Table
  dataSource={data}
  rowSelection={{
    getCheckboxProps: (record) => ({
      disabled: record.disabled,
    }),
  }}
  onRow={(record, index, rowStatus) => ({
    onClick: () => {
      // 现在可以直接获取 disabled 状态
      if (rowStatus?.disabled) {
        return;
      }
      // 处理点击逻辑
    },
  })}
/>
```