### PR TITLE
【Auto】Fix: Anchor component slide bar not showing when initially hidden with display: none

### DIFF
--- a/packages/semi-ui/anchor/index.tsx
+++ b/packages/semi-ui/anchor/index.tsx
@@ -93,6 +93,8 @@ class Anchor extends BaseComponent<AnchorProps, AnchorState> {
     handler: () => void;
     clickHandler: () => void;
     context: ContextValue;
+    linkWrapperRef: React.RefObject<HTMLDivElement>;
+    resizeObserver: ResizeObserver | null;
 
     constructor(props: AnchorProps) {
         super(props);
@@ -106,6 +108,8 @@ class Anchor extends BaseComponent<AnchorProps, AnchorState> {
 
         this.foundation = new AnchorFoundation(this.adapter);
         this.childMap = {};
+        this.linkWrapperRef = React.createRef();
+        this.resizeObserver = null;
     }
 
     get adapter(): AnchorAdapter<AnchorProps, AnchorState> {
@@ -205,6 +209,24 @@ class Anchor extends BaseComponent<AnchorProps, AnchorState> {
         this.foundation.handleClickLink();
     };
 
+    handleResize = (entries: ResizeObserverEntry[]) => {
+        const entry = entries[0];
+        if (entry) {
+            // Check if the element is visible (not display: none)
+            let isVisible = false;
+            if (entry.borderBoxSize) {
+                isVisible = !(entry.borderBoxSize[0].blockSize === 0 && entry.borderBoxSize[0].inlineSize === 0);
+            } else {
+                isVisible = !(entry.contentRect.height === 0 && entry.contentRect.width === 0);
+            }
+            
+            // If the element becomes visible, recalculate scroll height
+            if (isVisible) {
+                this.setScrollHeight();
+            }
+        }
+    };
+
     setChildMap = () => {
         this.foundation.setChildMap();
     };
@@ -254,6 +276,12 @@ class Anchor extends BaseComponent<AnchorProps, AnchorState> {
         this.setScrollHeight();
         this.setChildMap();
         Boolean(defaultAnchor) && this.foundation.handleClick(null, defaultAnchor, false);
+
+        // Set up ResizeObserver to detect when anchor becomes visible
+        if (this.linkWrapperRef.current) {
+            this.resizeObserver = new ResizeObserver(this.handleResize);
+            this.resizeObserver.observe(this.linkWrapperRef.current);
+        }
     }
 
     componentDidUpdate(prevProps: AnchorProps, prevState: AnchorState) {
@@ -264,6 +292,9 @@ class Anchor extends BaseComponent<AnchorProps, AnchorState> {
     componentWillUnmount() {
         this.scrollContainer.removeEventListener('scroll', this.handler);
         this.scrollContainer.removeEventListener('scroll', this.clickHandler);
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+        }
     }
 
     render() {
@@ -322,7 +353,7 @@ class Anchor extends BaseComponent<AnchorProps, AnchorState> {
                     <div aria-hidden className={slideCls} style={{ height: scrollHeight }}>
                         <span className={slideBarCls} style={{ top: slideBarTop }} />
                     </div>
-                    <div className={anchorWrapper} role="list">
+                    <div className={anchorWrapper} role="list" ref={this.linkWrapperRef}>
                         {this.renderChildren()}
                     </div>
                 </div>

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2398

**问题背景：**
当 Anchor 组件初始状态使用 `display: none` 隐藏，后续通过用户交互（如点击按钮）显示时，左侧的灰色滑轨不展示。

**根本原因：**
Anchor 组件在 `componentDidMount` 时调用 `setScrollHeight()` 方法获取 `anchor-wrapper` 元素的 `scrollHeight` 来设置滑轨高度。当组件初始状态为 `display: none` 时，隐藏元素的 `scrollHeight` 返回 0，导致滑轨高度被设置为 '0px'。后续组件显示时，没有触发重新计算，滑轨高度仍然是 '0px'，因此灰色滑轨不显示。

**解决方案：**
使用 ResizeObserver 监听 `anchor-link-wrapper` 容器的尺寸变化。当元素从隐藏状态（`display: none`）变为显示状态时，ResizeObserver 会检测到尺寸变化并触发回调。在回调中检查元素是否可见，如果可见则重新调用 `setScrollHeight()` 计算滑轨高度。

**修改内容：**
1. 新增实例属性 `linkWrapperRef` 和 `resizeObserver`
2. 新增 `handleResize` 方法处理 ResizeObserver 回调
3. 在 `componentDidMount` 中初始化 ResizeObserver
4. 在 `componentWillUnmount` 中清理 ResizeObserver
5. 在 `render` 中将 `linkWrapperRef` 绑定到 `anchor-link-wrapper` 元素

**审查者关注点：**
- ResizeObserver 的兼容性：ResizeObserver 在现代浏览器中有良好支持（Chrome 64+, Firefox 69+, Safari 13.1+）
- 内存管理：确保在组件卸载时正确断开 ResizeObserver 连接
- 可见性判断逻辑：使用 `borderBoxSize` 或 `contentRect` 来判断元素是否可见

### Changelog
🇨🇳 Chinese
- Fix: 修复 Anchor 组件在初始隐藏后显示时，左侧滑轨不展示的问题

---

🇺🇸 English
- Fix: Fixed Anchor component slide bar not showing when initially hidden with display: none


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
**技术细节：**
- 使用 ResizeObserver API 监听元素尺寸变化，当元素从 `display: none` 变为可见时，会触发回调
- 在回调中通过检查 `borderBoxSize` 或 `contentRect` 判断元素是否真正可见（非 0 尺寸）
- 只有当元素可见时才重新计算滑轨高度，避免不必要的计算
- 参考了 Collapsible 组件的 ResizeObserver 使用方式