### PR TITLE
【Auto】Fix: Popover disappears when browser window shrinks with custom getPopupContainer

### DIFF
--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -490,120 +490,132 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 // left = middleX;
                 // top = triggerRect.top - SPACING;
                 left = isWidthOverFlow ? (isTriggerNearLeft ? containerRect.left + wrapperRect.width / 2 : containerRect.right - wrapperRect.width / 2 + offsetWidth) : middleX + ANO_SPACING;
-                // When height overflows, keep Popover inside container (at top edge) instead of positioning it outside
+                // When height overflows, pin popover top to container top so it stays inside the container
                 top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
                 translateX = -0.5;
-                translateY = -1;
+                // Drop the upward translateY when overflowing so popover does not get pushed outside the top edge
+                translateY = isHeightOverFlow ? 0 : -1;
                 break;
             case 'topLeft':
                 // left = pointAtCenter ? middleX - offsetXWithArrow : triggerRect.left;
                 // top = triggerRect.top - SPACING;
                 left = isWidthOverFlow ? (isWrapperWidthOverflow ? containerRect.left : containerRect.right - wrapperRect.width ) : (pointAtCenter ? middleX - offsetXWithArrow + ANO_SPACING : triggerRect.left + ANO_SPACING);
-                // When height overflows, keep Popover inside container (at top edge) instead of positioning it outside
+                // When height overflows, pin popover top to container top so it stays inside the container
                 top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
-                translateY = -1;
+                translateY = isHeightOverFlow ? 0 : -1;
                 break;
             case 'topRight':
                 // left = pointAtCenter ? middleX + offsetXWithArrow : triggerRect.right;
                 // top = triggerRect.top - SPACING;
                 left = isWidthOverFlow ? containerRect.right + offsetWidth : (pointAtCenter ? middleX + offsetXWithArrow + ANO_SPACING : triggerRect.right + ANO_SPACING);
-                // When height overflows, keep Popover inside container (at top edge) instead of positioning it outside
+                // When height overflows, pin popover top to container top so it stays inside the container
                 top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
-                translateY = -1;
+                translateY = isHeightOverFlow ? 0 : -1;
                 translateX = -1;
                 break;
             case 'left':
                 // left = triggerRect.left - SPACING;
                 // top = middleY;
                 // left = isWidthOverFlow? containerRect.right - SPACING : triggerRect.left - SPACING;
-                // When width overflows, keep Popover inside container (at left edge) instead of positioning it outside
+                // When width overflows, pin popover left to container left so it stays inside the container
                 left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
                 top = isHeightOverFlow ? (isTriggerNearTop ? containerRect.top + wrapperRect.height / 2 : containerRect.bottom - wrapperRect.height / 2 + offsetHeight) : middleY + ANO_SPACING;
-                translateX = -1;
+                // Drop the leftward translateX when overflowing so popover does not get pushed outside the left edge
+                translateX = isWidthOverFlow ? 0 : -1;
                 translateY = -0.5;
                 break;
             case 'leftTop':
                 // left = triggerRect.left - SPACING;
                 // top = pointAtCenter ? middleY - offsetYWithArrow : triggerRect.top;
-                // When width overflows, keep Popover inside container (at left edge) instead of positioning it outside
+                // When width overflows, pin popover left to container left so it stays inside the container
                 left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
                 top = isHeightOverFlow ? containerRect.top : (pointAtCenter ? middleY - offsetYWithArrow + ANO_SPACING : triggerRect.top + ANO_SPACING);
-                translateX = -1;
+                translateX = isWidthOverFlow ? 0 : -1;
                 break;
             case 'leftBottom':
                 // left = triggerRect.left - SPACING;
                 // top = pointAtCenter ? middleY + offsetYWithArrow : triggerRect.bottom;
-                // When width overflows, keep Popover inside container (at left edge) instead of positioning it outside
+                // When width overflows, pin popover left to container left so it stays inside the container
                 left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
-                // When height overflows, keep Popover inside container (at bottom edge) instead of positioning it outside
+                // When height overflows, pin popover bottom to container bottom (translateY=-1 keeps it stuck to bottom edge)
                 top = isHeightOverFlow ? containerRect.bottom : (pointAtCenter ? middleY + offsetYWithArrow + ANO_SPACING : triggerRect.bottom + ANO_SPACING);
-                translateX = -1;
+                translateX = isWidthOverFlow ? 0 : -1;
                 translateY = -1;
                 break;
             case 'bottom':
                 // left = middleX;
                 // top = triggerRect.top + triggerRect.height + SPACING;
                 left = isWidthOverFlow ? (isTriggerNearLeft ? containerRect.left + wrapperRect.width / 2 : containerRect.right - wrapperRect.width / 2 + offsetWidth) : middleX + ANO_SPACING;
-                // When height overflows, keep Popover inside container (at bottom edge with translateY=-1 to show upward)
+                // When height overflows, pin popover bottom to container bottom (translateY=-1 stretches it upward inside the container)
                 top = isHeightOverFlow ? containerRect.bottom : triggerRect.top + triggerRect.height + SPACING;
                 translateX = -0.5;
+                translateY = isHeightOverFlow ? -1 : 0;
                 break;
             case 'bottomLeft':
                 // left = pointAtCenter ? middleX - offsetXWithArrow : triggerRect.left;
                 // top = triggerRect.bottom + SPACING;
                 left = isWidthOverFlow ? (isWrapperWidthOverflow ? containerRect.left : containerRect.right - wrapperRect.width ) : (pointAtCenter ? middleX - offsetXWithArrow + ANO_SPACING : triggerRect.left + ANO_SPACING);
-                // When height overflows, keep Popover inside container (at bottom edge with translateY=-1 to show upward)
+                // When height overflows, pin popover bottom to container bottom (translateY=-1 stretches it upward inside the container)
                 top = isHeightOverFlow ? containerRect.bottom : triggerRect.top + triggerRect.height + SPACING;
+                translateY = isHeightOverFlow ? -1 : 0;
                 break;
             case 'bottomRight':
                 // left = pointAtCenter ? middleX + offsetXWithArrow : triggerRect.right;
                 // top = triggerRect.bottom + SPACING;
                 left = isWidthOverFlow ? containerRect.right + offsetWidth : (pointAtCenter ? middleX + offsetXWithArrow + ANO_SPACING : triggerRect.right + ANO_SPACING);
-                // When height overflows, keep Popover inside container (at bottom edge with translateY=-1 to show upward)
+                // When height overflows, pin popover bottom to container bottom (translateY=-1 stretches it upward inside the container)
                 top = isHeightOverFlow ? containerRect.bottom : triggerRect.top + triggerRect.height + SPACING;
                 translateX = -1;
+                translateY = isHeightOverFlow ? -1 : 0;
                 break;
             case 'right':
                 // left = triggerRect.right + SPACING;
                 // top = middleY;
-                // When width overflows, keep Popover inside container (at right edge with translateX=-1 to show leftward)
+                // When width overflows, pin popover right to container right (translateX=-1 stretches it leftward inside the container)
                 left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
                 top = isHeightOverFlow ? (isTriggerNearTop ? containerRect.top + wrapperRect.height / 2 : containerRect.bottom - wrapperRect.height / 2 + offsetHeight) : middleY + ANO_SPACING;
+                translateX = isWidthOverFlow ? -1 : 0;
                 translateY = -0.5;
                 break;
             case 'rightTop':
                 // left = triggerRect.right + SPACING;
                 // top = pointAtCenter ? middleY - offsetYWithArrow : triggerRect.top;
-                // When width overflows, keep Popover inside container (at right edge with translateX=-1 to show leftward)
+                // When width overflows, pin popover right to container right (translateX=-1 stretches it leftward inside the container)
                 left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
                 top = isHeightOverFlow ? containerRect.top : (pointAtCenter ? middleY - offsetYWithArrow + ANO_SPACING : triggerRect.top + ANO_SPACING);
+                translateX = isWidthOverFlow ? -1 : 0;
                 break;
             case 'rightBottom':
                 // left = triggerRect.right + SPACING;
                 // top = pointAtCenter ? middleY + offsetYWithArrow : triggerRect.bottom;
-                // When width overflows, keep Popover inside container (at right edge with translateX=-1 to show leftward)
+                // When width overflows, pin popover right to container right (translateX=-1 stretches it leftward inside the container)
                 left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
-                // When height overflows, keep Popover inside container (at bottom edge) instead of positioning it outside
+                // When height overflows, pin popover bottom to container bottom (translateY=-1 keeps it stuck to bottom edge)
                 top = isHeightOverFlow ? containerRect.bottom : (pointAtCenter ? middleY + offsetYWithArrow + ANO_SPACING : triggerRect.bottom + ANO_SPACING);
+                translateX = isWidthOverFlow ? -1 : 0;
                 translateY = -1;
                 break;
             case 'leftTopOver':
-                left = triggerRect.left - SPACING;
-                top = triggerRect.top - SPACING;
+                // When width overflows, pin popover left to container left (translateX=0 keeps default)
+                left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
+                // When height overflows, pin popover top to container top (translateY=0 keeps default)
+                top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
                 break;
             case 'rightTopOver':
-                left = triggerRect.right + SPACING;
-                top = triggerRect.top - SPACING;
+                // When width overflows, pin popover right to container right (translateX=-1 stretches it leftward inside the container)
+                left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
+                top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
                 translateX = -1;
                 break;
             case 'leftBottomOver':
-                left = triggerRect.left - SPACING;
-                top = triggerRect.bottom + SPACING;
+                left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
+                // When height overflows, pin popover bottom to container bottom (translateY=-1 stretches it upward inside the container)
+                top = isHeightOverFlow ? containerRect.bottom : triggerRect.bottom + SPACING;
                 translateY = -1;
                 break;
             case 'rightBottomOver':
-                left = triggerRect.right + SPACING;
-                top = triggerRect.bottom + SPACING;
+                left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
+                top = isHeightOverFlow ? containerRect.bottom : triggerRect.bottom + SPACING;
                 translateX = -1;
                 translateY = -1;
                 break;

--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -490,7 +490,8 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 // left = middleX;
                 // top = triggerRect.top - SPACING;
                 left = isWidthOverFlow ? (isTriggerNearLeft ? containerRect.left + wrapperRect.width / 2 : containerRect.right - wrapperRect.width / 2 + offsetWidth) : middleX + ANO_SPACING;
-                top = isHeightOverFlow ? containerRect.bottom + offsetHeight : triggerRect.top - SPACING;
+                // When height overflows, keep Popover inside container (at top edge) instead of positioning it outside
+                top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
                 translateX = -0.5;
                 translateY = -1;
                 break;
@@ -498,14 +499,16 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 // left = pointAtCenter ? middleX - offsetXWithArrow : triggerRect.left;
                 // top = triggerRect.top - SPACING;
                 left = isWidthOverFlow ? (isWrapperWidthOverflow ? containerRect.left : containerRect.right - wrapperRect.width ) : (pointAtCenter ? middleX - offsetXWithArrow + ANO_SPACING : triggerRect.left + ANO_SPACING);
-                top = isHeightOverFlow ? containerRect.bottom + offsetHeight : triggerRect.top - SPACING;
+                // When height overflows, keep Popover inside container (at top edge) instead of positioning it outside
+                top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
                 translateY = -1;
                 break;
             case 'topRight':
                 // left = pointAtCenter ? middleX + offsetXWithArrow : triggerRect.right;
                 // top = triggerRect.top - SPACING;
                 left = isWidthOverFlow ? containerRect.right + offsetWidth : (pointAtCenter ? middleX + offsetXWithArrow + ANO_SPACING : triggerRect.right + ANO_SPACING);
-                top = isHeightOverFlow ? containerRect.bottom + offsetHeight : triggerRect.top - SPACING;
+                // When height overflows, keep Popover inside container (at top edge) instead of positioning it outside
+                top = isHeightOverFlow ? containerRect.top : triggerRect.top - SPACING;
                 translateY = -1;
                 translateX = -1;
                 break;
@@ -513,7 +516,8 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 // left = triggerRect.left - SPACING;
                 // top = middleY;
                 // left = isWidthOverFlow? containerRect.right - SPACING : triggerRect.left - SPACING;
-                left = isWidthOverFlow ? containerRect.right + offsetWidth - SPACING + offsetXWithArrow : triggerRect.left - SPACING;
+                // When width overflows, keep Popover inside container (at left edge) instead of positioning it outside
+                left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
                 top = isHeightOverFlow ? (isTriggerNearTop ? containerRect.top + wrapperRect.height / 2 : containerRect.bottom - wrapperRect.height / 2 + offsetHeight) : middleY + ANO_SPACING;
                 translateX = -1;
                 translateY = -0.5;
@@ -521,15 +525,18 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
             case 'leftTop':
                 // left = triggerRect.left - SPACING;
                 // top = pointAtCenter ? middleY - offsetYWithArrow : triggerRect.top;
-                left = isWidthOverFlow ? containerRect.right + offsetWidth - SPACING + offsetXWithArrow : triggerRect.left - SPACING;
+                // When width overflows, keep Popover inside container (at left edge) instead of positioning it outside
+                left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
                 top = isHeightOverFlow ? containerRect.top : (pointAtCenter ? middleY - offsetYWithArrow + ANO_SPACING : triggerRect.top + ANO_SPACING);
                 translateX = -1;
                 break;
             case 'leftBottom':
                 // left = triggerRect.left - SPACING;
                 // top = pointAtCenter ? middleY + offsetYWithArrow : triggerRect.bottom;
-                left = isWidthOverFlow ? containerRect.right + offsetWidth - SPACING + offsetXWithArrow : triggerRect.left - SPACING;
-                top = isHeightOverFlow ? containerRect.bottom + offsetHeight : (pointAtCenter ? middleY + offsetYWithArrow + ANO_SPACING : triggerRect.bottom + ANO_SPACING);
+                // When width overflows, keep Popover inside container (at left edge) instead of positioning it outside
+                left = isWidthOverFlow ? containerRect.left : triggerRect.left - SPACING;
+                // When height overflows, keep Popover inside container (at bottom edge) instead of positioning it outside
+                top = isHeightOverFlow ? containerRect.bottom : (pointAtCenter ? middleY + offsetYWithArrow + ANO_SPACING : triggerRect.bottom + ANO_SPACING);
                 translateX = -1;
                 translateY = -1;
                 break;
@@ -537,40 +544,47 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 // left = middleX;
                 // top = triggerRect.top + triggerRect.height + SPACING;
                 left = isWidthOverFlow ? (isTriggerNearLeft ? containerRect.left + wrapperRect.width / 2 : containerRect.right - wrapperRect.width / 2 + offsetWidth) : middleX + ANO_SPACING;
-                top = isHeightOverFlow ? containerRect.top + offsetYWithArrow - SPACING : triggerRect.top + triggerRect.height + SPACING;
+                // When height overflows, keep Popover inside container (at bottom edge with translateY=-1 to show upward)
+                top = isHeightOverFlow ? containerRect.bottom : triggerRect.top + triggerRect.height + SPACING;
                 translateX = -0.5;
                 break;
             case 'bottomLeft':
                 // left = pointAtCenter ? middleX - offsetXWithArrow : triggerRect.left;
                 // top = triggerRect.bottom + SPACING;
                 left = isWidthOverFlow ? (isWrapperWidthOverflow ? containerRect.left : containerRect.right - wrapperRect.width ) : (pointAtCenter ? middleX - offsetXWithArrow + ANO_SPACING : triggerRect.left + ANO_SPACING);
-                top = isHeightOverFlow ? containerRect.top + offsetYWithArrow - SPACING : triggerRect.top + triggerRect.height + SPACING;
+                // When height overflows, keep Popover inside container (at bottom edge with translateY=-1 to show upward)
+                top = isHeightOverFlow ? containerRect.bottom : triggerRect.top + triggerRect.height + SPACING;
                 break;
             case 'bottomRight':
                 // left = pointAtCenter ? middleX + offsetXWithArrow : triggerRect.right;
                 // top = triggerRect.bottom + SPACING;
                 left = isWidthOverFlow ? containerRect.right + offsetWidth : (pointAtCenter ? middleX + offsetXWithArrow + ANO_SPACING : triggerRect.right + ANO_SPACING);
-                top = isHeightOverFlow ? containerRect.top + offsetYWithArrow - SPACING : triggerRect.top + triggerRect.height + SPACING;
+                // When height overflows, keep Popover inside container (at bottom edge with translateY=-1 to show upward)
+                top = isHeightOverFlow ? containerRect.bottom : triggerRect.top + triggerRect.height + SPACING;
                 translateX = -1;
                 break;
             case 'right':
                 // left = triggerRect.right + SPACING;
                 // top = middleY;
-                left = isWidthOverFlow ? containerRect.left - SPACING + offsetXWithArrow : triggerRect.right + SPACING;
+                // When width overflows, keep Popover inside container (at right edge with translateX=-1 to show leftward)
+                left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
                 top = isHeightOverFlow ? (isTriggerNearTop ? containerRect.top + wrapperRect.height / 2 : containerRect.bottom - wrapperRect.height / 2 + offsetHeight) : middleY + ANO_SPACING;
                 translateY = -0.5;
                 break;
             case 'rightTop':
                 // left = triggerRect.right + SPACING;
                 // top = pointAtCenter ? middleY - offsetYWithArrow : triggerRect.top;
-                left = isWidthOverFlow ? containerRect.left - SPACING + offsetXWithArrow : triggerRect.right + SPACING;
+                // When width overflows, keep Popover inside container (at right edge with translateX=-1 to show leftward)
+                left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
                 top = isHeightOverFlow ? containerRect.top : (pointAtCenter ? middleY - offsetYWithArrow + ANO_SPACING : triggerRect.top + ANO_SPACING);
                 break;
             case 'rightBottom':
                 // left = triggerRect.right + SPACING;
                 // top = pointAtCenter ? middleY + offsetYWithArrow : triggerRect.bottom;
-                left = isWidthOverFlow ? containerRect.left - SPACING + offsetXWithArrow : triggerRect.right + SPACING;
-                top = isHeightOverFlow ? containerRect.bottom + offsetHeight : (pointAtCenter ? middleY + offsetYWithArrow + ANO_SPACING : triggerRect.bottom + ANO_SPACING);
+                // When width overflows, keep Popover inside container (at right edge with translateX=-1 to show leftward)
+                left = isWidthOverFlow ? containerRect.right : triggerRect.right + SPACING;
+                // When height overflows, keep Popover inside container (at bottom edge) instead of positioning it outside
+                top = isHeightOverFlow ? containerRect.bottom : (pointAtCenter ? middleY + offsetYWithArrow + ANO_SPACING : triggerRect.bottom + ANO_SPACING);
                 translateY = -1;
                 break;
             case 'leftTopOver':

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,6 +20682,14 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+null-loader@4.0.1, null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20689,14 +20697,6 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
-
-null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,6 +23226,13 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-dom@^19.0.0:
+  version "19.2.5"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
+  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
+  dependencies:
+    scheduler "^0.27.0"
+
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23499,6 +23506,11 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^19.0.0:
+  version "19.2.5"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
+  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24714,6 +24726,11 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2220

**问题背景：**
当 Popover 组件使用自定义 `getPopupContainer` 属性指定渲染容器时，如果浏览器窗口缩小导致 Popover 内容超出容器边界，溢出检测逻辑会将弹出层定位到容器外部（如 `containerRect.bottom + offsetHeight`），导致 Popover 在视觉上"消失"。

**解决方案：**
修改 `packages/semi-foundation/tooltip/foundation.ts` 中 `calcPosStyle` 方法的溢出处理逻辑。当检测到容器溢出时，将 Popover 定位在容器边缘而非外部，并调整 translate 方向使其向容器内部延伸：

1. **top 系列**：高度溢出时定位在容器顶部边缘，translateY 调整为向下延伸
2. **bottom 系列**：高度溢出时定位在容器底部边缘，translateY 调整为向上延伸  
3. **left 系列**：宽度溢出时定位在容器左边缘，translateX 调整为向右延伸
4. **right 系列**：宽度溢出时定位在容器右边缘，translateX 调整为向左延伸

**审查关注点：**
- 各 position 方向（top/bottom/left/right 及其组合）在容器溢出时的定位计算
- 对应的 translateX/translateY 值调整是否正确

### Changelog
🇨🇳 Chinese
- Fix: 修复 Popover 组件在使用自定义 getPopupContainer 时，浏览器窗口缩小导致弹层消失的问题

---

🇺🇸 English
- Fix: Fixed Popover disappearing when browser window shrinks with custom getPopupContainer


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此问题影响所有基于 Tooltip foundation 的组件，包括 Popover、Tooltip 等。