### PR TITLE
【Auto】Feat: Table supports highlighting all relevant rows when hovering over rowspan cells

### DIFF
--- a/packages/semi-foundation/table/foundation.ts
+++ b/packages/semi-foundation/table/foundation.ts
@@ -85,6 +85,7 @@ export interface TableAdapter<RecordType> extends DefaultAdapter {
     setFlattenData: (flattenData: RecordType[]) => void;
     setAllRowKeys: (allRowKeys: BaseRowKeyType[]) => void;
     setHoveredRowKey: (hoveredRowKey: BaseRowKeyType) => void;
+    setHoveredRowKeys: (hoveredRowKeys: BaseRowKeyType[]) => void;
     setCachedFilteredSortedDataSource: (filteredSortedDataSource: RecordType[]) => void;
     setCachedFilteredSortedRowKeys: (filteredSortedRowKeys: BaseRowKeyType[]) => void;
     setHalfCheckedRowKeys: (halfCheckedRowKeys: BaseRowKeyType[]) => void;
@@ -120,7 +121,7 @@ export interface TableAdapter<RecordType> extends DefaultAdapter {
     getMergePagination: () => (pagination: BasePagination) => BasePagination;
     setBodyHasScrollbar: (bodyHasScrollBar: boolean) => void;
     getTableLayout: () => 'fixed' | 'auto';
-    getCheckRelation: () => CheckRelation;
+    getCheckRelation: () => CheckRelation
 }
 
 class TableFoundation<RecordType> extends BaseFoundation<TableAdapter<RecordType>> {
@@ -1443,11 +1444,11 @@ export interface BaseEntity {
     children?: BaseEntity[];
     parent?: BaseEntity | null;
     data?: Record<string, any>;
-    [key: string]: any;
+    [key: string]: any
 }
 
 export interface BaseEntitys {
-    [key: string]: BaseEntity;
+    [key: string]: BaseEntity
 }
 
 export default TableFoundation;

--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -259,6 +259,23 @@ $module: #{$prefix}-table;
             display: table-row;
             background-color: $color-table_body-bg-default;
 
+            // Programmatic hover state (e.g. rowSpanHover feature)
+            // Keep visual effect consistent with native :hover
+            &.#{$module}-row-hovered {
+                & > .#{$module}-row-cell {
+                    background-image: linear-gradient(0deg, $color-table_body-bg-hover, $color-table_body-bg-hover);
+                    background-color: $color-table_cell-bg-hover;
+
+                    &.#{$module}-cell-fixed {
+                        &-left,
+                        &-right {
+                            background-image: linear-gradient(0deg, $color-table_body-bg-hover, $color-table_body-bg-hover);
+                            background-color: $color-table_body-bg-default;
+                        }
+                    }
+                }
+            }
+
             &:hover {
                 & > .#{$module}-row-cell {
                     // $color-table_body-bg-hover has transparency，will reveal the background color $color-table_body-bg-default\

--- a/packages/semi-ui/table/Body/index.tsx
+++ b/packages/semi-ui/table/Body/index.tsx
@@ -133,6 +133,8 @@ class Body extends BaseComponent<BodyProps, BodyState> {
     cellWidths: number[];
     flattenedColumns: ColumnProps[];
     context: TableContextProps;
+    /** keep track of highlighted rows for rowSpanHover DOM mode */
+    private hoveredRowKeySet: Set<string>;
     constructor(props: BodyProps, context: BodyContext) {
         super(props);
         this.ref = React.createRef();
@@ -152,6 +154,7 @@ class Body extends BaseComponent<BodyProps, BodyState> {
         this.flattenedColumns = flattenedColumns;
         this.cellWidths = getCellWidths(flattenedColumns);
         this.observer = null;
+        this.hoveredRowKeySet = new Set();
     }
 
     get adapter(): BodyAdapter<BodyProps, BodyState> {
@@ -226,6 +229,123 @@ class Body extends BaseComponent<BodyProps, BodyState> {
             this.foundation.observeBodyResize(bodyWrapDOM);
         }
     }
+
+    /**
+     * Handle row hover event
+     * When rowSpanHover is enabled, highlight all rows covered by rowSpan cells
+     */
+    onRowHover = (isHover: boolean, rowKey: string | number) => {
+        const { rowSpanHover } = this.context;
+        const rowKeyStr = String(rowKey);
+
+        if (!rowSpanHover) {
+            // default behavior relies on CSS :hover
+            return;
+        }
+
+        if (isHover) {
+            const keysToHighlight = this.getHoveredRowKeysFromDOM(rowKeyStr);
+            this.updateRowHoverClass(keysToHighlight);
+        } else {
+            this.updateRowHoverClass([]);
+        }
+    };
+
+    private updateRowHoverClass = (nextKeys: string[]) => {
+        const bodyNode = this.ref.current;
+        if (!bodyNode) {
+            this.hoveredRowKeySet.clear();
+            return;
+        }
+
+        // Sync hover style across main and fixed tables.
+        // Use the closest table wrapper as the query root.
+        const root: HTMLElement = (bodyNode.closest?.(`.${this.props.prefixCls}-wrapper`) as HTMLElement) || bodyNode;
+
+        const nextSet = new Set(nextKeys);
+
+        // remove old
+        for (const key of this.hoveredRowKeySet) {
+            if (!nextSet.has(key)) {
+                const rows = root.querySelectorAll(`tr[data-row-key="${this.cssEscape(key)}"]`);
+                rows.forEach(r => r.classList.remove(`${this.props.prefixCls}-row-hovered`));
+            }
+        }
+
+        // add new
+        for (const key of nextSet) {
+            if (!this.hoveredRowKeySet.has(key)) {
+                const rows = root.querySelectorAll(`tr[data-row-key="${this.cssEscape(key)}"]`);
+                rows.forEach(r => r.classList.add(`${this.props.prefixCls}-row-hovered`));
+            }
+        }
+
+        this.hoveredRowKeySet = nextSet;
+    };
+
+    /**
+     * Get all row keys that should be highlighted by reading rowSpan from DOM
+     * This is called during hover event, not during render, so it's safe
+     */
+    getHoveredRowKeysFromDOM = (currentRowKey: string): string[] => {
+        const keys = new Set<string>();
+        keys.add(currentRowKey);
+
+        // Find the current row element by data-row-key
+        const tbody = this.ref.current?.querySelector('.semi-table-tbody') || this.ref.current;
+        if (!tbody) {
+            return Array.from(keys);
+        }
+
+        const currentRow = tbody.querySelector(`tr[data-row-key="${this.cssEscape(currentRowKey)}"]`);
+        if (!currentRow) {
+            return Array.from(keys);
+        }
+
+        // Get all rows to calculate indices
+        const allRows = Array.from(tbody.querySelectorAll('tr[data-row-key]'));
+        const currentRowIndex = allRows.indexOf(currentRow);
+
+        if (currentRowIndex === -1) {
+            return Array.from(keys);
+        }
+
+        // Check all rows for cells with rowSpan that might include the current row
+        allRows.forEach((row, rowIndex) => {
+            const cells = row.querySelectorAll('td[rowspan]');
+            cells.forEach((cell) => {
+                const rowSpan = parseInt(cell.getAttribute('rowspan') || '1', 10);
+                if (rowSpan > 1) {
+                    const spanEndIndex = rowIndex + rowSpan - 1;
+                    // Check if current row is within the span
+                    if (currentRowIndex >= rowIndex && currentRowIndex <= spanEndIndex) {
+                        // Add all rows in the span
+                        for (let i = rowIndex; i <= spanEndIndex && i < allRows.length; i++) {
+                            const rowKeyAttr = allRows[i].getAttribute('data-row-key');
+                            if (rowKeyAttr) {
+                                keys.add(rowKeyAttr);
+                            }
+                        }
+                    }
+                }
+            });
+        });
+
+        return Array.from(keys);
+    };
+
+    /**
+     * Escape a string for safe use in querySelector attribute selector
+     */
+    cssEscape = (value: string) => {
+        // Prefer native CSS.escape when available
+        const cssAny = (globalThis as any).CSS;
+        if (cssAny && typeof cssAny.escape === 'function') {
+            return cssAny.escape(value);
+        }
+        // Fallback: escape quotes and backslashes to avoid selector breakage
+        return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+    };
 
     forwardRef = (node: HTMLDivElement) => {
         const { forwardedRef } = this.props;
@@ -583,6 +703,10 @@ class Body extends BaseComponent<BodyProps, BodyState> {
             disabled: isDisabled(disabledRowKeysSet, key),
         };
 
+        // Hover style is handled by CSS :hover by default.
+        // When rowSpanHover is enabled, we toggle a DOM class on related rows.
+        const hovered = false;
+
         const { getCellWidths } = this.context;
         const cellWidths = getCellWidths(columns, null, true);
 
@@ -594,6 +718,8 @@ class Body extends BaseComponent<BodyProps, BodyState> {
                 key={key}
                 rowKey={key}
                 cellWidths={cellWidths}
+                hovered={hovered}
+                onHover={this.onRowHover}
             />
         );
     }
@@ -793,6 +919,12 @@ class Body extends BaseComponent<BodyProps, BodyState> {
                 className={wrapCls}
                 style={bodyStyle}
                 ref={this.forwardRef}
+                onMouseLeave={() => {
+                    // Ensure programmatic hover state is cleared when mouse leaves the body wrapper
+                    if (this.context.rowSpanHover) {
+                        this.updateRowHoverClass([]);
+                    }
+                }}
                 onWheel={handleWheel}
                 onScroll={handleBodyScroll}
             >
@@ -831,6 +963,7 @@ class Body extends BaseComponent<BodyProps, BodyState> {
     render() {
         const { virtualized } = this.props;
         const { direction } = this.context;
+
         return virtualized ? this.renderVirtualizedBody(direction) : this.renderBody(direction);
     }
 }

--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -109,7 +109,7 @@ export interface NormalTableState<RecordType extends Record<string, any> = Data>
     /**
      * Key entities map for tree data structure
      */
-    keyEntities?: Record<string, any>;
+    keyEntities?: Record<string, any>
 }
 
 export type TableStateRowSelection<RecordType extends Record<string, any> = Data> = (RowSelectionProps<RecordType> & { selectedRowKeysSet?: Set<(string | number)> }) | boolean;
@@ -176,6 +176,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
         dropdownPrefixCls: PropTypes.string, // TODO: future api
         expandRowByClick: PropTypes.bool, // TODO: future api
         getVirtualizedListRef: PropTypes.func, // TODO: future api
+        rowSpanHover: PropTypes.bool,
     };
 
     static defaultProps = {
@@ -261,6 +262,9 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             setAllRowKeys: allRowKeys => this.setState({ allRowKeys }),
             setHoveredRowKey: hoveredRowKey => {
                 this.store.setState({ hoveredRowKey });
+            },
+            setHoveredRowKeys: hoveredRowKeys => {
+                this.store.setState({ hoveredRowKeys });
             },
             setCachedFilteredSortedDataSource: filteredSortedDataSource => {
                 this.cachedFilteredSortedDataSource = filteredSortedDataSource;
@@ -492,6 +496,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
 
         this.store = new Store({
             hoveredRowKey: null,
+            hoveredRowKeys: [],
         });
 
         this.debouncedWindowResize = debounce(this.handleWindowResize, 150);
@@ -1638,6 +1643,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             setBodyHasScrollbar: this.setBodyHasScrollbar,
             handleRowSelection: this.handleRowClickSelection,
             headerStyle: props.headerStyle,
+            rowSpanHover: props.rowSpanHover,
         };
 
         const dataAttr = this.getDataAttr(rest);

--- a/packages/semi-ui/table/TableContextProvider.tsx
+++ b/packages/semi-ui/table/TableContextProvider.tsx
@@ -17,7 +17,8 @@ const TableContextProvider = ({
     setBodyHasScrollbar,
     direction,
     handleRowSelection,
-    headerStyle
+    headerStyle,
+    rowSpanHover,
 }: TableContextProps) => {
     const tableContextValue = useMemo(
         () => ({
@@ -35,7 +36,8 @@ const TableContextProvider = ({
             setBodyHasScrollbar,
             direction,
             handleRowSelection,
-            headerStyle
+            headerStyle,
+            rowSpanHover,
         }),
         [
             anyColumnFixed,
@@ -52,7 +54,8 @@ const TableContextProvider = ({
             setBodyHasScrollbar,
             direction,
             handleRowSelection,
-            headerStyle
+            headerStyle,
+            rowSpanHover,
         ]
     );
 

--- a/packages/semi-ui/table/interface.ts
+++ b/packages/semi-ui/table/interface.ts
@@ -61,6 +61,8 @@ export interface TableProps<RecordType extends Record<string, any> = any> extend
     rowExpandable?: RowExpandable<RecordType>;
     rowKey?: RowKey<RecordType>;
     rowSelection?: RowSelection<RecordType>;
+    /** Whether to highlight all related rows when hovering over a rowspan cell */
+    rowSpanHover?: boolean;
     scroll?: Scroll;
     showHeader?: boolean;
     size?: Size;

--- a/packages/semi-ui/table/table-context.ts
+++ b/packages/semi-ui/table/table-context.ts
@@ -20,10 +20,12 @@ export interface TableContextProps {
     renderExpandIcon?: (record: Record<string, any>, isNested?: boolean, groupKey?: string | number) => React.ReactNode;
     renderSelection?: (record?: Record<string, any>, isHeader?: boolean) => React.ReactNode;
     getVirtualizedListRef?: GetVirtualizedListRef;
-    setBodyHasScrollbar?: (bodyHasScrollBar: boolean) => void;
+    setBodyHasScrollbar?: (bodyHasScrollbar: boolean) => void;
     direction?: ContextValue['direction'];
     handleRowSelection?: (rowKey: BaseRowKeyType, selected: boolean, e: React.MouseEvent) => void;
     headerStyle?: React.CSSProperties;
+    /** Whether to highlight all related rows when hovering over a rowspan cell */
+    rowSpanHover?: boolean
 }
 
 const TableContext = React.createContext<TableContextProps>({


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1177

本 PR 实现了 Table 组件在鼠标 hover 到包含 rowspan 的单元格时高亮所有相关行的功能。

**问题背景：**
当 Table 中存在 rowspan 单元格时，鼠标悬停只会高亮当前所在行，而不会高亮被该 rowspan 合并的所有相关行，导致视觉体验不连贯。

**解决方案：**
- 修改了 Table 组件的行高亮逻辑，当鼠标 hover 到包含 rowspan 的单元格时，会识别并高亮所有被合并的行
- 主要涉及 BaseRow 组件的 `onHover` 处理逻辑，需要计算 rowspan 覆盖的行范围并触发相应行的高亮状态

**审查者关注点：**
- 行高亮逻辑是否正确处理了各种 rowspan 场景（单个 rowspan、多个 rowspan 嵌套等）
- 性能影响：需要确保计算相关行的逻辑不会影响表格渲染性能
- 边界情况：rowSpan 为 0 的行（被合并的行）的处理是否正确


### Changelog
🇨🇳 Chinese
- Feat: Table 组件支持鼠标 hover 到 rowspan 单元格时高亮所有相关行

---

🇺🇸 English
- Feat: Table component supports highlighting all relevant rows when hovering over rowspan cells


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无