### PR TITLE
【Auto】Fix: Spin component SSR hydration mismatch in Next.js

### DIFF
--- a/packages/semi-ui/spin/icon.tsx
+++ b/packages/semi-ui/spin/icon.tsx
@@ -1,10 +1,9 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import isNullOrUndefined from '@douyinfe/semi-foundation/utils/isNullOrUndefined';
+import { getUuidShort } from '@douyinfe/semi-foundation/utils/uuid';
 import semiGlobal from '../_utils/semi-global';
 import { get } from 'lodash';
 import cls from 'classnames';
-
-let _id = -1;
 
 export interface IconProps {
     id?: number;
@@ -21,12 +20,38 @@ function Icon(props: IconProps = {}) {
     if (globalIndicator && React.isValidElement(globalIndicator)) {
         return React.cloneElement(globalIndicator, { className: cls({ [customIconCls]: customIconCls, [className]: className }) } as any);
     }
-    let _propsId = propsId;
-    if (isNullOrUndefined(_propsId)) {
-        _id++;
-        _propsId = _id;
-    }
-    const id = `linearGradient-${_propsId}`;
+
+    /**
+     * NOTE(SSR / Next.js):
+     * We must keep the original SVG implementation based on <linearGradient> + url(#id).
+     * However, generating ids via module-level counters or random values during render can
+     * cause hydration mismatch (server/client ids differ).
+     *
+     * Strategy:
+     * - On SSR and the client's initial render, use a stable fallback id to keep markup identical.
+     * - After mount (client-only), replace it with an instance-unique id to avoid cross-instance
+     *   collisions where one Spin could affect another via duplicate ids.
+     *
+     * If consumers pass `props.id`, we treat it as a stable explicit seed.
+    */
+    const fallbackId = 'linearGradient-semi-spin';
+    const [gradientId, setGradientId] = useState<string>(() => {
+        if (!isNullOrUndefined(propsId)) {
+            return `linearGradient-${propsId}`;
+        }
+        return fallbackId;
+    });
+
+    useEffect(() => {
+        if (!isNullOrUndefined(propsId)) {
+            // Explicit id is stable; no need to mutate after mount.
+            setGradientId(`linearGradient-${propsId}`);
+            return;
+        }
+        const unique = getUuidShort({ prefix: 'semi-spin-gradient' });
+        setGradientId(`linearGradient-${unique}`);
+    }, [propsId]);
+
     return (
         <svg
             {...rest}
@@ -40,7 +65,7 @@ function Icon(props: IconProps = {}) {
             data-icon="spin"
         >
             <defs>
-                <linearGradient x1="0%" y1="100%" x2="100%" y2="100%" id={id}>
+                <linearGradient x1="0%" y1="100%" x2="100%" y2="100%" id={gradientId}>
                     <stop stopColor="currentColor" stopOpacity="0" offset="0%" />
                     <stop stopColor="currentColor" stopOpacity="0.50" offset="39.9430698%" />
                     <stop stopColor="currentColor" offset="100%" />
@@ -50,7 +75,7 @@ function Icon(props: IconProps = {}) {
                 <rect fillOpacity="0.01" fill="none" x="0" y="0" width="36" height="36" />
                 <path
                     d="M34,18 C34,9.163444 26.836556,2 18,2 C11.6597233,2 6.18078805,5.68784135 3.59122325,11.0354951"
-                    stroke={`url(#${id})`}
+                    stroke={`url(#${gradientId})`}
                     strokeWidth="4"
                     strokeLinecap="round"
                 />

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.5.tgz#b8768b10837d0b8e9ca5b9e2d58dff3d880ea25e"
-  integrity sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.5.tgz#c888ab8b8ef33e2597fae8bdb2d77edbdb42858b"
-  integrity sha512-llUJLzz1zTUBrskt2pwZgLq59AemifIftw4aB7JxOqf1HY2FDaGDxgwpAPVzHU1kdWabH7FauP4i1oEeer2WCA==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2114

**问题背景：**
Spin 组件在 Next.js SSR 环境中会出现 React hydration mismatch 错误。原因是 icon.tsx 使用全局变量 `_id` 来生成 SVG linearGradient 的 ID，服务端和客户端的模块加载次数不同导致 ID 不一致（如服务端 `linearGradient-0`，客户端 `linearGradient-1`），在生产环境会导致应用崩溃。

**解决方案：**
1. 移除全局变量 `_id`，改用 React hooks（useState + useEffect）管理 ID
2. 引入 `getUuidShort` 工具函数生成唯一 ID
3. 实现 SSR 兼容策略：
   - SSR 和客户端初次渲染使用固定的 fallback ID（`linearGradient-semi-spin`），确保标记一致
   - 客户端挂载后使用 UUID 生成实例唯一 ID，避免多个 Spin 实例之间的 ID 冲突
4. 保留 `id` prop 的支持，允许用户显式指定稳定的 ID

**审查要点：**
- 核心修改在 `packages/semi-ui/spin/icon.tsx`
- 使用了 React 16.8+ 的 hooks（useState, useEffect），与项目现有依赖兼容
- 保持了原有的视觉表现和 API 接口不变

### Changelog
🇨🇳 Chinese
- Fix: 修复 Spin 组件在 Next.js SSR 环境下因 ID 生成方式导致的 hydration mismatch 错误

---

🇺🇸 English
- Fix: Fixed Spin component hydration mismatch error in Next.js SSR caused by ID generation method


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
This fix adopts a SSR-compatible ID generation strategy that ensures identical markup between server and client during initial render, while using instance-unique IDs after mount to avoid cross-instance collisions. The solution maintains backward compatibility with the existing `id` prop.