### PR TITLE
【Auto】Fix: Tree component expansion issue when TreeNode label is ReactNode

### DIFF
--- a/packages/semi-ui/tree/index.tsx
+++ b/packages/semi-ui/tree/index.tsx
@@ -214,18 +214,93 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
             return firstInProps || nameHasChange;
         };
 
-        // Determine whether treeData has changed
-        const needUpdateData = () => {
+        /**
+         * Compare treeData structure (key/value) to determine if expandedKeys needs recalculation.
+         * When label is ReactNode, isEqual would return false due to new ReactElement references,
+         * causing unnecessary expandedKeys recalculation that breaks user's expand state.
+         * We only care about structural changes (key/value/children), not label/icon/disabled etc.
+         */
+        const isTreeDataStructureEqual = (prevTreeData: any[], nextTreeData: any[]): boolean => {
+            if (prevTreeData === nextTreeData) {
+                return true;
+            }
+            if (!prevTreeData || !nextTreeData) {
+                return prevTreeData === nextTreeData;
+            }
+            if (prevTreeData.length !== nextTreeData.length) {
+                return false;
+            }
+
+            const realKeyName = get(keyMaps, 'key', 'key');
+            const realValueName = get(keyMaps, 'value', 'value');
+            const realChildrenName = get(keyMaps, 'children', 'children');
+
+            const compareNodes = (nodesA: any[], nodesB: any[]): boolean => {
+                if (nodesA.length !== nodesB.length) {
+                    return false;
+                }
+                for (let i = 0; i < nodesA.length; i++) {
+                    const nodeA = nodesA[i];
+                    const nodeB = nodesB[i];
+                    // Compare key and value (structure only, not label/icon/disabled)
+                    if (nodeA[realKeyName] !== nodeB[realKeyName] || nodeA[realValueName] !== nodeB[realValueName]) {
+                        return false;
+                    }
+                    // Recursively compare children
+                    const childrenA = nodeA[realChildrenName] || [];
+                    const childrenB = nodeB[realChildrenName] || [];
+                    if (childrenA.length !== childrenB.length) {
+                        return false;
+                    }
+                    if (childrenA.length > 0 && !compareNodes(childrenA, childrenB)) {
+                        return false;
+                    }
+                }
+                return true;
+            };
+
+            return compareNodes(prevTreeData, nextTreeData);
+        };
+
+        // Determine whether treeData reference has changed (for UI update and draggable mode)
+        const needUpdateTreeDataRef = () => {
             const firstInProps = !prevProps && 'treeData' in props;
             const treeDataHasChange = prevProps && prevProps.treeData !== props.treeData;
             return firstInProps || treeDataHasChange;
         };
 
-        const needUpdateTreeData = needUpdate('treeData');
+        /**
+         * Determine whether treeData structure has changed (key/value/children).
+         * This is used to decide if expandedKeys needs recalculation.
+         * When label is ReactNode, we use structure comparison instead of isEqual
+         * to avoid false positives that would break user's expand state.
+         */
+        const needUpdateTreeDataStructure = () => {
+            const firstInProps = !prevProps && 'treeData' in props;
+            if (firstInProps) {
+                return true;
+            }
+            if (prevProps) {
+                const prevTreeData = prevProps.treeData;
+                const nextTreeData = props.treeData;
+                // Use structure comparison instead of isEqual for treeData
+                return !isTreeDataStructureEqual(prevTreeData, nextTreeData);
+            }
+            return false;
+        };
+
         const needUpdateSimpleJson = needUpdate('treeDataSimpleJson');
+        const treeDataRefUpdated = needUpdateTreeDataRef();
+        const treeDataStructureUpdated = needUpdateTreeDataStructure();
 
         // Update the data of tree in state
-        if (needUpdateTreeData || (props.draggable && needUpdateData())) {
+        // - treeData ref change: always update treeData in state (so UI like label/icon/disabled can update)
+        // - treeData structure change: expandedKeys may need recalculation (handled below)
+        // - entities should be rebuilt whenever treeData ref changes, otherwise derived logic that relies on entity.data
+        //   (e.g. disableStrictly/calcDisabledKeys, filterTreeData) may use stale disabled/label/etc
+        // Note: This is more aggressive than original (which used isEqual deep comparison for non-draggable mode),
+        // but necessary to fix ReactNode label false positive issue. Users can use useMemo to stabilize treeData if needed.
+        if (treeDataRefUpdated) {
             treeData = props.treeData;
             newState.treeData = treeData;
             const entitiesMap = convertDataToEntities(treeData, keyMaps);
@@ -248,14 +323,16 @@ class Tree extends BaseComponent<TreeProps, TreeState> {
             valueEntities = newState.cachedKeyValuePairs;
         }
 
-        // If treeData keys changes, we won't show animation
-        if (treeData && props.motion) {
+        // If treeData structure changes, we won't show animation
+        // (treeData may change by reference only (e.g. label ReactNode), which shouldn't force-disable motion)
+        const dataStructureUpdated = needUpdateSimpleJson || treeDataStructureUpdated;
+        if (dataStructureUpdated && props.motion) {
             if (prevProps && props.motion) {
                 newState.motionKeys = new Set([]);
                 newState.motionType = null;
             }
         }
-        const dataUpdated = needUpdateSimpleJson || needUpdateTreeData;
+        const dataUpdated = dataStructureUpdated;
         const expandAllWhenDataChange = dataUpdated && props.expandAll;
         if (!isSeaching) {
             // Update expandedKeys


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1132

**问题背景：**
当 Tree 组件的 TreeNode 的 `label` 为 ReactNode（如 ReactElement、Space 组件等非 String/number 类型）时，在受控 `value` 模式下，当改变选中项且新旧选中项不属于同一父级时，展开行为不符合预期。

**根本原因：**
ReactNode 在每次渲染时都会创建新的对象引用。原代码使用 `lodash.isEqual` 进行深度比较来检测 `treeData` 是否变化，由于 ReactNode 每次都是新对象，导致 `isEqual` 误判 `treeData` 已变化，进而触发不必要的重新计算，错误地更新了 `expandedKeys` 状态。

**解决方案：**
在 `getDerivedStateFromProps` 中新增 `isTreeDataStructureEqual` 函数，用于比较 treeData 的结构（key、value、children），而不进行深度比较。这样避免了因 label 为 ReactNode 而导致的误判，确保 treeData 数据未变化时不会触发重新计算，从而正确维护展开状态。

**审查者应关注：**
- `isTreeDataStructureEqual` 函数的实现逻辑，确保只比较结构信息（key、value、children）而不比较 label
- `needUpdateTreeData` 函数从变量改为函数，使用结构比较替代深度比较
- 该修复不影响任何公开的 props，仅优化内部状态更新逻辑

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tree 组件在 TreeNode 的 label 为 ReactNode 时，受控 value 改变选中项的展开行为异常问题

---

🇺🇸 English
- Fix: Fixed Tree component expansion behavior issue when TreeNode label is ReactNode and controlled value changes selection


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
该问题仅在 label 为 ReactNode 时出现，当 label 为 String 或 number 时不会有此问题。修复通过优化 treeData 变化检测逻辑，避免 ReactNode 对象引用变化导致的误判。