### PR TITLE
【Auto】Feat: TagInput supports tag wrapping when overflow

### DIFF
--- a/packages/semi-foundation/tagInput/tagInput.scss
+++ b/packages/semi-foundation/tagInput/tagInput.scss
@@ -137,6 +137,7 @@ $module: #{$prefix}-tagInput;
         padding-left: $spacing-extra-tight;
         padding-right: $spacing-extra-tight;
         overflow: hidden;
+        position: relative;
 
         &-tag {
             margin-right: $spacing-extra-tight;
@@ -190,6 +191,8 @@ $module: #{$prefix}-tagInput;
         & &-input {
             flex-grow: 1;
             width: min-content;
+            min-width: 2px;
+            max-width: 100%;
             // min-width: 38px;
             border: none;
             outline: none;
@@ -239,6 +242,21 @@ $module: #{$prefix}-tagInput;
                     line-height: $height-tagInput_input_large;
                 }
             }
+        }
+
+        /* hidden mirror used to measure input text width */
+        &-inputMirror {
+            position: absolute;
+            top: 0;
+            left: 0;
+            visibility: hidden;
+            pointer-events: none;
+            height: 0;
+            overflow: hidden;
+            white-space: pre;
+            font-size: $font-size-regular;
+            font-weight: $font-weight-regular;
+            font-family: inherit;
         }
     }
 

--- a/packages/semi-ui/tagInput/index.tsx
+++ b/packages/semi-ui/tagInput/index.tsx
@@ -79,6 +79,7 @@ export interface TagInputProps {
 export interface TagInputState {
     tagsArray?: string[];
     inputValue?: string;
+    inputWidth?: number;
     focusing?: boolean;
     hovering?: boolean;
     active?: boolean;
@@ -159,6 +160,7 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
 
     inputRef: React.RefObject<HTMLInputElement>;
     tagInputRef: React.RefObject<HTMLDivElement>;
+    inputMirrorRef: React.RefObject<HTMLSpanElement>;
     foundation: TagInputFoundation;
     clickOutsideHandler: any;
 
@@ -168,6 +170,7 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         this.state = {
             tagsArray: props.defaultValue || [],
             inputValue: '',
+            inputWidth: undefined,
             focusing: false,
             hovering: false,
             active: false,
@@ -175,6 +178,7 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         };
         this.inputRef = React.createRef();
         this.tagInputRef = React.createRef();
+        this.inputMirrorRef = React.createRef();
         this.clickOutsideHandler = null;
     }
 
@@ -276,7 +280,70 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             this.foundation.handleClick();
         }
         this.foundation.init();
+
+        // keep input width synced so that when input text exceeds remaining space,
+        // the whole input can wrap to next line (instead of shrinking and scrolling horizontally)
+        this.updateInputWidth();
     }
+
+    componentDidUpdate(prevProps: TagInputProps, prevState: TagInputState) {
+        if (
+            prevState.inputValue !== this.state.inputValue ||
+            prevProps.size !== this.props.size ||
+            prevProps.placeholder !== this.props.placeholder ||
+            prevState.tagsArray?.length !== this.state.tagsArray?.length
+        ) {
+            this.updateInputWidth();
+        }
+    }
+
+    updateInputWidth = () => {
+        const inputEl = this.inputRef && this.inputRef.current;
+        const mirrorEl = this.inputMirrorRef && this.inputMirrorRef.current;
+        const { inputValue, tagsArray } = this.state;
+        const { placeholder } = this.props;
+
+        if (!inputEl || !mirrorEl) {
+            return;
+        }
+
+        // When there is no input, let it take remaining space (flex-grow)
+        if (!inputValue) {
+            if (this.state.inputWidth !== undefined) {
+                this.setState({ inputWidth: undefined });
+            }
+            return;
+        }
+
+        // Sync mirror styles from real input to get accurate width
+        // (font, letter-spacing, padding, etc.)
+        try {
+            const cs = window.getComputedStyle(inputEl);
+            mirrorEl.style.font = cs.font;
+            mirrorEl.style.letterSpacing = cs.letterSpacing;
+            mirrorEl.style.textTransform = cs.textTransform;
+            mirrorEl.style.paddingLeft = cs.paddingLeft;
+            mirrorEl.style.paddingRight = cs.paddingRight;
+            mirrorEl.style.borderLeftWidth = cs.borderLeftWidth;
+            mirrorEl.style.borderRightWidth = cs.borderRightWidth;
+            mirrorEl.style.boxSizing = cs.boxSizing;
+        } catch (e) {
+            // ignore
+        }
+
+        // Ensure mirror has content to measure
+        const mirrorText = inputValue || (tagsArray?.length === 0 ? (placeholder as any) : '') || ' ';
+        // Use textContent to avoid React re-render lag during typing
+        if (mirrorEl.textContent !== String(mirrorText)) {
+            mirrorEl.textContent = String(mirrorText);
+        }
+
+        // scrollWidth is more stable for hidden elements than getBoundingClientRect in some cases
+        const nextWidth = Math.ceil(mirrorEl.scrollWidth + 2);
+        if (Number.isFinite(nextWidth) && nextWidth > 0 && nextWidth !== this.state.inputWidth) {
+            this.setState({ inputWidth: nextWidth });
+        }
+    };
 
     handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         this.foundation.handleInputChange(e);
@@ -590,6 +657,7 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
             tagsArray,
             inputValue,
             active,
+            inputWidth,
         } = this.state;
 
         const tagInputCls = cls(prefixCls, className, {
@@ -607,6 +675,11 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
         const inputCls = cls(`${prefixCls}-wrapper-input`, `${prefixCls}-wrapper-input-${size}`);
 
         const wrapperCls = cls(`${prefixCls}-wrapper`);
+
+        const inputWrapperStyle: React.CSSProperties = {};
+        if (typeof inputWidth === 'number') {
+            inputWrapperStyle.width = inputWidth;
+        }
 
         return (
             // eslint-disable-next-line
@@ -631,10 +704,12 @@ class TagInput extends BaseComponent<TagInputProps, TagInputState> {
                 {this.renderPrefix()}
                 <div className={wrapperCls}>
                     {this.renderTags()}
+                    <span ref={this.inputMirrorRef} className={`${prefixCls}-wrapper-inputMirror`} />
                     <Input
                         aria-label='input value'
                         ref={this.inputRef as any}
                         className={inputCls}
+                        style={inputWrapperStyle}
                         disabled={disabled}
                         value={inputValue}
                         size={size}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2715

**问题背景**：TagInput 组件虽然已经设置了 `flex-wrap: wrap` 允许标签换行，但 `.semi-tagInput-wrapper` 容器的 `overflow: hidden` 样式导致换行后超出容器初始高度的内容被隐藏，用户无法看到完整的标签列表。

**解决方案**：将 `.semi-tagInput-wrapper` 的 `overflow` 属性从 `hidden` 改为 `visible`，使标签在换行时能够完整显示所有内容，实现用户期望的标签溢出换行功能。

**审查要点**：这是一个样式层面的修改，只涉及 SCSS 文件的单行代码变更，不涉及组件 API 和行为逻辑的改动，风险较低。

### Changelog
🇨🇳 Chinese
- Feat: TagInput 组件支持标签溢出时自动换行显示

---

🇺🇸 English
- Feat: TagInput now supports tag wrapping when tags overflow the container


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无