### PR TITLE
fix(#2729): improve monospace font fallback for code rendering on Windows/Linux

### DIFF
--- a/packages/semi-foundation/codeHighlight/codeHighlight.scss
+++ b/packages/semi-foundation/codeHighlight/codeHighlight.scss
@@ -16,7 +16,7 @@ $module: #{$prefix}-codeHighlight;
       font-size: 13px;
       text-shadow: none;
       // font-family: 'Inconsolata', Consolas, Monaco, "Andale Mono", "Ubuntu Mono", monospace;
-      font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', Menlo, Courier, monospace;
+      font-family: ui-monospace, 'SFMono-Regular', 'SF Mono', Menlo, Monaco, Consolas, 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace;
       direction: ltr;
       text-align: left;
       white-space: pre;

--- a/packages/semi-foundation/jsonViewer/jsonViewer.scss
+++ b/packages/semi-foundation/jsonViewer/jsonViewer.scss
@@ -64,7 +64,7 @@ $module: #{$prefix}-json-viewer;
     }
 
     &-view-line {
-        font-family: Menlo, Firecode, Monaco, 'Courier New', monospace;
+        font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Fira Code', Consolas, 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace;
         font-weight: normal;
         font-size: 12px;
         font-feature-settings: 'liga' 0, 'calt' 0;
@@ -76,7 +76,7 @@ $module: #{$prefix}-json-viewer;
     }
 
     &-line-number {
-        font-family: Menlo, Firecode, Monaco, 'Courier New', monospace;
+        font-family: ui-monospace, SFMono-Regular, 'SF Mono', Menlo, Monaco, 'Fira Code', Consolas, 'Liberation Mono', 'DejaVu Sans Mono', 'Courier New', monospace;
         font-weight: normal;
         font-size: 12px;
         font-feature-settings: 'liga' 0, 'calt' 0;

--- a/src/styles/layout.scss
+++ b/src/styles/layout.scss
@@ -33,7 +33,7 @@ body[theme-mode="dark"] {
 }
 
 pre,code:not(.semi-codeHighlight *) {
-    font-family: Inconsolata, monospace;
+    font-family: Inconsolata, ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
     background-color: var(--semi-color-fill-1);
     margin-left: 4px;
     margin-right: 4px;


### PR DESCRIPTION
## Summary

Closes #2729

Unify the monospace font stack across the docs site and code-related components so users on Windows / Linux without Menlo / SF Mono / Fira Code no longer fall back to the very thin Courier New, while macOS still picks `ui-monospace` / SF Mono first.

### Affected files

| File | Change |
| --- | --- |
| `src/styles/layout.scss` | Docs site global `pre, code` keeps Inconsolata as preferred webfont but adds a full system fallback chain |
| `packages/semi-foundation/codeHighlight/codeHighlight.scss` | Add `ui-monospace`, broaden fallback chain, replace ambiguous `Courier` with `"Courier New"` |
| `packages/semi-foundation/jsonViewer/jsonViewer.scss` | Fix typo `Firecode` -> `Fira Code`, add `ui-monospace` / `Consolas` / `Liberation Mono` / `DejaVu Sans Mono` |

### Unified font stack

```css
ui-monospace, SFMono-Regular, "SF Mono", Menlo, Monaco, Consolas, "Liberation Mono", "DejaVu Sans Mono", "Courier New", monospace;
```

- `ui-monospace` — macOS Big Sur+ / iOS default system monospace
- `SFMono-Regular` / `SF Mono` — older macOS fallback
- `Menlo` / `Monaco` — classic macOS monospace
- `Consolas` — preinstalled on Windows (the missing piece from #2729)
- `Liberation Mono` / `DejaVu Sans Mono` — mainstream Linux distros
- `Courier New` — universal fallback (replaces less portable `Courier`)
- `monospace` — CSS generic family

### Cross-platform expectation

| OS | Resolved font |
| --- | --- |
| macOS 11+ | `ui-monospace` / SF Mono |
| Windows 10/11 | `Consolas` (no more thin Courier New) |
| Linux (Ubuntu / Fedora / Arch / ...) | `Liberation Mono` or `DejaVu Sans Mono` |

## Test plan

- [ ] Verify docs site code blocks (`pre`, `code`) render with Consolas on Windows 11 (matches the screenshot in #2729)
- [ ] Verify CodeHighlight component in component docs still looks correct on macOS / Windows / Linux
- [ ] Verify JsonViewer (key / value text and line number) renders with the new stack on all three platforms
- [ ] No visual regressions on macOS where `ui-monospace` / SF Mono is selected
