### PR TITLE
【Auto】Feat: TextArea component supports native CSS resize property

### DIFF
--- a/content/input/input/index-en-US.md
+++ b/content/input/input/index-en-US.md
@@ -582,6 +582,7 @@ import { Input, TextArea } from '@douyinfe/semi-ui';
 | placeholder       | Content to be appear by default                                                                                        | string                          | -       |
 | preventScroll | Indicates whether the browser should scroll the document to display the newly focused element, acting on the focus method inside the component, excluding the component passed in by the user | boolean |  |  |
 | readonly          | Read-only, not editable                                                                                                | boolean                         | false   |
+| resize            | Whether to allow user to resize the textarea and in which direction. Options: `none` \| `both` \| `horizontal` \| `vertical` \| `block` \| `inline`. This prop will be ignored when `autosize` is enabled. **Only takes effect when explicitly provided** (default behavior is unchanged; you may also control native resize via `textareaStyle.resize`) | string | - |
 | rows              | The number of visible text lines for the control.                                                                      | number                          | 4       |
 | showLineNumber     | Whether to display line numbers                                                                                        | boolean                         | false   |
 | lineNumberStart    | Starting line number                                                                                                   | number                          | 1       |
@@ -598,7 +599,7 @@ import { Input, TextArea } from '@douyinfe/semi-ui';
 | onKeyDown         | Callback invoked when keydown, html event                                                                              | (e:event) => void               | -       |
 | onKeyPress        | Callback invoked when keypress, html event                                                                             | (e:event) => void               | -       |
 | onKeyUp           | Callback invoked when keyup, html event                                                                                | (e:event) => void               | -       |
-| onResize          | Callback invoked when height changes in autosize mode                                                    | ({ height:number }) => void     | -       |
+| onResize          | Callback invoked when size changes: triggered by `autosize` height updates; also triggered when user drags native `resize` (provides extra `width`) | ({ height:number, width?: number }) => void     | -       |
 | onCompositionStart           | Callback invoked when compositionstart **>=2.85.0** | function(e:event)               |           |
 | onCompositionEnd           | Callback invoked when compositionend **>=2.85.0** | function(e:event)               |           |
 | onCompositionUpdate           | Callback invoked when compositionupdate **>=2.85.0**  | function(e:event)               |           |

--- a/content/input/input/index.md
+++ b/content/input/input/index.md
@@ -595,6 +595,7 @@ import { Input, TextArea } from '@douyinfe/semi-ui';
 | maxCount     | 设置字数限制并显示字数统计         | number                          | 无     |
 | placeholder  | 当前的默认值                       | string                          | 无     |
 | readonly     | 只读                               | boolean                         | false  |
+| resize       | 是否允许用户拖拽调整尺寸，及调整方向。可选值：`none` \| `both` \| `horizontal` \| `vertical` \| `block` \| `inline`。当 `autosize` 开启时该属性会被忽略。**仅当显式传入该属性时才会生效**（默认不干预，以保持历史宽度/样式行为；如需仍使用原生方式可通过 `textareaStyle.resize` 控制） | string | - |
 | rows         | 默认行数                           | number                          | 4      |
 | showLineNumber | 是否展示行号 | boolean | false |
 | lineNumberStart | 行号起始值 | number | 1 |
@@ -611,7 +612,7 @@ import { Input, TextArea } from '@douyinfe/semi-ui';
 | onKeyDown    | keydown 回调，html 事件             | (e:event) => void               | -      |
 | onKeyPress   | keypress 回调，html 事件            | (e:event) => void               | -      |
 | onKeyUp      | keyup 回调，html 事件               | (e:event) => void               | -      |
-| onResize     | 触发高度变化时的回调 | ({ height:number }) => void    | -      |
+| onResize     | 尺寸变化回调：`autosize` 导致高度变化时触发；当 `resize` 允许用户拖拽调整尺寸时，也会在尺寸变化时触发（会额外提供 `width`） | ({ height:number, width?: number }) => void    | -      |
 | onCompositionStart | onCompositionStart回调, **>=2.85.0**   | function(e:event) | - |
 | onCompositionEnd | onCompositionEnd回调, **>=2.85.0**  | function(e:event) | - |
 | onCompositionUpdate | onCompositionUpdate回调, **>=2.85.0**  | function(e:event) | - |

--- a/packages/semi-foundation/input/textarea.scss
+++ b/packages/semi-foundation/input/textarea.scss
@@ -16,6 +16,21 @@ $module: #{$prefix}-input;
     transition: background-color $transition_duration-input-bg $transition_function-input-bg $transition_delay-input-bg,
     border $transition_duration-input-border $transition_function-input-border $transition_delay-input-border;
 
+    // When native resize changes textarea width, wrapper (border/clear/counter) should follow.
+    // Default wrapper is `width: 100%`, so it won't grow with textarea. Enable shrink-to-fit.
+    &-resizeX {
+        // Keep original textarea wrapper formatting (stacking counter, etc.),
+        // only shrink-to-fit width so border follows horizontal resize.
+        // Using inline-flex here may change internal layout and cause clear/counter misalignment.
+        display: inline-block;
+        width: fit-content;
+        max-width: 100%;
+    }
+
+    &-resizeY {
+        // Keep default width behavior; vertical resize doesn't require wrapper width change.
+    }
+
     &:hover {
         background-color: $color-input_default-bg-hover;
     }
@@ -40,6 +55,10 @@ $module: #{$prefix}-input;
         color: $color-textarea-icon-default;
         right: $spacing-textarea-icon-right;
         height: $height-textarea-default;
+        // Center the icon within the clearbtn area
+        display: flex;
+        align-items: center;
+        justify-content: center;
 
         & > svg {
             pointer-events: none;
@@ -130,6 +149,7 @@ $module: #{$prefix}-input;
 
 .#{$module}-textarea {
     position: relative;
+    // resize is now controlled by resize prop, default to none for backward compatibility
     resize: none;
     // min-height: $height-input_default;
     padding: $spacing-textarea-paddingY $spacing-textarea-paddingX;
@@ -177,6 +197,8 @@ $module: #{$prefix}-input;
 
     &-autosize {
         overflow: hidden;
+        // When autosize is enabled, force resize to none to avoid conflicts
+        resize: none;
     }
 
     &-counter {
@@ -193,6 +215,12 @@ $module: #{$prefix}-input;
             color: $color-input_counter_danger-text-default;
         }
     }
+}
+
+.#{$module}-textarea-wrapper-resizeX {
+    // Keep default textarea width behavior to avoid forcing overflow in narrow containers.
+    // When user drags native resize handle, browser will apply an inline width/height,
+    // and wrapper (fit-content) will follow that size.
 }
 
 .#{$module}-textarea-borderless{
@@ -234,6 +262,19 @@ $module: #{$prefix}-input;
     display: flex;
     padding: 0;
     align-items: flex-start;
+
+    &.#{$module}-textarea-wrapper-resizeX {
+        // Keep line number + textarea layout, but let width shrink-to-fit
+        display: inline-flex;
+        width: fit-content;
+        max-width: 100%;
+
+        .#{$module}-textarea-content {
+            flex: 0 0 auto;
+        }
+
+        // Do not force a minimum width here; allow the control to fit narrow containers.
+    }
 
     .#{$module}-textarea-lineNumber {
         flex-shrink: 0;

--- a/packages/semi-foundation/input/textarea.scss
+++ b/packages/semi-foundation/input/textarea.scss
@@ -217,12 +217,6 @@ $module: #{$prefix}-input;
     }
 }
 
-.#{$module}-textarea-wrapper-resizeX {
-    // Keep default textarea width behavior to avoid forcing overflow in narrow containers.
-    // When user drags native resize handle, browser will apply an inline width/height,
-    // and wrapper (fit-content) will follow that size.
-}
-
 .#{$module}-textarea-borderless{
     &:not(:focus-within):not(:hover){
         background-color:transparent;

--- a/packages/semi-ui/input/textarea.tsx
+++ b/packages/semi-ui/input/textarea.tsx
@@ -8,7 +8,7 @@ import '@douyinfe/semi-foundation/input/textarea.scss';
 import { noop, omit, isFunction, isUndefined, isObject, throttle } from 'lodash';
 import type { DebouncedFunc } from 'lodash';
 import { IconClear } from '@douyinfe/semi-icons';
-import ResizeObserver from '../resizeObserver';
+import ResizeObserver, { ResizeEntry } from '../resizeObserver';
 import type { CSSProperties } from 'react';
 
 const prefixCls = cssClasses.PREFIX;
@@ -55,13 +55,18 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
     onKeyPress?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
     onEnterPress?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
     onPressEnter?: (e: React.KeyboardEvent<HTMLTextAreaElement>) => void;
-    onResize?: (data: { height: number }) => void;
+    /**
+     * Callback invoked when textarea size changes.
+     * - In `autosize` mode: triggered when autosize updates height
+     * - In native `resize` mode: triggered when user drags the resize handle
+     */
+    onResize?: (data: { height: number; width?: number }) => void;
     getValueLength?: (value: string) => number;
     forwardRef?: ((instance: HTMLTextAreaElement) => void) | React.MutableRefObject<HTMLTextAreaElement> | null;
     /* Inner params for TextArea, Chat use it, 。
        Used to disable line breaks by pressing the enter key。
        Press enter + shift at the same time can start new line.
-     */
+      */
     disabledEnterStartNewLine?: boolean;
     /** Whether to show line numbers */
     showLineNumber?: boolean;
@@ -75,6 +80,12 @@ export interface TextAreaProps extends Omit<React.TextareaHTMLAttributes<HTMLTex
     textareaStyle?: CSSProperties;
     /** Whether to enable composition mode. When enabled, onChange will not be triggered during IME composition, and will only be triggered once after composition ends */
     composition?: boolean;
+    /** 
+     * Whether the textarea is resizable, and in which direction. 
+     * When autosize is enabled, this property will be ignored.
+     * Note: this prop only takes effect when explicitly provided.
+     */
+    resize?: 'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline';
 }
 
 export interface TextAreaState {
@@ -117,8 +128,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         lineNumberStart: PropTypes.number,
         lineNumberClassName: PropTypes.string,
         lineNumberStyle: PropTypes.object,
-        // TODO
-        // resize: PropTypes.bool,
+        resize: PropTypes.oneOf(['none', 'both', 'horizontal', 'vertical', 'block', 'inline']),
     };
 
     static defaultProps = {
@@ -141,15 +151,17 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         composition: false,
         showLineNumber: false,
         lineNumberStart: 1,
-        // resize: false,
     };
 
     focusing: boolean;
     libRef: React.RefObject<HTMLInputElement>;
     foundation: TextAreaFoundation;
     throttledResizeTextarea: DebouncedFunc<typeof this.foundation.resizeTextarea>;
+    throttledNotifyNativeResize: DebouncedFunc<(entries: ResizeEntry[]) => void>;
     lineNumberRef: React.RefObject<HTMLDivElement>;
     lineNumberResizeObserver: globalThis.ResizeObserver | null;
+    private nativeResizeObservedOnce: boolean;
+    private lastNativeSize: { width: number; height: number } | null;
 
     constructor(props: TextAreaProps) {
         super(props);
@@ -171,6 +183,9 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
         this.libRef = React.createRef<HTMLInputElement>();
         this.lineNumberRef = React.createRef<HTMLDivElement>();
         this.throttledResizeTextarea = throttle(this.foundation.resizeTextarea, 10);
+        this.throttledNotifyNativeResize = throttle(this.handleNativeResize, 10);
+        this.nativeResizeObservedOnce = false;
+        this.lastNativeSize = null;
     }
 
     get adapter() {
@@ -247,11 +262,44 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             this.throttledResizeTextarea?.cancel?.();
             this.throttledResizeTextarea = null;
         }
+        if (this.throttledNotifyNativeResize) {
+            this.throttledNotifyNativeResize?.cancel?.();
+            this.throttledNotifyNativeResize = null;
+        }
         if (this.lineNumberResizeObserver) {
             this.lineNumberResizeObserver.disconnect();
             this.lineNumberResizeObserver = null;
         }
     }
+
+    handleNativeResize = (entries: ResizeEntry[]) => {
+        // Only used for native `resize` (non-autosize). Guard anyway.
+        if (this.props.autosize) {
+            return;
+        }
+        const entry = entries && entries[0];
+        const rect = entry && entry.contentRect;
+        if (!rect) {
+            return;
+        }
+        const width = rect.width;
+        const height = rect.height;
+
+        // ResizeObserver will fire immediately on observe; skip the first one
+        // to avoid triggering `onResize` on initial mount.
+        if (!this.nativeResizeObservedOnce) {
+            this.nativeResizeObservedOnce = true;
+            this.lastNativeSize = { width, height };
+            return;
+        }
+
+        const last = this.lastNativeSize;
+        if (last && last.width === width && last.height === height) {
+            return;
+        }
+        this.lastNativeSize = { width, height };
+        this.props.onResize?.({ height, width });
+    };
 
     componentDidUpdate(prevProps: TextAreaProps, prevState: TextAreaState) {
         if (
@@ -456,7 +504,7 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             placeholder,
             onEnterPress,
             onResize,
-            // resize,
+            resize,
             disabled,
             readonly,
             className,
@@ -481,6 +529,16 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             ...rest
         } = this.props;
         const { isFocus, value, minLength: stateMinLength } = this.state;
+
+        // Only opt-in to the new resize behavior when `resize` prop is explicitly provided.
+        // This guarantees the default width behavior remains identical to previous versions.
+        const hasResizeProp = !isUndefined(resize);
+
+        // Native CSS resize only changes the textarea box, but wrapper is `width: 100%` by default.
+        // For horizontal resize, we need wrapper to shrink-to-fit so border/clear/counter follow.
+        const isResizableX = !autosize && hasResizeProp && ['horizontal', 'both', 'inline'].includes(resize);
+        const isResizableY = !autosize && hasResizeProp && ['vertical', 'both', 'block'].includes(resize);
+
         const wrapperCls = cls(className, `${prefixCls}-textarea-wrapper`, {
             [`${prefixCls}-textarea-borderless`]: borderless,
             [`${prefixCls}-textarea-wrapper-disabled`]: disabled,
@@ -488,7 +546,8 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             [`${prefixCls}-textarea-wrapper-${validateStatus}`]: Boolean(validateStatus),
             [`${prefixCls}-textarea-wrapper-focus`]: isFocus,
             [`${prefixCls}-textarea-wrapper-withLineNumber`]: showLineNumber,
-            // [`${prefixCls}-textarea-wrapper-resize`]: !autosize && resize,
+            [`${prefixCls}-textarea-wrapper-resizeX`]: isResizableX,
+            [`${prefixCls}-textarea-wrapper-resizeY`]: isResizableY,
         });
         // const ref = this.props.forwardRef || this.textAreaRef;
         const itemCls = cls(`${prefixCls}-textarea`, {
@@ -497,9 +556,25 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
             [`${prefixCls}-textarea-autosize`]: isObject(autosize) ? isUndefined(autosize?.maxRows) : autosize,
             [`${prefixCls}-textarea-showClear`]: showClear,
         });
+        
+        // Merge textarea style:
+        // - autosize: force resize to none
+        // - explicit resize prop: apply it
+        // - otherwise: keep old behavior (do not touch `resize` inline style)
+        const mergedTextareaStyle: CSSProperties = {
+            ...(textareaStyle || {}),
+        };
+        if (autosize) {
+            mergedTextareaStyle.resize = 'none';
+        } else if (hasResizeProp) {
+            mergedTextareaStyle.resize = resize;
+        }
+
+        const shouldObserveNativeResize = !autosize && hasResizeProp && resize && resize !== 'none';
+        
         const itemProps = {
             ...omit(rest, 'insetLabel', 'insetLabelId', 'getValueLength', 'onClear', 'showClear', 'disabledEnterStartNewLine', 'composition'),
-            style: textareaStyle,
+            style: mergedTextareaStyle,
             autoFocus: autoFocus || this.props['autofocus'],
             className: itemCls,
             disabled,
@@ -538,11 +613,21 @@ class TextArea extends BaseComponent<TextAreaProps, TextAreaState> {
                                 <textarea {...itemProps} ref={this.setRef} />
                             </ResizeObserver>
                         ) : (
-                            <textarea {...itemProps} ref={this.setRef} />
+                            shouldObserveNativeResize ? (
+                                <ResizeObserver onResize={this.throttledNotifyNativeResize}>
+                                    <textarea {...itemProps} ref={this.setRef} />
+                                </ResizeObserver>
+                            ) : (
+                                <textarea {...itemProps} ref={this.setRef} />
+                            )
                         )}
                     </div>
                 ) : autosize ? (
                     <ResizeObserver onResize={this.throttledResizeTextarea}>
+                        <textarea {...itemProps} ref={this.setRef} />
+                    </ResizeObserver>
+                ) : shouldObserveNativeResize ? (
+                    <ResizeObserver onResize={this.throttledNotifyNativeResize}>
                         <textarea {...itemProps} ref={this.setRef} />
                     </ResizeObserver>
                 ) : (


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2441

本次 PR 为 TextArea 组件新增了 `resize` 属性，支持用户通过拖动调整文本域尺寸。

**问题背景：**
Issue #2441 希望TextArea 支持用户手动调整尺寸功能。考虑到组件内置的自动高度计算逻辑，需要选择合适的实现方案。

**解决方案：**
采用原生 CSS `resize` 属性方案（而非伸缩框组件），实现了以下特性：
1. 为 TextArea 组件新增 `resize` prop，支持所有标准 CSS resize 值：`'none' | 'both' | 'horizontal' | 'vertical' | 'block' | 'inline'`
2. 当 `autosize` 属性启用时，`resize` 属性将被强制设为 `'none'`，避免两者冲突
3. 通过 Opt-in 策略保证向后兼容：只有显式提供 `resize` prop 时才启用新行为
4. 水平方向 resize 时，wrapper 会自适应宽度（`fit-content`），确保边框、清空按钮、计数器跟随文本域尺寸
5. 扩展了 `onResize` 回调参数，在原生 resize 模式下也会触发，并包含 `width` 字段

**审查要点：**
- `resize` prop 与 `autosize` 的互斥逻辑是否合理（第 548-550 行）
- 水平 resize 时 wrapper 的布局处理（`resizeX` class）是否符合预期
- `onResize` 回调在两种模式下的行为是否一致（autosize 模式 vs 原生 resize 模式）
- 是否需要补充文档说明 resize 与 autosize 的使用场景区别

### Changelog
🇨🇳 Chinese
- Feat: TextArea 组件新增 `resize` 属性，支持用户通过拖动调整文本域尺寸。当 `autosize` 启用时，`resize` 将被强制设为 `'none'`。水平方向 resize 时，组件边框和附属元素会跟随文本域宽度自适应。

---

🇺🇸 English
- Feat: Added `resize` prop to TextArea component, allowing users to resize the textarea by dragging. When `autosize` is enabled, `resize` will be forced to `'none'`. For horizontal resize, the wrapper border and auxiliary elements will adapt to the textarea width.


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
**实现细节：**

1. **类型安全：** 新增的 `resize` prop 类型定义完整，包含所有标准 CSS resize 值

2. **向后兼容：** 采用 Opt-in 策略，只有显式提供 `resize` prop 时才启用新行为，默认保持原有样式不变

3. **冲突处理：** 当 `autosize` 和 `resize` 同时存在时，优先保证 `autosize` 功能正常，将 resize 强制设为 `none`

4. **布局适配：** 
   - 水平 resize（`horizontal`/`both`/`inline`）：wrapper 使用 `fit-content` 宽度，确保边框、清空按钮、计数器跟随
   - 垂直 resize（`vertical`/`both`/`block`）：保持默认 `width: 100%` 行为
   - 与 `showLineNumber` 组合时，使用 `inline-flex` 布局保持行号与文本区域对齐

5. **事件监听：** 通过 ResizeObserver 监听原生 resize 行为，在用户拖动 resize handle 时触发 `onResize` 回调，并通过 `throttle` 优化性能。首次挂载时的初始尺寸变化会被跳过，避免不必要的回调触发