### PR TITLE
fix(Portal): reuse container el on re-attach to avoid remounting subtree under React StrictMode

### DIFF
--- a/packages/semi-ui/_portal/__test__/portal.test.js
+++ b/packages/semi-ui/_portal/__test__/portal.test.js
@@ -1,0 +1,43 @@
+import Portal from '../index';
+import { BASE_CLASS_PREFIX } from '../../../semi-foundation/base/constants';
+
+describe('Portal', () => {
+    afterEach(() => {
+        document.body.innerHTML = '';
+    });
+
+    it('reuses the same container el when re-attached after simulated remount (React StrictMode)', () => {
+        const wrapper = mount(
+            <Portal>
+                <span id="portal-child">portal content</span>
+            </Portal>
+        );
+        const el1 = document.querySelector(`.${BASE_CLASS_PREFIX}-portal`);
+        expect(el1).toBeTruthy();
+        expect(el1.querySelector('#portal-child')).toBeTruthy();
+
+        // Simulate what React 18+ StrictMode does right after mount:
+        // componentWillUnmount (detaches el) followed by componentDidMount (restores).
+        wrapper.instance().componentWillUnmount();
+        expect(document.querySelector(`.${BASE_CLASS_PREFIX}-portal`)).toBeNull();
+        wrapper.instance().componentDidMount();
+
+        const el2 = document.querySelector(`.${BASE_CLASS_PREFIX}-portal`);
+        // The same node must be reused: createPortal's container identity is preserved,
+        // so React will NOT unmount & remount the portal subtree on the next render.
+        expect(el2).toBe(el1);
+        expect(el2.querySelector('#portal-child')).toBeTruthy();
+        wrapper.unmount();
+    });
+
+    it('removes container el from DOM on unmount', () => {
+        const wrapper = mount(
+            <Portal>
+                <span>x</span>
+            </Portal>
+        );
+        expect(document.querySelector(`.${BASE_CLASS_PREFIX}-portal`)).toBeTruthy();
+        wrapper.unmount();
+        expect(document.querySelector(`.${BASE_CLASS_PREFIX}-portal`)).toBeNull();
+    });
+});

--- a/packages/semi-ui/_portal/index.tsx
+++ b/packages/semi-ui/_portal/index.tsx
@@ -56,7 +56,15 @@ class Portal extends PureComponent<PortalProps, PortalState> {
         try {
             let container: HTMLElement | undefined = undefined;
             if (!this.el || !this.state?.container || !Array.from(this.state.container.childNodes).includes(this.el)) {
-                this.el = document.createElement('div');
+                // Reuse the existing el if it was detached from the container — e.g. React 18+
+                // StrictMode's simulated remount runs componentWillUnmount (which removes el)
+                // and then componentDidMount lands here. Creating a new el would change
+                // createPortal's container identity and force React to unmount & remount the
+                // entire portal subtree (children effects re-run, data requests fire twice).
+                // Re-appending the same node restores the DOM without touching the React tree.
+                if (!this.el) {
+                    this.el = document.createElement('div');
+                }
                 const getContainer = this.props.getPopupContainer || context.getPopupContainer || defaultGetContainer;
                 const portalContainer = getContainer();
                 portalContainer.appendChild(this.el);


### PR DESCRIPTION
- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:

### PR description

Fixes #3315

**问题**:React 18+ StrictMode 的模拟 remount 会在挂载后立即执行 `componentWillUnmount`(其中 `container.removeChild(this.el)` 真的把容器节点摘出 DOM),随后的 `componentDidMount → initContainer` 发现 el 不在 container 中,走重建分支**新建**一个 el——但外层 container(body)未变,不触发 setState / re-render,已提交 fiber 的 `createPortal` 仍指向被摘除的旧节点。下一次任意 re-render(如 Modal 打开动画的 class setState)时 `createPortal` 的 container 身份变化,React 按 portal reconciliation 规则将子树**整棵 unmount + remount**——children 的 effects 全部重跑,children 内的数据请求重复发送(dev 实测:打开一次 Modal 请求发 4 次 = 2 轮 mount × StrictMode effect 双调)。详细时间线(MutationObserver 抓拍、StrictMode 开/关对照)见 #3315。

**修复**:`initContainer` 重建分支改为复用已存在的 `this.el`(仅当不存在时才新建)。节点身份不变 → `createPortal` 的 containerInfo 不变 → React 不再重挂子树;`willUnmount` 摘下节点时 children 的 DOM 仍挂在 el 内,re-append 即完整恢复,无需额外 re-render。

**影响面与安全性**:对所有基于 Portal 的浮层(Modal / Tooltip / Popover / Select / DatePicker …)一致生效。非 StrictMode 路径零行为变化——重建分支只在「el 已存在但被摘离容器」时与旧逻辑不同,该状态仅由 StrictMode 模拟 remount(或外部强拆 DOM)产生;SSR 首渲染路径(constructor 中 `catchError` 吞异常、el 未创建)仍走新建分支,不受影响。已跑通 `_portal` / `modal` / `tooltip` 单测(35 个)确认无回归。

注:#3315 中的另一症状(StrictMode 双调 constructor 导致残留空 `.semi-portal` div)源于 constructor 内的 DOM 副作用,涉及 SSR 兜底路径调整,不在本 PR 范围内。

**测试**:新增 `packages/semi-ui/_portal/__test__/portal.test.js`:
1. 复刻 StrictMode 模拟 remount 序列(`componentWillUnmount` → `componentDidMount`),断言恢复后复用同一容器节点且 children DOM 保留——修复前此断言失败(已反向验证);
2. 常规 unmount 后容器节点从 DOM 移除(防清理逻辑回归)。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Portal 在 React 18+ StrictMode 下于模拟 remount 时重建容器节点,导致 portal 子树被整棵卸载重挂(children effects 重跑、数据请求重复发送)的问题

---

🇺🇸 English
- Fix: fix portal subtree being unmounted & remounted under React 18+ StrictMode, caused by Portal recreating its container element on simulated remount (children effects re-run, duplicate data requests)

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

Root cause analysis with the measured timeline (MutationObserver traces, StrictMode on/off comparison, dev 4-requests breakdown) is in #3315.
