### PR TITLE
【Auto】Fix: Table right border not visible before scrolling in horizontal scroll mode

### DIFF
--- a/packages/semi-foundation/table/rtl.scss
+++ b/packages/semi-foundation/table/rtl.scss
@@ -144,6 +144,27 @@ $module: #{$prefix}-table;
                     border-left: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
                 }
             }
+
+            // Fix #441 (RTL): when horizontal scroll is enabled and table is NOT scrolled to the far left,
+            // the outer left border can be outside of viewport (the real border is rendered by the last column cell).
+            // Draw an overlay left border on the container to keep it visible.
+            // When scrolled to the far left, `.semi-table-scroll-position-left` exists and we should not draw it.
+            &:not(.#{$module}-scroll-position-left) {
+                & > .#{$module}-container {
+                    &::after {
+                        content: '';
+                        position: absolute;
+                        top: 0;
+                        left: 0;
+                        bottom: 0;
+                        width: $width-table_base_border;
+                        background-color: $color-table-border-default;
+                        display: block;
+                        z-index: $z-table_fixed_column + 2;
+                        pointer-events: none;
+                    }
+                }
+            }
         }
 
         &-fixed {

--- a/packages/semi-foundation/table/table.scss
+++ b/packages/semi-foundation/table/table.scss
@@ -538,6 +538,35 @@ $module: #{$prefix}-table;
             }
         }
 
+        // Fix #441: when horizontal scroll is enabled (e.g. scroll.x='101%') and table is NOT scrolled to the far right,
+        // the outer right border can be outside of viewport because the real right border is rendered by the
+        // last column cell border (which is scrollable). Draw an overlay right border on the container to keep it visible.
+        // When scrolled to the far right, `.semi-table-scroll-position-right` exists and we should not draw it to avoid
+        // double borders.
+        &:not(.#{$module}-scroll-position-right) {
+            & > .#{$module}-container {
+                &::after {
+                    content: '';
+                    position: absolute;
+                    top: 0;
+                    right: 0;
+                    bottom: 0;
+                    width: $width-table_base_border;
+                    background-color: $color-table-border-default;
+                    display: block;
+                    // Make sure the overlay border stays above table content/fixed columns
+                    z-index: $z-table_fixed_column + 2;
+                    pointer-events: none;
+                }
+
+                // Ensure header shows a visible right border even when the container overlay
+                // is covered by native scrollbars in some browsers.
+                & > .#{$module}-header {
+                    box-shadow: inset -$width-table_base_border 0 0 0 $color-table-border-default;
+                }
+            }
+        }
+
         :where(& > .#{$module}-container) {
             & > .#{$module}-body > .#{$module}-placeholder {
                 border-right: $width-table_base_border $border-table_base-borderStyle $color-table-border-default;
@@ -572,6 +601,9 @@ $module: #{$prefix}-table;
         position: sticky;
         left: 0px;
         z-index: 1;
+        // In bordered mode, placeholder may receive an extra side border to complete the outer frame.
+        // Use border-box to avoid 1px horizontal overflow (and unwanted horizontal scrollbar) in empty data + scroll.y cases.
+        box-sizing: border-box;
         padding: #{$spacing-table-paddingY} #{$spacing-table-paddingX};
         color: $color-table_placeholder-text-default;
         font-size: #{$font-table_base-fontSize};

--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -534,6 +534,14 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
         super.componentDidMount();
         this.setScrollPosition('left');
 
+        // Recompute scroll position based on actual DOM sizes after first paint,
+        // so `scroll-position-*` classNames are correct even before the user scrolls.
+        if (typeof window !== 'undefined' && typeof window.requestAnimationFrame === 'function') {
+            window.requestAnimationFrame(() => this.setScrollPositionClassName());
+        } else {
+            setTimeout(() => this.setScrollPositionClassName(), 0);
+        }
+
         if (this.adapter.isAnyColumnFixed() || (this.props.showHeader && this.adapter.useFixedHeader())) {
             this.handleWindowResize();
             window.addEventListener('resize', this.debouncedWindowResize);
@@ -821,6 +829,9 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             `${prefixCls}-scroll-position-left`,
             `${prefixCls}-scroll-position-right`,
         ];
+        // `render()` uses `this.position` to calculate wrapper classNames.
+        // Keep it in sync with the DOM classList updates to avoid losing classes after re-render.
+        this.position = position;
         this.scrollPosition = position;
         const tableNode = this.wrapRef.current;
         if (tableNode && tableNode.nodeType) {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #441

修复了 Table 组件在启用水平滚动（如 `scroll.x='101%'`）时，表头最右侧边框需要滚动后才能显示的问题。

**问题原因：** 当表格启用了水平滚动且未滚动到最右侧时，实际的右侧边框由最后一列单元格渲染，但该单元格可能不在可视区域内，导致右侧外边框不可见。

**解决方案：**
1. 当表格未滚动到最右侧时（无 `.semi-table-scroll-position-right` 类），在容器上使用 `::after` 伪元素绘制一个覆盖的右侧边框
2. 为表头添加 `box-shadow` 确保表头右侧边框始终可见
3. 为 RTL 模式添加了对应的左侧边框处理

**审查要点：**
- CSS 样式实现方案是否合理
- z-index 层级设置是否会影响其他固定列功能
- RTL 模式下的边框处理是否正确

### Changelog
🇨🇳 Chinese
- Fix: 修复 Table 组件在水平滚动模式下右侧边框未滚动时不显示的问题

---

🇺🇸 English
- Fix: Fixed Table right border not being visible before scrolling to the right edge in horizontal scroll mode


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
此修复为纯 CSS 层面的改动，不涉及组件 props 变更，不影响现有 API。