### PR TITLE
【Auto】Feat: TreeSelect component adds remote prop to support remote search

### DIFF
--- a/content/input/treeselect/index-en-US.md
+++ b/content/input/treeselect/index-en-US.md
@@ -407,6 +407,55 @@ class Demo extends React.Component {
 }
 ```
 
+### Remote Search
+
+By setting the `remote` property, you can enable remote search. When enabled, local filtering is skipped on input, only the `onSearch` callback is triggered, allowing users to handle remote data fetching and update `treeData`.
+
+```jsx live=true
+import React, { useState, useCallback } from 'react';
+import { TreeSelect, Toast } from '@douyinfe/semi-ui';
+
+() => {
+    const [value, setValue] = useState();
+    const [treeData, setTreeData] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    // Simulate remote search
+    const handleSearch = useCallback((inputValue) => {
+        if (!inputValue) {
+            setTreeData([]);
+            return;
+        }
+
+        setLoading(true);
+        
+        // Simulate network request
+        setTimeout(() => {
+            const mockData = [
+                { label: `${inputValue} - Result 1`, value: `${inputValue}-1`, key: `${inputValue}-1` },
+                { label: `${inputValue} - Result 2`, value: `${inputValue}-2`, key: `${inputValue}-2` },
+                { label: `${inputValue} - Result 3`, value: `${inputValue}-3`, key: `${inputValue}-3` },
+            ];
+            setTreeData(mockData);
+            setLoading(false);
+        }, 500);
+    }, []);
+
+    return (
+        <TreeSelect
+            style={{ width: 300 }}
+            placeholder="Enter keyword for remote search"
+            treeData={treeData}
+            filterTreeNode
+            remote
+            loading={loading}
+            value={value}
+            onChange={setValue}
+            onSearch={handleSearch}
+        />
+    );
+};
+```
 
 ### Search Box Position
 
@@ -1432,6 +1481,7 @@ function Demo() {
 | expandIcon | Custom expand icon, [example](/en-US/navigation/tree#Custom%20expansion%20icon) | ReactNode \| (props: expandProps)=>ReactNode | - | 2.75.0 |
 | keyMaps | Customize the key, label, and value fields in the node. If you set a custom name for the label in keyMaps and enable search, to ensure correct search, you need to set treeNodeFilterProp to one of the keys of treeData or use a custom search function through filterTreeNode. | object |  - | 2.47.0 |
 | filterTreeNode           | Toggle whether searchable or pass in a function to customize search behavior, data parameter provided since v2.28.0 | boolean\| <ApiType detail='(inputValue: string, treeNodeString: string, data?: TreeNodeData) => boolean'>Function</ApiType> | false       | -       |
+| remote | Enable remote search. When enabled, local filtering is skipped on input, only `onSearch` callback is triggered, allowing users to handle remote data fetching and update `treeData` | boolean | false | - |
 | getPopupContainer        | Container to render pop-up, you need to set 'position: relative`  This will change the DOM tree position, but not the view's rendering position.                                                    | function():HTMLElement                                            | -           | -       |
 | labelEllipsis | Toggle whether to ellipsis label when overflow | boolean | false\|true(virtualized) | - |  
 | leafOnly | Toggle whether to display tags for leaf nodes only and for onChange callback params in multiple mode | boolean | false | - |

--- a/content/input/treeselect/index.md
+++ b/content/input/treeselect/index.md
@@ -387,6 +387,56 @@ import { TreeSelect, Switch } from '@douyinfe/semi-ui';
 };
 ```
 
+### 远程搜索
+
+通过设置 `remote` 属性可启用远程搜索。开启后，输入时不会执行本地过滤，而是仅触发 `onSearch` 回调，用户可自行处理远程数据获取并更新 `treeData`。
+
+```jsx live=true
+import React, { useState, useCallback } from 'react';
+import { TreeSelect, Toast } from '@douyinfe/semi-ui';
+
+() => {
+    const [value, setValue] = useState();
+    const [treeData, setTreeData] = useState([]);
+    const [loading, setLoading] = useState(false);
+
+    // 模拟远程搜索
+    const handleSearch = useCallback((inputValue) => {
+        if (!inputValue) {
+            setTreeData([]);
+            return;
+        }
+
+        setLoading(true);
+        
+        // 模拟网络请求
+        setTimeout(() => {
+            const mockData = [
+                { label: `${inputValue} - 结果1`, value: `${inputValue}-1`, key: `${inputValue}-1` },
+                { label: `${inputValue} - 结果2`, value: `${inputValue}-2`, key: `${inputValue}-2` },
+                { label: `${inputValue} - 结果3`, value: `${inputValue}-3`, key: `${inputValue}-3` },
+            ];
+            setTreeData(mockData);
+            setLoading(false);
+        }, 500);
+    }, []);
+
+    return (
+        <TreeSelect
+            style={{ width: 300 }}
+            placeholder="请输入关键字进行远程搜索"
+            treeData={treeData}
+            filterTreeNode
+            remote
+            loading={loading}
+            value={value}
+            onChange={setValue}
+            onSearch={handleSearch}
+        />
+    );
+};
+```
+
 ### 搜索框位置
 
 可以使用 `searchPosition` 来设置搜索框的位置，可选: `dropdown`(默认)、`trigger`。
@@ -1373,6 +1423,7 @@ function Demo() {
 | expandIcon | 自定义展开图标，使用[示例](/zh-CN/navigation/tree#%E8%87%AA%E5%AE%9A%E4%B9%89%E5%B1%95%E5%BC%80%20Icon) | ReactNode \| (props: expandProps)=>ReactNode | - | 2.75.0 |
 | keyMaps | 自定义节点中 key、label、value 的字段。v2.47.0后提供。如果 keyMaps 中设置 label 的自定义名称并且开启了搜索，为保证搜索正确，需要将 treeNodeFilterProp 设置为 treeData 的键之一或者通过 filterTreeNode 自定义搜索函数                                                                                            | object |  - |
 | filterTreeNode | 是否根据输入项进行筛选，默认用 `treeNodeFilterProp` 的值作为要筛选的 `TreeNodeData` 的属性值, data 参数自 v2.28.0 开始提供                         | boolean\| <ApiType detail='(inputValue: string, treeNodeString: string, data?: TreeNodeData) => boolean'>Function</ApiType> | false |
+| remote | 是否启用远程搜索。开启后，输入时跳过本地过滤，仅触发 `onSearch` 回调，用户可自行处理远程数据获取并更新 `treeData` | boolean | false |
 | getPopupContainer  | 指定父级 DOM，弹层将会渲染至该 DOM 中，自定义需要设置 `position: relative` 这会改变浮层 DOM 树位置，但不会改变视图渲染位置。                                                                                       | function():HTMLElement | - |
 | labelEllipsis | 是否开启label的超出省略，默认虚拟化状态下开启                                                                                                   | boolean | false\|true(虚拟化) | 
 | leafOnly | 多选模式下是否开启 onChange 回调入参及展示标签只有叶子节点                                                                                            | boolean | false |

--- a/packages/semi-foundation/treeSelect/foundation.ts
+++ b/packages/semi-foundation/treeSelect/foundation.ts
@@ -119,6 +119,7 @@ export interface BasicTreeSelectProps extends Pick<BasicTreeProps,
     outerTopSlot?: any;
     placeholder?: string;
     prefix?: any;
+    remote?: boolean;
     searchAutoFocus?: boolean;
     searchPlaceholder?: string;
     showSearchClear?: boolean;
@@ -626,7 +627,15 @@ export default class TreeSelectFoundation<P = Record<string, any>, S = Record<st
         // Input is used as controlled component
         this._adapter.updateInputValue(sugInput);
         const { flattenNodes, expandedKeys, selectedKeys, keyEntities, treeData } = this.getStates();
-        const { showFilteredOnly, filterTreeNode, treeNodeFilterProp, keyMaps } = this.getProps();
+        const { showFilteredOnly, filterTreeNode, treeNodeFilterProp, keyMaps, remote } = this.getProps();
+
+        // When remote is true, skip local filtering, only update inputValue and trigger onSearch callback
+        if (remote) {
+            this._adapter.notifySearch(sugInput, [], []);
+            this._adapter.rePositionDropdown();
+            return;
+        }
+
         const realFilterProp = treeNodeFilterProp !== 'label' ? treeNodeFilterProp : get(keyMaps, 'label', 'label');
         const newExpandedKeys: Set<string> = new Set(expandedKeys);
         let filteredNodes: BasicTreeNodeData[] = [];

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -206,6 +206,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         // Whether to turn on the input box filtering function, when it is a function, it represents a custom filtering function
         filterTreeNode: PropTypes.oneOfType([PropTypes.func, PropTypes.bool]),
         multiple: PropTypes.bool,
+        remote: PropTypes.bool,
         searchPlaceholder: PropTypes.string,
         searchAutoFocus: PropTypes.bool,
         virtualize: PropTypes.object,
@@ -293,6 +294,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         zIndex: popoverNumbers.DEFAULT_Z_INDEX,
         disableStrictly: false,
         multiple: false,
+        remote: false,
         filterTreeNode: false,
         size: 'default' as const,
         treeNodeFilterProp: 'label' as const,
@@ -388,7 +390,8 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         const needUpdateTreeData = needUpdate('treeData');
         const needUpdateExpandedKeys = needUpdate('expandedKeys');
         const isExpandControlled = 'expandedKeys' in props;
-        const isSearching = Boolean(props.filterTreeNode && prevState.inputValue && prevState.inputValue.length);
+        // In remote mode, skip local filtering in getDerivedStateFromProps
+        const isSearching = Boolean(props.filterTreeNode && !props.remote && prevState.inputValue && prevState.inputValue.length);
         // TreeNode
         if (needUpdateTreeData) {
             treeData = props.treeData;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1190

本 PR 为 TreeSelect 组件新增 `remote` prop，支持远程搜索功能。在此之前，TreeSelect 的搜索功能只能过滤本地 treeData 数据，无法支持从服务器获取搜索结果的场景。

**主要变更：**

1. **新增 `remote` prop**：类型为 boolean，默认值为 false。设置为 true 时启用远程搜索模式。

2. **修改搜索逻辑**：当 `remote` 为 true 时，在输入时跳过本地过滤逻辑，仅更新输入值并触发 `onSearch` 回调，用户可以在回调中处理远程数据获取并更新 treeData。

3. **更新文档**：在中英文文档中添加了"远程搜索"章节，包含完整的使用示例和 API 说明。

**使用方式：**
- 设置 `remote={true}` 启用远程搜索
- 设置 `filterTreeNode={true}` 启用搜索功能
- 通过 `onSearch` 回调处理远程数据获取
- 可选设置 `loading` prop 显示加载状态
- 在 `onSearch` 中更新 `treeData`

**审查者关注点：**
- foundation.ts 中 handleInput 方法的修改逻辑
- getDerivedStateFromProps 中对 remote 模式的处理
- 文档示例的完整性

### Changelog
🇨🇳 Chinese
- Feat: TreeSelect 组件新增 remote prop，支持远程搜索功能

---

🇺🇸 English
- Feat: Added remote prop to TreeSelect component for remote search support


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无