### PR TITLE
【Auto】Feat: Calendar add onMoreClick callback for month view remaining items click event

### DIFF
--- a/content/show/calendar/index-en-US.md
+++ b/content/show/calendar/index-en-US.md
@@ -350,6 +350,7 @@ import { Avatar, Calendar } from '@douyinfe/semi-ui';
 | mode         | Mode, one of `day`, `week`, `month`, `range`                                         | "day" \| "week" \| "month" \| "range" | `week` |
 | onClick      | Callback invoked when clicking on date, basic unit for day and week mode is 0.5h, for month mode is 1d | function(e: Event, date: Date） | -            |
 | onClose | Callback invoked when event display card close in the month mode | function(e: Event） | - |
+| onMoreClick | Callback invoked when clicking "more items" in month mode | function(e: Event, date: Date, remaining: number） | - |
 | renderTimeDisplay | Customize the display of time in day/week mode | function(time: number): ReactNode | - |
 | renderDateDisplay | Customize the display of date | function(date: Date): ReactNode | - |
 | range | Date range to display in range mode, left-closed and right-open | Date[] | - |

--- a/content/show/calendar/index.md
+++ b/content/show/calendar/index.md
@@ -327,6 +327,7 @@ import { Avatar, Calendar } from '@douyinfe/semi-ui';
 | mode | 初始模式，`day`, `week`, `month`, `range` | "day" \| "week" \| "month" \| "range" | `week` |
 | onClick | 单击日期格的回调，日视图和周视图以半小时为单位，月视图以日为单位 | function(e: Event, date: Date） | - |
 | onClose | 月视图下，展示所有 event 的卡片关闭时的回调 | function(e: Event） | - |
+| onMoreClick | 月视图下，点击"还有几项"时的回调 | function(e: Event, date: Date, remaining: number） | - |
 | range | 多日视图模式下展示的日期范围，左闭右开 | Date[] | - |
 | renderTimeDisplay | 自定义日/周视图下的时间文案 | function(time: number): ReactNode | - |
 | renderDateDisplay | 自定义日期文案 | function(date: Date): ReactNode | - |

--- a/packages/semi-ui/calendar/interface.ts
+++ b/packages/semi-ui/calendar/interface.ts
@@ -14,6 +14,7 @@ export interface CalendarProps extends BaseProps {
     scrollTop?: number;
     onClick?: (e: React.MouseEvent, value: Date) => void;
     onClose?: (e: React.MouseEvent) => void;
+    onMoreClick?: (e: React.MouseEvent, date: Date, remaining: number) => void;
     renderTimeDisplay?: (time: number) => React.ReactNode;
     markWeekend?: boolean;
     minEventHeight?: number;

--- a/packages/semi-ui/calendar/monthCalendar.tsx
+++ b/packages/semi-ui/calendar/monthCalendar.tsx
@@ -48,6 +48,7 @@ export default class monthCalendar extends BaseComponent<MonthCalendarProps, Mon
         dateGridRender: PropTypes.func,
         onClick: PropTypes.func,
         onClose: PropTypes.func,
+        onMoreClick: PropTypes.func,
     };
 
     static defaultProps = {
@@ -180,6 +181,13 @@ export default class monthCalendar extends BaseComponent<MonthCalendarProps, Mon
         this.foundation.showCard(e, key);
     };
 
+    handleMoreClick = (e: React.MouseEvent, key: string, date: Date, remaining: number) => {
+        e.stopPropagation();
+        const { onMoreClick } = this.props;
+        this.showCard(e, key);
+        onMoreClick && onMoreClick(e, date, remaining);
+    };
+
     renderHeader = (dateFnsLocale: Locale['dateFnsLocale']) => {
         const { markWeekend, displayValue } = this.props;
         this.monthlyData = this.foundation.getMonthlyData(displayValue, dateFnsLocale);
@@ -279,7 +287,7 @@ export default class monthCalendar extends BaseComponent<MonthCalendarProps, Mon
                     <div
                         className={`${cardCls}-wrapper`}
                         style={{ bottom: 0 }}
-                        onClick={e => this.showCard(e, key)}
+                        onClick={e => this.handleMoreClick(e, key, date, remained)}
                     >
                         {locale.remaining.replace('${remained}', String(remained))}
                     </div>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #764

在 Calendar 日历组件的月视图中，当某一天有较多事件时，会显示"还有几项"的提示。此前点击"还有几项"时，会触发 onClick 事件，用户无法单独控制"还有几项"的点击行为。

本 PR 为 Calendar 组件新增了 `onMoreClick` prop，允许开发者自定义"还有几项"的点击事件处理。该回调函数接收三个参数：
- `e: React.MouseEvent` - 鼠标事件对象
- `date: Date` - 点击日期对应的 Date 对象
- `remaining: number` - 剩余未展示的事件数量

审查者应重点关注：
- `packages/semi-ui/calendar/interface.ts` 中新增的接口定义
- `packages/semi-ui/calendar/monthCalendar.tsx` 中 handleMoreClick 方法的实现逻辑
- 事件冒泡的处理（已使用 `e.stopPropagation()` 阻止冒泡）

### Changelog
🇨🇳 Chinese
- Feat: Calendar 组件新增 onMoreClick prop，支持自定义月视图下"还有几项"的点击事件

---

🇺🇸 English
- Feat: Added onMoreClick prop to Calendar component for customizing the click event on remaining items in month view


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无