### PR TITLE
【Auto】Docs: clarify Slider focus style tokens for different interaction scenarios

### DIFF
--- a/content/input/slider/index-en-US.md
+++ b/content/input/slider/index-en-US.md
@@ -297,4 +297,16 @@ import { Slider } from '@douyinfe/semi-ui';
 
 
 ## Design Tokens
+
+### Focus Style Variables
+
+The Slider component has two focus-related design tokens, each corresponding to different interaction scenarios:
+
+| Token Name | CSS Variable | Trigger Scenario | Description |
+| --- | --- | --- | --- |
+| Handle outline - focus | `--semi-color-primary-light-active` | Keyboard navigation (Tab focus) | Uses `:focus-visible` pseudo-class, displays outline only on keyboard focus |
+| Handle border color - active | `--semi-color-focus-border` | Mouse click/drag | Uses `.semi-slider-handle-clicked` class, displays border during mouse interaction |
+
+If you want to modify the focus style of the handle in theme configuration, please note that these two variables correspond to different interaction scenarios.
+
 <DesignToken/>

--- a/content/input/slider/index.md
+++ b/content/input/slider/index.md
@@ -286,4 +286,16 @@ import { Slider } from '@douyinfe/semi-ui';
 
 
 ## 设计变量
+
+### 聚焦样式说明
+
+Slider 组件有两个与聚焦相关的设计变量，分别对应不同的交互场景：
+
+| 变量名 | CSS 变量 | 触发场景 | 说明 |
+| --- | --- | --- | --- |
+| 圆形按钮轮廓 - 聚焦 | `--semi-color-primary-light-active` | 键盘导航（Tab 键聚焦） | 使用 `:focus-visible` 伪类，仅在键盘聚焦时显示 outline |
+| 滑动条圆形描边颜色 - 激活态 | `--semi-color-focus-border` | 鼠标点击/拖动 | 使用 `.semi-slider-handle-clicked` 类，在鼠标交互时显示 border |
+
+如果你希望在主题配置中修改圆形按钮的聚焦样式，请注意上述两个变量对应不同的交互场景。
+
 <DesignToken/>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #2614

**问题背景：**
用户反馈在主题设置中修改 Slider 组件的"圆形按钮轮廓 - 聚焦"设计变量后，在鼠标点击或拖动滑块时并未看到预期的样式变化，认为该设计变量无效。

**根本原因：**
Slider 组件有两个与聚焦相关的设计变量，分别对应不同的交互场景：
- "圆形按钮轮廓 - 聚焦" (`--semi-color-primary-light-active`) 仅在键盘导航（Tab 键聚焦）时生效，使用 `:focus-visible` 伪类
- "滑动条圆形描边颜色 - 激活态" (`--semi-color-focus-border`) 在鼠标点击/拖动时生效，使用 `.semi-slider-handle-clicked` 类

用户可能混淆了这两个变量的触发场景，导致误解。

**解决方案：**
在中英文文档中新增"聚焦样式说明"章节，通过表格清晰展示两个设计变量的 CSS 变量名、触发场景和实现原理，帮助用户正确理解和配置 Slider 组件的聚焦样式。

**审查要点：**
- 文档新增内容是否准确描述了两个聚焦相关设计变量的区别
- 中英文表述是否一致且易于理解

### Changelog
🇨🇳 Chinese
- Docs: 补充 Slider 组件聚焦样式说明文档，澄清"圆形按钮轮廓 - 聚焦"和"滑动条圆形描边颜色 - 激活态"两个设计变量的不同触发场景

---

🇺🇸 English
- Docs: Added Slider focus style documentation to clarify the different interaction scenarios for "Handle outline - focus" and "Handle border color - active" design tokens


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此问题并非代码 bug，而是用户对设计变量触发场景的理解偏差。通过文档澄清可以有效避免类似问题再次出现。