### PR TITLE
【Auto】Fix: Typography ellipsis.showTooltip not working when text has padding

### DIFF
--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -278,13 +278,26 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
      * By giving the content to the Range object, get the exact width of the content with the help of Range's getBoundingClientRect
      * Not affected by css ellipsis or not
      * https://github.com/DouyinFE/semi-design/issues/1731
+     * https://github.com/DouyinFE/semi-design/issues/2350
      */
     compareSingleRow = () => {
         if (!(document && document.createRange)) {
             return false;
         }
         const containerNode = this.wrapperRef.current;
-        const containerWidth = containerNode.getBoundingClientRect().width;
+        // NOTE:
+        // - For CSS ellipsis, truncation happens in the content box (excluding padding).
+        // - clientWidth excludes border/scrollbar, but includes padding.
+        //   So we use: contentBoxWidth = clientWidth - paddingLeft - paddingRight
+        const containerClientWidth = containerNode.clientWidth;
+        // Get computed style to account for padding
+        // CSS text-overflow: ellipsis truncates text in the content area (excluding padding)
+        // So we need to compare contentWidth with the actual content area width
+        const computedStyle = window.getComputedStyle(containerNode);
+        const paddingLeft = parseFloat(computedStyle.paddingLeft) || 0;
+        const paddingRight = parseFloat(computedStyle.paddingRight) || 0;
+        const contentAreaWidth = Math.max(0, containerClientWidth - paddingLeft - paddingRight);
+        
         const childNodes = Array.from(containerNode.childNodes) as Node[];
         const range = document.createRange();
         const contentWidth = childNodes.reduce((acc: number, node: Node) => {
@@ -292,7 +305,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
             return acc + (range.getBoundingClientRect().width ?? 0);
         }, 0);
         range.detach();
-        return contentWidth > containerWidth;
+        return contentWidth > contentAreaWidth;
     }
 
     showTooltip = () => {
@@ -350,7 +363,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
     }
 
     getEllipsisState = async () => {
-        const { rows, suffix, pos } = this.getEllipsisOpt();
+        const { rows, suffix, pos, showTooltip } = this.getEllipsisOpt();
         const { children, strong } = this.props;
         // wait until element mounted
         if (!this.wrapperRef || !this.wrapperRef.current) {
@@ -360,14 +373,25 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         const { expanded } = this.state;
         const canUseCSSEllipsis = this.canUseCSSEllipsis();
         if (canUseCSSEllipsis) {
-            // const updateOverflow = this.shouldTruncated(rows);
-            // // isOverflowed needs to be updated to show tooltip when using css ellipsis
-            // this.setState({
-            //     isOverflowed: updateOverflow,
-            //     isTruncated: false
-            // });
+            // When using CSS ellipsis, Tooltip wrapper rendering depends on isOverflowed.
+            // If we only update isOverflowed on hover, Tooltip may not be mounted at the
+            // time of the first hover, causing tooltip never to show.
+            //
+            // To avoid the timing issue, proactively compute overflow when showTooltip is enabled.
+            if (showTooltip) {
+                const updateOverflow = this.shouldTruncated(rows);
+                return new Promise<void>(resolve => {
+                    this.setState(
+                        {
+                            isOverflowed: updateOverflow,
+                            isTruncated: false,
+                        },
+                        resolve
+                    );
+                });
+            }
 
-            return ;
+            return;
         }
 
         // If children is null, css/js truncated flag isTruncate is false

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2350

**问题背景：**
当 Typography 组件设置了 `ellipsis.showTooltip` 和 `style.padding` 时，文本虽然显示了省略号，但 hover 时无法展示 tooltip。

**根本原因：**
在 `compareSingleRow()` 方法中，之前使用 `getBoundingClientRect().width` 获取容器宽度，该值包含了 padding。但 CSS 的 `text-overflow: ellipsis` 截断发生在 content box（不包括 padding）。这导致在判断文本是否溢出时，比较基准错误：将文本内容宽度与包含 padding 的容器宽度比较，而不是与实际的内容区域宽度比较，从而导致 `isOverflowed` 状态判断错误，tooltip 无法正常显示。

**解决方案：**
1. 修改 `compareSingleRow()` 方法：改用 `clientWidth` 并减去左右 padding，得到实际的内容区域宽度，再与文本内容宽度进行比较
2. 修改 `getEllipsisState()` 方法：当使用 CSS ellipsis 且 `showTooltip` 启用时，主动计算并更新 `isOverflowed` 状态，避免首次 hover 时 tooltip 未正确挂载的问题

**审查者应关注：**
- `compareSingleRow()` 方法中内容区域宽度的计算逻辑
- `getEllipsisState()` 中对 CSS ellipsis 场景的特殊处理

本次修复涉及 `Typography` 组件的 `ellipsis.showTooltip` 配置项，修复了在有 padding 时该配置无法正常工作的问题，未改变 props 的行为和类型定义。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Typography 组件 ellipsis.showTooltip 在设置 padding 时无法正常显示 tooltip 的问题

---

🇺🇸 English
- Fix: Fixed Typography ellipsis.showTooltip not working when padding is set


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无