### PR TITLE
fix(locale): add missing Japanese Upload crop modal text

### DIFF
--- a/packages/semi-ui/locale/source/ja_JP.ts
+++ b/packages/semi-ui/locale/source/ja_JP.ts
@@ -140,6 +140,9 @@ const local: Locale = {
         selectedFiles: '選択されたファイル',
         illegalSize: '不正なファイルサイズ',
         fail: 'アップロードに失敗しました',
+        cropTitle: '画像のトリミング',
+        cropOk: '確認する',
+        cropCancel: 'キャンセル',
     },
     TreeSelect: {
         searchPlaceholder: '検索する',


### PR DESCRIPTION
#3256 added image cropping to the Upload component and introduced three new locale keys: `cropTitle`, `cropOk`, and `cropCancel`. That PR only updated `en_US` and `zh_CN`, so `ja_JP` is still missing all three.

These keys are declared optional in `interface.ts`, so the gap does not show up as a type error. At runtime `upload/index.tsx` falls back to hardcoded Chinese defaults when a key is absent:

```ts
const modalTitle = cropConfig.modalTitle || locale.cropTitle || '裁切图片';
const modalOkText = cropConfig.modalOkText || locale.cropOk || '确定';
const modalCancelText = cropConfig.modalCancelText || locale.cropCancel || '取消';
```

The result is that a Japanese user who enables cropping sees the crop modal title and buttons in Chinese.

This adds the three keys to `ja_JP.ts`. I kept them consistent with the rest of the file: `確認する` is already used for the confirm/OK button in `Modal` and `Popconfirm`, and `キャンセル` for cancel.
