### PR TITLE
fix(Tooltip): wait for portal layout via ResizeObserver before calcPo…

### DIFF
--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -260,13 +260,49 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                         isPositionUpdated: false,
                     },
                     () => {
-                        setTimeout(() => {
-                            if ( this.cachedLatestTransitionState === 'enter' ) {
+                        // Wait for portal-inner to be actually laid out before emitting
+                        // 'portalInserted' (which triggers calcPosition). The previous
+                        // setTimeout(0) assumed React commit + DOM layout would finish
+                        // within one macrotask, which fails in large React apps + StrictMode
+                        // where commit can take 50+ms. The early emit causes calcPosition
+                        // to read a 0x0 wrapperRect, and the adjustPosIfNeed if-guard
+                        // (foundation.ts: `wrapperRect.width > 0 && wrapperRect.height > 0`)
+                        // silently skips the flip logic, leaving placement at default.
+                        const emit = () => {
+                            if (this.cachedLatestTransitionState === 'enter') {
                                 this.eventManager.emit('portalInserted');
                             }
-                            // waiting child component mounted
-
-                        }, 0);
+                        };
+                        const el = this.containerEl?.current;
+                        // Fast path: DOM already laid out — preserves prior behavior on simple apps
+                        if (el && (el.offsetWidth > 0 || el.offsetHeight > 0)) {
+                            emit();
+                            return;
+                        }
+                        // Slow path: observe portal-inner until it gets real dimensions
+                        if (el && typeof ResizeObserver !== 'undefined') {
+                            let emitted = false;
+                            const ro = new ResizeObserver(() => {
+                                if (!emitted && el.offsetWidth > 0 && el.offsetHeight > 0) {
+                                    emitted = true;
+                                    ro.disconnect();
+                                    emit();
+                                }
+                            });
+                            ro.observe(el);
+                            // Safety net: bail out after 50ms even if RO never fires
+                            setTimeout(() => {
+                                if (!emitted) {
+                                    emitted = true;
+                                    ro.disconnect();
+                                    emit();
+                                }
+                            }, 50);
+                            return;
+                        }
+                        // Final fallback (no containerEl yet, or no ResizeObserver):
+                        // preserve original setTimeout(0) behavior
+                        setTimeout(emit, 0);
                     }
                 );
             },


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
<!--
The relevant issue, background of this PR, and what should reviewers focus on
-->
Fixes # _(linked issue with full reproduction recipe + call-stack evidence will be added shortly)_

**Bug**: When a Tooltip / Popover / Select / TreeSelect / Cascader / DatePicker trigger sits near the viewport bottom (insufficient space below for the popup), opening it renders the popup downward overflowing the viewport. Only after the user scrolls 1px does the popup flip to the trigger's top side. **The flip logic itself is correct — only the mount-time timing is off.**

**Repro condition**: Only triggers when React commit time > `setTimeout(0)` macrotask firing time. Simple demos don't reproduce; large React apps + StrictMode + complex component trees reproduce reliably.

**Root cause** (confirmed via monkey-patched `getBoundingClientRect` call stack):

`packages/semi-ui/tooltip/index.tsx` `insertPortal` uses `setTimeout(0)` to wait for "child component mounted" (per the original inline comment). In large React apps + StrictMode, `setState` commit can take 50+ms — well beyond the `setTimeout(0)` macrotask. The `'portalInserted'` event therefore fires **before** `portal-inner` is actually laid out:

```
Element.getBoundingClientRect
 ← Object.getWrapperBounding
 ← Tooltip.calcPosition
returns: { width: 0, height: 0, top: 0 }
```

`packages/semi-foundation/tooltip/foundation.ts:905` then silently skips the entire `adjustPosIfNeed` block:

```ts
if (wrapperRect.width > 0 && wrapperRect.height > 0) {
  // ... all flip logic lives here
}
```

Result: `placement` stays at the default direction (e.g. `bottomLeft`) even when the dropdown overflows the viewport. Scrolling triggers `calcPosition` again with a correctly-laid-out wrapper, and it then flips properly — proving the flip logic itself is fine, only the mount-time read is too early.

**Fix**: Replace `setTimeout(0)` with a `ResizeObserver` that emits `'portalInserted'` only after `portal-inner` has real dimensions:

- **Fast path** — if `portal-inner` is already laid out (commit faster than `setTimeout(0)`): emit immediately. **Zero regression** on simple apps where the original setTimeout(0) already works.
- **Slow path** — observe `portal-inner` with `ResizeObserver`, emit when `offsetWidth/Height > 0`.
- **Safety net** — 50ms `setTimeout` in case `ResizeObserver` never fires.
- **Final fallback** — original `setTimeout(0)` if `containerEl` ref isn't ready or `ResizeObserver` is unsupported.

`ResizeObserver` is Baseline web and already used elsewhere in Semi (no new dependency).

**Verification**: Applied as a local `pnpm patch` in a real-world large React 19 + StrictMode codebase. Before patch: bug 100% reproducible on Tags / Symbols multi-Select etc. positioned near viewport bottom. After patch: 100% flip correctly on first open, no regression on Selects with ample space below (still bottomLeft as expected). Diff: 1 file, +41 / -5.

### Changelog
🇨🇳 Chinese
- Fix: 修复在 React 大型应用 / StrictMode 下，Tooltip 及其衍生组件（Popover / Select / TreeSelect / Cascader / DatePicker 等）下拉浮层 mount 时无法正确根据视口空间 flip 的问题

---

🇺🇸 English
- Fix: fix Tooltip-based popups (Popover / Select / TreeSelect / Cascader / DatePicker etc.) failing to flip on mount in large React apps / StrictMode where React commit outruns the `setTimeout(0)` macrotask


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
This is a timing-race fix in a portal-mount path, so a deterministic unit test isn't included — happy to add one if the team has an established way to simulate a "slow React commit" in test harness.