### PR TITLE
【Auto】Fix: Table expanded row width not updating when container width changes dynamically

### DIFF
--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -964,12 +964,19 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
 
         this.resizeObserver = new RO((_entries: ResizeObserverEntry[]) => {
             // Use requestAnimationFrame to ensure we get accurate dimensions
-            // and avoid layout thrashing
-            const requestAnimationFrame = window.requestAnimationFrame || window.setTimeout;
-            requestAnimationFrame(() => {
+            // and avoid layout thrashing.
+            // NOTE: rAF/setTimeout must be invoked with `window` as `this` (Safari
+            // throws "Illegal invocation" otherwise), so call them as methods on
+            // `window` instead of caching them as bare function references.
+            const cb = () => {
                 this.syncTableWidth();
                 this.setScrollPositionClassName();
-            });
+            };
+            if (typeof window.requestAnimationFrame === 'function') {
+                window.requestAnimationFrame(cb);
+            } else {
+                window.setTimeout(cb, 0);
+            }
         });
 
         this.resizeObserver.observe(tableWrapperDOM);

--- a/packages/semi-ui/table/Table.tsx
+++ b/packages/semi-ui/table/Table.tsx
@@ -442,6 +442,8 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
     position!: BodyScrollPosition;
     foundation: TableFoundation<RecordType>;
     context: TableContextProps;
+    resizeObserver: ResizeObserver | null;
+    hasBindWindowResize: boolean;
     constructor(props: NormalTableProps<RecordType>, context: TableContextProps) {
         super(props);
         this.foundation = new TableFoundation<RecordType>(this.adapter);
@@ -504,6 +506,8 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
         this.cachedFilteredSortedDataSource = [];
         this.cachedFilteredSortedRowKeys = [];
         this.cachedFilteredSortedRowKeysSet = new Set();
+        this.resizeObserver = null;
+        this.hasBindWindowResize = false;
     }
 
     static getDerivedStateFromProps(props: NormalTableProps, state: NormalTableState) {
@@ -589,10 +593,7 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             setTimeout(() => this.setScrollPositionClassName(), 0);
         }
 
-        if (this.adapter.isAnyColumnFixed() || (this.props.showHeader && this.adapter.useFixedHeader())) {
-            this.handleWindowResize();
-            window.addEventListener('resize', this.debouncedWindowResize);
-        }
+        this.syncResizeListeners();
     }
 
     // TODO: Extract the setState operation to the adapter or getDerivedStateFromProps function
@@ -724,20 +725,23 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
             }
         }
 
-        if (this.adapter.isAnyColumnFixed() || (this.props.showHeader && this.adapter.useFixedHeader())) {
-            if (!this.debouncedWindowResize) {
-                window.addEventListener('resize', this.debouncedWindowResize);
-            }
-        }
+        // Keep resize listeners in sync with current render mode.
+        // Must run on every update to correctly unbind when fixed mode is turned off.
+        this.syncResizeListeners();
     }
 
     componentWillUnmount() {
         super.componentWillUnmount();
 
+        this.unbindWindowResize();
         if (this.debouncedWindowResize) {
-            window.removeEventListener('resize', this.debouncedWindowResize);
             (this.debouncedWindowResize as any).cancel();
             this.debouncedWindowResize = null;
+        }
+
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
         }
     }
 
@@ -922,8 +926,95 @@ class Table<RecordType extends Record<string, any>> extends BaseComponent<Normal
     };
 
     syncTableWidth = () => {
-        if (this.rootWrapRef && this.rootWrapRef.current) {
-            this.setState({ tableWidth: this.rootWrapRef.current.getBoundingClientRect().width });
+        const wrapper = this.rootWrapRef?.current;
+        if (!wrapper) {
+            return;
+        }
+        const nextWidth = wrapper.getBoundingClientRect().width;
+        const prevWidth = this.state.tableWidth;
+        // Avoid unnecessary re-render when width hasn't changed.
+        if (typeof prevWidth === 'number' && Math.abs(prevWidth - nextWidth) < 0.5) {
+            return;
+        }
+        this.setState({ tableWidth: nextWidth });
+    };
+
+    /**
+     * Use ResizeObserver to monitor table wrapper width changes
+     * This handles cases where the container width changes but window size doesn't
+     * (e.g., sidebar collapse/expand, tab switch, modal appear/disappear)
+     */
+    observeTableWrapperResize = () => {
+        const tableWrapperDOM = this.rootWrapRef.current;
+        if (!tableWrapperDOM) {
+            return;
+        }
+
+        // Clean up existing observer if any
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
+
+        // Check if ResizeObserver is supported
+        const RO = get(window, 'ResizeObserver');
+        if (!RO) {
+            return;
+        }
+
+        this.resizeObserver = new RO((_entries: ResizeObserverEntry[]) => {
+            // Use requestAnimationFrame to ensure we get accurate dimensions
+            // and avoid layout thrashing
+            const requestAnimationFrame = window.requestAnimationFrame || window.setTimeout;
+            requestAnimationFrame(() => {
+                this.syncTableWidth();
+                this.setScrollPositionClassName();
+            });
+        });
+
+        this.resizeObserver.observe(tableWrapperDOM);
+    };
+
+    needSyncTableWidth = () => this.adapter.isAnyColumnFixed() || (this.props.showHeader && this.adapter.useFixedHeader());
+
+    bindWindowResize = () => {
+        if (this.hasBindWindowResize) {
+            return;
+        }
+        if (this.debouncedWindowResize) {
+            window.addEventListener('resize', this.debouncedWindowResize);
+            this.hasBindWindowResize = true;
+        }
+    };
+
+    unbindWindowResize = () => {
+        if (!this.hasBindWindowResize) {
+            return;
+        }
+        if (this.debouncedWindowResize) {
+            window.removeEventListener('resize', this.debouncedWindowResize);
+        }
+        this.hasBindWindowResize = false;
+    };
+
+    syncResizeListeners = () => {
+        const needSync = this.needSyncTableWidth();
+        if (needSync) {
+            // Only sync immediately when we are enabling the listeners.
+            const wasBound = this.hasBindWindowResize;
+            this.bindWindowResize();
+            if (!this.resizeObserver) {
+                this.observeTableWrapperResize();
+            }
+            if (!wasBound) {
+                this.handleWindowResize();
+            }
+        } else {
+            this.unbindWindowResize();
+            if (this.resizeObserver) {
+                this.resizeObserver.disconnect();
+                this.resizeObserver = null;
+            }
         }
     };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #659

**问题背景：**
Table 组件在容器宽度动态变化时（如侧边栏收起/展开、tab 切换等场景），展开行的宽度不会同步更新。这是因为之前只监听了 window 的 resize 事件，无法感知容器自身宽度的变化。

**解决方案：**
1. 引入 ResizeObserver 监听 table wrapper（.semi-table-wrapper）的宽度变化，覆盖容器宽度变化但 window 尺寸不变的场景
2. 重构 resize 监听器的管理逻辑，统一通过 `syncResizeListeners` 方法管理 window resize 和 ResizeObserver 的绑定/解绑
3. 优化 `syncTableWidth` 方法，避免小于 0.5px 的变化触发不必要的重渲染
4. 在 ResizeObserver 回调中使用 requestAnimationFrame 避免 layout thrashing

**审查要点：**
- ResizeObserver 的浏览器兼容性（主流浏览器均支持）
- 监听器的正确绑定和解绑，避免内存泄漏
- 宽度同步的性能优化（防抖、避免无效更新）

### Changelog
🇨🇳 Chinese
- Fix: 修复 Table 组件在容器宽度动态变化时展开行宽度不同步更新的问题

---

🇺🇸 English
- Fix: Fixed Table component expanded row width not updating when container width changes dynamically


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
测试场景：展开某一行后，通过侧边栏收起/展开或改变容器宽度，验证展开行宽度是否同步更新。