### PR TITLE
【Auto】Feat: Add keyboard navigation support for TreeSelect component

### DIFF
--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -24,7 +24,7 @@ import {
 } from '../tree/foundation';
 import { Motion } from '../utils/type';
 import isEnterPress from '../utils/isEnterPress';
-import { ESC_KEY } from '../utils/keyCode';
+import keyCode from '../utils/keyCode';
 
 /* Here ValidateStatus is the same as ValidateStatus in baseComponent */
 export type ValidateStatus = 'error' | 'warning' | 'default';
@@ -174,7 +174,8 @@ export interface BasicTreeSelectInnerData extends Pick<BasicTreeInnerData,
     rePosKey: number;
     dropdownMinWidth: null | number;
     isHovering: boolean;
-    prevProps: BasicTreeSelectProps
+    prevProps: BasicTreeSelectProps;
+    activeKey?: string | null;
 }
 
 export interface TreeSelectAdapter<P = Record<string, any>, S = Record<string, any>> extends DefaultAdapter<P, S> {
@@ -200,7 +201,18 @@ export interface TreeSelectAdapter<P = Record<string, any>, S = Record<string, a
     notifyLoad: (newLoadedKeys: Set<string>, data: BasicTreeNodeData) => void;
     updateInputFocus: (bool: boolean) => void;
     updateLoadKeys: (data: BasicTreeNodeData, resolve: (value?: any) => void) => void;
-    updateIsFocus: (bool: boolean) => void
+    updateIsFocus: (bool: boolean) => void;
+
+    /**
+     * A11y: move focus into the option list container
+     * (e.g. when pressing TAB from the search input)
+     */
+    focusOptionContainer?: () => void;
+
+    /**
+     * Scroll the specific node into view
+     */
+    scrollToNode?: (key: string) => void;
 }
 
 export default class TreeSelectFoundation<P = Record<string, any>, S = Record<string, any>> extends BaseFoundation<TreeSelectAdapter<P, S>, P, S> {
@@ -310,10 +322,199 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
     }
 
     handleKeyDown = (e: any) => {
-        if (e.key === ESC_KEY) {
-            const isOpen = this.getState('isOpen');
-            isOpen && this.close(e);
-        } 
+        const { disabled } = this.getProps();
+        const { isOpen } = this.getStates();
+
+        if (disabled) {
+            return;
+        }
+
+        const key = e.keyCode;
+
+        switch (key) {
+            case keyCode.ESC:
+                isOpen && this.close(e);
+                break;
+            case keyCode.UP:
+                // Prevent Input's cursor from following
+                e.preventDefault();
+                this.handleArrowKeyDown(-1);
+                break;
+            case keyCode.DOWN:
+                // Prevent Input's cursor from following
+                e.preventDefault();
+                this.handleArrowKeyDown(1);
+                break;
+            case keyCode.ENTER:
+                e.preventDefault();
+                this.handleEnterKeyDown(e);
+                break;
+            case keyCode.TAB:
+                this.handleTabKeyDown(e);
+                break;
+            default:
+                break;
+        }
+    }
+
+    /**
+     * A11y: Press TAB in search input to enter tree list
+     */
+    handleTabKeyDown(e: any) {
+        const { isOpen } = this.getStates();
+        // Only handle forward tab when dropdown is open
+        if (!isOpen || e.shiftKey) {
+            return;
+        }
+
+        const target = e.target as HTMLElement;
+        const tagName = target?.tagName?.toLowerCase?.();
+        const isInputLike = tagName === 'input' || tagName === 'textarea';
+        if (!isInputLike) {
+            return;
+        }
+
+        e.preventDefault();
+
+        // Init activeKey if missing
+        const { activeKey, flattenNodes } = this.getStates();
+        if (!activeKey && flattenNodes && flattenNodes.length) {
+            const firstKey = this.getFirstNavigableKey(flattenNodes);
+            if (firstKey) {
+                this._adapter.updateState({ activeKey: firstKey });
+                this.scrollToActiveNode(firstKey);
+            }
+        }
+
+        // Move focus to option container so that next arrow/enter works on tree
+        this._adapter.focusOptionContainer?.();
+    }
+
+    getFirstNavigableKey(flattenNodes: any[]): string | null {
+        if (!flattenNodes || flattenNodes.length === 0) {
+            return null;
+        }
+        for (let i = 0; i < flattenNodes.length; i++) {
+            const node = flattenNodes[i];
+            const treeNodeProps = this.getTreeNodeProps(node.key);
+            if (treeNodeProps && !treeNodeProps.disabled) {
+                return node.key;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Handle arrow key navigation (up/down)
+     * Move the active key through the flatten nodes
+     */
+    handleArrowKeyDown(offset: number) {
+        const { isOpen, activeKey, flattenNodes } = this.getStates();
+        
+        if (!isOpen) {
+            this.open();
+            return;
+        }
+
+        if (!flattenNodes || flattenNodes.length === 0) {
+            return;
+        }
+
+        // Find current index
+        let currentIndex = -1;
+        if (activeKey) {
+            currentIndex = flattenNodes.findIndex((node: any) => node.key === activeKey);
+        }
+
+        // Calculate next index
+        let nextIndex = currentIndex + offset;
+        
+        // Wrap around
+        if (nextIndex < 0) {
+            nextIndex = flattenNodes.length - 1;
+        } else if (nextIndex >= flattenNodes.length) {
+            nextIndex = 0;
+        }
+
+        // Skip disabled nodes
+        const maxIterations = flattenNodes.length;
+        let iterations = 0;
+        while (iterations < maxIterations) {
+            const node = flattenNodes[nextIndex];
+            const treeNodeProps = this.getTreeNodeProps(node.key);
+            
+            // If node is not disabled, use it
+            if (treeNodeProps && !treeNodeProps.disabled) {
+                break;
+            }
+            
+            // Move to next node
+            nextIndex = nextIndex + offset;
+            if (nextIndex < 0) {
+                nextIndex = flattenNodes.length - 1;
+            } else if (nextIndex >= flattenNodes.length) {
+                nextIndex = 0;
+            }
+            iterations++;
+        }
+
+        // Update active key
+        const newActiveKey = flattenNodes[nextIndex]?.key;
+        if (newActiveKey) {
+            this._adapter.updateState({ activeKey: newActiveKey });
+            // Scroll to active node
+            this.scrollToActiveNode(newActiveKey);
+        }
+    }
+
+    /**
+     * Handle Enter key press
+     * - If dropdown is closed, open it
+     * - If active node has children, toggle expand
+     * - If active node is a leaf, select it
+     */
+    handleEnterKeyDown(e: any) {
+        const { isOpen, activeKey, keyEntities } = this.getStates();
+
+        if (!isOpen) {
+            this.open();
+            return;
+        }
+
+        if (!activeKey) {
+            return;
+        }
+
+        const entity = keyEntities[activeKey];
+        if (!entity) {
+            return;
+        }
+
+        const treeNodeProps = this.getTreeNodeProps(activeKey);
+        if (!treeNodeProps || treeNodeProps.disabled) {
+            return;
+        }
+
+        const { data } = entity;
+        const { loadData, keyMaps } = this.getProps();
+        const childrenKey = get(keyMaps, 'children', 'children');
+        const children = get(data, childrenKey);
+        const hasChildren = Array.isArray(children) && children.length > 0;
+
+        // If node has children or loadData is provided, toggle expand
+        if (hasChildren || loadData) {
+            this.handleNodeExpand(e, { ...treeNodeProps, data, children });
+        } else {
+            // Otherwise, select the node
+            this.handleNodeSelect(e, { ...treeNodeProps, data });
+        }
+    }
+
+    /**
+     * Scroll to the active node in the tree
+     */
+    scrollToActiveNode(activeKey: string) {
+        this._adapter.scrollToNode?.(activeKey);
     }
 
     getTreeNodeProps(key: string) {

--- a/packages/semi-ui/tree/treeContext.tsx
+++ b/packages/semi-ui/tree/treeContext.tsx
@@ -41,7 +41,8 @@ export interface TreeContextValue {
     renderFullLabel?: (renderFullLabelProps: RenderFullLabelProps) => React.ReactNode;
     dragOverNodeKey?: string | string[];
     dropPosition?: number | null;
-    labelEllipsis?: boolean | Virtualize
+    labelEllipsis?: boolean | Virtualize;
+    activeKey?: string | null;
 }
 
 const TreeContext = React.createContext<TreeContextValue>(null);

--- a/packages/semi-ui/tree/treeNode.tsx
+++ b/packages/semi-ui/tree/treeNode.tsx
@@ -379,7 +379,8 @@ export default class TreeNode extends PureComponent<TreeNodeProps, TreeNodeState
             [`${prefixcls}-collapsed`]: !expanded,
             [`${prefixcls}-disabled`]: Boolean(disabled),
             [`${prefixcls}-selected`]: selected,
-            [`${prefixcls}-active`]: !multiple && active,
+            // A11y: show active indicator for keyboard navigation in both single & multiple modes
+            [`${prefixcls}-active`]: active,
             [`${prefixcls}-ellipsis`]: labelEllipsis,
             [`${prefixcls}-drag-over`]: !disabled && dragOver,
             [`${prefixcls}-draggable`]: !disabled && draggable && !renderFullLabel,

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -173,7 +173,8 @@ export interface TreeSelectState extends Omit<BasicTreeSelectInnerData, Override
     dropdownMinWidth: null | number;
     isHovering: boolean;
     prevProps: TreeSelectProps;
-    isFocus: boolean
+    isFocus: boolean;
+    activeKey?: string | null;
 }
 
 const prefixcls = cssClasses.PREFIX;
@@ -356,6 +357,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             cachedKeyValuePairs: {},
             loadedKeys: new Set(),
             loadingKeys: new Set(),
+            activeKey: null,
         };
         this.inputRef = React.createRef();
         this.tagInputRef = React.createRef();
@@ -697,6 +699,21 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             ...filterAdapter,
             ...treeSelectAdapter,
             ...treeAdapter,
+            focusOptionContainer: () => {
+                const optionsDom = this.optionContainerEl?.current;
+                // make popover content focusable so it can receive keyboard events
+                optionsDom?.focus?.();
+            },
+            scrollToNode: (key: string) => {
+                const optionsDom = this.optionContainerEl?.current;
+                if (!optionsDom) {
+                    return;
+                }
+                // Escape for attribute selector: keep it minimal & safe
+                const escaped = String(key).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+                const el = optionsDom.querySelector(`[data-key="${escaped}"]`) as HTMLElement;
+                el?.scrollIntoView?.({ block: 'nearest' });
+            },
             updateLoadKeys: (data, resolve) => {
                 this.setState(({ loadedKeys, loadingKeys }) =>
                     this.foundation.handleNodeLoad(loadedKeys, loadingKeys, data, resolve));
@@ -813,7 +830,14 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const style = { minWidth: dropdownMinWidth, ...dropdownStyle };
         const popoverCls = cls(dropdownClassName, `${prefixcls}-popover`);
         return (
-            <div className={popoverCls} style={style} onKeyDown={this.foundation.handleKeyDown} ref={this.optionContainerEl}>
+            <div
+                className={popoverCls}
+                style={style}
+                // Make container focusable for keyboard navigation
+                tabIndex={-1}
+                onKeyDown={this.foundation.handleKeyDown}
+                ref={this.optionContainerEl}
+            >
                 {this.renderTree()}
             </div>
         );
@@ -1265,6 +1289,9 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                 maxTagCount={maxTagCount}
                 disabled={disabled}
                 onInputChange={v => this.search(v)}
+                // In multiple mode, the search input is inside TagInput.
+                // Forward key events so TreeSelect can handle a11y navigation (Tab/Arrow/Enter/Esc).
+                onKeyDown={this.foundation.handleKeyDown}
                 ref={this.tagInputRef}
                 placeholder={placeholder}
                 value={triggerRenderKeys}
@@ -1410,6 +1437,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
 
     renderTreeNode = (treeNode: FlattenNode, ind: number, style: React.CSSProperties) => {
         const { data, key } = treeNode;
+        const { activeKey } = this.state;
         const treeNodeProps = this.foundation.getTreeNodeProps(key);
         const { showLine } = this.props;
         if (!treeNodeProps) {
@@ -1419,6 +1447,10 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const { keyMaps, expandIcon } = this.props;
         const children = data[get(keyMaps, 'children', 'children')];
         !isUndefined(children) && (props.children = children);
+        
+        // Add active state
+        const isActive = activeKey === key;
+        
         return <TreeNode 
             {...treeNodeProps} 
             {...data} 
@@ -1427,6 +1459,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             style={style} 
             showLine={showLine}
             expandIcon={expandIcon}
+            active={isActive}
         />;
     };
 
@@ -1490,7 +1523,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
     };
 
     renderTree = () => {
-        const { keyEntities, motionKeys, motionType, inputValue, filteredKeys, flattenNodes, checkedKeys, realCheckedKeys } = this.state;
+        const { keyEntities, motionKeys, motionType, inputValue, filteredKeys, flattenNodes, checkedKeys, realCheckedKeys, activeKey } = this.state;
         const {
             loadData,
             filterTreeNode,
@@ -1542,6 +1575,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                     renderLabel,
                     renderFullLabel,
                     labelEllipsis: typeof labelEllipsis === 'undefined' ? virtualize : labelEllipsis,
+                    activeKey,
                 }}
             >
                 <div className={wrapperCls}>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1424

本 PR 为 TreeSelect 组件新增了完整的键盘导航功能，提升了组件的可访问性（A11y）。

**背景问题：**
原 TreeSelect 组件缺少键盘导航支持，用户无法通过键盘在树节点之间导航，影响了可访问性和用户体验。

**解决方案：**
在 TreeSelect 组件的 foundation 层和组件层实现了完整的键盘导航逻辑：

1. **TAB 键支持**：在搜索框中按下 TAB 键可以将焦点移入树列表容器，自动激活第一个可用的节点
2. **上下箭头键导航**：支持使用 Up/Down 箭头键在树节点之间导航，自动跳过禁用节点，并在列表边界自动循环
3. **ENTER 键操作**：按下 ENTER 键可以展开有子节点的节点，或选择叶子节点
4. **ESC 键关闭**：保留了原有的 ESC 键关闭下拉面板功能

**技术实现：**
- 新增 `activeKey` 状态用于跟踪当前激活的节点
- 下拉容器添加 `tabIndex={-1}` 使其可接收键盘事件
- 实现了自动滚动到激活节点的功能
- 在多选模式下正确转发键盘事件

**审查者关注点：**
- 键盘导航逻辑的正确性，特别是在有 disabled 节点时的跳过逻辑
- 上下箭头键在列表边界时的循环行为是否符合预期
- 多选模式和单选模式下的键盘事件处理是否一致

### Changelog
🇨🇳 Chinese
- Feat: TreeSelect 组件新增键盘导航功能，支持 TAB 键从搜索框进入树列表、Up/Down 箭头键导航节点、Enter 键展开/选择节点

---

🇺🇸 English
- Feat: Added keyboard navigation support to TreeSelect component, including TAB key to enter tree from search input, Up/Down arrow keys to navigate nodes, and Enter key to expand/select nodes


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
本实现参考了 Select 组件的键盘导航逻辑，保持了组件间交互的一致性。功能已在 playground 中进行了测试验证，包括：
- 单选和多选模式下的键盘导航
- 禁用节点的跳过逻辑
- 多层嵌套树结构的导航
- 搜索过滤后的键盘导航