### PR TITLE
Fix: nested Dropdown/Tooltip positioning broken in React 19 due to findDOMNode removal

### DIFF
--- a/content/ecosystem/changelog/index-en-US.md
+++ b/content/ecosystem/changelog/index-en-US.md
@@ -16,6 +16,11 @@ Version：Major.Minor.Patch (follow the **Semver** specification)
 
 ---
 
+#### 🎉 2.95.1 (2026-04-21)
+- 【Fix】
+    - Fix nested Dropdown submenu positioning broken in React 19 (flashing at top-left corner then disappearing), caused by React 19 removing `ReactDOM.findDOMNode` which prevented Tooltip from resolving DOM nodes from class component instances for popup positioning [#3219](https://github.com/DouyinFE/semi-design/pull/3219)
+    - DropdownItem is now wrapped with `React.forwardRef`, making the standard ref point directly to the `<li>` DOM node per React 19 best practices [#3219](https://github.com/DouyinFE/semi-design/pull/3219)
+
 #### 🎉 2.95.0 (2026-04-17)
 - 【Feat】
     - Input and TextArea components add `composition` prop, when enabled onChange won't trigger during IME composition and only triggers once after composition ends, suitable for real-time search scenarios [#2134](https://github.com/DouyinFE/semi-design/issues/2134) [#3211](https://github.com/DouyinFE/semi-design/pull/3211)

--- a/content/ecosystem/changelog/index.md
+++ b/content/ecosystem/changelog/index.md
@@ -14,6 +14,11 @@ Semi 版本号遵循 **Semver** 规范（主版本号 - 次版本号 - 修订版
 -   不同版本间的详细关系，可查阅 [FAQ](/zh-CN/start/faq)
 
 
+#### 🎉 2.95.1 (2026-04-21)
+- 【Fix】
+    - 修复 React 19 下嵌套 Dropdown 子菜单定位异常（在左上角闪烁后消失）的问题，原因是 React 19 移除了 `ReactDOM.findDOMNode`，导致 Tooltip 无法从类组件实例获取 DOM 节点进行弹出层定位 [#3219](https://github.com/DouyinFE/semi-design/pull/3219)
+    - DropdownItem 使用 `React.forwardRef` 包裹，使标准 ref 直接指向 `<li>` DOM 节点，符合 React 19 推荐做法 [#3219](https://github.com/DouyinFE/semi-design/pull/3219)
+
 #### 🎉 2.95.0 (2026-04-17)
 - 【Feat】
     - Input 和 TextArea 组件新增 `composition` prop，开启后输入法未确认期间不触发 onChange，确认后触发一次，适用于实时搜索等场景 [#2134](https://github.com/DouyinFE/semi-design/issues/2134) [#3211](https://github.com/DouyinFE/semi-design/pull/3211)

--- a/packages/semi-ui/_utils/reactRender.ts
+++ b/packages/semi-ui/_utils/reactRender.ts
@@ -115,8 +115,53 @@ export function unmount(container: ContainerType) {
 // ======================== findDOMNode ========================
 
 /**
+ * React 19+ fallback for findDOMNode: traverse React Fiber tree downward
+ * from a class component instance to find the first DOM element.
+ * 
+ * Uses React internal Fiber structure (_reactInternals). If React changes
+ * its internals in future versions, this will safely return null without
+ * throwing errors, falling back to the warning path in resolveDOM.
+ */
+function findDOMFromFiber(instance: any): Element | null {
+    try {
+        const fiber = instance?._reactInternals ?? instance?._reactInternalFiber;
+        if (!fiber || typeof fiber !== 'object') {
+            return null;
+        }
+        let node = fiber.child;
+        let iterations = 0;
+        const MAX_ITERATIONS = 50;
+        while (node && iterations < MAX_ITERATIONS) {
+            iterations++;
+            // HostComponent: stateNode is a DOM element
+            if (node.stateNode instanceof Element) {
+                return node.stateNode;
+            }
+            if (node.child) {
+                node = node.child;
+                continue;
+            }
+            while (node && !node.sibling) {
+                if (node === fiber) {
+                    return null;
+                }
+                node = node.return;
+            }
+            if (node && node !== fiber) {
+                node = node.sibling;
+            } else {
+                break;
+            }
+        }
+    } catch (e) {
+        // Fiber structure may have changed in a future React version; fail silently
+    }
+    return null;
+}
+
+/**
  * React 16/17/18: use ReactDOM.findDOMNode to resolve real DOM from component instance.
- * React 19: findDOMNode is removed; returns null for non-HTMLElement instances.
+ * React 19: findDOMNode is removed; traverse Fiber tree to find DOM node.
  * 
  * 注意：findDOMNode 可能返回 Text 节点，但我们只返回 Element 类型以保证类型安全。
  */
@@ -142,7 +187,8 @@ export function resolveDOM(instance: any): Element | null {
             return null;
         }
     }
-    return null;
+    // React 19 fallback: traverse Fiber tree to find the first DOM element
+    return findDOMFromFiber(instance);
 }
 
 // ========================= getRef ===========================

--- a/packages/semi-ui/dropdown/dropdownItem.tsx
+++ b/packages/semi-ui/dropdown/dropdownItem.tsx
@@ -31,7 +31,7 @@ export interface DropdownItemProps extends BaseProps {
 
 const prefixCls = css.PREFIX;
 
-class DropdownItem extends BaseComponent<DropdownItemProps> {
+class DropdownItemInner extends BaseComponent<DropdownItemProps & { innerRef?: React.Ref<HTMLLIElement> }> {
 
     static propTypes = {
         children: PropTypes.oneOfType([PropTypes.string, PropTypes.node]),
@@ -77,7 +77,8 @@ class DropdownItem extends BaseComponent<DropdownItemProps> {
             icon,
             onKeyDown,
             showTick,
-            hover
+            hover,
+            innerRef,
         } = this.props;
         const { showTick: contextShowTick } = this.context;
         const realShowTick = contextShowTick ?? showTick;
@@ -127,7 +128,14 @@ class DropdownItem extends BaseComponent<DropdownItemProps> {
         }
         return (
             <li role="menuitem" tabIndex={-1} aria-disabled={disabled} {...events} onKeyDown={onKeyDown}
-                ref={ref => forwardRef(ref)} className={itemclass} style={style} {...this.getDataAttr(this.props)}>
+                ref={(node: HTMLLIElement) => {
+                    forwardRef(node);
+                    if (typeof innerRef === 'function') {
+                        innerRef(node);
+                    } else if (innerRef && typeof innerRef === 'object') {
+                        (innerRef as React.MutableRefObject<HTMLLIElement>).current = node;
+                    }
+                }} className={itemclass} style={style} {...this.getDataAttr(this.props)}>
                 {tick}
                 {iconContent}
                 {children}
@@ -135,6 +143,12 @@ class DropdownItem extends BaseComponent<DropdownItemProps> {
         );
     }
 }
+
+const DropdownItem = React.forwardRef<HTMLLIElement, DropdownItemProps>((props, ref) => {
+    return <DropdownItemInner {...props} innerRef={ref} />;
+}) as React.ForwardRefExoticComponent<DropdownItemProps & React.RefAttributes<HTMLLIElement>> & {
+    elementType?: string;
+};
 
 DropdownItem.elementType = 'Dropdown.Item';
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

This PR fixes nested Dropdown (and any Tooltip-based popup wrapping class components) failing to position correctly in React 19.

**Root cause:**
React 19 removed `ReactDOM.findDOMNode`. Semi's `Tooltip` component uses `resolveDOM()` (which calls `findDOMNode`) to get the real DOM node from class component instances for popup positioning. When wrapping class components like `Tag`, `Button`, or `DropdownItem`, `findDOMNode` returning `undefined` causes `getBoundingClientRect()` to fail, resulting in the popup appearing at `(0, 0)` (top-left corner) and immediately hiding.

**Changes:**

- 【Fix】
  - `resolveDOM` in `_utils/reactRender.ts`: Added `findDOMFromFiber()` as a React 19+ fallback. When `findDOMNode` is unavailable, it traverses the React Fiber internal tree to locate the first HostComponent (DOM element) from a class component instance.
    - Fully wrapped in `try/catch` — if React changes its Fiber internals in future versions, this degrades to returning `null` (no crash, just the existing warning).
    - Iteration guard (max 50) prevents infinite loops.
  - `DropdownItem` in `dropdown/dropdownItem.tsx`: Wrapped with `React.forwardRef` so the standard React `ref` points directly to the `<li>` DOM node. This is the React 19 recommended pattern and eliminates the need for `findDOMNode` for this specific component.

**Affected scenarios:**
- Nested `Dropdown` menus (multi-level submenus)
- `Nav` horizontal mode with nested sub-navigations
- Any `Tooltip`/`Popover`/`Dropdown` wrapping Semi class components (`Tag`, `Button`, etc.) in React 19


### Changelog
🇨🇳 Chinese
- 【Fix】修复 React 19 下嵌套 Dropdown 子菜单定位异常（在左上角闪烁后消失）的问题。原因是 React 19 移除了 `findDOMNode`，导致 Tooltip 无法从类组件实例获取 DOM 节点进行弹出层定位。通过 Fiber 遍历回退机制和 DropdownItem forwardRef 改造解决。
- 【Fix】`DropdownItem` 组件使用 `React.forwardRef` 包裹，使标准 ref 直接指向 `<li>` DOM 节点，符合 React 19 推荐做法。

---

🇺🇸 English
- [Fix] Fix nested Dropdown submenu positioning broken in React 19 (flashing at top-left corner then disappearing). Root cause: React 19 removed `findDOMNode`, preventing Tooltip from resolving DOM nodes from class component instances. Fixed via Fiber tree traversal fallback and DropdownItem forwardRef wrapping.
- [Fix] `DropdownItem` is now wrapped with `React.forwardRef`, making the standard ref point directly to the `<li>` DOM node per React 19 best practices.


### Checklist
- [x] Test or no need
- [ ] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
The Fiber traversal in `findDOMFromFiber` uses React's internal `_reactInternals` property, which is not a public API. This is intentionally designed to fail silently (try/catch + iteration guard) if React changes its internals. Long-term, all class components used as Tooltip triggers should be migrated to `forwardRef` to eliminate this dependency.