### PR TITLE
【Auto】Fix: AIChatInput input-slot placeholder covers IME input text

### DIFF
--- a/packages/semi-ui/aiChatInput/extension/inputSlot/component.tsx
+++ b/packages/semi-ui/aiChatInput/extension/inputSlot/component.tsx
@@ -1,10 +1,63 @@
 import { NodeViewWrapper, NodeViewContent } from '@tiptap/react';
-import React, { useRef, useLayoutEffect, useState } from 'react';
+import type { NodeViewProps } from '@tiptap/react';
+import React, { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { strings } from '@douyinfe/semi-foundation/aiChatInput/constants';
 
-const InputSlotComponent = (props: any) => {
-    const isEmpty = props.node.textContent === strings.ZERO_WIDTH_CHAR;
-    const placeholder = props.node.attrs.placeholder || '';
+const InputSlotComponent = (props: NodeViewProps) => {
+    const { editor, node, getPos } = props;
+    const isEmpty = node.textContent === strings.ZERO_WIDTH_CHAR;
+    const placeholder = node.attrs.placeholder || '';
+
+    /**
+     * IMPORTANT:
+     * inputSlot's NodeViewRenderer.update() is intentionally skipped during IME composition
+     * (see extension/inputSlot/index.tsx). That means React won't re-render when
+     * editor.view.composing changes.
+     *
+     * To avoid placeholder covering the live IME text, we listen to DOM
+     * composition events and drive a local state update.
+     */
+    const [hidePlaceholderInComposition, setHidePlaceholderInComposition] = useState(false);
+
+    const isSelectionInsideThisSlot = useCallback(() => {
+        if (!editor || typeof getPos !== 'function') {
+            return false;
+        }
+        const pos = getPos();
+        const { from, to } = editor.state.selection;
+        // getPos() returns the position before this node.
+        // Selection inside the node should be within (pos, pos + node.nodeSize).
+        return from > pos && to < pos + node.nodeSize;
+    }, [editor, getPos, node.nodeSize]);
+
+    useEffect(() => {
+        if (!editor?.view?.dom) {
+            return undefined;
+        }
+
+        const onCompositionStart = () => {
+            if (isSelectionInsideThisSlot()) {
+                setHidePlaceholderInComposition(true);
+            }
+        };
+        const onCompositionEnd = () => {
+            setHidePlaceholderInComposition(false);
+        };
+
+        // Use capture to ensure we catch events even when ProseMirror stops propagation.
+        const dom = editor.view.dom;
+        dom.addEventListener('compositionstart', onCompositionStart, true);
+        dom.addEventListener('compositionend', onCompositionEnd, true);
+        dom.addEventListener('compositioncancel', onCompositionEnd, true);
+        return () => {
+            dom.removeEventListener('compositionstart', onCompositionStart, true);
+            dom.removeEventListener('compositionend', onCompositionEnd, true);
+            dom.removeEventListener('compositioncancel', onCompositionEnd, true);
+        };
+    }, [editor, isSelectionInsideThisSlot]);
+
+    // Hide placeholder when composing to avoid covering IME input.
+    const shouldShowPlaceholder = isEmpty && !hidePlaceholderInComposition;
 
     const placeholderRef = useRef<HTMLSpanElement>(null);
     const [placeholderWidth, setPlaceholderWidth] = useState<number | undefined>(
@@ -12,7 +65,7 @@ const InputSlotComponent = (props: any) => {
     );
 
     useLayoutEffect(() => {
-        if (isEmpty && placeholderRef.current) {
+        if (shouldShowPlaceholder && placeholderRef.current) {
             const timer = setTimeout(() => {
                 setPlaceholderWidth(placeholderRef.current?.offsetWidth);
             });
@@ -21,13 +74,13 @@ const InputSlotComponent = (props: any) => {
             };
         }
         return undefined;
-    }, [isEmpty, placeholder]);
+    }, [shouldShowPlaceholder, placeholder]);
 
     return (
         <NodeViewWrapper
             as="span"
             className="input-slot"
-            style={{ minWidth: isEmpty && placeholderWidth ? `${placeholderWidth}px` : undefined }}
+            style={{ minWidth: shouldShowPlaceholder && placeholderWidth ? `${placeholderWidth}px` : undefined }}
         >
             {/* Keep placeholder DOM stable during IME updates. */}
             <span
@@ -35,7 +88,7 @@ const InputSlotComponent = (props: any) => {
                 data-placeholder={true}
                 contentEditable={false}
                 className="input-slot-placeholder"
-                style={{ display: isEmpty ? undefined : 'none' }}
+                style={{ display: shouldShowPlaceholder ? undefined : 'none' }}
             >
                 {placeholder}
             </span>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3261

修复了 AIChatInput 组件的 input-slot 在使用输入法（IME）输入时，未上屏的候选文字会被 placeholder 遮挡的问题。

**问题原因**：input-slot 的 NodeViewRenderer.update() 在 IME 输入期间被跳过，导致 React 不会重新渲染，`isEmpty` 状态不会更新，placeholder 一直显示从而遮挡了 IME 的候选文字。

**解决方案**：在 `inputSlot/component.tsx` 中添加了 `hidePlaceholderInComposition` 状态，监听 DOM 的 composition 事件，在 IME 输入期间隐藏 placeholder，避免遮挡未上屏的文字。

**审查者应关注**：
- `compositionstart`、`compositionend`、`compositioncancel` 事件的监听逻辑
- `isSelectionInsideThisSlot` 函数确保只在当前 input-slot 有焦点时才隐藏 placeholder

### Changelog
🇨🇳 Chinese
- Fix: 修复 AIChatInput 组件 input-slot 在 IME 输入时 placeholder 遮挡未上屏文字的问题

---

🇺🇸 English
- Fix: Fixed AIChatInput input-slot placeholder covering IME input text during composition


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此问题仅在非拼音输入场景下出现，例如中文五笔输入法等需要候选框的输入法。