### PR TITLE
Fix: AIChatInput onContentChange drops line break for hardBreak nodes

### DIFF
--- a/packages/semi-foundation/aiChatInput/utils.ts
+++ b/packages/semi-foundation/aiChatInput/utils.ts
@@ -74,11 +74,24 @@ export function transformText(obj: any) {
     };
 }
 
+// hardBreak 来源于 Shift+Enter 软换行，或某些剪贴板 HTML 中的 <br>。
+// 不处理时，单 paragraph + hardBreak 与多 paragraph 在 onContentChange 输出上会不一致（前者丢换行）。
+// hardBreak originates from Shift+Enter soft line breaks, or <br> in some clipboard HTML payloads.
+// Without handling, "single paragraph + hardBreak" and "multiple paragraphs"
+// would yield inconsistent onContentChange output (the former drops the line break).
+export function transformHardBreak() {
+    return {
+        type: 'text',
+        text: '\n',
+    };
+}
+
 export const transformMap = new Map<string, any>([
     ['text', transformText],
     ['selectSlot', transformSelectSlot],
     ['inputSlot', transformInputSlot],
     ['skillSlot', transformSkillSlot],
+    ['hardBreak', transformHardBreak],
 ]);
 
 export function transformJSONResult(input: any, customTransformObj: Map<string, (obj: any) => any> = new Map()) {


### PR DESCRIPTION
<!-- 非常感谢您的 PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR 指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR 类型 (请至少选择一个)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述

本 PR 修复 `AIChatInput` 在计算传给 `onContentChange` / `onMessageSend.inputContents` 的内容时，会静默丢弃 `hardBreak` 节点换行的问题。

**复现**

把同一段多行纯文本从两个不同来源复制粘贴到 `AIChatInput`，仅仅因为不同来源在剪贴板里塞的 HTML 结构不同，相同字符可能产生完全不同的输出：

- 来源 A —— 剪贴板 `text/html` 是 `<p>line1</p><p>line2</p>`（多段落）：`onContentChange` 收到 `[{ type: 'text', text: 'line1\nline2' }]`。✅
- 来源 B —— 剪贴板 `text/html` 是 `<p>line1<br>line2</p>`（单段落 + `<br>`），或者只有 `text/plain` 而被某些 App 渲染成单段落：`onContentChange` 收到 `[{ type: 'text', text: 'line1line2' }]`。❌ 换行丢失。

同样的问题也会发生在用户直接在编辑器里按 `Shift+Enter` 输入软换行的场景。

**根因**

`packages/semi-foundation/aiChatInput/utils.ts` 导出的 `transformMap` 被 `transformJSONResult` 消费，后者同时驱动 `onContentChange` 和 `onMessageSend.inputContents`。`transformMap` 中只声明了 `text`、`selectSlot`、`inputSlot`、`skillSlot` 的 transformer，**唯独没有 `hardBreak`**。ProseMirror 把 `<br>` 和 `Shift+Enter` 都表示为 `hardBreak` 节点，所以遍历时 `transformJSONResult` 的 switch 落到 `default` 分支后拿不到 transformer，直接产出空 result —— 这一节换行就被静默吞掉。段落之间的 `\n` 是由 `paragraph` 分支补的，所以多段落场景仍然正确，唯独「单段落 + `hardBreak`」场景输出错误，这正是用户在实际使用中观察到的不一致。

**修复**

新增一个 `transformHardBreak` transformer，产出 `{ type: 'text', text: '\n' }`，并在 `transformMap` 中以 `hardBreak` 为 key 注册。修复后，无论 ProseMirror 把剪贴板解析成哪种结构，输出都一致；编辑器内的软换行也能保留。

**影响面**

- `AIChatInput` 的 `onContentChange` 回调 —— 文本中 `hardBreak` 节点对应的 `\n` 不再丢失。
- `AIChatInput` 的 `onMessageSend.inputContents` —— 同上（两条路径都共用 `transformJSONResult`）。
- 来自剪贴板 `text/html` 使用 `<br>` 而非多个 `<p>` 的多行文本粘贴。
- 用户在编辑器里按 `Shift+Enter` 输入的软换行。

**不在影响范围内**

- 文件 / 图片粘贴（走 `RichTextInput.handlePaste` 通过 `clipboardData.items` 取 file，从未经过 `transformMap`）。
- `selectSlot` / `inputSlot` / `skillSlot` 的序列化（它们已有的 transformer 一字未改）。
- ProseMirror schema、paste 插件、零宽字符处理、IME、撤销栈 —— 均未改动。

### 更新日志
🇨🇳 Chinese
- 【Fix】修复 `AIChatInput` 在 `onContentChange` / `onMessageSend.inputContents` 中丢失 `hardBreak` 换行符的问题。粘贴同一段多行文本时，剪贴板若提供 `<p>line1<br>line2</p>` 这种「单段落 + 软换行」的 HTML，或用户在编辑器中 `Shift+Enter` 输入软换行，输出都会缺失 `\n`，与「多段落」结构（`<p>line1</p><p>line2</p>`，输出 `line1\nline2`）不一致。新增 `hardBreak` 节点的 transformer，使输出与剪贴板结构无关，软换行也能被保留。

---

🇺🇸 English
- [Fix] Fix `AIChatInput` dropping line breaks for `hardBreak` nodes in `onContentChange` / `onMessageSend.inputContents`. Pasting the same multi-line text could produce inconsistent output depending on whether the clipboard `text/html` was multi-paragraph (`<p>line1</p><p>line2</p>`) or single-paragraph with `<br>` (`<p>line1<br>line2</p>`); the latter — and also `Shift+Enter` soft line breaks — silently lost the `\n`. Add a `hardBreak` transformer so output is consistent regardless of clipboard structure and soft line breaks are preserved.


### 检查清单
- [x] 已增加测试用例或无须增加
- [x] 已补充文档或无须补充
- [x] Changelog 已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息

改动有意保持最小 —— 在 `transformMap` 里只新增了一个 transformer。已有的 `text`、`selectSlot`、`inputSlot`、`skillSlot` 条目一字未改，`transformJSONResult` 的 switch 也未改动，对编辑器 / 粘贴 / schema 层无任何影响。语义层面只有一处变化：`hardBreak` 之前被静默丢弃，现在产出 `\n` —— 变化方向单调，只会"补回缺失的换行"，不会"减少已有的换行"。