### PR TITLE
【Auto】Fix: Cascader search highlight lost and separator spaces swallowed after selection

### DIFF
--- a/packages/semi-foundation/cascader/foundation.ts
+++ b/packages/semi-foundation/cascader/foundation.ts
@@ -650,7 +650,9 @@ export default class CascaderFoundation extends BaseFoundation<CascaderAdapter, 
             } else if (selectedKeys.size && !multiple) {
                 inputValue = this.renderDisplayText([...selectedKeys][0]);
             }
-            this._adapter.updateStates({ inputValue });
+            // Reset isSearching immediately in close() instead of relying on afterClose callback
+            // This prevents timing issues where open() clears inputValue but isSearching is still true
+            this._adapter.updateStates({ inputValue, isSearching: false });
             !multiple && this.toggle2SearchInput(false);
             !multiple && this._adapter.updateFocusState(false);
         }

--- a/packages/semi-ui/cascader/item.tsx
+++ b/packages/semi-ui/cascader/item.tsx
@@ -196,13 +196,23 @@ export default class Item extends PureComponent<CascaderItemProps> {
                             </span>
                         );
                     }
-                    content.push(node);
+                    // Only push non-empty strings to avoid React merging adjacent text nodes
+                    // which would cause separator spaces to be lost
+                    if (node !== '') {
+                        content.push(node);
+                    }
                 });
             } else {
                 content.push(item);
             }
             if (idx !== searchText.length - 1) {
-                content.push(separator);
+                // Use a span wrapper for separator to prevent React from merging
+                // it with adjacent empty strings, which would lose spaces in " / "
+                content.push(
+                    <span className={`${prefixcls}-label-separator`} key={`sep-${idx}`}>
+                        {separator}
+                    </span>
+                );
             }
         });
         return content;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3295

修复了 Cascader 组件在可搜索模式下（`filterTreeNode` 开启）的两个问题：

1. **高亮丢失问题**：搜索并选中某项后，再次打开下拉时，搜索关键词的高亮消失。原因是 `close()` 方法中只更新了 `inputValue`，没有同步重置 `isSearching` 状态，导致后续 `open()` 时的时序问题。修复方案是在 `close()` 时立即将 `isSearching` 设为 `false`，而不是依赖 `afterClose` 回调。

2. **separator 空格丢失问题**：路径分隔符 `separator` 默认为 ` / `（前后有空格），但在某些渲染分支下，高亮拆分后空格会被 React 合并相邻文本节点而丢失。修复方案有两点：
   - 在 `highlight` 方法中，避免 push 空字符串到 content 数组
   - 用 `<span>` 包装 separator，防止 React 将其与相邻文本节点合并

审查者应重点关注：
- `packages/semi-foundation/cascader/foundation.ts` 中 `close()` 方法的状态更新逻辑
- `packages/semi-ui/cascader/item.tsx` 中 `highlight` 方法的空字符串过滤和 separator 包装逻辑

### Changelog
🇨🇳 Chinese
- Fix: 修复 Cascader 组件在搜索选中后关键词高亮丢失的问题
- Fix: 修复 Cascader 组件路径分隔符 separator 中的空格被吞掉的问题

---

🇺🇸 English
- Fix: Fixed Cascader search keyword highlight lost after selection
- Fix: Fixed Cascader separator spaces being swallowed during highlight rendering


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
已在 semi-playground-for-ai 中添加多个测试用例，覆盖以下场景：
- 搜索关键词在中间（如"杭"）
- 搜索关键词在开头（如"浙"）
- 搜索关键词在结尾（如"区"）
- 搜索关键词包含 separator 字符（如"/"或空格）