### PR TITLE
【Auto】Feat: Add image cropping support for Upload component

### DIFF
--- a/content/input/upload/index-en-US.md
+++ b/content/input/upload/index-en-US.md
@@ -1699,10 +1699,13 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |action | File upload address, required | string | | |
 |afterUpload | Hook after the file upload, update the file status according to the returned object | function(auProps) => afterUploadResult | | - |
 |beforeClear|Call back before clearing the file, judge whether to continue removing according to the return value, return false, Promise.resolve(false), Promise.reject() will prevent removal|(fileList: Array<FileItem \>) => boolean \| Promise||-|
+|beforeCrop|Callback before opening the crop modal. Returning `false` (or resolving to `false`) skips cropping and uploads directly. Async returns are supported.|(file: File, fileList: File[]) => boolean \| Promise<boolean>||2.97.0|
 |beforeRemove|Callback before removing the file, judge whether to continue removing according to the return value, return false, Promise.resolve(false), Promise.reject() will prevent removal|(file: <FileItem\>, fileList: Array<FileItem \>) => boolean \| Promise||-|
 |beforeUpload | The hook before uploading the file, according to the return object to update the file status, control whether to upload | function(buProps) => beforeUploadResult \| Promise \| boolean | | - |
 |capture | The way of media shooting in the file upload control | boolean \| string \| undefined | | |
 |className | class name | string | | |
+|crop | Enable image cropping. Pass `true` to use defaults, or a `CropProps` object to customize parameters. Works for click / drag-and-drop / paste / replace upload entries. | boolean \| CropProps | | 2.97.0 |
+|cropModalProps | Extra props forwarded to the underlying crop Modal (style, width, etc.) | ModalReactProps | | 2.97.0 |
 |customRequest | Asynchronous request method for custom upload | (object: customRequestArgs) => void | | - |
 |data | Additional parameters attached to the upload or the method to return the uploaded additional parameters| object\|(file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File)) => object | {} | |
 |defaultFileList | List of uploaded files | Array<FileItem\> | [] | |
@@ -1727,6 +1730,7 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |onAcceptInvalid | Triggered when the received file does not conform to the accept specification (generally because the folder selects all types of files / drags and drops files that do not conform to the format) | (files: File[]) => void | | 1.24 .0 |
 |onChange | Called when the file status changes, including upload success, failure, upload, the callback input parameter is Object, including fileList, currentFile, etc.| ({fileList: Array<FileItem\>, currentFile?: FileItem}) = > void | | - |
 |onClear | Callback when click to clear | () => void | | - |
+|onCropError | Callback when image cropping fails | (error: Error) => void | | 2.97.0 |
 |onDrop | Triggered when the dragged element is released on the drag area | (e, files: Array<File\>, fileList: Array<FileItem\>) => void | | - |
 |onError | Callback when uploading error| (error: Error, file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList: Array<FileItem\> , xhr: XMLHttpRequest) => void | | |
 |onExceed | Callback when the total number of uploaded files exceeds `limit` | (fileList:Array<FileItem\>) => void | | |
@@ -1808,6 +1812,25 @@ interface RenderFileListTitleProps {
     fileList: Array<FileItem>;  // Current file list
     onClear: () => void;        // Callback function to clear files
     clearText: string;          // Default text for the clear button (based on current locale)
+}
+```
+
+### CropProps Interface
+
+Configuration object accepted by the `crop` prop:
+
+```ts
+interface CropProps {
+    aspectRatio?: number;           // Crop box aspect ratio, e.g. 16/9, 1, 4/3
+    shape?: 'rect' | 'round' | 'roundRect';  // Crop box shape, default 'rect'
+    minZoom?: number;               // Minimum zoom ratio
+    maxZoom?: number;               // Maximum zoom ratio
+    zoomStep?: number;              // Zoom step size
+    quality?: number;               // Output image quality, range 0 - 1, default 0.92
+    fill?: string;                  // Fill color of the area outside the cropped region, default '#fff'
+    modalTitle?: string;            // Title text of the crop modal
+    modalOkText?: string;           // Confirm button text of the crop modal
+    modalCancelText?: string;       // Cancel button text of the crop modal
 }
 ```
 

--- a/content/input/upload/index-en-US.md
+++ b/content/input/upload/index-en-US.md
@@ -1490,6 +1490,205 @@ import { IconUpload } from '@douyinfe/semi-icons';
 };
 ```
 
+### Image Cropping
+
+Enable image cropping functionality through the `crop` property. Supports cropping when clicking to select, dragging, pasting, and replacing files.
+
+#### Basic Usage
+
+Set `crop={true}` to enable default cropping configuration.
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={true}
+            onSuccess={(response, file) => {
+                console.log('Upload success:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                Click to upload (with cropping)
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### Custom Cropping Configuration
+
+Configure cropping parameters through object form, including aspect ratio, shape, quality, etc.
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 16 / 9,
+                shape: 'rect',
+                quality: 0.8,
+                modalTitle: 'Crop Image',
+                modalOkText: 'Confirm',
+                modalCancelText: 'Cancel',
+            }}
+            onSuccess={(response, file) => {
+                console.log('Upload success:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                Click to upload (16:9 cropping)
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### Round Cropping
+
+Suitable for avatar upload scenarios, set `shape: 'round'` to enable round cropping.
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'round',
+                quality: 0.9,
+                modalTitle: 'Crop Avatar',
+            }}
+            listType="picture"
+            onSuccess={(response, file) => {
+                console.log('Upload success:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                Click to upload (round cropping)
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### Confirm Before Cropping
+
+Use the `beforeCrop` callback to confirm or perform other processing before cropping. Return `false` to skip cropping and upload directly.
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'round',
+            }}
+            beforeCrop={(file, fileList) => {
+                console.log('beforeCrop:', file, fileList);
+                // Return true to continue cropping, return false to skip cropping and upload directly
+                return window.confirm('Crop the image?');
+            }}
+            onCropError={(error) => {
+                console.error('Crop error:', error);
+            }}
+            onSuccess={(response, file) => {
+                console.log('Upload success:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                Click to upload (confirm before crop)
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### Drag and Drop Upload with Cropping
+
+Cropping is also triggered when uploading via drag and drop.
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'rect',
+            }}
+            draggable
+            onDrop={(e, files, fileList) => {
+                console.log('Dropped files:', files);
+            }}
+            onSuccess={(response, file) => {
+                console.log('Upload success:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                Drag to upload (with cropping)
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### Custom Cropping Modal Style
+
+Customize the style and properties of the cropping modal through `cropModalProps`.
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'rect',
+            }}
+            cropModalProps={{
+                width: 800,
+                style: { height: 600 },
+                bodyStyle: { height: 500, backgroundColor: '#f5f5f5' },
+            }}
+            onSuccess={(response, file) => {
+                console.log('Upload success:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                Custom Modal Style
+            </Button>
+        </Upload>
+    );
+};
+```
+
 ## API Reference
 
 ---

--- a/content/input/upload/index.md
+++ b/content/input/upload/index.md
@@ -1507,6 +1507,205 @@ import { IconUpload } from '@douyinfe/semi-icons';
 };
 ```
 
+### 图片裁切
+
+通过 `crop` 属性启用图片裁切功能。支持点击选择、拖拽、粘贴、替换文件时进行裁切。
+
+#### 基本用法
+
+设置 `crop={true}` 启用默认裁切配置。
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={true}
+            onSuccess={(response, file) => {
+                console.log('上传成功:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                点击上传（启用裁切）
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### 自定义裁切配置
+
+通过对象形式配置裁切参数，包括宽高比、形状、质量等。
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 16 / 9,
+                shape: 'rect',
+                quality: 0.8,
+                modalTitle: '裁切图片',
+                modalOkText: '确认裁切',
+                modalCancelText: '取消',
+            }}
+            onSuccess={(response, file) => {
+                console.log('上传成功:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                点击上传（16:9 裁切）
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### 圆形裁切
+
+适用于头像上传场景，设置 `shape: 'round'` 启用圆形裁切。
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'round',
+                quality: 0.9,
+                modalTitle: '裁切头像',
+            }}
+            listType="picture"
+            onSuccess={(response, file) => {
+                console.log('上传成功:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                点击上传（圆形裁切）
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### 裁切前确认
+
+通过 `beforeCrop` 回调，在裁切前进行确认或其他处理。返回 `false` 可跳过裁切直接上传。
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'round',
+            }}
+            beforeCrop={(file, fileList) => {
+                console.log('beforeCrop:', file, fileList);
+                // 返回 true 继续裁切，返回 false 跳过裁切直接上传
+                return window.confirm('是否裁切图片？');
+            }}
+            onCropError={(error) => {
+                console.error('裁切失败:', error);
+            }}
+            onSuccess={(response, file) => {
+                console.log('上传成功:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                点击上传（裁切前确认）
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### 拖拽上传裁切
+
+拖拽上传时也会触发裁切功能。
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'rect',
+            }}
+            draggable
+            onDrop={(e, files, fileList) => {
+                console.log('拖拽文件:', files);
+            }}
+            onSuccess={(response, file) => {
+                console.log('上传成功:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                拖拽上传（启用裁切）
+            </Button>
+        </Upload>
+    );
+};
+```
+
+#### 自定义裁切弹窗样式
+
+通过 `cropModalProps` 自定义裁切弹窗的样式和属性。
+
+```jsx live=true width=48%
+import React from 'react';
+import { Upload, Button } from '@douyinfe/semi-ui';
+import { IconUpload } from '@douyinfe/semi-icons';
+
+() => {
+    return (
+        <Upload
+            action="https://api.semi.design/upload"
+            crop={{
+                aspectRatio: 1,
+                shape: 'rect',
+            }}
+            cropModalProps={{
+                width: 800,
+                style: { height: 600 },
+                bodyStyle: { height: 500, backgroundColor: '#f5f5f5' },
+            }}
+            onSuccess={(response, file) => {
+                console.log('上传成功:', response, file);
+            }}
+        >
+            <Button icon={<IconUpload />} theme="light">
+                自定义弹窗样式
+            </Button>
+        </Upload>
+    );
+};
+```
+
 ## API 参考
 
 ---
@@ -1518,10 +1717,13 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |addOnPasting | 按下 ctrl/command + v时，是否自动将剪贴板中的文件添加至 fileList，当前仅支持图片类型; 需用户授权同意 | boolean | false | 2.43.0 |
 |afterUpload | 文件上传后的钩子，根据 return 的 object 更新文件状态 | function(auProps) => afterUploadResult |  |  |
 |beforeClear|清空文件前回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(fileList: Array<FileItem \>) => boolean\|Promise|| |
+|beforeCrop|图片裁切前的回调。返回 `false` 可跳过裁切直接上传，返回 `true` 或不返回则继续裁切。支持异步返回|(file: File, fileList: File[]) => boolean \| Promise<boolean> | | 2.x |
 |beforeRemove|移除文件前的回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(file: <FileItem\>, fileList: Array<FileItem \>) => boolean\|Promise|| |
 |beforeUpload | 上传文件前的钩子，根据 return 的 object 更新文件状态，控制是否上传 | function(buProps) => beforeUploadResult \| Promise \| boolean |  |  |
 |capture | 文件上传控件中媒体拍摄的方式 | boolean\|string\|undefined | | |
 |className | 类名 | string |  |  |
+|crop | 启用图片裁切功能。传入 `true` 使用默认配置，传入对象可自定义裁切参数。支持所有上传入口（点击选择、拖拽、粘贴、替换）的图片裁切 | boolean \| CropProps |  | 2.x |
+|cropModalProps | 自定义裁切弹窗的属性，可配置弹窗的样式、宽度等 | ModalReactProps |  | 2.x |
 |customRequest | 自定义上传使用的异步请求方法 | (object: customRequestArgs) => void |  |  |
 |data | 上传时附带的额外参数或返回上传额外参数的方法 | object\|(file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File)) => object | {} |  |
 |defaultFileList | 已上传的文件列表 | Array<FileItem\> | [] |  |
@@ -1546,6 +1748,7 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |onAcceptInvalid | 当接收到的文件不符合accept规范时触发（一般是因为文件夹选择了全部类型文件/拖拽不符合格式的文件时触发） | (files: File[]) => void | |  |
 |onChange | 文件状态发生变化时调用，包括上传成功，失败，上传中，回调入参为 Object，包含 fileList、currentFile 等值 | ({fileList: Array<FileItem\>, currentFile?: FileItem}) => void |  |  |
 |onClear | 点击清空时的回调 | () => void |  |  |
+|onCropError | 图片裁切失败时的回调 | (error: Error) => void |  | 2.x |
 |onDrop | 当拖拽的元素在拖拽区上被释放时触发 | (e, files: Array<File\>, fileList: Array<FileItem\>) => void |  |  |
 |onError | 上传错误时的回调 | (error: Error, file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList: Array<FileItem\>, xhr: XMLHttpRequest) => void |  |  |
 |onExceed | 上传文件总数超出 `limit` 时的回调 | (fileList:Array<FileItem\>) => void |  |  |
@@ -1619,6 +1822,25 @@ interface RenderFileListTitleProps {
     fileList: Array<FileItem>;  // 当前文件列表
     onClear: () => void;        // 清空文件的回调函数
     clearText: string;          // 清空按钮的默认文案（根据当前语言环境）
+}
+```
+
+### CropProps Interface
+
+`crop` 属性传入对象时的配置项：
+
+```ts
+interface CropProps {
+    aspectRatio?: number;           // 裁切框宽高比，例如 16/9, 1, 4/3
+    shape?: 'rect' | 'round' | 'roundRect';  // 裁切框形状，默认 'rect'
+    minZoom?: number;               // 最小缩放比例
+    maxZoom?: number;               // 最大缩放比例
+    zoomStep?: number;              // 缩放步长
+    quality?: number;               // 输出图片质量 0-1，默认 0.92
+    fill?: string;                  // 填充颜色，默认 '#fff'
+    modalTitle?: string;            // 裁切弹窗标题
+    modalOkText?: string;           // 确认按钮文字
+    modalCancelText?: string;       // 取消按钮文字
 }
 ```
 

--- a/content/input/upload/index.md
+++ b/content/input/upload/index.md
@@ -1717,13 +1717,13 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |addOnPasting | 按下 ctrl/command + v时，是否自动将剪贴板中的文件添加至 fileList，当前仅支持图片类型; 需用户授权同意 | boolean | false | 2.43.0 |
 |afterUpload | 文件上传后的钩子，根据 return 的 object 更新文件状态 | function(auProps) => afterUploadResult |  |  |
 |beforeClear|清空文件前回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(fileList: Array<FileItem \>) => boolean\|Promise|| |
-|beforeCrop|图片裁切前的回调。返回 `false` 可跳过裁切直接上传，返回 `true` 或不返回则继续裁切。支持异步返回|(file: File, fileList: File[]) => boolean \| Promise<boolean> | | 2.x |
+|beforeCrop|图片裁切前的回调。返回 `false` 可跳过裁切直接上传，返回 `true` 或不返回则继续裁切。支持异步返回|(file: File, fileList: File[]) => boolean \| Promise<boolean> | | 2.97.0 |
 |beforeRemove|移除文件前的回调，按照返回值来判断是否继续移除，返回false、Promise.resolve(false)、Promise.reject()会阻止移除|(file: <FileItem\>, fileList: Array<FileItem \>) => boolean\|Promise|| |
 |beforeUpload | 上传文件前的钩子，根据 return 的 object 更新文件状态，控制是否上传 | function(buProps) => beforeUploadResult \| Promise \| boolean |  |  |
 |capture | 文件上传控件中媒体拍摄的方式 | boolean\|string\|undefined | | |
 |className | 类名 | string |  |  |
-|crop | 启用图片裁切功能。传入 `true` 使用默认配置，传入对象可自定义裁切参数。支持所有上传入口（点击选择、拖拽、粘贴、替换）的图片裁切 | boolean \| CropProps |  | 2.x |
-|cropModalProps | 自定义裁切弹窗的属性，可配置弹窗的样式、宽度等 | ModalReactProps |  | 2.x |
+|crop | 启用图片裁切功能。传入 `true` 使用默认配置，传入对象可自定义裁切参数。支持所有上传入口（点击选择、拖拽、粘贴、替换）的图片裁切 | boolean \| CropProps |  | 2.97.0 |
+|cropModalProps | 自定义裁切弹窗的属性，可配置弹窗的样式、宽度等 | ModalReactProps |  | 2.97.0 |
 |customRequest | 自定义上传使用的异步请求方法 | (object: customRequestArgs) => void |  |  |
 |data | 上传时附带的额外参数或返回上传额外参数的方法 | object\|(file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File)) => object | {} |  |
 |defaultFileList | 已上传的文件列表 | Array<FileItem\> | [] |  |
@@ -1748,7 +1748,7 @@ import { IconUpload } from '@douyinfe/semi-icons';
 |onAcceptInvalid | 当接收到的文件不符合accept规范时触发（一般是因为文件夹选择了全部类型文件/拖拽不符合格式的文件时触发） | (files: File[]) => void | |  |
 |onChange | 文件状态发生变化时调用，包括上传成功，失败，上传中，回调入参为 Object，包含 fileList、currentFile 等值 | ({fileList: Array<FileItem\>, currentFile?: FileItem}) => void |  |  |
 |onClear | 点击清空时的回调 | () => void |  |  |
-|onCropError | 图片裁切失败时的回调 | (error: Error) => void |  | 2.x |
+|onCropError | 图片裁切失败时的回调 | (error: Error) => void |  | 2.97.0 |
 |onDrop | 当拖拽的元素在拖拽区上被释放时触发 | (e, files: Array<File\>, fileList: Array<FileItem\>) => void |  |  |
 |onError | 上传错误时的回调 | (error: Error, file: [File](https://developer.mozilla.org/zh-CN/docs/Web/API/File), fileList: Array<FileItem\>, xhr: XMLHttpRequest) => void |  |  |
 |onExceed | 上传文件总数超出 `limit` 时的回调 | (fileList:Array<FileItem\>) => void |  |  |

--- a/packages/semi-ui/locale/interface.ts
+++ b/packages/semi-ui/locale/interface.ts
@@ -137,7 +137,10 @@ export interface Locale {
         selectedFiles: string;
         replace: string;
         illegalSize: string;
-        fail: string
+        fail: string;
+        cropTitle?: string;
+        cropOk?: string;
+        cropCancel?: string;
     };
     TreeSelect: {
         searchPlaceholder: string

--- a/packages/semi-ui/locale/source/en_US.ts
+++ b/packages/semi-ui/locale/source/en_US.ts
@@ -139,6 +139,9 @@ const local: Locale = {
         selectedFiles: 'Selected Files',
         illegalSize: 'Illegal file size',
         fail: 'Upload fail',
+        cropTitle: 'Crop Image',
+        cropOk: 'OK',
+        cropCancel: 'Cancel',
     },
     TreeSelect: {
         searchPlaceholder: 'Search',

--- a/packages/semi-ui/locale/source/zh_CN.ts
+++ b/packages/semi-ui/locale/source/zh_CN.ts
@@ -140,6 +140,9 @@ const local: Locale = {
         selectedFiles: '已选择文件',
         illegalSize: '文件尺寸不合法',
         fail: '上传失败',
+        cropTitle: '裁切图片',
+        cropOk: '确定',
+        cropCancel: '取消',
     },
     TreeSelect: {
         searchPlaceholder: '搜索',

--- a/packages/semi-ui/upload/__test__/uploadCrop.test.js
+++ b/packages/semi-ui/upload/__test__/uploadCrop.test.js
@@ -1,0 +1,115 @@
+import sleep from '@douyinfe/semi-ui/_test_/utils/function/sleep';
+import React from 'react';
+import { IconUser } from '@douyinfe/semi-icons';
+import { Upload, Button } from '../../index';
+import { BASE_CLASS_PREFIX } from '../../../semi-foundation/base/constants';
+
+// Smoke tests for the crop feature added in #2889. Lives in its own file so it
+// is not affected by stray async side effects from other Upload tests.
+
+const action = 'https://semi.bytendance.com';
+
+function getUpload(props = {}) {
+    if (!props.children) {
+        props.children = (
+            <Button icon={<IconUser />} theme="light">
+                upload
+            </Button>
+        );
+    }
+    if (!props.action) {
+        props.action = action;
+    }
+    return mount(<Upload {...props} />);
+}
+
+function trigger(upload, event) {
+    const input = upload.find(`.${BASE_CLASS_PREFIX}-upload-hidden-input`);
+    input.simulate('change', event);
+}
+
+const createFile = (size = 100, name = 'avatar.png', type = 'image/png') => {
+    return new File([new ArrayBuffer(size)], name, { type });
+};
+
+describe('Upload crop', () => {
+    let xhr;
+    let requests;
+
+    beforeAll(() => {
+        window.URL.createObjectURL = jest.fn(() => 'blob:mock');
+        window.URL.revokeObjectURL = jest.fn();
+    });
+
+    beforeEach(() => {
+        xhr = sinon.useFakeXMLHttpRequest();
+        requests = [];
+        xhr.onCreate = req => requests.push(req);
+        window.URL.createObjectURL.mockImplementation(() => 'blob:mock');
+    });
+
+    afterEach(() => {
+        xhr.restore();
+    });
+
+    it('opens the cropper for image files when crop is enabled', async () => {
+        const upload = getUpload({ crop: true });
+        trigger(upload, { target: { files: [createFile(100, 'avatar.png', 'image/png')] } });
+        await sleep(50);
+        upload.update();
+        expect(upload.state('cropperVisible')).toBe(true);
+        expect(upload.state('cropperFile').name).toBe('avatar.png');
+        expect(upload.state('isReplaceOperation')).toBe(false);
+        upload.unmount();
+    });
+
+    it('skips the cropper for non-image files even when crop is enabled', async () => {
+        const upload = getUpload({ crop: true });
+        trigger(upload, { target: { files: [createFile(100, 'note.txt', 'text/plain')] } });
+        await sleep(50);
+        upload.update();
+        expect(upload.state('cropperVisible')).toBe(false);
+        upload.unmount();
+    });
+
+    it('beforeCrop returning false bypasses the cropper', async () => {
+        const beforeCrop = jest.fn(() => false);
+        const upload = getUpload({ crop: true, beforeCrop });
+        trigger(upload, { target: { files: [createFile(100, 'avatar.png', 'image/png')] } });
+        await sleep(50);
+        upload.update();
+        expect(beforeCrop).toHaveBeenCalled();
+        expect(upload.state('cropperVisible')).toBe(false);
+        upload.unmount();
+    });
+
+    it('queues additional images for sequential cropping (not silently dropped)', async () => {
+        const upload = getUpload({ crop: true, multiple: true });
+        const img1 = createFile(100, 'a.png', 'image/png');
+        const img2 = createFile(100, 'b.png', 'image/png');
+        const txt = createFile(100, 'note.txt', 'text/plain');
+        trigger(upload, { target: { files: [img1, img2, txt] } });
+        await sleep(50);
+        upload.update();
+        expect(upload.state('cropperVisible')).toBe(true);
+        expect(upload.state('cropperFile').name).toBe('a.png');
+        expect(upload.state('pendingImageFiles').map(f => f.name)).toEqual(['b.png']);
+        expect(upload.state('nonImageFiles').map(f => f.name)).toEqual(['note.txt']);
+        upload.unmount();
+    });
+
+    it('cancelling the crop tears down the queue and resets the file input', async () => {
+        const upload = getUpload({ crop: true });
+        trigger(upload, { target: { files: [createFile(100, 'avatar.png', 'image/png')] } });
+        await sleep(50);
+        upload.update();
+        const beforeKey = upload.state('inputKey');
+        upload.instance().handleCropCancel();
+        await sleep(20);
+        upload.update();
+        expect(upload.state('cropperVisible')).toBe(false);
+        expect(upload.state('cropperFile')).toBeNull();
+        expect(upload.state('inputKey')).not.toBe(beforeKey);
+        upload.unmount();
+    });
+});

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -129,14 +129,20 @@ export interface UploadProps {
     validateStatus?: ValidateStatus;
     withCredentials?: boolean;
     showTooltip?: boolean | ShowTooltip;
-    /** 启用图片裁切功能，可传入裁切配置对象 */
+    /**
+     * Enable image cropping. Pass `true` to use defaults, or a `CropProps` object
+     * to customize aspect ratio, shape, output quality, etc.
+     */
     crop?: boolean | CropProps;
-    /** 裁切前的回调，返回 false 可阻止裁切 */
+    /**
+     * Callback invoked before opening the crop modal for each image.
+     * Return `false` (or resolve to `false`) to skip cropping and upload directly.
+     */
     beforeCrop?: (file: File, fileList: File[]) => boolean | Promise<boolean>;
-    /** 裁切失败的回调 */
+    /** Callback invoked when cropping fails. */
     onCropError?: (error: Error) => void;
-    /** 自定义裁切弹窗属性 */
-    cropModalProps?: ModalReactProps;
+    /** Extra props forwarded to the underlying crop Modal. */
+    cropModalProps?: ModalReactProps
 }
 
 export interface UploadState {
@@ -149,10 +155,18 @@ export interface UploadState {
     replaceInputKey: number;
     // Cropper state
     cropperVisible: boolean;
+    /** The image file currently being cropped */
     cropperFile: File | null;
+    /** Object URL for the image currently being cropped */
     cropperSrc: string;
-    pendingFiles: File[];
-    isReplaceOperation: boolean; // Flag to indicate if this is a replace operation
+    /** Remaining image files queued for cropping (cropped one at a time) */
+    pendingImageFiles: File[];
+    /** Non-image files that bypass cropping but are uploaded together */
+    nonImageFiles: File[];
+    /** Image files already cropped, accumulated until the queue drains */
+    croppedFiles: File[];
+    /** Flag to indicate this round was triggered by a replace action */
+    isReplaceOperation: boolean
 }
 
 class Upload extends BaseComponent<UploadProps, UploadState> {
@@ -281,7 +295,9 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
             cropperVisible: false,
             cropperFile: null,
             cropperSrc: '',
-            pendingFiles: [],
+            pendingImageFiles: [],
+            nonImageFiles: [],
+            croppedFiles: [],
             isReplaceOperation: false,
         };
         this.foundation = new UploadFoundation(this.adapter);
@@ -418,17 +434,14 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
                 }
             },
             registerPasteEventHandler: (cb?: (e: ClipboardEvent) => void): void => {
-                // Wrap the callback to intercept cropping
+                // Intercept paste events when crop is enabled and the clipboard contains images;
+                // otherwise pass through to the foundation-supplied handler unchanged.
                 const wrappedCb = (e: ClipboardEvent) => {
                     const { crop } = this.props;
-                    
-                    // If crop is enabled and this is a paste event with files
                     if (crop && e.clipboardData && e.clipboardData.items) {
-                        const items = e.clipboardData.items;
                         const files: File[] = [];
-                        
-                        for (let i = 0; i < items.length; i++) {
-                            const item = items[i];
+                        for (let i = 0; i < e.clipboardData.items.length; i++) {
+                            const item = e.clipboardData.items[i];
                             if (item.kind === 'file') {
                                 const file = item.getAsFile();
                                 if (file) {
@@ -436,23 +449,15 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
                                 }
                             }
                         }
-                        
-                        if (files.length > 0) {
-                            const imageFiles = files.filter(file => this.isImageFile(file));
-                            
-                            if (imageFiles.length > 0) {
-                                // Intercept and start cropping
-                                e.preventDefault();
-                                this.handleCropFiles(files);
-                                return;
-                            }
+                        if (files.length > 0 && files.some(file => this.isImageFile(file))) {
+                            e.preventDefault();
+                            this.handleCropFiles(files);
+                            return;
                         }
                     }
-                    
-                    // Otherwise, call original callback
                     cb?.(e);
                 };
-                
+
                 document.body.addEventListener('paste', wrappedCb);
                 this.pasteEventCb = wrappedCb;
             },
@@ -506,18 +511,15 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     onChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const { files } = e.target;
         const { crop } = this.props;
-        
+
         if (crop && files && files.length > 0) {
-            // Check if any files are images that need cropping
-            const imageFiles = Array.from(files).filter(file => this.isImageFile(file));
-            
-            if (imageFiles.length > 0) {
-                // Start cropping process
-                this.handleCropFiles(Array.from(files));
+            const fileArr = Array.from(files);
+            if (fileArr.some(file => this.isImageFile(file))) {
+                this.handleCropFiles(fileArr);
                 return;
             }
         }
-        
+
         this.foundation.handleChange(files);
     };
 
@@ -529,134 +531,152 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     };
 
     /**
-     * Handle files that may need cropping
-     * Note: Currently only processes the first image file for cropping.
-     * Multiple image cropping can be extended in the future if needed.
+     * Entry point that decides whether incoming files need cropping.
+     * Image files are queued for sequential cropping; non-image files are kept aside
+     * and uploaded together with the cropped results once the queue drains.
      */
-    handleCropFiles = async (files: File[]): Promise<void> => {
-        const { beforeCrop, onCropError } = this.props;
-        
-        // Filter image files that need cropping
+    handleCropFiles = async (files: File[], isReplaceOperation = false): Promise<void> => {
         const imageFiles = files.filter(file => this.isImageFile(file));
         const nonImageFiles = files.filter(file => !this.isImageFile(file));
-        
-        // Check beforeCrop hook
-        if (beforeCrop) {
-            try {
-                const shouldCrop = await beforeCrop(imageFiles[0], files);
-                if (shouldCrop === false) {
-                    // Skip cropping, process files directly
-                    this.foundation.handleChange(files);
-                    return;
-                }
-            } catch (error) {
-                // If beforeCrop throws, fallback to normal upload flow to avoid blocking user
-                console.error('beforeCrop error:', error);
-                onCropError?.(error as Error);
-                this.foundation.handleChange(files);
-                return;
-            }
+
+        if (imageFiles.length === 0) {
+            // No images to crop, fall back to the normal upload path
+            this.dispatchUpload(files, isReplaceOperation);
+            return;
         }
-        
-        // Store all files for later processing
-        // Currently only the first image is cropped.
-        // Other selected files (including additional images) will be uploaded without cropping.
-        if (imageFiles.length > 0) {
-            const restFiles = [...imageFiles.slice(1), ...nonImageFiles];
-            this.setState({
-                cropperVisible: true,
-                cropperFile: imageFiles[0],
-                cropperSrc: URL.createObjectURL(imageFiles[0]),
-                pendingFiles: restFiles,
-                isReplaceOperation: false,
-            });
-        } else {
-            // No images to crop, process directly
-            this.foundation.handleChange(files);
+
+        const shouldCrop = await this.shouldCropFile(imageFiles[0], files);
+        if (!shouldCrop) {
+            this.dispatchUpload(files, isReplaceOperation);
+            return;
+        }
+
+        // Replace only ever consumes a single file, ignore extras for safety
+        const queue = isReplaceOperation ? [imageFiles[0]] : imageFiles;
+        const [first, ...rest] = queue;
+        this.setState({
+            cropperVisible: true,
+            cropperFile: first,
+            cropperSrc: URL.createObjectURL(first),
+            pendingImageFiles: rest,
+            nonImageFiles: isReplaceOperation ? [] : nonImageFiles,
+            croppedFiles: [],
+            isReplaceOperation,
+        });
+    };
+
+    /**
+     * Run the user-provided beforeCrop hook (if any) and return whether cropping should proceed.
+     * Errors fall back to skipping cropping so users are never blocked.
+     */
+    shouldCropFile = async (file: File, files: File[]): Promise<boolean> => {
+        const { beforeCrop, onCropError } = this.props;
+        if (!beforeCrop) {
+            return true;
+        }
+        try {
+            const result = await beforeCrop(file, files);
+            return result !== false;
+        } catch (error) {
+            onCropError?.(error as Error);
+            return false;
         }
     };
 
     /**
-     * Handle crop confirmation
+     * Forward files to the appropriate foundation handler based on operation type.
+     */
+    dispatchUpload = (files: File[], isReplaceOperation: boolean): void => {
+        if (isReplaceOperation) {
+            this.foundation.handleReplaceChange(files as any);
+        } else {
+            this.foundation.handleChange(files as any);
+        }
+    };
+
+    /**
+     * Confirm the current crop. If more images are queued, advance to the next one;
+     * otherwise dispatch the accumulated cropped files together with any non-image files.
      */
     handleCropOk = async (): Promise<void> => {
-        const { cropperFile, pendingFiles, isReplaceOperation } = this.state;
+        const { cropperFile, pendingImageFiles, nonImageFiles, croppedFiles, isReplaceOperation } = this.state;
         const { crop, onCropError } = this.props;
-        
+
         try {
-            // Get cropped canvas
             const cropperInstance = this.cropperRef.current;
-            if (!cropperInstance) {
+            if (!cropperInstance || !cropperFile) {
                 throw new Error('Cropper instance not found');
             }
-            
             const canvas = cropperInstance.getCropperCanvas();
-            
-            // Convert canvas to blob
+
             const cropConfig = typeof crop === 'object' ? crop : {};
             const quality = cropConfig.quality ?? 0.92;
-            const type = cropperFile?.type || 'image/png';
-            
+            const type = cropperFile.type || 'image/png';
+
             const blob = await new Promise<Blob>((resolve, reject) => {
                 canvas.toBlob(
-                    (b) => {
-                        if (b) {
-                            resolve(b);
-                        } else {
-                            reject(new Error('Failed to create blob'));
-                        }
-                    },
+                    b => (b ? resolve(b) : reject(new Error('Failed to create blob'))),
                     type,
                     quality
                 );
             });
-            
-            // Create new File from blob
-            const croppedFile = new File([blob], cropperFile?.name || 'cropped-image.png', {
+
+            // Preserve the original filename and lastModified so downstream consumers
+            // can keep meaningful metadata about the user-chosen file.
+            const croppedFile = new File([blob], cropperFile.name, {
                 type,
-                lastModified: Date.now(),
+                lastModified: cropperFile.lastModified,
             });
-            
-            // Close cropper and clean up
-            this.handleCropCancel();
-            
-            // Process files based on operation type
-            if (isReplaceOperation) {
-                // For replace operation, only pass the cropped file
-                this.foundation.handleReplaceChange([croppedFile]);
-            } else {
-                // For normal upload, combine cropped file with other pending files
-                const allFiles = [croppedFile, ...pendingFiles];
-                this.foundation.handleChange(allFiles as any);
+
+            const nextCropped = [...croppedFiles, croppedFile];
+
+            if (pendingImageFiles.length > 0) {
+                // Move on to the next queued image
+                const [next, ...rest] = pendingImageFiles;
+                if (this.state.cropperSrc) {
+                    URL.revokeObjectURL(this.state.cropperSrc);
+                }
+                this.setState({
+                    cropperFile: next,
+                    cropperSrc: URL.createObjectURL(next),
+                    pendingImageFiles: rest,
+                    croppedFiles: nextCropped,
+                });
+                return;
             }
-            
+
+            // Queue exhausted: close cropper and dispatch results
+            this.closeCropperAndReset();
+            this.dispatchUpload([...nextCropped, ...nonImageFiles], isReplaceOperation);
         } catch (error) {
-            console.error('Crop error:', error);
-            if (onCropError) {
-                onCropError(error as Error);
-            }
+            onCropError?.(error as Error);
         }
     };
 
     /**
-     * Handle crop cancellation
+     * Cancel the current crop session, revoke object URLs and reset state.
      */
     handleCropCancel = (): void => {
+        this.closeCropperAndReset();
+    };
+
+    /** Internal helper that tears down crop state and resets the file input. */
+    closeCropperAndReset = (): void => {
         const { cropperSrc } = this.state;
-        
-        // Revoke object URL
         if (cropperSrc) {
             URL.revokeObjectURL(cropperSrc);
         }
-        
         this.setState({
             cropperVisible: false,
             cropperFile: null,
             cropperSrc: '',
-            pendingFiles: [],
+            pendingImageFiles: [],
+            nonImageFiles: [],
+            croppedFiles: [],
             isReplaceOperation: false,
-            // Reset input so selecting the same file again can trigger onChange
+            // Reset input key so picking the same file again re-triggers onChange
             inputKey: Math.random(),
+            replaceInputKey: Math.random(),
         });
     };
 
@@ -671,65 +691,14 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
         const { crop } = this.props;
 
         if (crop && files && files.length > 0) {
-            const imageFiles = Array.from(files).filter(file => this.isImageFile(file));
-
-            if (imageFiles.length > 0) {
-                // For replace, we need to handle cropping specially
-                // Store the replace context so we can replace after cropping
-                this.setState({
-                    replaceIdx: this.state.replaceIdx,
-                });
-                // Start cropping process - handleCropFiles will eventually call foundation.handleChange
-                // But we need a different flow for replace...
-                // Actually, we should handle replace differently
-                this.handleReplaceCropFiles(Array.from(files));
+            const fileArr = Array.from(files);
+            if (fileArr.some(file => this.isImageFile(file))) {
+                this.handleCropFiles(fileArr, true);
                 return;
             }
         }
 
         this.foundation.handleReplaceChange(files);
-    };
-
-    /**
-     * Handle files that need cropping for replace operation
-     */
-    handleReplaceCropFiles = async (files: File[]): Promise<void> => {
-        const { beforeCrop, onCropError } = this.props;
-        const { replaceIdx } = this.state;
-
-        const imageFiles = files.filter(file => this.isImageFile(file));
-
-        // Check beforeCrop hook
-        if (beforeCrop) {
-            try {
-                const shouldCrop = await beforeCrop(imageFiles[0], files);
-                if (shouldCrop === false) {
-                    // Skip cropping, process replace directly
-                    this.foundation.handleReplaceChange(files);
-                    return;
-                }
-            } catch (error) {
-                // If beforeCrop throws, fallback to normal replace flow
-                console.error('beforeCrop error:', error);
-                onCropError?.(error as Error);
-                this.foundation.handleReplaceChange(files);
-                return;
-            }
-        }
-
-        // For replace, only first image is processed
-        if (imageFiles.length > 0) {
-            this.setState({
-                cropperVisible: true,
-                cropperFile: imageFiles[0],
-                cropperSrc: URL.createObjectURL(imageFiles[0]),
-                pendingFiles: [], // No pending files for replace
-                isReplaceOperation: true,
-            });
-        } else {
-            // No images to crop, process replace directly
-            this.foundation.handleReplaceChange(files);
-        }
     };
 
     clear = (): void => {
@@ -982,46 +951,31 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     };
 
     onDrop = (e: DragEvent<HTMLDivElement>): void => {
-        // Block file opening in browser
-        e.preventDefault();
-        e.stopPropagation();
-        
         const { crop, directory, disabled } = this.props;
-        const fileList = this.state.fileList.slice();
-        
-        // If disabled, do nothing
-        if (disabled) {
-            return;
-        }
-        
-        // If directory upload, delegate to foundation (folder upload doesn't support cropping)
-        if (directory) {
+
+        // For disabled / directory / no-crop scenarios, defer to the foundation
+        // so existing accept / limit / drag-area-status / notifyDrop logic still applies.
+        if (disabled || directory || !crop) {
             this.foundation.handleDrop(e);
             return;
         }
-        
-        const files = Array.from(e.dataTransfer.files);
-        
-        // If crop is enabled and there are image files, intercept for cropping
-        if (crop && files.length > 0) {
-            const imageFiles = files.filter(file => this.isImageFile(file));
-            
-            if (imageFiles.length > 0) {
-                // Update drag area status
-                this.setState({ dragAreaStatus: 'default' as const });
-                // Notify drop callback
-                // Use nativeEvent to match public API typing: onDrop(e: Event, ...)
-                // React DragEvent is not assignable to DOM Event in TS.
-                const eventForCb: Event = (e as any).nativeEvent || (e as any);
-                this.props.onDrop(eventForCb, files, fileList);
-                // Start cropping process
-                this.handleCropFiles(files);
-                return;
-            }
+
+        const files = e.dataTransfer && e.dataTransfer.files ? Array.from(e.dataTransfer.files) : [];
+        if (files.length === 0 || !files.some(file => this.isImageFile(file))) {
+            this.foundation.handleDrop(e);
+            return;
         }
-        
-        // Fall back to foundation's default handling
-        this.foundation.handleDrop(e);
+
+        // We need to short-circuit the foundation's default handling so the original files
+        // are not uploaded before cropping. Reproduce only the side effects that would
+        // otherwise happen: prevent default browser open, reset drag status, fire onDrop.
+        e.preventDefault();
+        e.stopPropagation();
+        const fileList = this.state.fileList.slice();
+        this.setState({ dragAreaStatus: 'default' as const });
+        const eventForCb: Event = (e as any).nativeEvent || (e as any);
+        this.props.onDrop(eventForCb, files, fileList);
+        this.handleCropFiles(files);
     };
 
     onDragOver = (e: DragEvent<HTMLDivElement>): void => {

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -8,6 +8,8 @@ import FileCard from './fileCard';
 import BaseComponent from '../_base/baseComponent';
 import LocaleConsumer from '../locale/localeConsumer';
 import { IconUpload } from '@douyinfe/semi-icons';
+import Cropper from '../cropper';
+import Modal, { type ModalReactProps } from '../modal';
 import type {
     FileItem,
     RenderFileItemProps,
@@ -20,6 +22,7 @@ import type {
     CustomError,
     RenderPictureCloseProps,
     RenderFileListTitleProps,
+    CropProps,
 } from './interface';
 import { Locale } from '../locale/interface';
 import '@douyinfe/semi-foundation/upload/upload.scss';
@@ -50,6 +53,7 @@ export type {
     BeforeUploadObjectResult,
     AfterUploadResult,
     RenderFileListTitleProps,
+    CropProps,
 };
 
 export interface UploadProps {
@@ -124,7 +128,15 @@ export interface UploadProps {
     validateMessage?: ReactNode;
     validateStatus?: ValidateStatus;
     withCredentials?: boolean;
-    showTooltip?: boolean | ShowTooltip
+    showTooltip?: boolean | ShowTooltip;
+    /** 启用图片裁切功能，可传入裁切配置对象 */
+    crop?: boolean | CropProps;
+    /** 裁切前的回调，返回 false 可阻止裁切 */
+    beforeCrop?: (file: File, fileList: File[]) => boolean | Promise<boolean>;
+    /** 裁切失败的回调 */
+    onCropError?: (error: Error) => void;
+    /** 自定义裁切弹窗属性 */
+    cropModalProps?: ModalReactProps;
 }
 
 export interface UploadState {
@@ -134,7 +146,13 @@ export interface UploadState {
     // Track objectURL created by Upload (legacy, kept for compatibility)
     localUrls: Array<string>;
     replaceIdx: number;
-    replaceInputKey: number
+    replaceInputKey: number;
+    // Cropper state
+    cropperVisible: boolean;
+    cropperFile: File | null;
+    cropperSrc: string;
+    pendingFiles: File[];
+    isReplaceOperation: boolean; // Flag to indicate if this is a replace operation
 }
 
 class Upload extends BaseComponent<UploadProps, UploadState> {
@@ -207,7 +225,11 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
         validateMessage: PropTypes.node,
         validateStatus: PropTypes.oneOf<UploadProps['validateStatus']>(strings.VALIDATE_STATUS),
         withCredentials: PropTypes.bool,
-        showTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.object])
+        showTooltip: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+        crop: PropTypes.oneOfType([PropTypes.bool, PropTypes.object]),
+        beforeCrop: PropTypes.func,
+        onCropError: PropTypes.func,
+        cropModalProps: PropTypes.object,
     };
 
     static defaultProps: Partial<UploadProps> = {
@@ -255,10 +277,17 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
             // Status of the drag zone
             dragAreaStatus: 'default',
             localUrls: [],
+            // Cropper state
+            cropperVisible: false,
+            cropperFile: null,
+            cropperSrc: '',
+            pendingFiles: [],
+            isReplaceOperation: false,
         };
         this.foundation = new UploadFoundation(this.adapter);
         this.inputRef = React.createRef<HTMLInputElement>();
         this.replaceInputRef = React.createRef<HTMLInputElement>();
+        this.cropperRef = React.createRef<Cropper>();
     }
 
     /**
@@ -317,8 +346,71 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
                 return navigator.platform.toUpperCase().indexOf('MAC') >= 0;
             },
             registerPastingHandler: (cb?: (e: KeyboardEvent | ClipboardEvent) => void): void => {
-                document.body.addEventListener('keydown', cb);
-                this.pastingCb = cb;
+                // Wrap the callback to intercept cropping
+                const wrappedCb = (e: KeyboardEvent | ClipboardEvent) => {
+                    const { crop } = this.props;
+                    
+                    // Handle keydown event (Ctrl/Cmd+V) with crop interception
+                    if (crop && e.type === 'keydown' && 'code' in e) {
+                        const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
+                        const isCombineKeydown = isMac ? e.metaKey : e.ctrlKey;
+                        
+                        if (isCombineKeydown && e.code === 'KeyV') {
+                            // Check if navigator.clipboard is available
+                            if (navigator.clipboard && typeof navigator.clipboard.read === 'function') {
+                                const permissionName = 'clipboard-read' as PermissionName;
+                                navigator.permissions
+                                    .query({ name: permissionName })
+                                    .then(result => {
+                                        if (result.state === 'granted' || result.state === 'prompt') {
+                                            navigator.clipboard.read().then(clipboardItems => {
+                                                const files: File[] = [];
+                                                const processClipboardItems = async () => {
+                                                    for (const clipboardItem of clipboardItems) {
+                                                        for (const type of clipboardItem.types) {
+                                                            if (type.startsWith('image')) {
+                                                                const blob = await clipboardItem.getType(type);
+                                                                const buffer = await blob.arrayBuffer();
+                                                                const format = type.split('/')[1];
+                                                                const file = new File([buffer], `paste.${format}`, { type });
+                                                                files.push(file);
+                                                            }
+                                                        }
+                                                    }
+                                                    
+                                                    if (files.length > 0) {
+                                                        const imageFiles = files.filter(file => this.isImageFile(file));
+                                                        
+                                                        if (imageFiles.length > 0) {
+                                                            // Start cropping
+                                                            this.handleCropFiles(files);
+                                                        } else {
+                                                            // No images, let foundation handle it
+                                                            this.foundation.handleChange(files);
+                                                        }
+                                                    }
+                                                };
+                                                processClipboardItems();
+                                            }).catch(error => {
+                                                this.props.onPastingError(error);
+                                            });
+                                        }
+                                    })
+                                    .catch(error => {
+                                        this.props.onPastingError(error);
+                                    });
+                                // Don't call original callback, we've handled it
+                                return;
+                            }
+                        }
+                    }
+                    
+                    // Otherwise, call original callback
+                    cb?.(e);
+                };
+                
+                document.body.addEventListener('keydown', wrappedCb);
+                this.pastingCb = wrappedCb;
             },
             unRegisterPastingHandler: (): void => {
                 if (this.pastingCb) {
@@ -326,8 +418,43 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
                 }
             },
             registerPasteEventHandler: (cb?: (e: ClipboardEvent) => void): void => {
-                document.body.addEventListener('paste', cb);
-                this.pasteEventCb = cb;
+                // Wrap the callback to intercept cropping
+                const wrappedCb = (e: ClipboardEvent) => {
+                    const { crop } = this.props;
+                    
+                    // If crop is enabled and this is a paste event with files
+                    if (crop && e.clipboardData && e.clipboardData.items) {
+                        const items = e.clipboardData.items;
+                        const files: File[] = [];
+                        
+                        for (let i = 0; i < items.length; i++) {
+                            const item = items[i];
+                            if (item.kind === 'file') {
+                                const file = item.getAsFile();
+                                if (file) {
+                                    files.push(file);
+                                }
+                            }
+                        }
+                        
+                        if (files.length > 0) {
+                            const imageFiles = files.filter(file => this.isImageFile(file));
+                            
+                            if (imageFiles.length > 0) {
+                                // Intercept and start cropping
+                                e.preventDefault();
+                                this.handleCropFiles(files);
+                                return;
+                            }
+                        }
+                    }
+                    
+                    // Otherwise, call original callback
+                    cb?.(e);
+                };
+                
+                document.body.addEventListener('paste', wrappedCb);
+                this.pasteEventCb = wrappedCb;
             },
             unRegisterPasteEventHandler: (): void => {
                 if (this.pasteEventCb) {
@@ -351,6 +478,7 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     foundation: UploadFoundation;
     inputRef: RefObject<HTMLInputElement> = null;
     replaceInputRef: RefObject<HTMLInputElement> = null;
+    cropperRef: RefObject<Cropper> = null;
     pastingCb: null | ((params: any) => void) = null;
     pasteEventCb: null | ((params: any) => void) = null;
 
@@ -377,7 +505,159 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
 
     onChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const { files } = e.target;
+        const { crop } = this.props;
+        
+        if (crop && files && files.length > 0) {
+            // Check if any files are images that need cropping
+            const imageFiles = Array.from(files).filter(file => this.isImageFile(file));
+            
+            if (imageFiles.length > 0) {
+                // Start cropping process
+                this.handleCropFiles(Array.from(files));
+                return;
+            }
+        }
+        
         this.foundation.handleChange(files);
+    };
+
+    /**
+     * Check if file is an image
+     */
+    isImageFile = (file: File): boolean => {
+        return file.type.startsWith('image/');
+    };
+
+    /**
+     * Handle files that may need cropping
+     * Note: Currently only processes the first image file for cropping.
+     * Multiple image cropping can be extended in the future if needed.
+     */
+    handleCropFiles = async (files: File[]): Promise<void> => {
+        const { beforeCrop, onCropError } = this.props;
+        
+        // Filter image files that need cropping
+        const imageFiles = files.filter(file => this.isImageFile(file));
+        const nonImageFiles = files.filter(file => !this.isImageFile(file));
+        
+        // Check beforeCrop hook
+        if (beforeCrop) {
+            try {
+                const shouldCrop = await beforeCrop(imageFiles[0], files);
+                if (shouldCrop === false) {
+                    // Skip cropping, process files directly
+                    this.foundation.handleChange(files);
+                    return;
+                }
+            } catch (error) {
+                // If beforeCrop throws, fallback to normal upload flow to avoid blocking user
+                console.error('beforeCrop error:', error);
+                onCropError?.(error as Error);
+                this.foundation.handleChange(files);
+                return;
+            }
+        }
+        
+        // Store all files for later processing
+        // Currently only the first image is cropped.
+        // Other selected files (including additional images) will be uploaded without cropping.
+        if (imageFiles.length > 0) {
+            const restFiles = [...imageFiles.slice(1), ...nonImageFiles];
+            this.setState({
+                cropperVisible: true,
+                cropperFile: imageFiles[0],
+                cropperSrc: URL.createObjectURL(imageFiles[0]),
+                pendingFiles: restFiles,
+                isReplaceOperation: false,
+            });
+        } else {
+            // No images to crop, process directly
+            this.foundation.handleChange(files);
+        }
+    };
+
+    /**
+     * Handle crop confirmation
+     */
+    handleCropOk = async (): Promise<void> => {
+        const { cropperFile, pendingFiles, isReplaceOperation } = this.state;
+        const { crop, onCropError } = this.props;
+        
+        try {
+            // Get cropped canvas
+            const cropperInstance = this.cropperRef.current;
+            if (!cropperInstance) {
+                throw new Error('Cropper instance not found');
+            }
+            
+            const canvas = cropperInstance.getCropperCanvas();
+            
+            // Convert canvas to blob
+            const cropConfig = typeof crop === 'object' ? crop : {};
+            const quality = cropConfig.quality ?? 0.92;
+            const type = cropperFile?.type || 'image/png';
+            
+            const blob = await new Promise<Blob>((resolve, reject) => {
+                canvas.toBlob(
+                    (b) => {
+                        if (b) {
+                            resolve(b);
+                        } else {
+                            reject(new Error('Failed to create blob'));
+                        }
+                    },
+                    type,
+                    quality
+                );
+            });
+            
+            // Create new File from blob
+            const croppedFile = new File([blob], cropperFile?.name || 'cropped-image.png', {
+                type,
+                lastModified: Date.now(),
+            });
+            
+            // Close cropper and clean up
+            this.handleCropCancel();
+            
+            // Process files based on operation type
+            if (isReplaceOperation) {
+                // For replace operation, only pass the cropped file
+                this.foundation.handleReplaceChange([croppedFile]);
+            } else {
+                // For normal upload, combine cropped file with other pending files
+                const allFiles = [croppedFile, ...pendingFiles];
+                this.foundation.handleChange(allFiles as any);
+            }
+            
+        } catch (error) {
+            console.error('Crop error:', error);
+            if (onCropError) {
+                onCropError(error as Error);
+            }
+        }
+    };
+
+    /**
+     * Handle crop cancellation
+     */
+    handleCropCancel = (): void => {
+        const { cropperSrc } = this.state;
+        
+        // Revoke object URL
+        if (cropperSrc) {
+            URL.revokeObjectURL(cropperSrc);
+        }
+        
+        this.setState({
+            cropperVisible: false,
+            cropperFile: null,
+            cropperSrc: '',
+            pendingFiles: [],
+            isReplaceOperation: false,
+            // Reset input so selecting the same file again can trigger onChange
+            inputKey: Math.random(),
+        });
     };
 
     replace = (index: number): void => {
@@ -388,7 +668,68 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
 
     onReplaceChange = (e: ChangeEvent<HTMLInputElement>): void => {
         const { files } = e.target;
+        const { crop } = this.props;
+
+        if (crop && files && files.length > 0) {
+            const imageFiles = Array.from(files).filter(file => this.isImageFile(file));
+
+            if (imageFiles.length > 0) {
+                // For replace, we need to handle cropping specially
+                // Store the replace context so we can replace after cropping
+                this.setState({
+                    replaceIdx: this.state.replaceIdx,
+                });
+                // Start cropping process - handleCropFiles will eventually call foundation.handleChange
+                // But we need a different flow for replace...
+                // Actually, we should handle replace differently
+                this.handleReplaceCropFiles(Array.from(files));
+                return;
+            }
+        }
+
         this.foundation.handleReplaceChange(files);
+    };
+
+    /**
+     * Handle files that need cropping for replace operation
+     */
+    handleReplaceCropFiles = async (files: File[]): Promise<void> => {
+        const { beforeCrop, onCropError } = this.props;
+        const { replaceIdx } = this.state;
+
+        const imageFiles = files.filter(file => this.isImageFile(file));
+
+        // Check beforeCrop hook
+        if (beforeCrop) {
+            try {
+                const shouldCrop = await beforeCrop(imageFiles[0], files);
+                if (shouldCrop === false) {
+                    // Skip cropping, process replace directly
+                    this.foundation.handleReplaceChange(files);
+                    return;
+                }
+            } catch (error) {
+                // If beforeCrop throws, fallback to normal replace flow
+                console.error('beforeCrop error:', error);
+                onCropError?.(error as Error);
+                this.foundation.handleReplaceChange(files);
+                return;
+            }
+        }
+
+        // For replace, only first image is processed
+        if (imageFiles.length > 0) {
+            this.setState({
+                cropperVisible: true,
+                cropperFile: imageFiles[0],
+                cropperSrc: URL.createObjectURL(imageFiles[0]),
+                pendingFiles: [], // No pending files for replace
+                isReplaceOperation: true,
+            });
+        } else {
+            // No images to crop, process replace directly
+            this.foundation.handleReplaceChange(files);
+        }
     };
 
     clear = (): void => {
@@ -641,6 +982,45 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
     };
 
     onDrop = (e: DragEvent<HTMLDivElement>): void => {
+        // Block file opening in browser
+        e.preventDefault();
+        e.stopPropagation();
+        
+        const { crop, directory, disabled } = this.props;
+        const fileList = this.state.fileList.slice();
+        
+        // If disabled, do nothing
+        if (disabled) {
+            return;
+        }
+        
+        // If directory upload, delegate to foundation (folder upload doesn't support cropping)
+        if (directory) {
+            this.foundation.handleDrop(e);
+            return;
+        }
+        
+        const files = Array.from(e.dataTransfer.files);
+        
+        // If crop is enabled and there are image files, intercept for cropping
+        if (crop && files.length > 0) {
+            const imageFiles = files.filter(file => this.isImageFile(file));
+            
+            if (imageFiles.length > 0) {
+                // Update drag area status
+                this.setState({ dragAreaStatus: 'default' as const });
+                // Notify drop callback
+                // Use nativeEvent to match public API typing: onDrop(e: Event, ...)
+                // React DragEvent is not assignable to DOM Event in TS.
+                const eventForCb: Event = (e as any).nativeEvent || (e as any);
+                this.props.onDrop(eventForCb, files, fileList);
+                // Start cropping process
+                this.handleCropFiles(files);
+                return;
+            }
+        }
+        
+        // Fall back to foundation's default handling
         this.foundation.handleDrop(e);
     };
 
@@ -730,6 +1110,56 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
         );
     };
 
+    renderCropperModal = (): ReactNode => {
+        const { cropperVisible, cropperSrc } = this.state;
+        const { crop, cropModalProps } = this.props;
+        const cropConfig = typeof crop === 'object' ? crop : {};
+        const {
+            style: modalStyle,
+            bodyStyle: modalBodyStyle,
+            ...restModalProps
+        } = (cropModalProps || {}) as ModalReactProps;
+        
+        return (
+            <LocaleConsumer componentName="Upload">
+                {(locale: Locale['Upload']) => {
+                    const modalTitle = cropConfig.modalTitle || locale.cropTitle || '裁切图片';
+                    const modalOkText = cropConfig.modalOkText || locale.cropOk || '确定';
+                    const modalCancelText = cropConfig.modalCancelText || locale.cropCancel || '取消';
+                    
+                    return (
+                        <Modal
+                            {...restModalProps}
+                            width={600}
+                            title={modalTitle}
+                            visible={cropperVisible}
+                            onOk={this.handleCropOk}
+                            onCancel={this.handleCropCancel}
+                            okText={modalOkText}
+                            cancelText={modalCancelText}
+                            style={{ height: 500, ...(modalStyle || {}) }}
+                            bodyStyle={{ height: 400, ...(modalBodyStyle || {}) }}
+                        >
+                            {cropperSrc && (
+                                <Cropper
+                                    ref={this.cropperRef}
+                                    src={cropperSrc}
+                                    shape={cropConfig.shape || 'rect'}
+                                    aspectRatio={cropConfig.aspectRatio}
+                                    minZoom={cropConfig.minZoom}
+                                    maxZoom={cropConfig.maxZoom}
+                                    zoomStep={cropConfig.zoomStep}
+                                    fill={cropConfig.fill}
+                                    style={{ width: '100%', height: '100%' }}
+                                />
+                            )}
+                        </Modal>
+                    );
+                }}
+            </LocaleConsumer>
+        );
+    };
+
     render(): ReactNode {
         const {
             style,
@@ -806,6 +1236,7 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
                     </div>
                 ) : null}
                 {this.renderFileList()}
+                {this.renderCropperModal()}
             </div>
         );
     }

--- a/packages/semi-ui/upload/interface.ts
+++ b/packages/semi-ui/upload/interface.ts
@@ -2,6 +2,7 @@ import { ReactNode, CSSProperties, MouseEvent } from 'react';
 import { BaseFileItem } from '@douyinfe/semi-foundation/upload/foundation';
 import { strings } from '@douyinfe/semi-foundation/upload/constants';
 import { ArrayElement } from '../_base/base';
+// keep imports minimal; Upload crop modal props type is declared in Upload component
 
 export type PromptPositionType = ArrayElement<typeof strings.PROMPT_POSITION>;
 export type UploadListType = ArrayElement<typeof strings.LIST_TYPE>;
@@ -72,4 +73,27 @@ export interface RenderFileListTitleProps {
     fileList: Array<FileItem>;
     onClear: () => void;
     clearText: string;
+}
+
+export interface CropProps {
+    /** 裁切框比例 */
+    aspectRatio?: number;
+    /** 裁切框形状 */
+    shape?: 'rect' | 'round' | 'roundRect';
+    /** 最小缩放比例 */
+    minZoom?: number;
+    /** 最大缩放比例 */
+    maxZoom?: number;
+    /** 缩放步长 */
+    zoomStep?: number;
+    /** 输出图片质量 0-1 */
+    quality?: number;
+    /** 填充颜色 */
+    fill?: string;
+    /** 弹窗标题 */
+    modalTitle?: string;
+    /** 确认按钮文字 */
+    modalOkText?: string;
+    /** 取消按钮文字 */
+    modalCancelText?: string;
 }

--- a/packages/semi-ui/upload/interface.ts
+++ b/packages/semi-ui/upload/interface.ts
@@ -72,28 +72,28 @@ export interface RenderPictureCloseProps {
 export interface RenderFileListTitleProps {
     fileList: Array<FileItem>;
     onClear: () => void;
-    clearText: string;
+    clearText: string
 }
 
 export interface CropProps {
-    /** 裁切框比例 */
+    /** Crop box aspect ratio (width / height), e.g. 16/9, 1, 4/3 */
     aspectRatio?: number;
-    /** 裁切框形状 */
+    /** Crop box shape */
     shape?: 'rect' | 'round' | 'roundRect';
-    /** 最小缩放比例 */
+    /** Minimum zoom ratio */
     minZoom?: number;
-    /** 最大缩放比例 */
+    /** Maximum zoom ratio */
     maxZoom?: number;
-    /** 缩放步长 */
+    /** Zoom step size */
     zoomStep?: number;
-    /** 输出图片质量 0-1 */
+    /** Output image quality, range 0 - 1, defaults to 0.92 */
     quality?: number;
-    /** 填充颜色 */
+    /** Fill color of the area outside the cropped region */
     fill?: string;
-    /** 弹窗标题 */
+    /** Title text of the crop modal (overrides locale value) */
     modalTitle?: string;
-    /** 确认按钮文字 */
+    /** Confirm button text of the crop modal (overrides locale value) */
     modalOkText?: string;
-    /** 取消按钮文字 */
-    modalCancelText?: string;
+    /** Cancel button text of the crop modal (overrides locale value) */
+    modalCancelText?: string
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,14 +20682,6 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
-null-loader@4.0.1, null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
-
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20697,6 +20689,14 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
+
+null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,13 +23226,6 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
-react-dom@^19.0.0:
-  version "19.2.6"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.6.tgz#44a81b0bcca22da814c00847d09d01c8615529b7"
-  integrity sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==
-  dependencies:
-    scheduler "^0.27.0"
-
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23506,11 +23499,6 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-
-react@^19.0.0:
-  version "19.2.6"
-  resolved "https://registry.yarnpkg.com/react/-/react-19.2.6.tgz#3dadb8e12b2a7934c1d5317973e5dce1301f9a4d"
-  integrity sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24726,11 +24714,6 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
-
-scheduler@^0.27.0:
-  version "0.27.0"
-  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
-  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6149,7 +6149,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1":
+"@types/react-dom@<18.0.0", "@types/react-dom@>=16.0.0", "@types/react-dom@^18.0.1", "@types/react-dom@^19.0.0":
   version "18.3.0"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-18.3.0.tgz#0cbc818755d87066ab6ca74fbedb2547d74a82b0"
   integrity sha512-EhwApuTmMBmXuFOikhQLIBUn6uFg81SwLMOAUgodJF14SOBOCMdU04gDoYi0WOJJHD144TL32z4yDqCW3dnkQg==
@@ -6194,7 +6194,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5":
+"@types/react@*", "@types/react@>=16.0.0", "@types/react@^18.0.5", "@types/react@^19.0.0":
   version "18.3.5"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-18.3.5.tgz#5f524c2ad2089c0ff372bbdabc77ca2c4dbadf8f"
   integrity sha512-WeqMfGJLGuLCqHGYRGHxnKrXcTitc6L/nBUWfWPcTarG3t9PsquqUMuVeXZeca+mglY4Vo5GZjCi0A3Or2lnxA==
@@ -20682,6 +20682,14 @@ nth-check@^2.0.1:
   dependencies:
     boolbase "^1.0.0"
 
+null-loader@4.0.1, null-loader@^4.0.1:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
+  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
+  dependencies:
+    loader-utils "^2.0.0"
+    schema-utils "^3.0.0"
+
 null-loader@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-3.0.0.tgz#3e2b6c663c5bda8c73a54357d8fa0708dc61b245"
@@ -20689,14 +20697,6 @@ null-loader@^3.0.0:
   dependencies:
     loader-utils "^1.2.3"
     schema-utils "^1.0.0"
-
-null-loader@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/null-loader/-/null-loader-4.0.1.tgz#8e63bd3a2dd3c64236a4679428632edd0a6dbc6a"
-  integrity sha512-pxqVbi4U6N26lq+LmgIbB5XATP0VdZKOG25DhHi8btMmJJefGArFyDg1yc4U3hWCJbMqSrw0qyrz1UQX+qYXqg==
-  dependencies:
-    loader-utils "^2.0.0"
-    schema-utils "^3.0.0"
 
 num2fraction@^1.2.2:
   version "1.2.2"
@@ -23226,6 +23226,13 @@ react-dom@^16.14.0:
     prop-types "^15.6.2"
     scheduler "^0.19.1"
 
+react-dom@^19.0.0:
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-19.2.6.tgz#44a81b0bcca22da814c00847d09d01c8615529b7"
+  integrity sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==
+  dependencies:
+    scheduler "^0.27.0"
+
 react-draggable@^4.0.3:
   version "4.4.6"
   resolved "https://registry.yarnpkg.com/react-draggable/-/react-draggable-4.4.6.tgz#63343ee945770881ca1256a5b6fa5c9f5983fe1e"
@@ -23499,6 +23506,11 @@ react@^16.14.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
+
+react@^19.0.0:
+  version "19.2.6"
+  resolved "https://registry.yarnpkg.com/react/-/react-19.2.6.tgz#3dadb8e12b2a7934c1d5317973e5dce1301f9a4d"
+  integrity sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==
 
 read-cmd-shim@^2.0.0:
   version "2.0.0"
@@ -24714,6 +24726,11 @@ scheduler@^0.19.1:
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
+
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.27.0.tgz#0c4ef82d67d1e5c1e359e8fc76d3a87f045fe5bd"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
 
 schema-utils@^0.4.0, schema-utils@^0.4.5:
   version "0.4.7"


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2889

本 PR 为 Upload 组件新增了图片裁切功能，使用 Semi Design 现有的 Cropper 组件实现。

**功能特性：**
1. Upload 组件新增 `crop` prop，支持启用图片裁切功能，可传入裁切配置对象
2. 新增 `beforeCrop` prop，允许在裁切前进行拦截，返回 false 可阻止裁切
3. 新增 `onCropError` prop，用于处理裁切失败的回调
4. 新增 `cropModalProps` prop，支持自定义裁切弹窗的属性
5. 新增 `CropProps` 接口，支持配置裁切框比例、形状、缩放范围、输出质量等参数

**实现细节：**
- 支持多种上传方式：点击上传、拖拽上传、粘贴上传、替换上传
- 文件选择后自动判断是否为图片，若是图片且启用了 crop，则打开裁切弹窗
- 裁切完成后，使用 canvas.toBlob() 生成裁切后的文件，继续原有上传流程
- 支持自定义裁切框比例、形状
- 支持国际化：裁切弹窗标题、按钮文字

**审查要点：**
- Upload 组件的 `crop`、`beforeCrop`、`onCropError`、`cropModalProps` 四个新增 props 的类型定义和使用方式
- Cropper 组件的集成方式和状态管理
- 拖拽、粘贴、替换等场景下的裁切流程拦截逻辑
- 国际化文本的添加

### Changelog
🇨🇳 Chinese
- Feat: Upload 组件新增 crop prop，支持图片上传前裁切，可配置裁切框比例、形状等参数
- Feat: Upload 组件新增 beforeCrop prop，支持裁切前拦截
- Feat: Upload 组件新增 onCropError prop，支持裁切失败回调
- Feat: Upload 组件新增 cropModalProps prop，支持自定义裁切弹窗

---

🇺🇸 English
- Feat: Added crop prop to Upload component to support image cropping before upload, with configurable crop box ratio, shape and other parameters
- Feat: Added beforeCrop prop to Upload component for pre-crop interception
- Feat: Added onCropError prop to Upload component for crop error callback
- Feat: Added cropModalProps prop to Upload component for customizing crop modal


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
本次实现复用了 Semi Design 现有的 Cropper 组件，无需引入额外的第三方库。裁切功能支持所有上传场景（点击、拖拽、粘贴、替换），并在裁切完成后自动继续原有的上传流程。