### PR TITLE
【Auto】Feat: Add independent knob background color variables for Switch component's checked/unchecked states

### DIFF
--- a/packages/semi-foundation/switch/switch.scss
+++ b/packages/semi-foundation/switch/switch.scss
@@ -43,6 +43,7 @@ $module: #{$prefix}-switch;
 
         .#{$module}-knob {
             transform: translateX($spacing-switch_checked-translateX);
+            background-color: $color-switch_knob-bg-checked;
         }
 
         &:active {

--- a/packages/semi-foundation/switch/variables.scss
+++ b/packages/semi-foundation/switch/variables.scss
@@ -30,7 +30,8 @@ $color-switch_disabled-border-default: var(--semi-color-border); // 禁用态开
 $color-switch_disabled-bg-hover: transparent; // 禁用态开关背景色 - 悬浮
 $color-switch_checked_disabled-bg-default: var(--semi-color-success-disabled); // 禁用开启态开关背景颜色
 $color-switch_checked_disabled-border-default: transparent; // 禁用开启态开关描边颜色
-$color-switch_knob-bg-default: rgba(var(--semi-white), 1); // 开关滑块背景颜色
+$color-switch_knob-bg-default: rgba(var(--semi-white), 1); // 开关滑块背景颜色 - 关闭态
+$color-switch_knob-bg-checked: rgba(var(--semi-white), 1); // 开关滑块背景颜色 - 开启态
 $color-switch_knob-border-default: var(--semi-color-border); // 开关滑块描边颜色
 $color-switch_checked-text-default: var(--semi-color-white); // 开启态开关文案颜色
 $color-switch_unchecked-text-default: var(--semi-color-text-2); // 关闭态开关文案颜色


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2635

**问题背景：**
Switch 组件的开关按钮背景颜色之前只有一个变量 `$color-switch_knob-bg-default`，无法分别控制开启态和关闭态的背景颜色。用户反馈希望能够独立控制这两种状态下的按钮颜色，以满足更灵活的设计需求。

**解决方案：**
1. 在 `packages/semi-foundation/switch/variables.scss` 中新增变量 `$color-switch_knob-bg-checked`，用于控制开关按钮在开启状态下的背景颜色
2. 更新原变量 `$color-switch_knob-bg-default` 的注释，明确其用于关闭态
3. 在 `packages/semi-foundation/switch/switch.scss` 中，为开启状态的按钮应用新的背景颜色变量

**审查要点：**
- 新增的 CSS 变量命名遵循现有规范（`$color-switch_knob-bg-checked`）
- 默认值与原变量保持一致，确保向后兼容
- 仅修改了 SCSS 文件，无需更新 TypeScript 类型定义

### Changelog
🇨🇳 Chinese
- Feat: Switch 组件新增 `$color-switch_knob-bg-checked` CSS 变量，支持独立控制开关按钮在开启和关闭状态下的背景颜色

---

🇺🇸 English
- Feat: Added `$color-switch_knob-bg-checked` CSS variable to Switch component, allowing independent control of knob background color in checked and unchecked states


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此功能通过新增 CSS 变量实现，用户可以通过自定义 `$color-switch_knob-bg-default` 和 `$color-switch_knob-bg-checked` 变量来分别设置关闭态和开启态的开关按钮背景颜色。设计变量的文档页面会自动展示新增的变量，无需手动更新文档。