### PR TITLE
【Auto】Fix: InputNumber max/min limits not working when input contains non-numeric characters

### DIFF
--- a/packages/semi-foundation/inputNumber/foundation.ts
+++ b/packages/semi-foundation/inputNumber/foundation.ts
@@ -284,6 +284,36 @@ class InputNumberFoundation extends BaseFoundation<InputNumberAdapter> {
                 numHasChanged = true;
             }
 
+            // Fix issue #38: When input contains non-numeric characters (e.g., "1000CNY"),
+            // doParse returns NaN, but we should still apply max/min limit if a number
+            // can be extracted from the input or if currentNumber is out of range.
+            if (!this.isValidNumber(parsedNum)) {
+                // Try to extract a number from the input using parseFloat
+                // (parseFloat can extract numbers from strings like "1000CNY" -> 1000)
+                const extractedNum = parseFloat(currentValue);
+                if (!isNaN(extractedNum)) {
+                    const limitedNum = this.fetchMinOrMax(extractedNum);
+                    if (limitedNum !== currentNumber) {
+                        willSetNum = limitedNum;
+                        if (!this.isControlled()) {
+                            currentNumber = willSetNum;
+                        }
+                        numHasChanged = true;
+                    }
+                } else if (typeof currentNumber === 'number' && !isNaN(currentNumber)) {
+                    // If we can't extract a number but currentNumber exists and is out of range,
+                    // apply the max/min limit to currentNumber
+                    const limitedNum = this.fetchMinOrMax(currentNumber);
+                    if (limitedNum !== currentNumber) {
+                        willSetNum = limitedNum;
+                        if (!this.isControlled()) {
+                            currentNumber = willSetNum;
+                        }
+                        numHasChanged = true;
+                    }
+                }
+            }
+
             const currentFormattedNum = this.doFormat(currentNumber, true, true);
 
             if (currentFormattedNum !== currentValue) {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #38

**问题背景：**
InputNumber 组件在设置 `max` 和 `min` 属性后，当用户输入包含非数字字符的字符串（如 "1000CNY"）并失焦时，max/min 限制不生效。这是因为 `doParse` 方法在解析此类输入时返回 NaN，导致原有的限制逻辑被跳过。

**解决方案：**
在 `packages/semi-foundation/inputNumber/foundation.ts` 的 `handleInputBlur` 方法中添加了额外的处理逻辑：
1. 当解析结果为无效数字（NaN）时，使用 `parseFloat` 尝试从输入字符串中提取数字
2. 如果成功提取到数字，则对该数字应用 `max` 和 `min` 限制
3. 如果无法提取数字，但当前值存在且超出范围，同样应用限制

**审查者应关注的点：**
- `InputNumber` 组件的 `max` 和 `min` props 在处理包含非数字字符的输入时的行为变化
- 新增逻辑对性能的影响（仅在解析失败时执行）
- 边界情况的处理：纯数字字符串、包含前缀/后缀的字符串、完全无效的字符串等

### Changelog
🇨🇳 Chinese
- Fix: 修复 InputNumber 组件在输入包含非数字字符的字符串时 `max` 和 `min` 限制不生效的问题

---

🇺🇸 English
- Fix: Fixed InputNumber component's `max` and `min` limits not working when input contains non-numeric characters


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
测试用例已添加到 `semi-playground-for-ai/src/App.tsx`，包括非受控模式、受控模式、直接输入超出范围的数字、纯数字字符串、以及使用 formatter/parser 等多种场景。