### PR TITLE
【Auto】Feat: Add condition prop for Tooltip and Popover components

### DIFF
--- a/content/show/popover/index-en-US.md
+++ b/content/show/popover/index-en-US.md
@@ -228,6 +228,35 @@ import { Popover, Button } from '@douyinfe/semi-ui';
 };
 ```
 
+### Conditional trigger (condition)
+
+When `condition={false}`, Popover will not respond to hover/click/focus triggers (does not affect `trigger='custom'`).
+
+```jsx live=true dir="column"
+import React, { useMemo, useState } from 'react';
+import { Popover, Button, Switch, Space, Typography } from '@douyinfe/semi-ui';
+
+function Demo() {
+    const [enabled, setEnabled] = useState(true);
+    const content = useMemo(() => `condition is ${enabled ? 'true' : 'false'}`, [enabled]);
+
+    return (
+        <Space align="center">
+            <Typography.Text>condition</Typography.Text>
+            <Switch checked={enabled} onChange={(v) => setEnabled(v)} />
+            <Popover content={content} condition={enabled}>
+                <Button>Hover me</Button>
+            </Popover>
+            <Popover content={content} trigger="click" condition={enabled}>
+                <Button>Click me</Button>
+            </Popover>
+        </Space>
+    );
+}
+
+render(Demo);
+```
+
 ### Show Small Triangle
 
 Popover also supports the display of a small triangle.
@@ -526,6 +555,7 @@ Please refer to [Use with Tooltip/Popconfirm](/en-US/show/tooltip#%E6%90%AD%E9%8
 | arrowPointAtCenter | Whether the "small triangle" points to the center of the element, you need to pass in "showArrow = true" at the same time                                                                                                                     | boolean | true | - |
 | className | Pop-up layer classname                                                                                                                                                                                                      | string |  |  |
 | closeOnEsc | Whether to close the panel by pressing the Esc key in the trigger or popup layer. It does not take effect when visible is under controlled                                                                                                    | boolean | true | **2.8.0** |
+| condition | Whether to allow Popover to be triggered. Only when explicitly set to false, hover/click/focus triggers will not take effect (does not affect trigger='custom') | boolean | true | |
 | content | Content displayed                                                                                                                                                                                                                             | string \| ReactNode |  |
 | clickToHide | Whether to automatically close the elastic layer when clicking on the floating layer and any element inside                                                                                                                                   | boolean | false | - |
 | disableFocusListener | When trigger is `hover`, does not respond to the keyboard focus popup event, see details at [issue#977](https://github.com/DouyinFE/semi-design/issues/977)                                                                                   | boolean | true | **2.17.0** |

--- a/content/show/popover/index.md
+++ b/content/show/popover/index.md
@@ -231,6 +231,35 @@ import { IllustrationSuccess, IllustrationSuccessDark } from '@douyinfe/semi-ill
 }
 ```
 
+### condition 条件触发
+
+当 `condition={false}` 时，Popover 不响应 hover/click/focus 等触发行为（`trigger='custom'` 不受影响）。
+
+```jsx live=true dir="column"
+import React, { useMemo, useState } from 'react';
+import { Popover, Button, Switch, Space, Typography } from '@douyinfe/semi-ui';
+
+function Demo() {
+    const [enabled, setEnabled] = useState(true);
+    const content = useMemo(() => `condition is ${enabled ? 'true' : 'false'}`, [enabled]);
+
+    return (
+        <Space align="center">
+            <Typography.Text>condition</Typography.Text>
+            <Switch checked={enabled} onChange={(v) => setEnabled(v)} />
+            <Popover content={content} condition={enabled}>
+                <Button>Hover me</Button>
+            </Popover>
+            <Popover content={content} trigger="click" condition={enabled}>
+                <Button>Click me</Button>
+            </Popover>
+        </Space>
+    );
+}
+
+render(Demo);
+```
+
 ### 显示小三角
 
 通过设置`showArrow`, Popover 同样也支持展示一个小三角。
@@ -532,6 +561,7 @@ import { Button, Input, Popover, Space } from '@douyinfe/semi-ui';
 | arrowPointAtCenter | "小三角"是否指向元素中心，需要同时传入"showArrow=true"                                                                                      | boolean                    | true                                        | - |
 | className | 弹出层的样式名                                                                                                                                              | string |  |  |
 | closeOnEsc         | 在 trigger 或 弹出层按 Esc 键是否关闭面板，受控时不生效 | boolean | true | **2.8.0**  |
+| condition | 是否允许 Popover 触发显示。仅当显式设置为 false 时，hover/click/focus 等触发行为不生效（trigger='custom' 场景不受影响） | boolean | true | |
 | content            | 显示的内容（函数类型，2.8.0 版本支持）                                                                                                                                  | ReactNode \| ({ initialFocusRef }) => ReactNode          |            |            |
 | clickToHide        | 点击弹出层及内部任一元素时是否自动关闭弹层                                                                                                  | boolean                    | false                                       | - |
 | disableFocusListener | trigger为`hover`时，不响应键盘聚焦弹出浮层事件，详见[issue#977](https://github.com/DouyinFE/semi-design/issues/977) | boolean | true | **2.17.0** |

--- a/content/show/tooltip/index-en-US.md
+++ b/content/show/tooltip/index-en-US.md
@@ -257,6 +257,35 @@ function Demo() {
 }
 ```
 
+### Conditional trigger (condition)
+
+When `condition={false}`, Tooltip will not respond to hover/click/focus triggers (does not affect `trigger='custom'`).
+
+```jsx live=true dir="column"
+import React, { useMemo, useState } from 'react';
+import { Tooltip, Button, Switch, Space, Typography } from '@douyinfe/semi-ui';
+
+function Demo() {
+    const [enabled, setEnabled] = useState(true);
+    const content = useMemo(() => `condition is ${enabled ? 'true' : 'false'}`, [enabled]);
+
+    return (
+        <Space align="center">
+            <Typography.Text>condition</Typography.Text>
+            <Switch checked={enabled} onChange={(v) => setEnabled(v)} />
+            <Tooltip content={content} trigger="hover" condition={enabled}>
+                <Button>Hover me</Button>
+            </Tooltip>
+            <Tooltip content={content} trigger="click" condition={enabled}>
+                <Button>Click me</Button>
+            </Tooltip>
+        </Space>
+    );
+}
+
+render(Demo);
+```
+
 ### Override Style
 
 Configure specific styles for the pop-up layer through the `className` and `style` API, such as overriding the default maxWidth (240px)
@@ -334,6 +363,7 @@ import { Popconfirm, Tooltip, Button } from '@douyinfe/semi-ui';
 | --- |-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| --- | --- | --- |
 | autoAdjustOverflow | Whether the floating layer automatically adjusts its direction when it is blocked                                                                                                                                           | boolean | true |  |
 | arrowPointAtCenter | Whether the "small triangle" points to the center of the element, you need to pass in "showArrow = true" at the same time                                                                                                   | boolean | true | - |
+| condition | Whether to allow Tooltip to be triggered. Only when explicitly set to false, hover/click/focus triggers will not take effect (does not affect trigger='custom') | boolean | true | |
 | className | Pop-up layer classname                                                                                                                                                                                                      | string |  |  |
 | content | Pop-up layer content                                                                                                                                                                                                        | string | ReactNode |  |
 | clickToHide | Whether to automatically close the elastic layer when clicking on the floating layer and any element inside                                                                                                                 | boolean | false | - |

--- a/content/show/tooltip/index.md
+++ b/content/show/tooltip/index.md
@@ -259,6 +259,35 @@ function Demo() {
 }
 ```
 
+### condition 条件触发
+
+当 `condition={false}` 时，Tooltip 不响应 hover/click/focus 等触发行为（`trigger='custom'` 不受影响）。
+
+```jsx live=true dir="column"
+import React, { useMemo, useState } from 'react';
+import { Tooltip, Button, Switch, Space, Typography } from '@douyinfe/semi-ui';
+
+function Demo() {
+    const [enabled, setEnabled] = useState(true);
+    const content = useMemo(() => `condition is ${enabled ? 'true' : 'false'}`, [enabled]);
+
+    return (
+        <Space align="center">
+            <Typography.Text>condition</Typography.Text>
+            <Switch checked={enabled} onChange={(v) => setEnabled(v)} />
+            <Tooltip content={content} trigger="hover" condition={enabled}>
+                <Button>Hover me</Button>
+            </Tooltip>
+            <Tooltip content={content} trigger="click" condition={enabled}>
+                <Button>Click me</Button>
+            </Tooltip>
+        </Space>
+    );
+}
+
+render(Demo);
+```
+
 ### 覆盖特定样式
 
 你可以通过 className、style 为弹出层配置特定样式，例如覆盖默认的 maxWidth （240px）
@@ -371,6 +400,7 @@ function Demo() {
 | --- |------------------------------------------------------------------------------------------------------------------------------------------------------| --- | --- | --- |
 | autoAdjustOverflow | 弹出层被遮挡时是否自动调整方向                                                                                                                                      | boolean | true |  |
 | arrowPointAtCenter | “小三角”是否指向元素中心，需要同时传入"showArrow=true"                                                                                                                 | boolean | true |  |
+| condition | 是否允许 Tooltip 触发显示。仅当显式设置为 false 时，hover/click/focus 等触发行为不生效（trigger='custom' 场景不受影响） | boolean | true | |
 | content | 弹出层内容                                                                                                                                                | string\|ReactNode |  |  |
 | className | 弹出层的样式名                                                                                                                                              | string |  |  |
 | clickToHide | 点击弹出层及内部任一元素时是否自动关闭弹层                                                                                                                                | boolean | false |  |

--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -210,7 +210,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
         switch (types) {
             case 'focus':
                 triggerEventSet[eventNames.focus] = () => {
-                    this.delayShow();
+                    this.getProp('condition') !== false && this.delayShow();
                 };
                 triggerEventSet[eventNames.blur] = () => {
                     this.delayHide();
@@ -220,7 +220,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
             case 'click':
                 triggerEventSet[eventNames.click] = () => {
                     // this.delayShow();
-                    this.show();
+                    this.getProp('condition') !== false && this.show();
                 };
                 portalEventSet = {};
                 // Click outside needs special treatment, can not be directly tied to the trigger Element, need to be bound to the document
@@ -229,7 +229,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 triggerEventSet[eventNames.mouseEnter] = () => {
                     // console.log(e);
                     this.setCache('isClickToHide', false);
-                    this.delayShow();
+                    this.getProp('condition') !== false && this.delayShow();
                     // this.show('trigger');
                 };
                 triggerEventSet[eventNames.mouseLeave] = () => {
@@ -240,7 +240,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 // bind focus to hover trigger for a11y
                 triggerEventSet[eventNames.focus] = () => {
                     const { disableFocusListener } = this.getProps();
-                    !disableFocusListener && this.delayShow();
+                    this.getProp('condition') !== false && !disableFocusListener && this.delayShow();
                 };
                 triggerEventSet[eventNames.blur] = () => {
                     const { disableFocusListener } = this.getProps();
@@ -259,7 +259,7 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                             return;
                         }
 
-                        this.delayShow();
+                        this.getProp('condition') !== false && this.delayShow();
                     };
                 }
                 break;
@@ -269,6 +269,9 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
                 break;
             case 'contextMenu':
                 triggerEventSet[eventNames.contextMenu] = (e) => {
+                    if (this.getProp('condition') === false) {
+                        return;
+                    }
                     e.preventDefault();
                     this.show();
                 };

--- a/packages/semi-ui/popover/index.tsx
+++ b/packages/semi-ui/popover/index.tsx
@@ -50,7 +50,13 @@ export interface PopoverProps extends BaseProps {
     clickToHide?: TooltipProps['clickToHide'];
     disableFocusListener?: boolean;
     afterClose?: () => void;
-    keepDOM?: boolean
+    keepDOM?: boolean;
+    /**
+     * Whether to allow the popover to show
+     * When set to false, the popover will not show when triggered
+     * @default true
+     */
+    condition?: boolean;
 }
 
 export interface PopoverState {
@@ -90,6 +96,7 @@ class Popover extends React.PureComponent<PopoverProps, PopoverState> {
         prefixCls: PropTypes.string,
         guardFocus: PropTypes.bool,
         disableArrowKeyDown: PropTypes.bool,
+        condition: PropTypes.bool,
     };
     static __SemiComponentName__ = "Popover";
 

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -89,7 +89,13 @@ export interface TooltipProps extends BaseProps {
     preventScroll?: boolean;
     disableFocusListener?: boolean;
     afterClose?: () => void;
-    keepDOM?: boolean
+    keepDOM?: boolean;
+    /**
+     * Whether to allow the tooltip to show
+     * When set to false, the tooltip will not show when triggered
+     * @default true
+     */
+    condition?: boolean;
 }
 
 interface TooltipState {
@@ -155,6 +161,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         returnFocusOnClose: PropTypes.bool,
         preventScroll: PropTypes.bool,
         keepDOM: PropTypes.bool,
+        condition: PropTypes.bool,
     };
     static __SemiComponentName__ = "Tooltip";
     static defaultProps = getDefaultPropsFromGlobalConfig(Tooltip.__SemiComponentName__, {
@@ -182,7 +189,8 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         onEscKeyDown: noop,
         disableFocusListener: false,
         disableArrowKeyDown: false,
-        keepDOM: false
+        keepDOM: false,
+        condition: true,
     });
 
     eventManager: Event;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [ ] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1648

本 PR 为 Tooltip 和 Popover 组件新增了 `condition` 属性，用于简化条件显示的场景。

**问题背景：**
在需要条件显示提示的场景下（如按钮不可点时显示原因），开发者不得不使用三元表达式来条件渲染 Tooltip/Popover，这存在两个问题：
1. 大量重复代码
2. 无法保持组件内部状态，因为三元表达式会重新创建一个新的组件实例

**解决方案：**
新增 `condition` 属性，当 `condition={false}` 时，Tooltip 和 Popover 不响应 hover/click/focus 等触发行为（但不影响 `trigger='custom'` 场景）。这样可以避免组件重新创建，保持组件实例和内部状态。

**实现细节：**
- 在 `packages/semi-foundation/tooltip/foundation.ts` 中为 focus、click、hover、contextMenu 等触发事件添加 condition 检查
- 在 `packages/semi-ui/tooltip/index.tsx` 中为 Tooltip 组件新增 `condition` prop，默认值为 `true`
- 在 `packages/semi-ui/popover/index.tsx` 中为 Popover 组件新增 `condition` prop，默认值为 `true`
- 更新了中英文文档，添加了使用示例和 API 说明

**审查要点：**
- `condition` 的默认值为 `true`，仅当显式设置为 `false` 时才会阻止触发
- `trigger='custom'` 场景不受 `condition` 影响，保持手动控制的灵活性
- 所有触发类型都正确处理了 condition 检查

### Changelog
🇨🇳 Chinese
- Feat: Tooltip 和 Popover 组件新增 condition 属性，用于控制是否允许触发显示。当 condition 为 false 时，hover/click/focus 等触发行为不生效（trigger='custom' 场景不受影响）

---

🇺🇸 English
- Feat: Added condition prop to Tooltip and Popover components for controlling trigger behavior. When condition is false, hover/click/focus triggers will not work (trigger='custom' is not affected)


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
**使用示例：**
```jsx
// 条件显示 Tooltip，避免使用三元表达式
<Tooltip content="按钮已禁用" condition={isDisabled}>
  <Button disabled={isDisabled}>提交</Button>
</Tooltip>

// condition=false 时，点击不会显示 Popover
<Popover content="详细信息" condition={hasPermission} trigger="click">
  <Button>查看详情</Button>
</Popover>
```