### PR TITLE
【Auto】Fix: ArrayField Field initValue not working after conditional remount

### DIFF
--- a/packages/semi-ui/form/hoc/withField.tsx
+++ b/packages/semi-ui/form/hoc/withField.tsx
@@ -128,10 +128,23 @@ function withField<
         try {
             arrayFieldState = useArrayFieldState();
             if (arrayFieldState) {
-                initVal =
-                    arrayFieldState.shouldUseInitValue && typeof initValue !== 'undefined'
-                        ? initValue
-                        : initValueInFormOpts;
+                /**
+                 * In ArrayField, when setValues causes ArrayField re-render, ArrayField will set shouldUseInitValue to false.
+                 * But Field may be conditionally unmounted/remounted later. In that case, if the value in form state is
+                 * still undefined (e.g. API data doesn't provide that key), we should still fall back to initValue.
+                 *
+                 * This keeps behavior consistent with fields outside ArrayField and avoids overriding values
+                 * that were already provided by setValues.
+                 */
+                if (typeof initValue !== 'undefined') {
+                    if (arrayFieldState.shouldUseInitValue) {
+                        initVal = initValue;
+                    } else {
+                        initVal = typeof initValueInFormOpts !== 'undefined' ? initValueInFormOpts : initValue;
+                    }
+                } else {
+                    initVal = initValueInFormOpts;
+                }
             }
         } catch (err) {}
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1849

**问题背景：**
在 ArrayField 中，如果 Field 组件设置了 `initValue` 属性并且有条件显隐，当该 Field 被卸载后重新挂载时，`initValue` 未能正确生效，与 ArrayField 外的 Field 行为不一致。

**根本原因：**
当调用 `formApi.setValues()` 设置表单值时，ArrayField 会将 `shouldUseInitValue` 标记为 false。此时如果 ArrayField 行内某个 Field 因条件显隐被卸载再重新挂载，withField HOC 会重新初始化该 Field。由于 `shouldUseInitValue=false`，原逻辑会直接从 formState 中获取值（`initValueInFormOpts`），但如果 API 数据中未提供该字段，则 `initValueInFormOpts` 为 undefined，导致 Field 既没有使用 formState 的值，也没有回退使用 `initValue` prop。

**解决方案：**
修改 `packages/semi-ui/form/hoc/withField.tsx` 中的 initValue 判断逻辑：
- 当 `shouldUseInitValue=true` 时，优先使用 `props.initValue`
- 当 `shouldUseInitValue=false` 时，如果 formState 中有值（`initValueInFormOpts` 不为 undefined），则使用它；否则回退到使用 `props.initValue`

这样既避免了覆盖 `setValues` 已设置的值，又保证了条件卸载/重挂载时 `initValue` 能够作为兜底值生效，与 ArrayField 外的 Field 行为保持一致。

**审查者应关注：**
- 第 131-146 行的 initValue 判断逻辑是否符合预期
- 该修改不会影响现有的 ArrayField 功能，只是在特定边界情况下补充了回退逻辑

### Changelog
🇨🇳 Chinese
- Fix: 修复 ArrayField 内的 Field 组件在条件显隐卸载后重新挂载时 initValue 未生效的问题

---

🇺🇸 English
- Fix: Fixed ArrayField Field initValue not working after conditional unmount and remount


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此修复保证了 ArrayField 内的 Field 组件在以下场景下的行为一致性：
1. Field 带有 `initValue` 属性
2. Field 有条件显隐逻辑
3. 调用 `formApi.setValues()` 后触发 ArrayField 更新
4. Field 因条件变化被卸载后重新挂载

修改后的行为与 ArrayField 外的普通 Field 保持一致，`initValue` 会作为有效的兜底值使用。