### PR TITLE
【Auto】Feat: Add keepState prop to Form Field for preserving state on unmount

### DIFF
--- a/content/input/form/index-en-US.md
+++ b/content/input/form/index-en-US.md
@@ -1521,6 +1521,10 @@ In the example above:
 - The field with `keepState` will retain its previously entered value, validation state, etc. after being hidden and then shown again
 - The field without `keepState` will have its state reset after being hidden and then shown again
 
+<Notice type="primary" title="Notes">
+<div>`keepState` is designed for the "conditional unmount/remount" scenario and restores state by the field path. Fields inside an <code>ArrayField</code> do NOT support <code>keepState</code>: calling <code>remove(i)</code> shifts the positional field paths of the following rows (for example <code>people[1].name</code> becomes <code>people[0].name</code>), so "restore by path" no longer matches the user intent and easily revives state of removed rows. Passing <code>keepState</code> on a Field inside an <code>ArrayField</code> will be ignored and a warning will be printed. Manage array items via the <code>ArrayField</code>'s own <code>add</code> / <code>remove</code> / <code>addWithInitValue</code> instead.</div>
+</Notice>
+
 ### ArrayField Usage
 
 For array items that are dynamically added or deleted, we provide the `ArrayField` component to simplify the operation of add / remove

--- a/content/input/form/index-en-US.md
+++ b/content/input/form/index-en-US.md
@@ -1489,6 +1489,38 @@ import { Form, Button } from '@douyinfe/semi-ui';
 );
 ```
 
+#### Keep field state on unmount (keepState)
+
+By default, when a Field component is unmounted, its value, error, and touched state are all reset. If you want to preserve these states after the field is unmounted (for example, in conditional rendering scenarios), you can use the `keepState` property.
+
+```jsx live=true dir="column"
+import React from 'react';
+import { Form, Switch, Button } from '@douyinfe/semi-ui';
+
+() => {
+    const [show, setShow] = React.useState(true);
+
+    return (
+        <Form style={{ width: 450 }}>
+            <Form.Switch field="alwaysShow" label='Always visible field' />
+            <Switch checked={show} onChange={setShow} style={{ marginBottom: 12 }} />
+            <span style={{ marginLeft: 8, color: 'var(--semi-color-text-2)' }}>Show conditional fields</span>
+            {show ? (
+                <Form.Input field="conditionalField" label='Conditional field (keepState)' keepState />
+            ) : null}
+            {show ? (
+                <Form.Input field="noKeepState" label='Conditional field (no keepState)' />
+            ) : null}
+            <Button htmlType="submit">Submit</Button>
+        </Form>
+    );
+};
+```
+
+In the example above:
+- The field with `keepState` will retain its previously entered value, validation state, etc. after being hidden and then shown again
+- The field without `keepState` will have its state reset after being hidden and then shown again
+
 ### ArrayField Usage
 
 For array items that are dynamically added or deleted, we provide the `ArrayField` component to simplify the operation of add / remove
@@ -2344,6 +2376,7 @@ import { Form, Button } from '@douyinfe/semi-ui';
 | onChange              | Callback invoked when this field value changes                                                                                                                                                                                           |
 | transform             | transform field values before validation                                                                                                                                                                                                 | function(fieldValue)                   |           | (value) => Number(value)                                           |
 | allowEmptyString      | Whether to allow values to be empty strings. <br/>When the value is '' by default, the key corresponding to this field will be removed from `values`. <br/>If you want to keep the key, you need to set allowEmptyString to true           | boolean                                |           | false                                                              |
+| keepState             | Whether to retain the field state (value, error, touched) after the field is unmounted. When true, the field's value, validation message, and interaction state are preserved after unmounting, and will be automatically restored upon remounting           | boolean                                |           | false                                                              |
 | convert               | After the field value changes, before rerender, update the value of filed                                                                                                                                                                | function(fieldValue)                   |           | (value) => newValue                                        |
 | stopValidateWithError | When it is true, the rules check is used. After encountering the first rule that fails the check, it will no longer trigger the check of subsequent rules                                                          | boolean                                |           | false                                                              |
 | helpText              | Custom prompt information, which is displayed in the same block as the verification information. When both have values, the verification information is displayed first                                             | ReactNode                              |           |                                                                    |

--- a/content/input/form/index.md
+++ b/content/input/form/index.md
@@ -1590,6 +1590,10 @@ import { Form, Switch, Button } from '@douyinfe/semi-ui';
 - 设置了 `keepState` 的字段在隐藏再显示后，之前输入的值、校验状态等会被保留
 - 未设置 `keepState` 的字段在隐藏再显示后，状态会被重置
 
+<Notice type="primary" title="注意事项">
+<div>`keepState` 仅适用于「条件渲染卸载/重挂」的场景，并以 field 字段路径作为恢复依据。在 <code>ArrayField</code> 内部的 Field 不支持 <code>keepState</code>：调用 <code>remove(i)</code> 会让后续行的字段路径整体前移（例如 <code>people[1].name</code> 变为 <code>people[0].name</code>），按路径恢复的语义不再匹配，容易出现已被删除的状态被"复活"等问题。在 <code>ArrayField</code> 中传入 <code>keepState</code> 将被忽略并打印 warning，请通过 <code>ArrayField</code> 自身的 <code>add</code> / <code>remove</code> / <code>addWithInitValue</code> 管理数组项。</div>
+</Notice>
+
 ### 使用 ArrayField
 
 针对动态增删的数组类表单项，我们提供了 ArrayField 作用域来简化 add/remove 的操作  

--- a/content/input/form/index.md
+++ b/content/input/form/index.md
@@ -1558,6 +1558,38 @@ import { Form, Button } from '@douyinfe/semi-ui';
 );
 ```
 
+#### 动态表单保留状态（keepState）
+
+默认情况下，当 Field 组件卸载后，其对应的值（value）、校验信息（error）、交互状态（touched）都会被重置。如果你希望 Field 卸载后保留这些状态（例如在条件渲染的场景中），可以使用 `keepState` 属性。
+
+```jsx live=true dir="column"
+import React from 'react';
+import { Form, Switch, Button } from '@douyinfe/semi-ui';
+
+() => {
+    const [show, setShow] = React.useState(true);
+
+    return (
+        <Form style={{ width: 450 }}>
+            <Form.Switch field="alwaysShow" label='始终显示的字段' />
+            <Switch checked={show} onChange={setShow} style={{ marginBottom: 12 }} />
+            <span style={{ marginLeft: 8, color: 'var(--semi-color-text-2)' }}>显示条件字段</span>
+            {show ? (
+                <Form.Input field="conditionalField" label='条件字段（keepState）' keepState />
+            ) : null}
+            {show ? (
+                <Form.Input field="noKeepState" label='条件字段（无 keepState）' />
+            ) : null}
+            <Button htmlType="submit">提交</Button>
+        </Form>
+    );
+};
+```
+
+在上面的示例中：
+- 设置了 `keepState` 的字段在隐藏再显示后，之前输入的值、校验状态等会被保留
+- 未设置 `keepState` 的字段在隐藏再显示后，状态会被重置
+
 ### 使用 ArrayField
 
 针对动态增删的数组类表单项，我们提供了 ArrayField 作用域来简化 add/remove 的操作  
@@ -2354,6 +2386,7 @@ class FormApiDemo extends React.Component {
 | onBlur                | 失去焦点时触发的回调                                                                                                                                                                                                | function() （具体参见各组件的 onBlur 方法）                                                   |
 | transform             | 校验前转换字段值，转换后的值仅会在校验时被消费，对 formState 无影响<br/> 使用示例: (value) => Number                                                                                                                 | function(fieldValue)                                                                          |           |
 | allowEmptyString      | 是否允许值为空字符串。默认情况下值为''时，该 field 对应的 key 会从 values 中移除，如果你希望保留该 key，那么需要将 allowEmptyString 设为 true                                                                       | boolean                                                                                       | false     |
+| keepState             | 是否在 Field 卸载后保留其状态（value、error、touched）。为 true 时，Field 卸载后其值、校验信息、交互状态不会丢失，再次挂载时会自动恢复                                                                                       | boolean                                                                                       | false     |
 | stopValidateWithError | 为 true 时，使用 rules 校验，碰到第一个检验不通过的 rules 后，将不再触发后续 rules 的校验                                                                                                  | boolean                                                                                       | false     |
 | helpText              | 自定义提示信息，与校验信息公用同一区块展示，两者均有值时，优先展示校验信息                                                                                                                | ReactNode                                                                                     |           |
 | extraText             | 额外的提示信息，当需要错误信息和提示文案同时出现时，可以使用这个，位于 helpText/errorMessage 后                                                                                           | ReactNode                                                                                     |           |

--- a/packages/semi-foundation/form/foundation.ts
+++ b/packages/semi-foundation/form/foundation.ts
@@ -94,14 +94,58 @@ export default class FormFoundation extends BaseFoundation<BaseFormAdapter> {
         const registered = this.registered[field];
         this.registered[field] = true;
         this.fields.set(field, fieldStuff);
-        if (fieldStuff.keepState) {
-            // TODO support keepState
-        } else {
+        if (fieldStuff.keepState && registered) {
+            // When keepState is true and the field was previously registered (remounting),
+            // restore the saved state from formState instead of using the initial value
+            const hasSavedValue = ObjectUtil.has(this.data.values, field);
+            const savedValue = ObjectUtil.get(this.data.values, field);
+            const hasSavedError = ObjectUtil.has(this.data.errors, field);
+            const savedError = ObjectUtil.get(this.data.errors, field);
+            const hasSavedTouched = ObjectUtil.has(this.data.touched, field);
+            const savedTouched = ObjectUtil.get(this.data.touched, field);
+
             const allowEmpty = fieldStuff.allowEmpty || false;
-            const opts = {
+            const opts: CallOpts = {
                 notNotify: true,
                 notUpdate: false,
-                allowEmpty,
+                // updateStateValue reads `fieldAllowEmpty` (field-level override)
+                fieldAllowEmpty: allowEmpty,
+            };
+
+            // Restore value from formState if it exists
+            if (hasSavedValue) {
+                // Keep formState as source of truth; still trigger a forceUpdate so that
+                // consumers of formState can get the latest snapshot when field remounts.
+                this.updateStateValue(field, savedValue, opts);
+                // Sync the restored value back to the field component's local state.
+                // Avoid a second forceUpdate/notify from FieldApi.
+                fieldStuff.fieldApi.setValue(savedValue, { ...opts, notUpdate: true });
+            } else {
+                // No saved value, use initial value
+                let fieldValue = fieldState.value;
+                if (!allowEmpty && fieldValue === '') {
+                    fieldValue = undefined;
+                }
+                this.updateStateValue(field, fieldValue, opts);
+            }
+
+            // Restore error from formState if it exists
+            if (hasSavedError) {
+                this.updateStateError(field, savedError, opts);
+                fieldStuff.fieldApi.setError(savedError, { ...opts, notUpdate: true });
+            }
+
+            // Restore touched from formState if it exists
+            if (hasSavedTouched) {
+                this.updateStateTouched(field, savedTouched, opts);
+                fieldStuff.fieldApi.setTouched(savedTouched, { ...opts, notUpdate: true });
+            }
+        } else {
+            const allowEmpty = fieldStuff.allowEmpty || false;
+            const opts: CallOpts = {
+                notNotify: true,
+                notUpdate: false,
+                fieldAllowEmpty: allowEmpty,
             };
             let fieldValue = fieldState.value;
             // When allowEmpty is false, 'is equivalent to undefined, and the key of the field does not need to be reflected on values

--- a/packages/semi-ui/form/arrayField.tsx
+++ b/packages/semi-ui/form/arrayField.tsx
@@ -221,6 +221,7 @@ class ArrayFieldComponent extends Component<ArrayFieldProps, ArrayFieldState> {
         const { addWithInitValue } = this;
         const contextVal = {
             shouldUseInitValue: this.shouldUseInitValue,
+            inArrayField: true,
         };
         return (
             <ArrayFieldContext.Provider value={contextVal}>

--- a/packages/semi-ui/form/context.tsx
+++ b/packages/semi-ui/form/context.tsx
@@ -12,6 +12,11 @@ FormUpdaterContext.displayName = 'FormUpdater';
 
 const ArrayFieldContext = React.createContext({
     shouldUseInitValue: true,
+    // Whether the current subtree is rendered inside an <ArrayField/>.
+    // Used by withField to disable `keepState` semantics inside an ArrayField,
+    // because positional field paths (e.g. people[0].name) shift on remove,
+    // which conflicts with the "preserve unmounted state by path" model.
+    inArrayField: false,
 });
 
 export { FormStateContext, FormApiContext, FormUpdaterContext, ArrayFieldContext };

--- a/packages/semi-ui/form/hoc/withField.tsx
+++ b/packages/semi-ui/form/hoc/withField.tsx
@@ -124,9 +124,11 @@ function withField<
 
         // use arrayFieldState to fix issue 615
         let arrayFieldState;
+        let inArrayField = false;
         try {
             arrayFieldState = useArrayFieldState();
             if (arrayFieldState) {
+                inArrayField = Boolean(arrayFieldState.inArrayField);
                 /**
                  * In ArrayField, when setValues causes ArrayField re-render, ArrayField will set shouldUseInitValue to false.
                  * But Field may be conditionally unmounted/remounted later. In that case, if the value in form state is
@@ -152,6 +154,20 @@ function withField<
         const validateOnMount = mergeTrigger.includes('mount');
 
         allowEmpty = allowEmpty || updater.getFormProps().allowEmpty;
+
+        // `keepState` semantically preserves a field's state when the component unmounts and
+        // restores it on remount, keyed by the field path. Inside an <ArrayField>, removing a
+        // row shifts the subsequent rows' positional field paths (e.g. people[1].name becomes
+        // people[0].name), so "restore by path" no longer matches the user's intent and easily
+        // surfaces stale state (touched flags, registered markers, etc.). To avoid that
+        // ambiguity, ignore `keepState` for fields rendered inside an ArrayField and warn once.
+        if (keepState && inArrayField) {
+            warning(
+                true,
+                `[Semi Form]: 'keepState' is not supported on Field "${field}" inside <ArrayField/>. It will be ignored. Use add/remove on the ArrayField to manage array items instead.`
+            );
+            keepState = false;
+        }
 
         // Error information: Array, String, undefined
         const [error, setError, getError] = useStateWithGetter();

--- a/packages/semi-ui/form/interface.ts
+++ b/packages/semi-ui/form/interface.ts
@@ -60,7 +60,9 @@ export type CommonFieldProps = {
     /** These declaration just hack for Omit, not valid props in CommonFieldProps */
     defaultValue?: any;
     /** Whether to take over only the data stream, when true, it will not automatically insert modules such as ErrorMessage, Label, extraText, etc. The style and DOM structure are consistent with the original component */
-    pure?: boolean
+    pure?: boolean;
+    /** Whether to retain field state (value, error, touched) after the field is unmounted. When the field remounts, the saved state will be restored */
+    keepState?: boolean;
 };
 
 export type CommonexcludeType = {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #186

本 PR 为 Form 组件的 Field 新增了 `keepState` 属性，解决了 #186 提出的需求。

**问题背景：**
在动态表单场景中，当 Field 组件因条件渲染而被卸载后，其对应的值、校验信息和交互状态都会被重置。用户希望在某些场景下（如条件渲染切换时）能够保留 Field 的状态。

**解决方案：**
1. 在 `CommonFieldProps` 接口中新增 `keepState?: boolean` 属性定义
2. 在 `FormFoundation.registerField` 方法中实现了状态保留逻辑：
   - 当 `keepState` 为 true 且字段重新挂载时，从 formState 中恢复之前保存的 value、error、touched 状态
   - 自动同步恢复的状态到 Field 组件的本地状态
3. 更新了中英文文档，添加了使用示例和 API 说明

**审查者应关注：**
- `packages/semi-foundation/form/foundation.ts` 中的状态恢复逻辑实现
- `packages/semi-ui/form/interface.ts` 中的类型定义
- 文档示例的准确性和完整性

### Changelog
🇨🇳 Chinese
- Feat: Form 组件的 Field 新增 keepState 属性，支持在 Field 卸载后保留其状态（value、error、touched），重新挂载时自动恢复

---

🇺🇸 English
- Feat: Added keepState prop to Form Field component, allowing state (value, error, touched) to be preserved after unmounting and restored upon remounting


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
**使用示例：**
```jsx
<Form>
    <Form.Input field="conditionalField" label='条件字段' keepState />
</Form>
```

当设置了 `keepState` 的 Field 被卸载后再重新挂载，之前输入的值、校验状态、交互状态都会被保留。