### PR TITLE
【Auto】Fix: Toast and Notification global config not working

### DIFF
--- a/packages/semi-ui/notification/index.tsx
+++ b/packages/semi-ui/notification/index.tsx
@@ -21,6 +21,7 @@ import {
     NoticeState
 } from '@douyinfe/semi-foundation/notification/notificationFoundation';
 import CSSAnimation from "../_cssAnimation";
+import semiGlobal from '../_utils/semi-global';
 
 // TODO: Automatic folding + unfolding function when there are more than N
 
@@ -98,7 +99,11 @@ class NotificationList extends BaseComponent<NotificationListProps, Notification
     }
 
     static addNotice(notice: NoticeProps) {
-        notice = { ...defaultConfig, ...notice };
+        // Get global config for Notification
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Notification || {};
+        
+        // Merge configs with priority: notice > globalConfig > defaultConfig
+        notice = { ...defaultConfig, ...globalConfig, ...notice };
         const id = notice.id ?? getUuid('notification');
         if (!ref) {
             const { getPopupContainer } = notice;
@@ -143,23 +148,33 @@ class NotificationList extends BaseComponent<NotificationListProps, Notification
     }
 
     static info(opts: NoticeProps) {
-        return this.addNotice({ ...opts, type: 'info' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Notification || {};
+        return this.addNotice({ ...defaultConfig, ...globalConfig, ...opts, type: 'info' });
     }
 
     static success(opts: NoticeProps) {
-        return this.addNotice({ ...opts, type: 'success' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Notification || {};
+        return this.addNotice({ ...defaultConfig, ...globalConfig, ...opts, type: 'success' });
     }
 
     static error(opts: NoticeProps) {
-        return this.addNotice({ ...opts, type: 'error' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Notification || {};
+        return this.addNotice({ ...defaultConfig, ...globalConfig, ...opts, type: 'error' });
     }
 
     static warning(opts: NoticeProps) {
-        return this.addNotice({ ...opts, type: 'warning' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Notification || {};
+        return this.addNotice({ ...defaultConfig, ...globalConfig, ...opts, type: 'warning' });
     }
 
     static open(opts: NoticeProps) {
-        return this.addNotice({ ...opts, type: 'default' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Notification || {};
+        return this.addNotice({ ...defaultConfig, ...globalConfig, ...opts, type: 'default' });
     }
 
     static close(id: string) {

--- a/packages/semi-ui/toast/index.tsx
+++ b/packages/semi-ui/toast/index.tsx
@@ -15,6 +15,7 @@ import useToast from './useToast';
 import { ConfigProps, ToastInstance, ToastProps, ToastState } from '@douyinfe/semi-foundation/toast/toastFoundation';
 import CSSAnimation from '../_cssAnimation';
 import cls from 'classnames';
+import semiGlobal from '../_utils/semi-global';
 
 
 export interface ToastReactProps extends ToastProps{
@@ -99,6 +100,13 @@ const createBaseToast = () => class ToastList extends BaseComponent<ToastListPro
     static create(opts: ToastReactProps) {
         const id = opts.id ?? getUuid('toast');
         // this.id = id;
+        
+        // Get global config for Toast
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Toast || {};
+        
+        // Merge configs with priority: opts > globalConfig > defaultOpts
+        const mergedOpts = { ...ToastList.defaultOpts, ...globalConfig, ...opts };
+        
         if (!ToastList.ref) {
             const div = document.createElement('div');
             if (!this.wrapperId) {
@@ -107,16 +115,16 @@ const createBaseToast = () => class ToastList extends BaseComponent<ToastListPro
             div.className = cssClasses.WRAPPER;
             div.id = this.wrapperId;
             div.style.zIndex = String(typeof opts.zIndex === 'number' ?
-                opts.zIndex : ToastList.defaultOpts.zIndex);
+                opts.zIndex : mergedOpts.zIndex);
             ['top', 'left', 'bottom', 'right'].map(pos => {
-                if (pos in ToastList.defaultOpts || pos in opts) {
-                    const val = opts[pos] ? opts[pos] : ToastList.defaultOpts[pos];
+                if (pos in mergedOpts) {
+                    const val = mergedOpts[pos];
                     div.style[pos] = typeof val === 'number' ? `${val}px` : val;
                 }
             });
             // document.body.appendChild(div);
-            if (ToastList.defaultOpts.getPopupContainer) {
-                const container = ToastList.defaultOpts.getPopupContainer();
+            if (mergedOpts.getPopupContainer) {
+                const container = mergedOpts.getPopupContainer();
                 container.appendChild(div);
             } else {
                 document.body.appendChild(div);
@@ -126,25 +134,25 @@ const createBaseToast = () => class ToastList extends BaseComponent<ToastListPro
                 { ref: (instance: ToastList) => {
                     if (instance) {
                         ToastList.ref = instance;
-                        instance.add({ ...opts, id });
-                        instance.stack = Boolean(opts.stack);
+                        instance.add({ ...mergedOpts, id });
+                        instance.stack = Boolean(mergedOpts.stack);
                     }
                 } }
             ), div);
         } else {
             const node = document.querySelector(`#${this.wrapperId}`) as HTMLElement;
             ['top', 'left', 'bottom', 'right'].map(pos => {
-                if (pos in opts) {
-                    node.style[pos] = typeof opts[pos] === 'number' ? `${opts[pos]}px` : opts[pos];
+                if (pos in mergedOpts) {
+                    node.style[pos] = typeof mergedOpts[pos] === 'number' ? `${mergedOpts[pos]}px` : mergedOpts[pos];
                 }
             });
-            if (Boolean(opts.stack) !== ToastList.ref.stack) {
-                ToastList.ref.stack = Boolean(opts.stack);
+            if (Boolean(mergedOpts.stack) !== ToastList.ref.stack) {
+                ToastList.ref.stack = Boolean(mergedOpts.stack);
             }
             if (ToastList.ref.has(id)) {
-                ToastList.ref.update(id, { ...opts, id });
+                ToastList.ref.update(id, { ...mergedOpts, id });
             } else {
-                ToastList.ref.add({ ...opts, id });
+                ToastList.ref.add({ ...mergedOpts, id });
             }
         }
         return id;
@@ -177,28 +185,36 @@ const createBaseToast = () => class ToastList extends BaseComponent<ToastListPro
         if (typeof opts === 'string') {
             opts = { content: opts };
         }
-        return this.create({ ...ToastList.defaultOpts, ...opts, type: 'info' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Toast || {};
+        return this.create({ ...ToastList.defaultOpts, ...globalConfig, ...opts, type: 'info' });
     }
 
     static warning(opts: Omit<ToastReactProps, 'type'> | string) {
         if (typeof opts === 'string') {
             opts = { content: opts };
         }
-        return this.create({ ...ToastList.defaultOpts, ...opts, type: 'warning' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Toast || {};
+        return this.create({ ...ToastList.defaultOpts, ...globalConfig, ...opts, type: 'warning' });
     }
 
     static error(opts: Omit<ToastReactProps, 'type'> | string) {
         if (typeof opts === 'string') {
             opts = { content: opts };
         }
-        return this.create({ ...ToastList.defaultOpts, ...opts, type: 'error' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Toast || {};
+        return this.create({ ...ToastList.defaultOpts, ...globalConfig, ...opts, type: 'error' });
     }
 
     static success(opts: Omit<ToastReactProps, 'type'> | string) {
         if (typeof opts === 'string') {
             opts = { content: opts };
         }
-        return this.create({ ...ToastList.defaultOpts, ...opts, type: 'success' });
+        // Merge with global config
+        const globalConfig = semiGlobal?.config?.overrideDefaultProps?.Toast || {};
+        return this.create({ ...ToastList.defaultOpts, ...globalConfig, ...opts, type: 'success' });
     }
 
     static config(opts: ConfigProps) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2549

修复了 Toast 和 Notification 组件的全局配置不生效的问题。此前用户通过 `semiGlobal.config.overrideDefaultProps` 配置 Toast 或 Notification 的属性（如 `bottom`、`top` 等）后，调用 `Toast.info()` 或 `Notification.info()` 等方法时配置无法生效。

**问题原因：**
Toast 和 Notification 的静态方法在创建实例时，只合并了默认配置和调用时传入的参数，没有读取全局配置。

**解决方案：**
1. 在 Toast 组件的 `create`、`info`、`warning`、`error`、`success` 静态方法中，添加从 `semiGlobal.config.overrideDefaultProps.Toast` 读取全局配置的逻辑
2. 在 Notification 组件的 `addNotice`、`info`、`success`、`error`、`warning`、`open` 静态方法中，添加从 `semiGlobal.config.overrideDefaultProps.Notification` 读取全局配置的逻辑
3. 配置合并优先级：调用参数 > 全局配置 > 默认配置

**审查者应关注的点：**
- 配置合并的优先级是否正确（用户传入参数应优先于全局配置）
- 是否正确处理了全局配置不存在的情况（使用 `|| {}` 提供默认值）
- 位置属性（`top`、`bottom`、`left`、`right`）在创建 wrapper 和更新时是否都使用了合并后的配置

### Changelog
🇨🇳 Chinese
- Fix: 修复 Toast 和 Notification 组件的 `bottom`、`top` 等位置属性通过 `semiGlobal.config.overrideDefaultProps` 配置后不生效的问题

---

🇺🇸 English
- Fix: Fixed Toast and Notification components' position props (`bottom`, `top`, etc.) not taking effect when configured via `semiGlobal.config.overrideDefaultProps`


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此修复确保了 Toast 和 Notification 组件支持与其他组件一致的 `semiGlobal.config.overrideDefaultProps` 全局配置模式，提升了 API 的一致性。