### PR TITLE
【Auto】Fix: JsonViewer autoWrap mode not updating correctly on container resize

### DIFF
--- a/packages/semi-ui/jsonViewer/index.tsx
+++ b/packages/semi-ui/jsonViewer/index.tsx
@@ -89,6 +89,9 @@ class JsonViewerCom extends BaseComponent<JsonViewerProps, JsonViewerState> {
     private searchInputRef: React.RefObject<HTMLInputElement>;
     private replaceInputRef: React.RefObject<HTMLInputElement>;
     private isComposing: boolean = false;
+    private resizeObserver: ResizeObserver | null = null;
+    private resizeRafId: number | null = null;
+    private lastObservedWidth: number | null = null;
 
     foundation: JsonViewerFoundation;
 
@@ -111,12 +114,87 @@ class JsonViewerCom extends BaseComponent<JsonViewerProps, JsonViewerState> {
 
     componentDidMount() {
         this.foundation.init();
+        this.setupResizeObserver();
+    }
+
+    private teardownResizeObserver() {
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
+        if (this.resizeRafId !== null) {
+            cancelAnimationFrame(this.resizeRafId);
+            this.resizeRafId = null;
+        }
+        this.lastObservedWidth = null;
+    }
+
+    private setupResizeObserver() {
+        // Only needed for autoWrap, since line wraps depend on container width.
+        if (!this.props.options?.autoWrap) {
+            this.teardownResizeObserver();
+            return;
+        }
+
+        const el = this.editorRef.current;
+        if (!el || typeof ResizeObserver === 'undefined') {
+            return;
+        }
+
+        // Avoid duplicated observers when re-init.
+        this.teardownResizeObserver();
+
+        this.lastObservedWidth = el.getBoundingClientRect().width;
+        this.resizeObserver = new ResizeObserver((entries) => {
+            const entry = entries && entries[0];
+            if (!entry) {
+                return;
+            }
+            const nextWidth = entry.contentRect?.width;
+            if (typeof nextWidth !== 'number') {
+                return;
+            }
+
+            // Only react to width changes, which affect wrapping.
+            if (this.lastObservedWidth !== null && Math.abs(nextWidth - this.lastObservedWidth) < 0.5) {
+                return;
+            }
+            this.lastObservedWidth = nextWidth;
+
+            // Coalesce multiple resize events.
+            if (this.resizeRafId !== null) {
+                cancelAnimationFrame(this.resizeRafId);
+            }
+            this.resizeRafId = requestAnimationFrame(() => {
+                this.resizeRafId = null;
+
+                // Clear measured heights cache when container size changes.
+                // NOTE: _view and _measuredHeights are internal implementation details.
+                const jsonViewer: any = this.foundation.jsonViewer;
+                if (jsonViewer && jsonViewer._view && jsonViewer._view._measuredHeights) {
+                    jsonViewer._view._measuredHeights = {};
+                }
+                this.foundation.jsonViewer?.layout();
+            });
+        });
+        this.resizeObserver.observe(el);
+    }
+
+    componentWillUnmount() {
+        this.teardownResizeObserver();
     }
 
     componentDidUpdate(prevProps: JsonViewerProps): void {
         if (!isEqual(prevProps.options, this.props.options) || this.props.value !== prevProps.value) {
             this.foundation.jsonViewer.dispose();
             this.foundation.init();
+            this.setupResizeObserver();
+            return;
+        }
+
+        // autoWrap toggle may require attaching/detaching observer.
+        if (prevProps.options?.autoWrap !== this.props.options?.autoWrap) {
+            this.setupResizeObserver();
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2837

**问题背景：**
当 JsonViewer 组件设置 `options.autoWrap` 为 `true` 时,如果容器尺寸发生变化（如窗口调整、父容器宽度变化等），组件内部的文本换行计算未能正确更新，导致内容显示异常，出现空白区域或内容截断的问题。

**解决方案：**
为 JsonViewer 组件添加 ResizeObserver 监听机制：
1. 当 `options.autoWrap` 为 `true` 时，自动监听容器宽度变化
2. 宽度变化时，清空内部测量高度缓存 `_measuredHeights` 并调用 `layout()` 方法重新布局
3. 使用 `requestAnimationFrame` 合并多次 resize 事件，避免性能问题
4. 在组件卸载或 `autoWrap` 配置变更时正确清理 ResizeObserver 资源

**审查者关注点：**
- 核心修改在 `packages/semi-ui/jsonViewer/index.tsx`，新增了 `setupResizeObserver()` 和 `teardownResizeObserver()` 方法
- 通过 ResizeObserver 实现对容器宽度变化的监听（仅响应宽度变化，忽略高度变化）
- 使用 RAF 合并多次 resize 事件，防止频繁重绘
- 修改涉及 JsonViewer 组件的 `options.autoWrap` 配置项的行为，确保在容器尺寸变化时能正确重新计算文本换行

### Changelog
🇨🇳 Chinese
- Fix: 修复 JsonViewer 组件在 `options.autoWrap` 为 `true` 时，容器尺寸变化后内容显示不正确的问题

---

🇺🇸 English
- Fix: Fixed JsonViewer component not updating content display correctly when container size changes with `options.autoWrap` enabled


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此修复确保了在响应式布局场景下，JsonViewer 组件能够正确处理容器宽度变化带来的文本换行调整，避免了显示异常。修改向后兼容，不影响现有功能。