### PR TITLE
fix(modal): make centered modal scrollable when content overflows viewport (#3300)

### DIFF
--- a/packages/semi-foundation/modal/modal.scss
+++ b/packages/semi-foundation/modal/modal.scss
@@ -46,7 +46,14 @@ $module: #{$prefix}-modal;
         outline: 0;
         &-center{
             display: flex;
-            align-items: center;
+            // Use flex-start + auto margin instead of `align-items: center`.
+            // When content fits the viewport, `margin: auto` on the modal
+            // centers it vertically. When content exceeds the viewport, auto
+            // margins collapse to 0 per the flexbox spec, so the modal aligns
+            // to the top of the wrap and the wrap's `overflow: auto` can scroll
+            // to both the top and the bottom of the modal. This prevents the
+            // "centered modal becomes unreachable" bug when content overflows.
+            align-items: flex-start;
         }
     }
 
@@ -194,7 +201,10 @@ $module: #{$prefix}-modal;
 }
 
 .#{$module}-centered {
-    margin: 0 auto;
+    // `margin: auto` (instead of `0 auto`) lets the wrap's `display: flex;
+    // align-items: flex-start` produce visual vertical centering when content
+    // fits, while degrading to top-aligned + scrollable when content overflows.
+    margin: auto;
 }
 
 .#{$module}-popup {


### PR DESCRIPTION
## What does this PR do?

Fixes #3300 — when `Modal` is opened with `centered=true` and content height exceeds the viewport, the modal becomes partially unreachable (title / close button / footer buttons are all clipped, scroll doesn't reach the top).

## Root cause

In `packages/semi-foundation/modal/modal.scss`:

```scss
.semi-modal-wrap-center {
  display: flex;
  align-items: center;   // ← problem
}
.semi-modal-centered {
  margin: 0 auto;
}
```

Per the flexbox spec, when a flex item is taller than its container, an `align-items: center` item overflows both top and bottom of the container, and the scroll origin is fixed at the vertical center. The wrap's `overflow: auto` cannot scroll past `scrollTop = 0`, so the top of the modal is permanently unreachable.

## Fix

Switch to the **safe-centering pattern** used by Ant Design, Mantine, Chakra, and Material UI: `align-items: flex-start` on the wrap + `margin: auto` on the modal.

```scss
.semi-modal-wrap-center {
  display: flex;
  align-items: flex-start;   // was: center
}
.semi-modal-centered {
  margin: auto;              // was: 0 auto
}
```

### How it works

| Content size | Behavior |
|--------------|----------|
| Fits in viewport | `margin: auto` on top/bottom evenly distributes remaining vertical space → modal visually centered (unchanged) |
| Exceeds viewport | Per the flex spec, `auto` margins **degrade to 0** when there is no remaining space → modal aligns to the top of the wrap → wrap's existing `overflow: auto` works, modal is fully scrollable |

This is a 2-property change with no new API and no behavior change for content that fits.

## Reproduction (before vs after)

```jsx
import { Modal, Button } from '@douyinfe/semi-ui';
import { useState } from 'react';

export default () => {
  const [v, setV] = useState(false);
  return (
    <>
      <Button onClick={() => setV(true)}>Open</Button>
      <Modal title="Tall" visible={v} centered onCancel={() => setV(false)}>
        {Array.from({ length: 50 }).map((_, i) => (
          <p key={i}>Line {i + 1}</p>
        ))}
      </Modal>
    </>
  );
};
```

- **Before**: Title and OK/Cancel are clipped, cannot be reached by scrolling.
- **After**: Modal is fully scrollable, header and footer reachable.

## Backward compatibility

- No API change.
- No behavior change when content fits viewport (still visually centered).
- The `.semi-modal-wrap-center` and `.semi-modal-centered` class names are preserved.
- Existing centered modal unit tests (`packages/semi-ui/modal/__test__/modal.test.js` — `it('centered', ...)` and `it('centered without motion', ...)`) only assert that the `.semi-modal-wrap-center` class is applied, and continue to pass.

## Checklist

- [x] Targets the `release` branch
- [x] Commit message in English
- [x] Linked to bug report issue (#3300)
- [x] No public API change
- [x] No new dependencies

## References

- Issue #3300 — full reproduction, debug analysis, and discussion
- [Ant Design Modal centered](https://github.com/ant-design/ant-design/blob/master/components/modal/style/index.ts) — uses the same `flex-start + margin: auto` pattern
- [CSS Flexible Box Layout Module Level 1 — auto margins](https://www.w3.org/TR/css-flexbox-1/#auto-margins)
