### PR TITLE
【Auto】Fix: JsonViewer cursor position incorrect after multi-line replacement

### DIFF
--- a/packages/semi-json-viewer-core/src/model/jsonModel.ts
+++ b/packages/semi-json-viewer-core/src/model/jsonModel.ts
@@ -135,9 +135,37 @@ export class JSONModel {
             this.lastChangeBufferPos = op.keepPosition;
             return;
         }
+
+        const getEndPosition = (
+            startLineNumber: number,
+            startColumn: number,
+            text: string
+        ): { lineNumber: number; column: number } => {
+            // Handle LF/CRLF/CR consistently
+            const parts = text.split(/\r\n|\r|\n/);
+            const lineBreakCount = parts.length - 1;
+
+            if (lineBreakCount === 0) {
+                return {
+                    lineNumber: startLineNumber,
+                    column: startColumn + text.length,
+                };
+            }
+
+            return {
+                lineNumber: startLineNumber + lineBreakCount,
+                // After a line break, column is based on the last line segment
+                column: parts[parts.length - 1].length + 1,
+            };
+        };
+
         switch (op.type) {
             case 'insert':
-                this.lastChangeBufferPos.column += op.newText.length;
+                this.lastChangeBufferPos = getEndPosition(
+                    op.range.startLineNumber,
+                    op.range.startColumn,
+                    op.newText
+                );
                 break;
             case 'delete':
                 if (this.lastChangeBufferPos.column === 1) {
@@ -150,10 +178,11 @@ export class JSONModel {
                 }
                 break;
             case 'replace':
-                const newLineNumber = op.range.startLineNumber;
-                const newColumn = op.range.startColumn + op.newText.length;
-                this.lastChangeBufferPos.lineNumber = newLineNumber;
-                this.lastChangeBufferPos.column = newColumn;
+                this.lastChangeBufferPos = getEndPosition(
+                    op.range.startLineNumber,
+                    op.range.startColumn,
+                    op.newText
+                );
                 break;
         }
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2908

**问题背景**：JsonViewer 组件在进行多行文本的插入或替换操作时，`updateLastChangeBufferPos` 方法计算光标位置时假设新文本都在同一行，没有考虑 `newText` 中可能包含换行符的情况，导致光标定位不正确。

**解决方案**：修改 `jsonModel.ts` 中 `updateLastChangeBufferPos` 方法的 `insert` 和 `replace` 分支，增加对换行符的处理：
1. 统计 `newText` 中的换行符数量
2. 如果存在换行符，正确计算光标所在的行号和列号

**审查关注点**：光标位置计算逻辑的正确性，特别是多行文本边界情况的处理。

### Changelog
🇨🇳 Chinese
- Fix: 修复 JsonViewer 组件多行替换/插入操作时光标位置计算不正确的问题

---

🇺🇸 English
- Fix: Fixed incorrect cursor position calculation in JsonViewer component during multi-line replacement/insertion operations


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无