### PR TITLE
Fix: correct DragMove handler/constrainer types from ReactNode to HTMLElement

### DIFF
--- a/content/plus/dragMove/index-en-US.md
+++ b/content/plus/dragMove/index-en-US.md
@@ -222,10 +222,10 @@ function CustomMove() {
 | Property | Description | Type | Default value |
 | --- | --- | --- | ----- |
 | allowInputDrag | Whether to allow dragging when clicking on native input/textarea | boolean | false |
-| allowMove | Determine whether dragging is allowed when clicking/touching. | (event: TouchEvent \|MouseEvent, element: ReactNode) => boolean | - |
-| constrainer | Returns the element that limits the draggable range. | () => ReactNode \| 'parent' | - |
-| customMove | Customize position processing after dragging| (element: ReactNode, top: number, left: number) => void | -|
-| handler | Returns the element that triggers dragging. | () => ReactNode | - |
+| allowMove | Determine whether dragging is allowed when clicking/touching. | (event: TouchEvent \| MouseEvent, element: HTMLElement) => boolean | - |
+| constrainer | Returns the element that limits the draggable range. | () => HTMLElement \| 'parent' | - |
+| customMove | Customize position processing after dragging| (element: HTMLElement, top: number, left: number) => void | -|
+| handler | Returns the element that triggers dragging. | () => HTMLElement | - |
 | onMouseDown | Callback when mouse is pressed | (e: MouseEvent) => void | - |
 | onMouseMove | Callback when mouse moves | (e: MouseEvent) => void | - |
 | onMouseUp | Callback when mouse is raised | (e: MouseEvent) => void | - |

--- a/content/plus/dragMove/index.md
+++ b/content/plus/dragMove/index.md
@@ -223,10 +223,10 @@ function CustomMove() {
 | 属性 | 说明 | 类型 | 默认值 |
 | --- | --- | --- | ----- |
 | allowInputDrag | 点击原生 input/textarea 时是否允许拖动 | boolean | false |
-| allowMove | 点击/触摸时是否允许拖动的判断函数 | (event: TouchEvent \|MouseEvent, element: ReactNode) => boolean | - |
-| constrainer | 返回限制可拖拽的范围的元素 | () => ReactNode | - |
-| customMove | 自定义拖动后的位置处理| (element: ReactNode, top: number, left: number) => void | -|
-| handler | 返回触发拖动的元素 | () => ReactNode | - |
+| allowMove | 点击/触摸时是否允许拖动的判断函数 | (event: TouchEvent \| MouseEvent, element: HTMLElement) => boolean | - |
+| constrainer | 返回限制可拖拽的范围的元素 | () => HTMLElement \| 'parent' | - |
+| customMove | 自定义拖动后的位置处理| (element: HTMLElement, top: number, left: number) => void | -|
+| handler | 返回触发拖动的元素 | () => HTMLElement | - |
 | onMouseDown | 鼠标按下时的回调 | (e: MouseEvent) => void | - |
 | onMouseMove | 鼠标移动时的回调 | (e: MouseEvent) => void | - |
 | onMouseUp | 鼠标抬起时的回调 | (e: MouseEvent) => void | - |

--- a/packages/semi-ui/dragMove/index.ts
+++ b/packages/semi-ui/dragMove/index.ts
@@ -8,9 +8,9 @@ import { resolveDOM, getRef } from '../_utils/reactRender';
 
 export interface DragMoveProps {
     // The element that triggers the drag event，default is element
-    handler?: () => ReactNode;
+    handler?: () => HTMLElement;
     // The element that constrains the movement range, This element requires relative positioning
-    constrainer?: () => ReactNode | 'parent';
+    constrainer?: () => HTMLElement | 'parent';
     children?: ReactNode | undefined | any;
     onMouseDown?: (e: MouseEvent) => void;
     onMouseMove?: (e: MouseEvent) => void;
@@ -33,6 +33,9 @@ export default class DragMove extends BaseComponent<DragMoveProps> {
         handler: PropTypes.func,
         allowInputDrag: PropTypes.bool,
         constrainNode: PropTypes.func,
+        constrainer: PropTypes.oneOfType([PropTypes.func, PropTypes.oneOf(['parent'])]),
+        allowMove: PropTypes.func,
+        customMove: PropTypes.func,
         onMouseDown: PropTypes.func,
         onMouseMove: PropTypes.func,
         onMouseUp: PropTypes.func,


### PR DESCRIPTION
<!-- 非常感谢您的 PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR 指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR 类型 (请至少选择一个)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR 描述

本 PR 修复 `DragMove` 组件中 `handler` / `constrainer` 等 prop 的类型与文档描述错误地标注为 `ReactNode`，但底层 foundation 实际消费的是 DOM 元素的问题。

**现状**

`packages/semi-ui/dragMove/index.ts` 与中英文文档（`content/plus/dragMove/index.md` / `index-en-US.md`）中：

- `handler?: () => ReactNode`
- `constrainer?: () => ReactNode | 'parent'`
- 文档里 `customMove` / `allowMove` 的 element 参数也被写成 `ReactNode`（TS 类型本身已经是 `HTMLElement`，仅文档错）

**根因**

`packages/semi-foundation/dragMove/foundation.ts` 中所有这些值都是按真实 DOM 元素消费的：

\`\`\`ts
this.handler.style.cursor = 'move';
this.handler.addEventListener('mousedown', this.onMouseDown);
this.handler.addEventListener('touchstart', this.onTouchStart);
this.constrainer.offsetWidth;
this.constrainer.offsetHeight;
\`\`\`

`DragMoveAdapter` 中的相应 getter 也都声明为 `() => HTMLElement` / `() => HTMLElement | null`。组件内部的 demo 同样是把 ref（`handlerRef.current`、`containerRef.current`）作为返回值传入，本质都是 DOM 节点，而不是 `ReactNode`。

把 prop 类型标成 `ReactNode` 在语义上是错的，会误导用户在 `handler` 里返回 JSX —— 这种用法在运行时会立刻抛错（`undefined.style` / `undefined.addEventListener`）。

**修复**

- `packages/semi-ui/dragMove/index.ts`
  - `handler`：`() => ReactNode` → `() => HTMLElement`
  - `constrainer`：`() => ReactNode | 'parent'` → `() => HTMLElement | 'parent'`
  - `propTypes` 补全此前缺失的 `constrainer` / `allowMove` / `customMove`
- `content/plus/dragMove/index.md` / `index-en-US.md`
  - `handler`：`() => ReactNode` → `() => HTMLElement`
  - `constrainer`：`() => ReactNode` / `() => ReactNode \| 'parent'` → `() => HTMLElement \| 'parent'`
  - `customMove`：元素参数 `ReactNode` → `HTMLElement`（与 TS 类型对齐）
  - `allowMove`：元素参数 `ReactNode` → `HTMLElement`（与 TS 类型对齐）

**影响面**

- 仅修正类型声明与文档，foundation / 运行时行为完全不变，对组件用户无 break：以前被标成 `ReactNode` 的，运行时都是按 `HTMLElement` 实际工作的，新类型只是把这件事从「文档/.d.ts 错配运行时」纠正为「文档/.d.ts 与运行时一致」。
- 用户侧若此前为了配合错误的类型声明特意用 `as any` 绕过，可以删除这些断言；若此前在 `handler` 里直接返回 JSX，那本来就是运行时坏的，新类型现在能在编译期把这个错误暴露出来。

**不在影响范围内**

- `DragMove` 的 foundation、运行时拖拽逻辑、事件绑定、`customMove` / `allowMove` 的实际签名（这两个 TS 类型本来就是 `HTMLElement`，只是文档错）。
- 其他组件的类型 / 文档。

### 更新日志
🇨🇳 Chinese
- 【Fix】修正 `DragMove` 的 `handler` / `constrainer` prop 在 TS 类型声明里被错标为 `() => ReactNode` 的问题，改为正确的 `() => HTMLElement` / `() => HTMLElement \| 'parent'`，与底层 foundation 实际消费 DOM 元素的行为对齐。
- 【Docs】修正中英文文档中 `handler` / `constrainer` / `customMove` / `allowMove` 四个 API 的元素类型从 `ReactNode` 改为 `HTMLElement`。
- 【Chore】补全 `DragMove` 中 `constrainer` / `allowMove` / `customMove` 缺失的 `propTypes` 声明。

---

🇺🇸 English
- [Fix] Correct `DragMove` `handler` / `constrainer` prop type from `() => ReactNode` to `() => HTMLElement` / `() => HTMLElement | 'parent'`, matching the foundation that actually consumes them as DOM nodes.
- [Docs] Update Chinese / English docs so the `handler` / `constrainer` / `customMove` / `allowMove` element types are documented as `HTMLElement` instead of `ReactNode`.
- [Chore] Add missing `propTypes` entries for `constrainer` / `allowMove` / `customMove` on `DragMove`.


### 检查清单
- [x] 已增加测试用例或无须增加
- [x] 已补充文档或无须补充
- [x] Changelog 已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息

改动严格限定在「TS 类型 + 文档 + propTypes」三个层面，没有触碰 `packages/semi-foundation/dragMove/foundation.ts` 与组件运行时逻辑。运行时行为前后完全一致，只是把类型声明纠正回它一直以来真正在做的事。