### PR TITLE
【Auto】Feat: TreeSelect supports wrapping selected tags in trigger with triggerTagWrap prop

### DIFF
--- a/content/input/treeselect/index-en-US.md
+++ b/content/input/treeselect/index-en-US.md
@@ -503,6 +503,99 @@ import { TreeSelect } from '@douyinfe/semi-ui';
 };
 ```
 
+### Wrap tags in trigger (triggerTagWrap)
+
+In **multiple + searchable + searchPosition="trigger"** mode, if there are many selected items or the input is long, the trigger may prefer to keep a single-line layout by default.
+
+Set `triggerTagWrap={true}` to allow selected tags to wrap into multiple lines within the trigger.
+
+```jsx live=true
+import React from 'react';
+import { TreeSelect } from '@douyinfe/semi-ui';
+
+() => {
+    const treeData = [
+        {
+            label: 'Asia',
+            value: 'Asia',
+            key: '0',
+            children: [
+                {
+                    label: 'China',
+                    value: 'China',
+                    key: '0-0',
+                    children: [
+                        {
+                            label: 'Beijing',
+                            value: 'Beijing',
+                            key: '0-0-0',
+                        },
+                        {
+                            label: 'Shanghai',
+                            value: 'Shanghai',
+                            key: '0-0-1',
+                        },
+                        {
+                            label: 'Shenzhen',
+                            value: 'Shenzhen',
+                            key: '0-0-2',
+                        },
+                        {
+                            label: 'Guangzhou',
+                            value: 'Guangzhou',
+                            key: '0-0-3',
+                        },
+                    ],
+                },
+                {
+                    label: 'Japan',
+                    value: 'Japan',
+                    key: '0-1',
+                    children: [
+                        {
+                            label: 'Osaka',
+                            value: 'Osaka',
+                            key: '0-1-0'
+                        }
+                    ]
+                },
+            ],
+        },
+        {
+            label: 'North America',
+            value: 'North America',
+            key: '1',
+            children: [
+                {
+                    label: 'United States',
+                    value: 'United States',
+                    key: '1-0'
+                },
+                {
+                    label: 'Canada',
+                    value: 'Canada',
+                    key: '1-1'
+                }
+            ]
+        }
+    ];
+
+    return (
+        <TreeSelect
+            searchPosition="trigger"
+            triggerTagWrap
+            style={{ width: 260 }}
+            dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+            treeData={treeData}
+            multiple
+            filterTreeNode
+            placeholder="Select multiple items or input long text"
+            defaultValue={['Beijing', 'Shanghai', 'Shenzhen', 'Guangzhou']}
+        />
+    );
+};
+```
+
 ### Size
 
 You can set the size by `size`, one of: 'small'、'default'、'large'
@@ -1454,6 +1547,7 @@ function Demo() {
 | searchAutoFocus        | Whether autofocus for search box           | boolean      | false           |-|
 | searchPlaceholder        | Placeholder for search box                                                          | string                                                            | -           | -       |
 | searchPosition | Set the position of the search box, one of: `dropdown`、`trigger` | string | `dropdown` | - |
+| triggerTagWrap | Whether to allow selected tags to wrap into multiple lines within the trigger. Only works when `multiple` and `filterTreeNode` are enabled, and `searchPosition="trigger"` | boolean | false | - |
 | showClear | When the value is not empty, whether the trigger displays the clear button | boolean | false |  |
 | showFilteredOnly | Toggle whether to displayed filtered result only in search mode | boolean | false | - |
 | showLine | The option in the options panel shows connecting lines | boolean | false | 2.50.0 |

--- a/content/input/treeselect/index.md
+++ b/content/input/treeselect/index.md
@@ -482,6 +482,99 @@ import { TreeSelect } from '@douyinfe/semi-ui';
 };
 ```
 
+### Trigger 内多行换行（triggerTagWrap）
+
+当你在 **多选 + 搜索框位于 trigger** 的场景下，选择了较多项或输入较长文本时，默认 trigger 可能会更倾向于保持单行展示。
+
+通过设置 `triggerTagWrap={true}`，可以让 trigger 内的已选标签支持自动换行（多行展示）。
+
+```jsx live=true
+import React from 'react';
+import { TreeSelect } from '@douyinfe/semi-ui';
+
+() => {
+    const treeData = [
+        {
+            label: 'Asia',
+            value: 'Asia',
+            key: '0',
+            children: [
+                {
+                    label: 'China',
+                    value: 'China',
+                    key: '0-0',
+                    children: [
+                        {
+                            label: 'Beijing',
+                            value: 'Beijing',
+                            key: '0-0-0',
+                        },
+                        {
+                            label: 'Shanghai',
+                            value: 'Shanghai',
+                            key: '0-0-1',
+                        },
+                        {
+                            label: 'Shenzhen',
+                            value: 'Shenzhen',
+                            key: '0-0-2',
+                        },
+                        {
+                            label: 'Guangzhou',
+                            value: 'Guangzhou',
+                            key: '0-0-3',
+                        },
+                    ],
+                },
+                {
+                    label: 'Japan',
+                    value: 'Japan',
+                    key: '0-1',
+                    children: [
+                        {
+                            label: 'Osaka',
+                            value: 'Osaka',
+                            key: '0-1-0'
+                        }
+                    ]
+                },
+            ],
+        },
+        {
+            label: 'North America',
+            value: 'North America',
+            key: '1',
+            children: [
+                {
+                    label: 'United States',
+                    value: 'United States',
+                    key: '1-0'
+                },
+                {
+                    label: 'Canada',
+                    value: 'Canada',
+                    key: '1-1'
+                }
+            ]
+        }
+    ];
+
+    return (
+        <TreeSelect
+            searchPosition="trigger"
+            triggerTagWrap
+            style={{ width: 260 }}
+            dropdownStyle={{ maxHeight: 400, overflow: 'auto' }}
+            treeData={treeData}
+            multiple
+            filterTreeNode
+            placeholder="请选择多个选项或输入长文本"
+            defaultValue={['Beijing', 'Shanghai', 'Shenzhen', 'Guangzhou']}
+        />
+    );
+};
+```
+
 ### 尺寸大小
 
 可以通过 `size` 设置尺寸大小，可选: 'small'、'default'、'large'
@@ -1395,6 +1488,7 @@ function Demo() {
 | searchAutoFocus | 搜索框自动聚焦                                                                                                                              | boolean | false |
 | searchPlaceholder | 搜索框默认文字                                                                                                                            | string | - | 
 | searchPosition | 设置搜索框的位置，可选: `dropdown`、`trigger`                                                                                                  | string | `dropdown` |
+| triggerTagWrap | 是否允许在 trigger 内将多选标签换行展示。仅在 `multiple` 且 `filterTreeNode` 开启、并且 `searchPosition="trigger"` 时生效 | boolean | false |
 | showClear | 当值不为空时，trigger 是否展示清除按钮                                                                                                               | boolean | false | 
 | showFilteredOnly | 搜索状态下是否只展示过滤后的结果                                                                                                               | boolean | false | 
 | showLine | 选项面板中选项显示连接线。v2.50.0后提供                                                                                                                | boolean | false |

--- a/packages/semi-foundation/treeSelect/treeSelect.scss
+++ b/packages/semi-foundation/treeSelect/treeSelect.scss
@@ -258,13 +258,61 @@ $module: #{$prefix}-tree-select;
 
     &-multiple {
         display: inline-flex;
-
         .#{$module}-selection {
             padding-left: $spacing-treeSelect_selection_multiple-paddingLeft;
             padding-right: 0;
 
             &-placeholder {
                 padding-left: $spacing-treeSelect_placeholder_multiple-paddingLeft;
+            }
+        }
+    }
+
+    /**
+     * Enable wrapping selected tags in trigger.
+     * Only takes effect in multiple + searchPosition="trigger" mode (class added by component).
+     */
+    &-triggerTagWrap {
+        // Prevent trigger from expanding beyond its container
+        max-width: 100%;
+
+        .#{$module}-selection {
+            // Allow selection area to shrink so inner TagInput can wrap
+            min-width: 0;
+        }
+
+        &.#{$module}-multiple {
+            // multiple tags may wrap to multiple lines
+            height: auto;
+
+            .#{$module}-selection {
+                // allow height to grow when wrapping
+                height: auto;
+                min-height: $height-treeSelect_default - 2 * $width-treeSelect-border;
+                overflow: visible;
+            }
+
+            &.#{$module}-small {
+                .#{$module}-selection {
+                    min-height: $height-treeSelect_small - 2 * $width-treeSelect-border;
+                }
+            }
+
+            &.#{$module}-large {
+                .#{$module}-selection {
+                    min-height: $height-treeSelect_large - 2 * $width-treeSelect-border;
+                }
+            }
+        }
+
+        // Make TagInput shrinkable as a flex item, and constrain measured input width
+        .#{$prefix}-tagInput {
+            min-width: 0;
+            max-width: 100%;
+            flex: 1 1 auto;
+
+            .#{$prefix}-tagInput-wrapper-input {
+                max-width: 100%;
             }
         }
     }

--- a/packages/semi-ui/treeSelect/index.tsx
+++ b/packages/semi-ui/treeSelect/index.tsx
@@ -157,6 +157,11 @@ export interface TreeSelectProps extends Omit<BasicTreeSelectProps, OverrideComm
     onVisibleChange?: (isVisible: boolean) => void;
     onClear?: (e: React.MouseEvent | React.KeyboardEvent<HTMLDivElement>) => void;
     autoMergeValue?: boolean
+    /**
+     * Whether to allow selected tags to wrap to multiple lines in trigger (multiple + searchPosition="trigger").
+     * When enabled, TreeSelect will constrain trigger width and allow TagInput to wrap.
+     */
+    triggerTagWrap?: boolean;
 }
 
 export type OverrideCommonState =
@@ -278,6 +283,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         preventScroll: PropTypes.bool,
         clickTriggerToHide: PropTypes.bool,
         autoMergeValue: PropTypes.bool,
+        triggerTagWrap: PropTypes.bool,
     };
 
     static defaultProps: Partial<TreeSelectProps> = {
@@ -312,6 +318,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
         restTagsPopoverProps: {},
         clickTriggerToHide: true,
         autoMergeValue: true,
+        triggerTagWrap: false,
     };
     inputRef: React.RefObject<typeof Input>;
     tagInputRef: React.RefObject<TagInput>;
@@ -1067,6 +1074,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
             borderless,
             autoMergeValue,
             checkRelation,
+            triggerTagWrap,
             ...rest
         } = this.props;
         const { inputValue, selectedKeys, checkedKeys, keyEntities, isFocus, realCheckedKeys } = this.state;
@@ -1101,6 +1109,7 @@ class TreeSelect extends BaseComponent<TreeSelectProps, TreeSelectState> {
                     [`${prefixcls}-with-prefix`]: prefix || insetLabel,
                     [`${prefixcls}-with-suffix`]: suffix,
                     [`${prefixcls}-with-suffix`]: suffix,
+                    [`${prefixcls}-triggerTagWrap`]: Boolean(triggerTagWrap) && multiple && isTriggerPositionSearch,
                 },
                 className
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and follow [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1709

在 TreeSelect 组件的 **多选 + 搜索框位于 trigger** 场景下，当选择了较多选项或输入较长搜索文本时，默认 trigger 会保持单行布局，导致内容显示不全或需要横向滚动。

本 PR 为 TreeSelect 组件新增了 `triggerTagWrap` prop（默认值 `false`）。当设置 `triggerTagWrap={true}` 时，trigger 内的已选标签会自动换行展示（多行布局），提供更好的用户体验。

**主要变更：**
1. 新增 TreeSelect 组件的 `triggerTagWrap` prop（boolean 类型，默认 false）
2. 添加对应的样式规则，支持高度自适应和多行展示
3. 更新中英文文档，添加示例代码和 API 说明

**审查者应关注：**
- 样式实现方式：通过 flex 布局和 `min-height` 约束确保换行后的高度自适应
- 条件判断逻辑：`triggerTagWrap` 仅在 `multiple` 为 true 且 `searchPosition="trigger"` 时生效

### Changelog
🇨🇳 Chinese
- Feat: TreeSelect 组件新增 `triggerTagWrap` prop，支持在 trigger 内多行换行展示已选标签

---

🇺🇸 English
- Feat: Added `triggerTagWrap` prop to TreeSelect component to allow wrapping selected tags in trigger


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
该功能主要用于解决 TreeSelect 在多选 + 搜索场景下的内容展示问题，使行为与 Select 组件保持一致。