### PR TITLE
【Auto】Fix: Tooltip/Popover arrowPointAtCenter API works correctly for center positions (top/bottom/left/right)

### DIFF
--- a/packages/semi-foundation/tooltip/arrow.scss
+++ b/packages/semi-foundation/tooltip/arrow.scss
@@ -23,7 +23,7 @@
 
         &[x-placement='top'] {
             .#{$module-icon} {
-                left: 50%;
+                left: var(--semi-tooltip-arrow-offset-x, 50%);
                 transform: translateX(-50%);
                 bottom: (-$height-tooltip_arrow + $spacing-tooltip_arrow_offset-y);
             }
@@ -61,7 +61,7 @@
                 width: $width-tooltip_arrow_vertical;
                 height: $height-tooltip_arrow_vertical;
                 right: (-$width-tooltip_arrow_vertical + $spacing-tooltip_arrow_offset-x);
-                top: 50%;
+                top: var(--semi-tooltip-arrow-offset-y, 50%);
                 transform: translateY(-50%);
             }
 
@@ -93,7 +93,7 @@
                 width: $width-tooltip_arrow_vertical;
                 height: $height-tooltip_arrow_vertical;
                 left: -$width-tooltip_arrow_vertical + $spacing-tooltip_arrow_offset-x;
-                top: 50%;
+                top: var(--semi-tooltip-arrow-offset-y, 50%);
                 transform: translateY(-50%) rotate(180deg);
             }
 
@@ -122,7 +122,7 @@
         &[x-placement='bottom'] {
             .#{$module-icon} {
                 top: (-$height-tooltip_arrow + $spacing-tooltip_arrow_offset-y);
-                left: 50%;
+                left: var(--semi-tooltip-arrow-offset-x, 50%);
                 transform: translateX(-50%) rotate(180deg);
             }
 

--- a/packages/semi-foundation/tooltip/foundation.ts
+++ b/packages/semi-foundation/tooltip/foundation.ts
@@ -674,11 +674,89 @@ export default class Tooltip<P = Record<string, any>, S = Record<string, any>> e
             }
         }
 
+        // Handle arrowPointAtCenter for center positions (top/bottom/left/right)
+        // For center positions, the arrow needs to point at trigger center, not Popover center
+        let cssArrowOffsetX: string | undefined;
+        let cssArrowOffsetY: string | undefined;
+        
+        if (showArrow) {
+            const isCenterPosition = ['top', 'bottom', 'left', 'right'].includes(position);
+            
+            if (isCenterPosition) {
+                if (arrowPointAtCenter) {
+                    // arrowPointAtCenter=true: arrow should point at trigger center
+                    // Calculate arrow position relative to Popover left/top edge
+                    
+                    if ((position === 'top' || position === 'bottom') && wrapperRect.width > 0) {
+                        // Popover center is at `left`, trigger center is at `middleX`
+                        // Arrow position from Popover left edge:
+                        // = middleX - (left - wrapperRect.width/2)
+                        // = middleX - left + wrapperRect.width/2
+                        // Percentage: (middleX - left) / wrapperRect.width + 0.5
+                        const arrowOffsetPercent = (middleX - left) / wrapperRect.width + 0.5;
+                        
+                        // Clamp to valid range to prevent arrow going outside Popover
+                        const minOffset = (horizontalArrowWidth / 2 + positionOffsetX) / wrapperRect.width;
+                        const maxOffset = 1 - minOffset;
+                        const clampedOffset = Math.max(minOffset, Math.min(maxOffset, arrowOffsetPercent));
+                        
+                        // Only set CSS variable if different from default 50%
+                        if (Math.abs(clampedOffset - 0.5) > 0.01) {
+                            cssArrowOffsetX = `${clampedOffset * 100}%`;
+                        }
+                    }
+                    
+                    if ((position === 'left' || position === 'right') && wrapperRect.height > 0) {
+                        const arrowOffsetPercent = (middleY - top) / wrapperRect.height + 0.5;
+                        
+                        const minOffset = (verticalArrowHeight / 2 + positionOffsetY) / wrapperRect.height;
+                        const maxOffset = 1 - minOffset;
+                        const clampedOffset = Math.max(minOffset, Math.min(maxOffset, arrowOffsetPercent));
+                        
+                        if (Math.abs(clampedOffset - 0.5) > 0.01) {
+                            cssArrowOffsetY = `${clampedOffset * 100}%`;
+                        }
+                    }
+                } else {
+                    // arrowPointAtCenter=false: arrow should be at Popover edge
+                    // Determine which edge based on trigger position in viewport
+                    
+                    if ((position === 'top' || position === 'bottom') && wrapperRect.width > 0) {
+                        const offsetXWithArrow = positionOffsetX + horizontalArrowWidth / 2;
+                        
+                        if (isTriggerNearLeft) {
+                            cssArrowOffsetX = `${(offsetXWithArrow / wrapperRect.width) * 100}%`;
+                        } else {
+                            cssArrowOffsetX = `${((wrapperRect.width - offsetXWithArrow) / wrapperRect.width) * 100}%`;
+                        }
+                    }
+                    
+                    if ((position === 'left' || position === 'right') && wrapperRect.height > 0) {
+                        const offsetYWithArrow = positionOffsetY + verticalArrowHeight / 2;
+                        
+                        if (isTriggerNearTop) {
+                            cssArrowOffsetY = `${(offsetYWithArrow / wrapperRect.height) * 100}%`;
+                        } else {
+                            cssArrowOffsetY = `${((wrapperRect.height - offsetYWithArrow) / wrapperRect.height) * 100}%`;
+                        }
+                    }
+                }
+            }
+        }
+
         // The left/top value here must be rounded, otherwise it will cause the small triangle to shake
         const style: Record<string, string | number> = {
             left: this._roundPixel(left),
             top: this._roundPixel(top),
         };
+
+        // Add CSS variables for arrow positioning
+        if (cssArrowOffsetX) {
+            style['--semi-tooltip-arrow-offset-x'] = cssArrowOffsetX;
+        }
+        if (cssArrowOffsetY) {
+            style['--semi-tooltip-arrow-offset-y'] = cssArrowOffsetY;
+        }
 
         let transform = '';
 

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -673,6 +673,13 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
         const icon = this.renderIcon();
         const portalInnerStyle = omit(containerStyle, motion ? ['transformOrigin'] : undefined);
         const transformOrigin = get(containerStyle, 'transformOrigin');
+        // Extract CSS variables for arrow positioning and apply to wrapper element
+        const arrowOffsetX = get(containerStyle, '--semi-tooltip-arrow-offset-x');
+        const arrowOffsetY = get(containerStyle, '--semi-tooltip-arrow-offset-y');
+        const wrapperArrowStyle = {
+            ...(arrowOffsetX ? { '--semi-tooltip-arrow-offset-x': arrowOffsetX } : {}),
+            ...(arrowOffsetY ? { '--semi-tooltip-arrow-offset-y': arrowOffsetY } : {}),
+        } as React.CSSProperties;
         const userOpacity: CSSProperties['opacity'] | null = get(style, 'opacity', null);
         const opacity = userOpacity ? userOpacity : 1;
         const inner =
@@ -698,6 +705,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                                 ...(displayNone ? { display: "none" } : {}),
                                 transformOrigin,
                                 ...style,
+                                ...wrapperArrowStyle,
                                 ...(userOpacity ? { opacity: isPositionUpdated ? opacity : "0" } : {})
                             }}
                             {...portalEventSet}


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #1822

**问题背景：**
Tooltip 和 Popover 组件的 `arrowPointAtCenter` API 在 position 为居中位置时不起作用，箭头始终固定在 50% 位置，无法根据实际场景动态调整。这导致在 Select 组件的 `showRestTagsPopover` 场景下，即使设置 `arrowPointAtCenter: false`，箭头也无法正确指向 trigger。

**解决方案：**
1. **样式层（arrow.scss）**：将箭头的 `left: 50%` 和 `top: 50%` 改为使用 CSS 变量 `var(--semi-tooltip-arrow-offset-x, 50%)` 和 `var(--semi-tooltip-arrow-offset-y, 50%)`，支持动态调整
2. **逻辑层**：添加箭头位置计算逻辑，根据 `arrowPointAtCenter` 的值和 trigger 在视口中的位置来动态计算箭头偏移量
   - `arrowPointAtCenter: true`：箭头指向 trigger 的中心位置
   - `arrowPointAtCenter: false`：箭头指向 Popover 的边缘位置，并根据 trigger 在视口中的位置决定是左边缘还是右边缘
3. **组件层**：提取 CSS 变量并应用到 wrapper 元素，实现箭头位置的动态渲染

**审查要点：**
- 关注 foundation.ts 中新增的箭头位置计算逻辑（677-745 行），特别是边界条件处理（clamp 到有效范围）
- 验证 CSS 变量在样式层和组件层的传递是否正确
- 测试用例已添加在 semi-playground-for-ai/src/App.tsx 中，包含 Select 和 Popover 的各种场景

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tooltip/Popover 组件的 arrowPointAtCenter prop 在 position 为 top/bottom/left/right 时不起作用的问题，箭头位置现在可以根据实际场景动态调整

---

🇺🇸 English
- Fix: Fixed Tooltip/Popover arrowPointAtCenter prop not working for center positions (top/bottom/left/right), arrow position now adjusts dynamically based on actual scenario


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此修复通过引入 CSS 变量机制，实现了箭头位置的动态调整，确保 `arrowPointAtCenter` API 在所有位置场景下都能正确工作。