### PR TITLE
【Auto】Fix: JsonViewer customRenderRule now passes typed value to match function for strict equality comparison

### DIFF
--- a/content/plus/jsonviewer/index-en-US.md
+++ b/content/plus/jsonviewer/index-en-US.md
@@ -148,13 +148,30 @@ render(FormatJsonComponent);
 
 By configuring the `options.customRenderRule` parameter, you can customize how JSON content is rendered (Note: only works in read-only mode).
 
+> **Behavior change in 2.96.0**
+>
+> Starting from 2.96.0, `path` in `customRenderRule` is computed more accurately: **the key token and the value token of the same key-value pair share the same `path`** (they both map to the property path, e.g. `root.<key>`).
+>
+> As a result, rules that only rely on `path` (such as `path === 'root.<key>'`) may match both the key and the value, which can change which rule “wins” compared to previous versions.
+>
+> If you want to match only the key or only the value, use the third argument `tokenType` of function match:
+>
+> ```ts
+> const targetPath = 'root.<key>';
+> // Key only
+> match: (_value, path, tokenType) => tokenType === 'key' && path === targetPath
+> // Value only
+> match: (value, path, tokenType) => tokenType === 'value' && path === targetPath
+> ```
+
 `customRenderRule` is an array of rules, where each rule contains two properties:
 - `match`: Matching condition, can be one of three types:
   - String: Exact match
   - Regular expression: Match by regex
-  - Function: Custom matching logic, with signature `(value: string, pathChain: string) => boolean`
-    - `value`: Value to match (key or value from JSON key-value pairs, as strings since internal processing only filters quotes)
+  - Function: Custom matching logic, with signature `(value: string | number | boolean | null, pathChain: string, tokenType: 'key' | 'value') => boolean`
+    - `value`: Value to match (JSON key or value). When `match` is a function, `value` will be passed as the parsed primitive when possible (number / boolean / null / string), so strict comparisons like `===` work; when `match` is a string or RegExp, matching is still based on textual content (string tokens are unquoted)
     - `path`: Current matching path, format is `root.key1.key2.key3[0].key4`
+    - `tokenType`: Current token type, `'key'` for JSON property name, `'value'` for JSON value. Useful for distinguishing between key and value matching
 - `render`: Custom render function, with signature `(content: string) => React.ReactNode`
   - `content`: Matched content. For string values, includes double quotes (e.g., `"name"`, `"Semi"`)
 
@@ -295,7 +312,7 @@ render(CustomSearchButtonDemo);
 
 | Attribute | Description | Type | Default |
 | --- | --- | --- | --- |
-| match | Matching rule | string \| RegExp \| (value: string, path: string) => boolean | - |
+| match | Matching rule | string \| RegExp \| (value: string \| number \| boolean \| null, path: string, tokenType: 'key' \| 'value') => boolean | - |
 | render | Render function | (content: string) => React.ReactNode | - |
 
 ### SearchControls

--- a/content/plus/jsonviewer/index.md
+++ b/content/plus/jsonviewer/index.md
@@ -146,13 +146,30 @@ render(FormatJsonComponent);
 
 通过配置 `options.customRenderRule` 参数，你可以自定义 JSON 内容的渲染方式（注意：仅在只读模式下生效）。
 
+> **2.96.0 行为变更说明**
+>
+> 从 2.96.0 起，`customRenderRule` 在计算 `path` 时会更精确：**同一条键值对的 key token 与 value token 会拥有相同的 `path`**（即都对应到该属性所在的路径，例如 `root.<key>`）。
+>
+> 因此，像 `path === 'root.<key>'` 这类仅依赖 `path` 的规则，可能同时命中 key 和 value，导致与后续 value 匹配规则产生“覆盖/优先级”差异。
+>
+> 若你希望只匹配 key 或只匹配 value，请使用函数匹配的第三个参数 `tokenType`：
+>
+> ```ts
+> const targetPath = 'root.<key>';
+> // 仅匹配 key
+> match: (_value, path, tokenType) => tokenType === 'key' && path === targetPath
+> // 仅匹配 value
+> match: (value, path, tokenType) => tokenType === 'value' && path === targetPath
+> ```
+
 `customRenderRule` 是一个规则数组，每条规则包含两个属性：
 - `match`: 匹配条件，可以是以下三种类型之一：
   - 字符串：精确匹配
   - 正则表达式：按正则匹配
-  - 函数：自定义匹配逻辑，函数签名为 `(value: string, path: string) => boolean`
-    - `value`: 待匹配的值（为Json字符串的键值对的键或者值，由于内部处理注入时仅过滤引号，因此类型全部为string）
+  - 函数：自定义匹配逻辑，函数签名为 `(value: string | number | boolean | null, path: string, tokenType: 'key' | 'value') => boolean`
+    - `value`: 待匹配的值（JSON 键或值）。当 `match` 为函数时，`value` 会尽量传入解析后的原始类型（number / boolean / null / string），因此可以使用 `===` 进行严格匹配；当 `match` 为字符串或正则时，仍基于文本内容匹配（字符串类型会去除两侧引号）
     - `path`: 当前匹配到的路径，格式为 `root.key1.key2.key3[0].key4`
+    - `tokenType`: 当前 token 的类型，`'key'` 表示 JSON 键名，`'value'` 表示 JSON 值。可用于区分同名键和值的匹配
 - `render`: 自定义渲染函数，函数签名为 `(content: string) => React.ReactNode`
   - `content`: 匹配到的内容。如果是字符串类型的值，将包含双引号（如 `"name"`，`"Semi"`）
 
@@ -285,7 +302,7 @@ render(CustomSearchButtonDemo);
 ### CustomRenderRule
 | 属性                | 说明                                          | 类型                              | 默认值    |
 |-------------------|------------------------------------------------|---------------------------------|-----------|
-| match             | 匹配规则                                   | string \| RegExp \| (value: string, path: string) => boolean | -  |
+| match             | 匹配规则                                   | string \| RegExp \| (value: string \| number \| boolean \| null, path: string, tokenType: 'key' \| 'value') => boolean | -  |
 | render            | 渲染函数                                   | (content: string) => React.ReactNode | -  |
 
 ### FormattingOptions

--- a/packages/semi-foundation/jsonViewer/foundation.ts
+++ b/packages/semi-foundation/jsonViewer/foundation.ts
@@ -1,7 +1,7 @@
-import { JsonViewer, JsonViewerOptions, CustomRenderRule } from '@douyinfe/semi-json-viewer-core';
+import { JsonViewer, JsonViewerOptions, CustomRenderRule, TokenRenderType } from '@douyinfe/semi-json-viewer-core';
 import BaseFoundation, { DefaultAdapter } from '../base/foundation';
 import { cssClasses } from './constants';
-export type { JsonViewerOptions, CustomRenderRule };
+export type { JsonViewerOptions, CustomRenderRule, TokenRenderType };
 
 export interface JsonViewerAdapter<P = Record<string, any>, S = Record<string, any>> extends DefaultAdapter<P, S> {
     getEditorRef: () => HTMLElement;

--- a/packages/semi-json-viewer-core/src/json-viewer/jsonViewer.ts
+++ b/packages/semi-json-viewer-core/src/json-viewer/jsonViewer.ts
@@ -29,9 +29,19 @@ export interface FormattingOptions {
     eol?: string
 }
 
+export type TokenRenderType = 'key' | 'value';
+
 export interface CustomRenderRule {
-    match: string | RegExp | ((value: string, pathChain: string) => boolean);
-    render: (value: string) => HTMLElement
+    /**
+     * Match rule
+     * - string / RegExp: matches against the textual content (string tokens are unquoted)
+     * - function: receives the parsed primitive value (number/boolean/null/string), path, and token type ('key' or 'value')
+     */
+    match: string | RegExp | ((value: string | number | boolean | null, pathChain: string, tokenType: TokenRenderType) => boolean);
+    /**
+     * Render result can be a DOM element or any value that will be handled by upper layer (e.g. React portal)
+     */
+    render: (value: string) => any;
 }
 
 export class JsonViewer {

--- a/packages/semi-json-viewer-core/src/view/view.ts
+++ b/packages/semi-json-viewer-core/src/view/view.ts
@@ -11,7 +11,7 @@ import {
 } from '../tokens/tokenize';
 import { Emitter, getEmitter } from '../common/emitter';
 import { SelectionModel } from '../model/selectionModel';
-import { CustomRenderRule, JsonViewerOptions } from '../json-viewer/jsonViewer';
+import { CustomRenderRule, JsonViewerOptions, TokenRenderType } from '../json-viewer/jsonViewer';
 import { getJsonWorkerManager, JsonWorkerManager } from '../worker/jsonWorkerManager';
 import { FoldingModel } from '../model/foldingModel';
 import { SearchWidget } from './search/searchWidget';
@@ -25,7 +25,7 @@ import { HoverWidget } from './hover/hoverWidget';
 import { GlobalEvents } from '../common/emitterEvents';
 import { ErrorWidget } from './error/errorWidget';
 import { ViewDOMBuilder } from './viewDOMBuilder';
-import { getNodePath, getPathChain, JsonDocument, parseJson } from '../service/parse';
+import { getNodePath, getPathChain, getNodeValue, JsonDocument, parseJson } from '../service/parse';
 //TODO 实现ViewModel抽离代码
 
 /**
@@ -402,11 +402,14 @@ export class View {
                 container.appendChild(highlightedSpan);
             } else {
                 if (this._options?.readOnly && this._tryApplyCustomRender(token.scopes, content)) {
-                    const offset = this._jsonModel.getOffsetAt(lineNumber, (start + end) / 2);
+                    // Use token start column to locate the correct AST node.
+                    // Using a middle position may hit whitespace or ':' and resolve to a 'property' node,
+                    // which would produce an empty path.
+                    const offset = this._jsonModel.getOffsetAt(lineNumber, start + 1);
                     const node = this._root?.getNodeFromOffset(offset);
-                    const path = getNodePath(node);
+                    const path = node ? getNodePath(node) : [];
                     const pathChain = getPathChain(path);
-                    const customElement = this._renderCustomToken(content, this._customRenderRule, token, pathChain);
+                    const customElement = this._renderCustomToken(content, this._customRenderRule, token, pathChain, node);
                     if (customElement instanceof HTMLElement) {
                         container.appendChild(customElement);
                         continue;
@@ -496,10 +499,16 @@ export class View {
         return false;
     }
 
-    private isMatch(content: string, pathChain: string, rule: CustomRenderRule) {
+    private isMatch(
+        content: string,
+        typedValue: string | number | boolean | null,
+        pathChain: string,
+        tokenType: TokenRenderType,
+        rule: CustomRenderRule
+    ) {
         const match = rule.match;
         if (typeof match === 'function') {
-            return match(content, pathChain);
+            return match(typedValue, pathChain, tokenType);
         } else if (typeof match === 'string') {
             return match === content;
         } else if (match instanceof RegExp) {
@@ -508,10 +517,31 @@ export class View {
         return false;
     }
 
-    private _renderCustomToken(content: string, rule: CustomRenderRule[], token: Token, pathChain: string): HTMLElement | null {
+    private _renderCustomToken(
+        content: string,
+        rule: CustomRenderRule[],
+        token: Token,
+        pathChain: string,
+        node: any
+    ): HTMLElement | null {
+        // For string tokens we strip quotes for matching convenience.
         const realContent = content.replace(/^"|"$/g, '');
+
+        // Determine token type: 'key' for property names, 'value' for value tokens
+        const tokenType: TokenRenderType = token.scopes === TOKEN_PROPERTY_NAME ? 'key' : 'value';
+
+        // For function match, pass the parsed primitive value when possible.
+        // - For number/boolean/null tokens, we can reliably read from AST.
+        // - For string tokens and property names, realContent already equals the actual value.
+        let typedValue: string | number | boolean | null = realContent;
+        if (token.scopes === TOKEN_VALUE_NUMBER || token.scopes === TOKEN_VALUE_BOOLEAN || token.scopes === TOKEN_VALUE_NULL) {
+            if (node) {
+                typedValue = getNodeValue(node);
+            }
+        }
+
         for (const item of rule) {
-            if (this.isMatch(realContent, pathChain, item)) {
+            if (this.isMatch(realContent, typedValue, pathChain, tokenType, item)) {
                 const element = item.render(content);
                 return element;
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2995

This PR updates the **JsonViewer** component's `customRenderRule` function match behavior and related documentation.

- 【Breaking Change】
  - JsonViewer `customRenderRule` 的函数匹配（function match）现在提供更精确的上下文：同一键值对的 key/value token 会共享同一个 `path`。因此仅依赖 `path` 的规则可能同时命中 key 与 value，进而改变原有规则的生效顺序/覆盖关系。
  - 若你希望只匹配 key 或只匹配 value，请在 JsonViewer 函数 match 中使用第三个参数 `tokenType`（`'key' | 'value'`）进行区分。

- 【Feat】
  - JsonViewer `customRenderRule.match` 支持传入解析后的原始类型（`string | number | boolean | null`），从而可以使用 `===` 进行严格匹配。
  - JsonViewer `customRenderRule.match` 新增第三个参数 `tokenType: 'key' | 'value'`，用于区分当前匹配的是 JSON key 还是 value。

- 【Fix】
  - 修复 JsonViewer AST offset 定位不稳定导致的 pathChain 为空/错误的问题（避免落在空格或 `:` 上误命中 `property` 节点），提升复杂条件（如 value + path 组合）匹配的可靠性。


### Changelog
🇨🇳 Chinese
- 【Breaking Change】JsonViewer `customRenderRule` 的 `path` 计算更精确：同一键值对的 key/value token 共享同一路径，可能影响仅依赖 `path` 的规则命中与覆盖顺序；可通过 `tokenType` 区分 key/value。
- 【Feat】JsonViewer `customRenderRule.match`（函数形式）支持接收解析后的原始类型（`string | number | boolean | null`），支持 `===` 严格匹配。
- 【Feat】JsonViewer `customRenderRule.match`（函数形式）新增第三个参数 `tokenType: 'key' | 'value'`。
- 【Fix】JsonViewer 修复 offset 计算导致的节点定位不准/路径为空问题，确保 `value + path` 组合条件能稳定命中。

---

🇺🇸 English
- [Breaking Change] JsonViewer `customRenderRule` path resolution is more precise: key/value tokens of the same pair share the same path, which may change rule precedence for rules that only rely on `path`. Use `tokenType` to disambiguate key vs value.
- [Feat] JsonViewer `customRenderRule.match` (function) now receives parsed primitive values (`string | number | boolean | null`) to enable strict equality (`===`) matching.
- [Feat] JsonViewer `customRenderRule.match` (function) adds a third argument `tokenType: 'key' | 'value'`.
- [Fix] JsonViewer fixes unstable AST offset/node resolution that could produce empty/wrong paths and break complex match conditions.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
This change includes a behavior update in JsonViewer: key/value tokens of the same pair now share the same path. If you need to match only key or only value, use the third argument `tokenType` in function match.