### PR TITLE
【Auto】Fix: resolve useMemo dependency array size warning when Tooltip wraps Form.Input

### DIFF
--- a/packages/semi-ui/form/hoc/withField.tsx
+++ b/packages/semi-ui/form/hoc/withField.tsx
@@ -16,6 +16,45 @@ import type { CallOpts, WithFieldOption } from '@douyinfe/semi-foundation/form/i
 import type { CommonFieldProps, CommonexcludeType } from '../interface';
 import { noop } from "lodash";
 
+function shallowEqualArray(a: any[] | undefined, b: any[] | undefined): boolean {
+    if (a === b) {
+        return true;
+    }
+    if (!a || !b || a.length !== b.length) {
+        return false;
+    }
+    for (let i = 0; i < a.length; i++) {
+        if (!Object.is(a[i], b[i])) {
+            return false;
+        }
+    }
+    return true;
+}
+
+/**
+ * Keep a stable array reference when items are shallow-equal.
+ *
+ * Why do we need this?
+ * - In this file we memoize the rendered Field subtree for performance.
+ * - We need to make the `useMemo` dependency list have a CONSTANT length between renders.
+ *   React will warn if the deps array size changes:
+ *   "The final argument passed to useMemo changed size between renders"
+ * - Some wrappers (Tooltip/Popover) inject event handlers into children via `cloneElement`.
+ *   That can ADD/REMOVE props keys (e.g. onMouseEnter/onMouseLeave) and therefore change
+ *   the length of something like `Object.values(props)`.
+ *
+ * So we represent `props` as two arrays (sorted keys + values in that key order), and then
+ * stabilize those arrays by shallow-equality so we don't trigger memo recalculation when
+ * nothing actually changed.
+ */
+function useShallowStableArray<T extends any[]>(next: T): T {
+    const ref = useRef<T>(next);
+    if (!shallowEqualArray(ref.current, next)) {
+        ref.current = next;
+    }
+    return ref.current;
+}
+
 const prefix = cssClasses.PREFIX;
 
 // To avoid useLayoutEffect warning when ssr, refer: https://gist.github.com/gaearon/e7d97cdf38a2907924ea12e4ebdf3c85
@@ -651,9 +690,32 @@ function withField<
         };
 
         // !important optimization
+        // IMPORTANT: do NOT use `...Object.values(props)` as `useMemo` deps.
+        //
+        // Background
+        // - Tooltip/Popover (and similar wrappers) may inject props into their child via
+        //   `React.cloneElement`, typically event handlers like `onMouseEnter` / `onMouseLeave`.
+        // - When those injected props appear/disappear, the number of keys in `props` changes.
+        // - If we spread `Object.values(props)` into the deps list, the deps array length changes
+        //   between renders and React will warn:
+        //   "The final argument passed to useMemo changed size between renders".
+        //
+        // Solution
+        // Represent `props` with a FIXED-LENGTH deps list:
+        // - `stablePropKeys`: sorted list of prop keys (stable reference when unchanged)
+        // - `stablePropValues`: values in the same key order (stable reference when unchanged)
+        // This keeps the deps list length constant while still re-running memo when:
+        // - injected handler props change
+        // - any prop value changes
+        // - prop keys are added/removed
+        const sortedPropKeys = Object.keys(props).sort();
+        const stablePropKeys = useShallowStableArray(sortedPropKeys);
+        const stablePropValues = useShallowStableArray(stablePropKeys.map(key => props[key]) as any[]);
+
         const shouldUpdate = [
             ...Object.values(fieldState),
-            ...Object.values(props),
+            stablePropKeys,
+            stablePropValues,
             field,
             mergeLabelPos,
             mergeLabelAlign,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1017

**问题背景**：
当 Tooltip 或 Popover 组件包裹 Form 组件的 Field Component（如 `Form.Input`）时，React 控制台会显示警告："The final argument passed to useMemo changed size between renders"。这是因为 Tooltip/Popover 等组件通过 `React.cloneElement` 向子组件动态注入事件处理器（如 `onMouseEnter`、`onMouseLeave`），导致子组件 props 的键数量在渲染之间发生变化。而在 `withField` HOC 中，`useMemo` 的依赖数组使用了 `...Object.values(props)` 展开，当 props 键数量变化时，依赖数组的长度也会改变，从而触发 React 警告。

**解决方案**：
修改了 `withField` HOC 中 `useMemo` 依赖数组的管理方式，不再使用动态长度的 `...Object.values(props)`。具体实现：
1. 新增 `shallowEqualArray` 函数用于比较两个数组的浅相等性
2. 新增 `useShallowStableArray` hook 用于保持数组的稳定引用（当数组内容浅相等时返回相同引用）
3. 将 props 表示为固定长度的两个稳定数组：
   - `stablePropKeys`：排序后的 prop 键列表
   - `stablePropValues`：按相同键顺序对应的值列表
4. 在 `useMemo` 依赖数组中使用这两个稳定数组替代原来的 `...Object.values(props)`

这样既保持了依赖列表长度恒定（避免 React 警告），又能在 props 键或值发生变化时正确触发 memo 重新计算。

**审查要点**：
- `shallowEqualArray` 和 `useShallowStableArray` 的实现是否正确
- `useMemo` 依赖数组改造后是否仍能正确响应 props 变化
- 性能影响评估：新增的浅比较逻辑是否会影响渲染性能

### Changelog
🇨🇳 Chinese
- Fix: 修复 Form 组件的 withField HOC 在被 Tooltip/Popover 等组件包裹时，因动态注入 props 导致 useMemo 依赖数组长度变化而触发 React 警告的问题

---

🇺🇸 English
- Fix: Fixed React warning about useMemo dependency array size changing when Form Field components wrapped by Tooltip/Popover inject dynamic event handler props


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
测试覆盖：
- Tooltip 包裹 Form.Input（原问题场景）
- Popover 包裹 Form.Input
- Tooltip 包裹 Form.TextArea
- Tooltip 包裹 Form.Select
- 多个 Form.Input + Tooltip 组合
- 对照组：普通 Input 不在 Form 中