### PR TITLE
【Auto】Feat: DatePicker range selection disables confirm button when incomplete

### DIFF
--- a/packages/semi-foundation/datePicker/foundation.ts
+++ b/packages/semi-foundation/datePicker/foundation.ts
@@ -1265,6 +1265,8 @@ export default class DatePickerFoundation extends BaseFoundation<DatePickerAdapt
     _isRangeValueComplete = (value: Date[] | Date) => {
         let result = false;
         if (Array.isArray(value)) {
+            // Note: empty array should be treated as "complete" (not partially selected)
+            // to keep behaviors such as clear/confirm/change consistent.
             result = !value.some(date => isNullOrUndefined(date));
         }
         return result;

--- a/packages/semi-ui/datePicker/datePicker.tsx
+++ b/packages/semi-ui/datePicker/datePicker.tsx
@@ -734,6 +734,16 @@ export default class DatePicker extends BaseComponent<DatePickerProps, DatePicke
 
     renderFooter = (locale: Locale['DatePicker'], localeCode: string) => {
         if (this.adapter.needConfirm()) {
+            const { cachedSelectedValue } = this.state;
+            // Disable confirm when range selection is not complete.
+            // For range types, "confirm" should only be available when both start and end are selected.
+            const isRangeType = /range/i.test(this.props.type ?? '');
+            const disabledConfirm = isRangeType
+                ? !(Array.isArray(cachedSelectedValue) &&
+                    cachedSelectedValue.length === 2 &&
+                    cachedSelectedValue.every(v => v !== null && v !== undefined))
+                : false;
+            
             return (
                 <Footer
                     {...this.props}
@@ -741,6 +751,7 @@ export default class DatePicker extends BaseComponent<DatePickerProps, DatePicke
                     localeCode={localeCode}
                     onConfirmClick={this.handleConfirm}
                     onCancelClick={this.handleCancel}
+                    disabledConfirm={disabledConfirm}
                 />
             );
         }

--- a/packages/semi-ui/datePicker/footer.tsx
+++ b/packages/semi-ui/datePicker/footer.tsx
@@ -8,12 +8,13 @@ interface FooterProps {
     prefixCls?: string;
     locale: Locale['DatePicker'];
     localeCode: string;
+    disabledConfirm?: boolean;
     onCancelClick?: React.MouseEventHandler<HTMLButtonElement>;
     onConfirmClick?: React.MouseEventHandler<HTMLButtonElement>
 }
 
 export default function Footer(props = {} as FooterProps) {
-    const { prefixCls, locale, onCancelClick, onConfirmClick } = props;
+    const { prefixCls, locale, onCancelClick, onConfirmClick, disabledConfirm } = props;
     const wrapCls = classnames(`${prefixCls}-footer`);
 
     return (
@@ -21,7 +22,7 @@ export default function Footer(props = {} as FooterProps) {
             <Button theme="borderless" onClick={onCancelClick}>
                 {get(locale, 'footer.cancel', '')}
             </Button>
-            <Button theme="solid" onClick={onConfirmClick}>
+            <Button theme="solid" onClick={onConfirmClick} disabled={disabledConfirm}>
                 {get(locale, 'footer.confirm', '')}
             </Button>
         </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #552

**问题背景：**
DatePicker 组件在范围选择（`type` 为 `dateRange`、`dateTimeRange` 等）模式下，配合 `needConfirm` 属性使用时，用户可能只选择了开始日期而未选择结束日期。此时确认按钮仍然是可点击的，这不符合预期的交互体验——用户可能误以为已经完成了完整的日期范围选择。

**解决方案：**
1. 在 `datePicker.tsx` 的 `renderFooter` 方法中增加判断逻辑：当 `needConfirm` 为 true 且 `type` 为范围类型时，检查 `cachedSelectedValue` 是否为完整的范围值（数组长度为 2 且所有元素都不为 null/undefined）
2. 如果范围选择未完成，将 `disabledConfirm` 设为 true，传递给 Footer 组件
3. Footer 组件新增 `disabledConfirm` prop，用于控制确认按钮的禁用状态

**审查者应关注的点：**
- `disabledConfirm` 的判断逻辑是否正确：范围类型 + 未选完完整的开始和结束日期
- Footer 组件新增的 `disabledConfirm` prop 的类型定义和传递是否正确
- 在 `foundation.ts` 中添加的注释说明空数组应被视为"完整"（以保持清空/确认/变更行为一致性）

### Changelog
🇨🇳 Chinese
- Feat: DatePicker 组件新增范围选择未完成时确认按钮禁用功能，当 `type` 为 range 类型且 `needConfirm` 为 true 时，如果日期范围未选完（只选了开始或结束），确认按钮将被禁用

---

🇺🇸 English
- Feat: Added disabled confirm button feature for DatePicker range selection when incomplete. When `type` is range type and `needConfirm` is true, the confirm button will be disabled if the date range is not fully selected

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
测试用例已包含在 `semi-playground-for-ai/src/App.tsx` 中，可验证以下场景：
- `dateTimeRange` + `needConfirm`：只选开始日期时确认按钮禁用，选完范围后确认按钮可用
- `dateTime` + `needConfirm`：选择日期后确认按钮可用（单日期不涉及范围完整性）