### PR TITLE
【Auto】Feat: Add headerStyle prop to Table component for easier header customization

### DIFF
--- a/content/show/table/index-en-US.md
+++ b/content/show/table/index-en-US.md
@@ -5385,6 +5385,7 @@ render(App);
 | expandRowByClick | Expand row when click row                                                                                                 | boolean | false | - |
 | footer | End of form                                                                                                               | string<br/>\|ReactNode<br/>\|(pageData: object) => string\|ReactNode |  |
 | groupBy | Grouping basis, generally a method of a key name or a return value of a string or number in the dataSource element        | string\|number<br/>\|(record: any) => string\|number |  | - |
+| headerStyle | Style for header cells (applies to all header <th>, including fixed columns) | CSSProperties | - | - |
 | hideExpandedColumn | Whether to hide the expansion button column and turn off the rendering of the expansion button when it is turned on       | boolean | true |
 | indentSize | indent size of TableCell                                                                                                  | number | 20 |
 | keepDOM | Whether to not destroy the collapsed DOM when folding a row                                                               | boolean | false |
@@ -5411,6 +5412,58 @@ render(App);
 | onGroupedRow | Similar to onRow, but this parameter is used to define the row attribute of the grouping header alone                     | (record: RecordType, index: number) => object |  | - |
 | onHeaderRow | Set the header row property, and the returned object is merged to the header line                                         | (columns: Column[], index: number) => object |  |
 | onRow | Set the row property, and the returned object is merged to the table row | (record: RecordType, index: number, rowStatus?: { disabled?: boolean; selected?: boolean }) => object |  | - |
+
+### headerStyle Example
+
+`headerStyle` will be applied to all header `<th>` elements, including fixed columns.
+
+```jsx
+import React from 'react';
+import { Table } from '@douyinfe/semi-ui';
+
+const columns = [
+    {
+        title: 'Name',
+        dataIndex: 'name',
+        width: 180,
+        fixed: 'left',
+    },
+    {
+        title: 'Age',
+        dataIndex: 'age',
+        width: 120,
+    },
+    {
+        title: 'Address',
+        dataIndex: 'address',
+        width: 280,
+    },
+    {
+        title: 'Company',
+        dataIndex: 'company',
+        width: 280,
+    },
+];
+
+const dataSource = Array.from({ length: 6 }).map((_, i) => ({
+    key: i,
+    name: `Edward ${i}`,
+    age: 20 + i,
+    address: 'No. 1, Lake Park',
+    company: 'Semi Design',
+}));
+
+export default function Demo() {
+    return (
+        <Table
+            columns={columns}
+            dataSource={dataSource}
+            scroll={{ x: 900 }}
+            headerStyle={{ backgroundColor: '#F5F6F7', fontWeight: 600 }}
+        />
+    );
+}
+```
 
 Some of the type definitions used above:
 

--- a/content/show/table/index.md
+++ b/content/show/table/index.md
@@ -5772,6 +5772,7 @@ render(App);
 | footer | 表格尾部                                                                | ReactNode<br/>\|(pageData: object) => ReactNode |  |
 | getVirtualizedListRef | 返回虚拟化表格所用 VariableSizeList 的 ref，仅在配置 virtualized 时有效               | (ref: React.RefObject) => void |  | - |
 | groupBy | 分组依据，一般为 dataSource 元素中某个键名或者返回值为字符串、数字的一个方法                        | string\|number<br/>\|(record: RecordType) => string\|number |  | - |
+| headerStyle | 表头单元格的内联样式（会应用到所有表头 th，包括 fixed 表头） | CSSProperties | - | - |
 | hideExpandedColumn | 当表格可展开时，展开按钮默认会与第一列文案渲染在同一个单元格内，设为 false 时默认将展开按钮单独作为一列渲染           | boolean | true |
 | indentSize | 树形结构 TableCell 的缩进大小                                                | number | 20 |
 | keepDOM | 折叠行时是否不销毁被折叠的 DOM                                                   | boolean | false |
@@ -5798,6 +5799,58 @@ render(App);
 | onGroupedRow | 类似于 onRow，不过这个参数单独用于定义分组表头的行属性                                      | (record: RecordType, index: number) => object |  | - |
 | onHeaderRow | 设置头部行属性，返回的对象会被合并传给表头行                                              | (columns: Column[], index: number) => object |  |
 | onRow | 设置行属性，返回的对象会被合并传给表格行 | (record: RecordType, index: number, rowStatus?: { disabled?: boolean; selected?: boolean }) => object |  | - |
+
+### headerStyle 示例
+
+`headerStyle` 会应用到所有表头 `<th>` 元素，包括 fixed 表头。
+
+```jsx
+import React from 'react';
+import { Table } from '@douyinfe/semi-ui';
+
+const columns = [
+    {
+        title: '姓名',
+        dataIndex: 'name',
+        width: 180,
+        fixed: 'left',
+    },
+    {
+        title: '年龄',
+        dataIndex: 'age',
+        width: 120,
+    },
+    {
+        title: '地址',
+        dataIndex: 'address',
+        width: 280,
+    },
+    {
+        title: '公司',
+        dataIndex: 'company',
+        width: 280,
+    },
+];
+
+const dataSource = Array.from({ length: 6 }).map((_, i) => ({
+    key: i,
+    name: `Edward ${i}`,
+    age: 20 + i,
+    address: '西湖区湖底公园 1 号',
+    company: 'Semi Design',
+}));
+
+export default function Demo() {
+    return (
+        <Table
+            columns={columns}
+            dataSource={dataSource}
+            scroll={{ x: 900 }}
+            headerStyle={{ backgroundColor: '#F5F6F7', fontWeight: 600 }}
+        />
+    );
+}
+```
 
 一些上面用到的类型定义：
 

--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -156,6 +156,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             y: PropTypes.oneOfType([PropTypes.number, PropTypes.string]),
         }),
         groupBy: PropTypes.oneOfType([PropTypes.string, PropTypes.number, PropTypes.func]),
+        headerStyle: PropTypes.object,
         renderGroupSection: PropTypes.oneOfType([PropTypes.func]),
         onGroupedRow: PropTypes.func,
         clickGroupedRowToExpand: PropTypes.bool,
@@ -1572,6 +1573,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             getVirtualizedListRef,
             setBodyHasScrollbar: this.setBodyHasScrollbar,
             handleRowSelection: this.handleRowClickSelection,
+            headerStyle: props.headerStyle,
         };
 
         const dataAttr = this.getDataAttr(rest);

--- a/packages/semi-ui/table/TableContextProvider.tsx
+++ b/packages/semi-ui/table/TableContextProvider.tsx
@@ -16,7 +16,8 @@ const TableContextProvider = ({
     getVirtualizedListRef,
     setBodyHasScrollbar,
     direction,
-    handleRowSelection
+    handleRowSelection,
+    headerStyle
 }: TableContextProps) => {
     const tableContextValue = useMemo(
         () => ({
@@ -33,7 +34,8 @@ const TableContextProvider = ({
             getVirtualizedListRef,
             setBodyHasScrollbar,
             direction,
-            handleRowSelection
+            handleRowSelection,
+            headerStyle
         }),
         [
             anyColumnFixed,
@@ -49,7 +51,8 @@ const TableContextProvider = ({
             getVirtualizedListRef,
             setBodyHasScrollbar,
             direction,
-            handleRowSelection
+            handleRowSelection,
+            headerStyle
         ]
     );
 

--- a/packages/semi-ui/table/TableHeaderRow.tsx
+++ b/packages/semi-ui/table/TableHeaderRow.tsx
@@ -104,7 +104,7 @@ export default class TableHeaderRow extends BaseComponent<TableHeaderRowProps, R
 
     render() {
         const { components, row, prefixCls, onHeaderRow, index, style, columns } = this.props;
-        const { getCellWidths, direction } = this.context;
+        const { getCellWidths, direction, headerStyle } = this.context;
         const isRTL = direction === 'rtl';
         const slicedColumns = sliceColumnsByLevel(columns, index);
         const headWidths = getCellWidths(slicedColumns);
@@ -119,7 +119,10 @@ export default class TableHeaderRow extends BaseComponent<TableHeaderRowProps, R
             const { column, ...cellProps } = cell;
             const customProps =
                 typeof column.onHeaderCell === 'function' ? column.onHeaderCell(column, cellIndex, index) : {};
-            let cellStyle = { ...customProps.style };
+            // Merge order:
+            // - headerStyle provides a global default for header cells
+            // - column.onHeaderCell().style can override it for a specific column
+            let cellStyle = { ...headerStyle, ...customProps.style };
             if (column.align) {
                 const textAlign = getRTLAlign(column.align, direction);
                 cellStyle = { ...cellStyle, textAlign };

--- a/packages/semi-ui/table/interface.ts
+++ b/packages/semi-ui/table/interface.ts
@@ -47,6 +47,7 @@ export interface TableProps<RecordType extends Record<string, any> = any> extend
     footer?: Footer<RecordType>;
     getVirtualizedListRef?: GetVirtualizedListRef;
     groupBy?: GroupBy<RecordType>;
+    headerStyle?: React.CSSProperties;
     hideExpandedColumn?: boolean;
     id?: string;
     indentSize?: number;

--- a/packages/semi-ui/table/table-context.ts
+++ b/packages/semi-ui/table/table-context.ts
@@ -23,6 +23,7 @@ export interface TableContextProps {
     setBodyHasScrollbar?: (bodyHasScrollBar: boolean) => void;
     direction?: ContextValue['direction'];
     handleRowSelection?: (rowKey: BaseRowKeyType, selected: boolean, e: React.MouseEvent) => void;
+    headerStyle?: React.CSSProperties;
 }
 
 const TableContext = React.createContext<TableContextProps>({


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2347

**问题背景：**
Issue #2347 指出，在自定义 Table 表头背景色时非常麻烦，特别是在存在固定列（fixed columns）的情况下，需要编写多个 CSS 选择器来覆盖不同场景（普通表头、固定表头、吸顶表头等）。用户对这些 CSS 细节不清楚，定制成本高。

**解决方案：**
为 Table 组件新增 `headerStyle` prop，允许用户通过一个属性统一设置所有表头单元格的样式。该 prop 会应用到所有表头 `<th>` 元素，包括固定列的表头，从而简化了自定义流程。

**实现细节：**
1. 在 Table 组件中添加了 `headerStyle` prop（类型为 `React.CSSProperties`）
2. 通过 React Context 将 `headerStyle` 传递给 `TableHeaderRow` 组件
3. 在 `TableHeaderRow` 中，将 `headerStyle` 应用到每个表头单元格的样式中
4. 样式合并遵循优先级：`headerStyle`（全局默认）→ `column.onHeaderCell().style`（列级覆盖），确保列级样式可以覆盖全局样式

**审查者应关注：**
- `packages/semi-ui/table/Table.tsx`：添加 prop 定义和传递逻辑
- `packages/semi-ui/table/interface.ts`：添加 TypeScript 类型定义
- `packages/semi-ui/table/TableHeaderRow.tsx`：样式合并逻辑的实现
- `content/show/table/index.md` 和 `index-en-US.md`：文档更新和示例代码

### Changelog
🇨🇳 Chinese
- Feat: Table 组件新增 `headerStyle` prop，支持统一设置所有表头单元格样式（包括 fixed 列）

---

🇺🇸 English
- Feat: Added `headerStyle` prop to Table component for setting styles on all header cells (including fixed columns)


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
使用示例：
```jsx
<Table
    columns={columns}
    dataSource={dataSource}
    scroll={{ x: 900 }}
    headerStyle={{ backgroundColor: '#F5F6F7', fontWeight: 600 }}
/>
```

此功能解决了用户在自定义表头背景色时需要覆盖多个 CSS 选择器的痛点，特别是在有固定列的场景下，提供了更简洁的 API。