### PR TITLE
fix(InputNumber): handle scientific notation in _getPrecLen so step <…

### DIFF
--- a/packages/semi-foundation/inputNumber/foundation.ts
+++ b/packages/semi-foundation/inputNumber/foundation.ts
@@ -534,9 +534,20 @@ class InputNumberFoundation extends BaseFoundation<InputNumberAdapter> {
      * @param {number} num
      * @returns {number}
      */
-    _getPrecLen(num: string | number) {
+   _getPrecLen(num: string | number) {
         if (typeof num !== 'string') {
-            num = String(Math.abs(Number(num || '')));
+            const n = Number(num || '');
+            if (!isFinite(n) || n === 0) return 0;
+            const s = Math.abs(n).toString();
+            // Numbers with abs < 1e-6 are stringified in scientific notation by
+            // `Number.prototype.toString` per ECMAScript spec — e.g. (1e-8).toString() === "1e-8".
+            // Detect that explicitly so step values smaller than 1e-6 keep correct precision.
+            if (/e/i.test(s)) {
+                const [mantissa, exp] = s.split(/e/i);
+                const mantissaDecimals = (mantissa.split('.')[1] || '').length;
+                return Math.max(0, mantissaDecimals - parseInt(exp, 10));
+            }
+            num = s;
         }
         const idx = num.indexOf('.') + 1;
         return idx ? num.length - idx : 0;


### PR DESCRIPTION
## What this fixes

`InputNumber` with `step` smaller than `1e-6` (typically paired with `precision >= 7`, e.g. crypto/fixed-point amounts) ignores +/- button clicks — the displayed value never changes.

### Reproduction

```jsx
<InputNumber precision={8} step={0.00000001} min={0} />
```

Click `+` from empty/0 → expected `0.00000001`, actual stays at `0.00000000`. Same for `-`.

### Boundary

| `step` | `String(step)` | `_getPrecLen` before | works? |
|---|---|---|---|
| `0.000001` (1e-6) | `"0.000001"` | 6 | ✅ |
| `0.0000001` (1e-7) | `"1e-7"` | 0 | ❌ |
| `0.00000001` (1e-8) | `"1e-8"` | 0 | ❌ |

## Root cause

`_getPrecLen` counts decimals via `String(num).indexOf('.')`. Per ECMAScript spec, `Number.prototype.toString()` uses scientific notation for absolute values `< 1e-6`, so `String(1e-8) === "1e-8"` — no `.`, precision returns 0.

Then in `add()`:

```ts
const stepPrecLen = this._getPrecLen(step);  // 0
const scale = Math.pow(10, Math.max(...));   // 1
curNum = Math.round(curNum * scale + step * scale) / scale;
// Math.round(0 + 1e-8) = 0 → value collapses
```

`minus()` calls `this.add(-step, event)`; the unary `-` coerces any string-step workaround back to a number, so the down button is broken too.

## Fix

Detect scientific notation in `_getPrecLen` and compute `precLen = mantissaDecimals − exponent`. Decimal-form numbers fall through unchanged.

## Validation

| input | before | after |
|---|---|---|
| `1e-8` | 0 | **8** |
| `1.5e-7` | 0 | **8** |
| `0.01` | 2 | 2 (unchanged) |
| `1e21` | 0 | 0 |
| `0` | 0 | 0 |

## Tests

- Unit tests for `_getPrecLen` covering decimal/scientific/zero/non-finite/large cases.
- Integration test: `precision=8 step=1e-8`, simulate + click, expect `0.00000001`.

## Compat

Decimal-stringified numbers (step ≥ 1e-6) fall through the existing path unchanged. No behavior change for current users; bug-fix-only for `step < 1e-6`.