### PR TITLE
fix(JsonViewer): avoid unsafe HTML writes

### DIFF
--- a/packages/semi-json-viewer-core/src/view/complete/completeWidget.ts
+++ b/packages/semi-json-viewer-core/src/view/complete/completeWidget.ts
@@ -139,7 +139,7 @@ export class CompleteWidget {
         });
 
         // 清空并添加新的建议
-        this._suggestionsContainer.innerHTML = '';
+        this._suggestionsContainer.textContent = '';
         this._renderCompletions();
     }
 
@@ -204,16 +204,19 @@ export class CompleteWidget {
 
     private _renderCompletions() {
         const className = `${this._view.prefixCls}-complete-suggestions-item`;
-        this._suggestionsContainer.innerHTML = this._suggestions
-            .map(
-                (item, index) => `
-        <li class="${className}" style="background-color: ${index === this._selectedIndex ? 'var(--semi-color-fill-0)' : 'transparent'
-}" data-index="${index}">
-            ${item.label}
-        </li>
-    `
-            )
-            .join('');
+        const fragment = document.createDocumentFragment();
+
+        this._suggestions.forEach((item, index) => {
+            const suggestionItem = document.createElement('li');
+            suggestionItem.className = className;
+            suggestionItem.style.backgroundColor = index === this._selectedIndex ? 'var(--semi-color-fill-0)' : 'transparent';
+            suggestionItem.dataset.index = index.toString();
+            suggestionItem.textContent = item.label;
+            fragment.appendChild(suggestionItem);
+        });
+
+        this._suggestionsContainer.textContent = '';
+        this._suggestionsContainer.appendChild(fragment);
     }
 
     public hide() {

--- a/packages/semi-json-viewer-core/src/view/hover/hoverWidget.ts
+++ b/packages/semi-json-viewer-core/src/view/hover/hoverWidget.ts
@@ -73,7 +73,7 @@ export class HoverWidget {
         setStyles(this._tooltipDom, {
             visibility: 'hidden',
         });
-        this._tooltipDom.innerHTML = '';
+        this._tooltipDom.textContent = '';
         this._hoverDom = null;
     }
 
@@ -89,7 +89,7 @@ export class HoverWidget {
 
     render(el: HTMLElement) {
         if (!this._hoverDom) return;
-        this._tooltipDom.innerHTML = '';
+        this._tooltipDom.textContent = '';
         this._tooltipDom.appendChild(el);
 
         // 获取必要的位置信息

--- a/packages/semi-json-viewer-core/src/view/view.ts
+++ b/packages/semi-json-viewer-core/src/view/view.ts
@@ -237,7 +237,7 @@ export class View {
             width: '60%',
             height: '100%',
         });
-        lineNumber.innerHTML = actualLineNumber.toString();
+        lineNumber.textContent = actualLineNumber.toString();
         lineNumberElement.appendChild(lineNumber);
         lineNumberElement.dataset.lineNumber = actualLineNumber.toString();
         return lineNumberElement;
@@ -293,8 +293,8 @@ export class View {
     }
 
     private clearContainers() {
-        this._lineScrollDom.innerHTML = '';
-        this._scrollDom.innerHTML = '';
+        this._lineScrollDom.textContent = '';
+        this._scrollDom.textContent = '';
     }
 
     public resetScalingManagerConfigAndCell(index: number) {
@@ -339,7 +339,7 @@ export class View {
         this._lineScrollDom.style.height = `${totalSize}px`;
         if (this._options?.readOnly && this._customRenderMap.size > 0) {
             this._customRenderMap.forEach((value, key) => {
-                key.innerHTML = '';
+                key.textContent = '';
             });
             this.emitter.emit('customRender', {
                 customRenderMap: this._customRenderMap


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes BYT-2

JSON Viewer had several direct `innerHTML` writes in its core view layer. Most were used for clearing nodes, but the completion widget also rendered `CompletionItem.label` through an HTML string template, which could execute attacker-controlled markup if completion labels contain HTML.

This change replaces those HTML writes with safer DOM/text APIs:
- Completion items are created with `document.createElement('li')` and labels are assigned via `textContent`.
- Container clearing, hover tooltip clearing, custom-render placeholder clearing, and line-number rendering now use text-based DOM APIs instead of `innerHTML`.

Reviewers should focus on the completion item rendering path and confirm that existing keyboard/click completion behavior remains unchanged.

### Changelog
🇨🇳 Chinese
- Fix: 修复 JSON Viewer 补全项及视图清理逻辑中直接写入 HTML 带来的 XSS 风险

---

🇺🇸 English
- Fix: fix potential XSS risk in JSON Viewer by avoiding direct HTML writes in completion and view rendering paths


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
Validation:
- `rg "innerHTML\\s*=|insertAdjacentHTML|outerHTML|createContextualFragment" packages/semi-json-viewer-core/src` returned no matches.
- `yarn lerna run build:lib --scope @douyinfe/semi-json-viewer-core` passed.
- `npx cypress run --spec cypress/e2e/jsonViewer.spec.js` passed, 4 tests passing.

Made with [Cursor](https://cursor.com)