### PR TITLE
【Auto】Feat: Table columns render add isHovering parameter

### DIFF
--- a/content/show/table/index-en-US.md
+++ b/content/show/table/index-en-US.md
@@ -408,6 +408,14 @@ render(App);
 
 Users can use Column.render to customize the rendering of a column of cells, which is suitable for rendering more complex cell content.
 
+The fourth parameter `options` of the `render` function is an object containing the following properties:
+- `expandIcon`: Expand icon (when using tree data or expandable rows)
+- `selection`: Selection checkbox (when row selection is enabled)
+- `indentText`: Indent content (when using tree data)
+- `isHovering`: Whether the current row is in hover state (supported in v2.98.0)
+
+With the `isHovering` parameter, you can implement interaction effects such as displaying action buttons on mouse hover.
+
 ```jsx live=true noInline=true dir="column"
 import React from 'react';
 import { Table, Avatar, Button, Empty, Typography } from '@douyinfe/semi-ui';
@@ -5197,6 +5205,7 @@ type Render = (
 
 interface RenderOptions {
     expandIcon?: React.ReactNode;
+    isHovering?: boolean;
 }
 ```
 
@@ -5598,7 +5607,7 @@ import { Table } from '@douyinfe/semi-ui';
 | filters | Filter menu items for the header | Filter[] |  |
 | fixed | Whether the column is fixed, optional true (equivalent to left) 'left' 'right' | boolean\|string | false |
 | key | The key required by React, if a unique dataIndex has been set, can ignore this property | string |  |
-| render | A rendering function that generates complex data, the parameters are the value of the current row, the current row data, the row index, and the table row / column merge can be set in return object | (text: any, record: RecordType, index: number, { expandIcon?: ReactNode, selection?: ReactNode, indentText?: ReactNode }) => React\|object |  |
+| render | A rendering function that generates complex data, the parameters are the value of the current row, the current row data, the row index, and the table row / column merge can be set in return object | (text: any, record: RecordType, index: number, { expandIcon?: ReactNode, selection?: ReactNode, indentText?: ReactNode, isHovering?: boolean }) => React\|object |  |
 | renderFilterDropdown | Custom filter dropdown panel, for usage details, see [Custom Filter Rendering](#Custom-Filter-Rendering) | (props?: RenderFilterDropdownProps) => React.ReactNode; | - | **2.52.0** |
 | renderFilterDropdownItem | Customize the rendering method of each filter item. For usage details, see [Custom Filter Item Rendering](#Custom-Filter-Item-Rendering) | ({ value: any, text: any, onChange: Function, level: number, ...otherProps }) => ReactNode | - | - |
 | resize | Whether to enable resize mode, this property will take effect only after Table resizable is enabled | boolean |  | **2.42.0** |

--- a/content/show/table/index.md
+++ b/content/show/table/index.md
@@ -451,6 +451,14 @@ render(App);
 
 用户可以使用 `Column.render` 来自定义某一列单元格的渲染，该功能适用于需要渲染较为复杂的单元格内容时。
 
+`render` 函数的第四个参数 `options` 是一个对象，包含以下属性：
+- `expandIcon`: 展开图标（当使用树形数据或可展开行时）
+- `selection`: 选择框（当开启行选择时）
+- `indentText`: 缩进内容（当使用树形数据时）
+- `isHovering`: 当前行是否处于悬停状态（v2.98.0 支持）
+
+通过 `isHovering` 参数，可以实现鼠标悬停时显示操作按钮等交互效果。
+
 ```jsx live=true noInline=true dir="column"
 import React from 'react';
 import { Table, Avatar, Button, Empty, Typography, Tag } from '@douyinfe/semi-ui';
@@ -5579,6 +5587,7 @@ type Render = (text: string, record: Object, index: number, options?: RenderOpti
 
 interface RenderOptions {
     expandIcon?: React.ReactNode;
+    isHovering?: boolean;
 }
 ```
 
@@ -5990,7 +5999,7 @@ import { Table } from '@douyinfe/semi-ui';
 | filters | 表头的筛选菜单项。 | Filter[] |  |
 | fixed | 列是否固定，可选 true(等效于 left) 'left' 'right'，在 RTL 时会自动切换 | boolean\|string | false |
 | key | React 需要的 key，如果已经设置了唯一的 dataIndex，可以忽略这个属性 | string |  |
-| render | 生成复杂数据的渲染函数，参数分别为当前行的值，当前行数据，行索引，@return 里面可以设置表格行/列合并 | (text: any, record: RecordType, index: number, { expandIcon?: ReactNode, selection?: ReactNode, indentText?: ReactNode }) => object\|ReactNode |  |
+| render | 生成复杂数据的渲染函数，参数分别为当前行的值，当前行数据，行索引，@return 里面可以设置表格行/列合并 | (text: any, record: RecordType, index: number, { expandIcon?: ReactNode, selection?: ReactNode, indentText?: ReactNode, isHovering?: boolean }) => object\|ReactNode |  |
 | renderFilterDropdown | 自定义筛选器 dropdown 面板，用法详见[自定义筛选器](#自定义筛选器) | (props?: RenderFilterDropdownProps) => React.ReactNode; | - | **2.52.0** |
 | renderFilterDropdownItem | 自定义每个筛选项渲染方式，用法详见[自定义筛选项渲染](#自定义筛选项渲染) | ({ value: any, text: any, onChange: Function, level: number, ...otherProps }) => ReactNode | - | - |
 | resize | 是否开启 resize 模式，只有 Table resizable 开启后此属性才会生效 | boolean |  | **2.42.0** |

--- a/packages/semi-ui/table/Body/BaseRow.tsx
+++ b/packages/semi-ui/table/Body/BaseRow.tsx
@@ -38,7 +38,8 @@ export interface BaseRowProps {
     fixed?: Fixed;
     height?: string | number;
     hideExpandedColumn?: boolean;
-    hovered: boolean; // required
+    /** Whether the current row is hovered */
+    hovered?: boolean;
     indent?: number;
     indentSize?: number;
     index?: number;
@@ -84,7 +85,7 @@ export const baseRowPropTypes = {
     fixed: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
     height: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
     hideExpandedColumn: PropTypes.bool,
-    hovered: PropTypes.bool.isRequired,
+    hovered: PropTypes.bool,
     indent: PropTypes.number,
     indentSize: PropTypes.number,
     index: PropTypes.number,
@@ -222,6 +223,7 @@ export default class TableRow extends BaseComponent<BaseRowProps, Record<string,
             expanded,
             disabled,
             onDidUpdate,
+            hovered,
         } = this.props;
 
         const BodyCell = get(components, 'body.cell', strings.DEFAULT_COMPONENTS.body.cell);
@@ -292,6 +294,7 @@ export default class TableRow extends BaseComponent<BaseRowProps, Record<string,
                         expanded={expanded}
                         disabled={disabled}
                         onDidUpdate={onDidUpdate}
+                        hovered={hovered}
                     />
                 );
             }

--- a/packages/semi-ui/table/Body/index.tsx
+++ b/packages/semi-ui/table/Body/index.tsx
@@ -84,7 +84,8 @@ export interface BodyState {
         virtualizedScrollLeft?: number
     };
     cachedExpandBtnShouldInRow?: boolean;
-    cachedExpandRelatedProps?: any[]
+    cachedExpandRelatedProps?: any[];
+    hoveredRowKey?: string | number;
 }
 
 export interface BodyContext {
@@ -133,6 +134,7 @@ class Body extends BaseComponent<BodyProps, BodyState> {
     cellWidths: number[];
     flattenedColumns: ColumnProps[];
     context: TableContextProps;
+    unsubscribe: () => void;
     constructor(props: BodyProps, context: BodyContext) {
         super(props);
         this.ref = React.createRef();
@@ -144,6 +146,7 @@ class Body extends BaseComponent<BodyProps, BodyState> {
             },
             cachedExpandBtnShouldInRow: null,
             cachedExpandRelatedProps: [],
+            hoveredRowKey: null,
         };
 
         this.listRef = React.createRef();
@@ -153,6 +156,33 @@ class Body extends BaseComponent<BodyProps, BodyState> {
         this.cellWidths = getCellWidths(flattenedColumns);
         this.observer = null;
     }
+
+    componentDidMount() {
+        const { store } = this.props;
+        if (store) {
+            this.unsubscribe = store.subscribe((state: { hoveredRowKey?: string | number }) => {
+                const { hoveredRowKey } = state;
+                if (hoveredRowKey !== this.state.hoveredRowKey) {
+                    this.setState({ hoveredRowKey });
+                }
+            });
+        }
+    }
+
+    componentWillUnmount() {
+        if (this.unsubscribe) {
+            this.unsubscribe();
+            this.unsubscribe = null;
+        }
+    }
+
+    onRowHover = (isHover: boolean, rowKey: string | number) => {
+        const { store } = this.props;
+        if (store) {
+            const hoveredRowKey = isHover ? rowKey : null;
+            store.setState({ hoveredRowKey });
+        }
+    };
 
     get adapter(): BodyAdapter<BodyProps, BodyState> {
         return {
@@ -586,6 +616,10 @@ class Body extends BaseComponent<BodyProps, BodyState> {
         const { getCellWidths } = this.context;
         const cellWidths = getCellWidths(columns, null, true);
 
+        // Calculate hovered state based on current hoveredRowKey
+        const { hoveredRowKey } = this.state;
+        const hovered = hoveredRowKey === key;
+
         return (
             <BaseRow
                 {...baseRowProps}
@@ -594,6 +628,8 @@ class Body extends BaseComponent<BodyProps, BodyState> {
                 key={key}
                 rowKey={key}
                 cellWidths={cellWidths}
+                hovered={hovered}
+                onHover={this.onRowHover}
             />
         );
     }

--- a/packages/semi-ui/table/TableCell.tsx
+++ b/packages/semi-ui/table/TableCell.tsx
@@ -40,7 +40,8 @@ export interface TableCellProps extends BaseProps {
     selected?: boolean; // Whether the current row is selected
     expanded?: boolean; // Whether the current line is expanded
     disabled?: boolean;
-    colIndex?: number
+    colIndex?: number;
+    hovered?: boolean; // Whether the current row is hovered
 }
 
 function isInvalidRenderCellText(text: any) {
@@ -82,6 +83,7 @@ export default class TableCell extends BaseComponent<TableCellProps, Record<stri
         selected: PropTypes.bool,
         expanded: PropTypes.bool,
         colIndex: PropTypes.number,
+        hovered: PropTypes.bool,
     };
 
     get adapter(): TableCellAdapter {
@@ -228,6 +230,7 @@ export default class TableCell extends BaseComponent<TableCellProps, Record<stri
             expandIcon,
             renderExpandIcon,
             column = {},
+            hovered,
         } = this.props;
         const { dataIndex, render, useFullRender } = column;
 
@@ -255,6 +258,7 @@ export default class TableCell extends BaseComponent<TableCellProps, Record<stri
         if (render) {
             const renderOptions = {
                 expandIcon: realExpandIcon,
+                isHovering: hovered,
             };
 
             // column.useFullRender

--- a/packages/semi-ui/table/interface.ts
+++ b/packages/semi-ui/table/interface.ts
@@ -175,7 +175,8 @@ export interface FilterDropdownItem {
 export interface RenderOptions {
     expandIcon?: React.ReactNode;
     selection?: React.ReactNode;
-    indentText?: React.ReactNode
+    indentText?: React.ReactNode;
+    isHovering?: boolean;
 }
 export interface OnCellReturnObject extends React.TdHTMLAttributes<HTMLElement> {
     [x: string]: any;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and follow [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #669

本 PR 为 Table 组件的 `columns.render` 函数的第四个参数 `options` 新增了 `isHovering` 属性，用于判断当前行是否处于悬停状态。

**实现方案：**
1. 在 `RenderOptions` 接口中添加 `isHovering?: boolean` 属性定义
2. 在 Body 组件中通过 store 管理 `hoveredRowKey` 状态，监听行的 hover 事件
3. 将 hovered 状态从 Body → BaseRow → TableCell 逐层传递
4. 在 TableCell 的 render 函数调用时，将 `hovered` 状态作为 `isHovering` 参数传入 renderOptions

**使用场景：**
开发者可以在 render 函数中根据 `isHovering` 参数实现仅在鼠标悬停时显示操作按钮等交互效果，避免列内容过于拥挤。

**审查要点：**
- hover 状态的订阅和取消订阅逻辑是否正确（componentDidMount/componentWillUnmount）
- hoveredRowKey 在 store 中的状态管理是否合理
- 文档更新是否清晰说明了 render 函数第四个参数的使用方法

### Changelog
🇨🇳 Chinese
- Feat: Table 组件 `columns.render` 函数的第四个参数 `options` 新增 `isHovering` 属性，支持判断当前行是否处于悬停状态

---

🇺🇸 English
- Feat: Added `isHovering` property to the fourth parameter `options` of Table component's `columns.render` function, supporting to determine whether the current row is in hover state


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无