### PR TITLE
【Auto】Feat: Add virtualization support for Transfer selected panel

### DIFF
--- a/content/input/transfer/index-en-US.md
+++ b/content/input/transfer/index-en-US.md
@@ -1420,6 +1420,7 @@ import { Transfer, Button } from '@douyinfe/semi-ui';
 | style | Inline style | CSSProperties | | |
 | treeProps | When the type is `treeList`, it can be passed as TreeProps to the Tree component on the left | [TreeProps](/en-US/navigation/tree#Tree) | | - |
 | type | Transfer type, optional `list`, `groupList`, `treeList` | string |'list' | - |
+| virtualize | Virtualize the selected list on the right. Only works with default right panel rendering and when `draggable` is `false` | VirtualizeProps |  | - |
 | value | The selected value, when the item is passed in, it will be used as a controlled component | Array<string\|number> | | |
 
 ### Item Interface
@@ -1450,6 +1451,14 @@ TreeItem inherits all the properties of Item
 | props    | description    | data type        | default |
 | -------- | -------------- | ---------------- | ------- |
 | children | Children Items | array<TreeItem\> |         |
+
+### VirtualizeProps Interface
+
+| props | description | data type | default |
+| --- | --- | --- | --- |
+| height | Height of the virtualized list. If it is a `number`, it takes effect directly. If it is a `string` (e.g. `100%`), it adapts to remaining height | number \| string | |
+| width | Width of the virtualized list | number \| string | |
+| itemSize | Fixed height of each item row | number | |
 
 ## Methods
 Some internal methods provided by Transfer can be accessed through ref:

--- a/content/input/transfer/index.md
+++ b/content/input/transfer/index.md
@@ -1425,6 +1425,7 @@ import { Transfer, Button } from '@douyinfe/semi-ui';
 | style | 内联样式 | CSSProperties |  |  |
 | treeProps | 当 type 为`treeList`时，可作为 TreeProps 传入左侧的 Tree 组件 | [TreeProps](/zh-CN/navigation/tree#Tree) | | - |
 | type | Transfer 类型，可选`list`，`groupList`，`treeList` | string | 'list' | - |
+| virtualize | 右侧已选列表虚拟化，仅在默认右侧面板渲染且 `draggable` 为 `false` 时生效 | VirtualizeProps |  | - |
 | value | 已选中值，传入该项时，将作为受控组件使用 | Array<string\|number> |  |  |
 
 ### Item Interface
@@ -1455,6 +1456,14 @@ TreeItem 继承 Item 的所有属性
 | 属性     | 说明   | 类型             | 默认值 |
 | -------- | ------ | ---------------- | ------ |
 | children | 子元素 | Array<TreeItem\> |        |
+
+### VirtualizeProps Interface
+
+| 属性 | 说明 | 类型 | 默认值 |
+| --- | --- | --- | --- |
+| height | 虚拟列表高度，传入 `number` 则直接生效，传入 `string`（如 `100%`）则根据剩余高度自适应 | number \| string | |
+| width | 虚拟列表宽度 | number \| string | |
+| itemSize | 每行高度（固定） | number | |
 
 ## Methods
 绑定在组件实例上的方法，可以通过 ref 调用实现某些特殊交互

--- a/packages/semi-ui/transfer/index.tsx
+++ b/packages/semi-ui/transfer/index.tsx
@@ -18,6 +18,8 @@ import { IconClose, IconSearch, IconHandle } from '@douyinfe/semi-icons';
 import { Value as TreeValue, TreeProps } from '../tree/interface';
 import { RenderItemProps, Sortable } from '../_sortable';
 import { verticalListSortingStrategy } from '@dnd-kit/sortable';
+import { FixedSizeList as VirtualList } from 'react-window';
+import AutoSizer from '../tree/autoSizer';
 
 export interface DataItem extends BasicDataItem {
     label?: React.ReactNode;
@@ -106,6 +108,15 @@ export interface SelectedPanelProps {
     onSortEnd: OnSortEnd
 }
 
+export interface VirtualizeProps {
+    /* Height of virtualized list */
+    height?: number | string;
+    /* Width of virtualized list */
+    width?: number | string;
+    /* Size of each item in the virtualized list */
+    itemSize: number
+}
+
 export interface ResolvedDataItem extends DataItem {
     _parent?: {
         title: string
@@ -168,6 +179,7 @@ export interface TransferProps {
     treeProps?: Omit<TreeProps, 'value' | 'ref' | 'onChange'>;
     showPath?: boolean;
     loading?: boolean;
+    virtualize?: VirtualizeProps;
     onChange?: (values: Array<string | number>, items: Array<DataItem>) => void;
     onSelect?: (item: DataItem) => void;
     onDeselect?: (item: DataItem) => void;
@@ -209,6 +221,7 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         renderSourcePanel: PropTypes.func,
         renderSelectedPanel: PropTypes.func,
         draggable: PropTypes.bool,
+        virtualize: PropTypes.object,
     };
 
     static defaultProps = {
@@ -665,9 +678,83 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
         return sortList;
     }
 
+    renderVirtualizedSelectedList(selectedData: Array<ResolvedDataItem>) {
+        const { virtualize } = this.props;
+        if (!virtualize || isEmpty(virtualize)) {
+            return null;
+        }
+        const { height, width, itemSize } = virtualize;
+
+        // Keep item identity stable when removing/inserting items.
+        // Otherwise react-window may reuse DOM nodes by index and cause visual glitches.
+        const itemKey = (index: number) => {
+            const item = selectedData[index];
+            return item?.key ?? index;
+        };
+
+        // Add semantics back to the scroll container (react-window renders divs by default).
+        const OuterElement = React.forwardRef<HTMLDivElement, any>((props: any, ref) => (
+            <div {...props} ref={ref} role="list" aria-label="Selected list" />
+        ));
+
+        const listCls = `${prefixCls}-right-list ${prefixCls}-right-virtual-list`;
+
+        // Virtual list item renderer
+        const VirtualizedItem = ({ index, style }: { index: number; style: React.CSSProperties }) => {
+            const item = selectedData[index];
+            return (
+                <div role="presentation" style={style}>
+                    {this.renderRightItem(item)}
+                </div>
+            );
+        };
+
+        // Use AutoSizer to automatically calculate height if height is not specified or is percentage
+        if (typeof height !== 'number') {
+            return (
+                <div style={{ flexGrow: 1, minHeight: 0 }}>
+                    <AutoSizer defaultHeight={height} defaultWidth={width}>
+                        {({ height: autoHeight, width: autoWidth }: { height: string | number; width: string | number }) => (
+                            <VirtualList
+                                height={autoHeight}
+                                // Keep consistent with existing TreeSelect usage: AutoSizer width may be string (e.g. '100%').
+                                // @ts-ignore react-window typing expects number but runtime can handle CSS width strings.
+                                width={autoWidth}
+                                itemCount={selectedData.length}
+                                itemSize={itemSize}
+                                itemKey={itemKey}
+                                className={listCls}
+                                // @ts-ignore react-window typing is too strict for custom outer element
+                                outerElementType={OuterElement}
+                            >
+                                {VirtualizedItem}
+                            </VirtualList>
+                        )}
+                    </AutoSizer>
+                </div>
+            );
+        }
+
+        // Directly use VirtualList with specified height
+        return (
+            <VirtualList
+                height={height}
+                width={width || '100%'}
+                itemCount={selectedData.length}
+                itemSize={itemSize}
+                itemKey={itemKey}
+                className={listCls}
+                // @ts-ignore react-window typing is too strict for custom outer element
+                outerElementType={OuterElement}
+            >
+                {VirtualizedItem}
+            </VirtualList>
+        );
+    }
+
     renderRight(locale: Locale['Transfer']) {
         const { selectedItems } = this.state;
-        const { emptyContent, renderSelectedPanel, draggable } = this.props;
+        const { emptyContent, renderSelectedPanel, draggable, virtualize } = this.props;
         const selectedData = [...selectedItems.values()].map(item => ({
             ...item,
             fullPath: this.getFullPath(item)
@@ -701,12 +788,20 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
 
         let content = null;
 
+        // Check if virtualization should be used
+        const shouldVirtualize = virtualize && !isEmpty(virtualize);
+
         switch (true) {
             // when empty
             case !selectedData.length:
                 content = emptyCom;
                 break;
-            case selectedData.length && !draggable:
+            // Use virtualized list when virtualize prop is provided
+            case shouldVirtualize && selectedData.length && !draggable:
+                content = this.renderVirtualizedSelectedList(selectedData);
+                break;
+            // Use normal list
+            case !shouldVirtualize && selectedData.length && !draggable:
                 const list = (
                     <div className={`${prefixCls}-right-list`} role="list" aria-label="Selected list">
                         {selectedData.map(item => this.renderRightItem({ ...item }))}
@@ -714,6 +809,7 @@ class Transfer extends BaseComponent<TransferProps, TransferState> {
                 );
                 content = list;
                 break;
+            // Use sortable list when draggable is true
             case selectedData.length && draggable:
                 content = this.renderRightSortableList(selectedData);
                 break;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2586

Transfer 组件在处理大量数据（1000+ 条）时，右侧已选择面板会出现明显的卡顿，甚至无法正常使用。本 PR 为 Transfer 组件新增了 `virtualize` prop，用于为右侧已选择面板启用虚拟化渲染，解决大数据量场景下的性能问题。

**主要变更：**
1. 为 Transfer 组件新增 `virtualize` prop，支持配置虚拟化列表的高度、宽度和单项大小
2. 引入 `react-window` 的 `FixedSizeList` 和 `AutoSizer` 实现虚拟滚动
3. 当 `draggable` 为 true 时，不启用虚拟化（因为拖拽排序需要完整的 DOM 结构）

**审查者应关注：**
- `virtualize` prop 的接口设计是否合理（包含 `height`、`width`、`itemSize`）
- `renderVirtualizedSelectedList` 方法的实现逻辑
- `AutoSizer` 的使用是否与 TreeSelect 保持一致
- 虚拟化与拖拽功能（draggable）的互斥处理是否合理

### Changelog
🇨🇳 Chinese
- Feat: Transfer 组件新增 virtualize prop，支持右侧已选择面板的虚拟化渲染，解决大数据量场景下的性能问题

---

🇺🇸 English
- Feat: Added virtualize prop to Transfer component for virtualized rendering of selected panel, improving performance with large datasets


### Checklist
- [x] Test or no need
- [ ] Document improve
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
**使用示例：**
```tsx
<Transfer
  dataSource={largeDataset}
  virtualize={{
    height: 400,
    itemSize: 36,
  }}
/>
```

**测试数据：** 在 semi-playground-for-ai 中创建了包含 2000 条数据的测试用例，验证虚拟化功能的性能提升。