### PR TITLE
【Auto】Fix: improve Tree drag performance with throttled state updates

### DIFF
--- a/packages/semi-foundation/tree/foundation.ts
+++ b/packages/semi-foundation/tree/foundation.ts
@@ -3,7 +3,7 @@
  * https://github.com/react-component/tree
  */
 
-import { isUndefined, difference, pick, get } from 'lodash';
+import { isUndefined, difference, pick, get, throttle } from 'lodash';
 import BaseFoundation, { DefaultAdapter } from '../base/foundation';
 import {
     flattenTreeData,
@@ -322,11 +322,35 @@ export interface TreeAdapter extends DefaultAdapter<BasicTreeProps, BasicTreeInn
 
 export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTreeProps, BasicTreeInnerData> {
     delayedDragEnterLogic: any;
+    throttledDragOverUpdate: ReturnType<typeof throttle>;
 
     constructor(adapter: TreeAdapter) {
         super({
             ...adapter,
         });
+        // Throttle drag over state updates to improve performance during fast dragging
+        // 16ms ≈ 60fps, ensuring smooth updates without excessive re-renders
+        this.throttledDragOverUpdate = throttle((dropPosition: number) => {
+            this._adapter.updateState({
+                dropPosition,
+            });
+        }, 16);
+    }
+
+    destroy() {
+        super.destroy();
+        // Cancel any pending throttled updates
+        if (this.throttledDragOverUpdate) {
+            this.throttledDragOverUpdate.cancel();
+        }
+
+        // Clear pending delayed drag enter timers to avoid updates after unmount
+        if (this.delayedDragEnterLogic) {
+            Object.keys(this.delayedDragEnterLogic).forEach(key => {
+                clearTimeout(this.delayedDragEnterLogic[key]);
+            });
+            this.delayedDragEnterLogic = null;
+        }
     }
 
     _isMultiple() {
@@ -863,21 +887,22 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
             return;
         }
 
-        // Update the drag position
+        // Update the drag position with throttle to improve performance
         if (dragNode && eventKey === dragOverNodeKey) {
             const newPos = calcDropRelativePosition(e, treeNode);
             if (dropPosition === newPos) {
                 return;
             }
-            this._adapter.updateState({
-                dropPosition: newPos,
-            });
+            // Use throttled update to reduce re-renders during fast dragging
+            this.throttledDragOverUpdate(newPos);
         }
 
         this.triggerDragEvent('onDragOver', e, treeNode);
     }
 
     handleNodeDragLeave(e: any, treeNode: BasicTreeNodeData) {
+        // Cancel pending throttled updates when leaving a node
+        this.throttledDragOverUpdate.cancel();
         this._adapter.updateState({
             dragOverNodeKey: '',
         });
@@ -885,12 +910,16 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
     }
 
     handleNodeDragEnd(e: any, treeNode: BasicTreeNodeData) {
+        // Flush any pending throttled updates before clearing drag state
+        this.throttledDragOverUpdate.flush();
         this.clearDragState();
         this.triggerDragEvent('onDragEnd', e, treeNode);
         this._adapter.setDragNode(null);
     }
 
     handleNodeDrop(e: any, treeNode: BasicTreeNodeData, dragNode: any) {
+        // Flush any pending throttled updates to ensure accurate drop position
+        this.throttledDragOverUpdate.flush();
         const { dropPosition, dragNodesKeys } = this.getStates();
         const { eventKey, pos } = treeNode;
         this.clearDragState();


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #558

**问题背景**：当 Tree 组件展开节点数量较多（超过 300 项）且开启拖拽功能时，快速拖拽节点会出现明显的卡顿。经排查，问题根源在于拖拽过程中 `dropPosition` 状态快速变化导致频繁的组件重渲染，而每次拖拽移动都会立即触发状态更新。

**解决方案**：
1. 引入 lodash 的 `throttle` 函数，对拖拽过程中的状态更新进行节流处理
2. 在 `TreeFoundation` 构造函数中创建节流函数 `throttledDragOverUpdate`，时间间隔设为 16ms（约 60fps），确保流畅的用户体验
3. 在 `handleNodeDragOver` 中使用节流函数替代直接的状态更新，减少不必要的重渲染
4. 在 `handleNodeDragLeave` 中取消 pending 的节流更新
5. 在 `handleNodeDragEnd` 和 `handleNodeDrop` 中 flush pending 更新，确保拖拽结束时状态准确
6. 新增 `destroy` 方法，在组件卸载时清理节流函数和定时器，避免内存泄漏

**审查关注点**：
- 节流间隔 16ms 是否合适（60fps 标准）
- `flush()` 和 `cancel()` 调用时机是否正确
- 销毁逻辑是否完整，避免组件卸载后的状态更新

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tree 组件在展开节点较多时快速拖拽发生卡顿的问题，通过节流拖拽状态更新来优化性能

---

🇺🇸 English
- Fix: Fixed Tree component lag during fast dragging with many expanded nodes by throttling drag state updates

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
性能测试场景：使用 `defaultExpandAll` 展开约 300+ 可见节点的树结构，快速拖拽节点测试流畅度。优化后拖拽操作应无明显卡顿，保持在 60fps 左右的更新频率。