### PR TITLE
【Auto】Fix: Form field onChange callback now receives updated form values

### DIFF
--- a/packages/semi-ui/form/hoc/withField.tsx
+++ b/packages/semi-ui/form/hoc/withField.tsx
@@ -412,11 +412,6 @@ function withField<
          *
          */
         const handleChange = (newValue: any, e: any, ...other: any[]) => {
-            let fnKey = options.onKeyChangeFnName;
-            if (fnKey in props && typeof props[options.onKeyChangeFnName] === 'function') {
-                props[options.onKeyChangeFnName](newValue, e, ...other);
-            }
-
             // support various type component
             let val;
             if (!options.valuePath) {
@@ -461,6 +456,14 @@ function withField<
             // only validate when trigger includes change
             if (mergeTrigger.includes('change')) {
                 fieldValidate(val);
+            }
+
+            // Call user's onChange callback after value is updated, with latest values as additional parameter
+            let fnKey = options.onKeyChangeFnName;
+            if (fnKey in props && typeof props[options.onKeyChangeFnName] === 'function') {
+                // Get the latest values from foundation (already updated above)
+                const latestValues = updater.getValue();
+                props[options.onKeyChangeFnName](newValue, e, ...other, latestValues);
             }
         };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #579

**问题背景：**
在 Form 组件中，当在 `onChange` 回调中读取 `formState.values` 时，值尚未更新。这导致在非 ArrayField 场景下，用户无法在 `onChange` 回调中获取到最新的表单值。

**解决方案：**
将用户自定义的 `onChange` 回调执行时机从 `updateValue` 之前移动到之后，确保在回调执行时表单值已完成更新。同时，新增 `latestValues` 作为 `onChange` 回调的额外参数，方便用户直接获取最新的表单值。

**审查关注点：**
- `handleChange` 函数中 `onChange` 回调的执行顺序变更
- 新增的 `latestValues` 参数（作为回调的最后一个参数）

### Changelog
🇨🇳 Chinese
- Fix: 修复 Form 组件 onChange 回调中无法获取最新 formState.values 的问题，回调现已在表单值更新后执行，并新增 latestValues 作为回调参数

---

🇺🇸 English
- Fix: Fixed Form component onChange callback not receiving updated formState.values. The callback now executes after form value is updated, with latestValues added as an additional parameter


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
无