### PR TITLE
fix(form): rebind useForm api on remount

### DIFF
--- a/packages/semi-ui/form/__test__/formApi.test.js
+++ b/packages/semi-ui/form/__test__/formApi.test.js
@@ -50,6 +50,31 @@ describe('Form-formApi', () => {
             document.body.removeChild(div);
         }
     });
+
+    it('keeps useForm api bound after a StrictMode simulated remount', () => {
+        let formApi;
+        const HookForm = () => {
+            const [api] = Form.useForm();
+            formApi = api;
+            return (
+                <Form form={api} initValues={{ name: 'semi' }}>
+                    <Form.Input field="name" />
+                </Form>
+            );
+        };
+        const wrapper = mount(<HookForm />, {
+            attachTo: document.getElementById('container'),
+        });
+        const form = wrapper.find(Form).instance();
+
+        expect(formApi.getValues()).toEqual({ name: 'semi' });
+        form.componentWillUnmount();
+        form.componentDidMount();
+        expect(formApi.getValues()).toEqual({ name: 'semi' });
+
+        wrapper.unmount();
+    });
+
     it('formApi-getFieldExist', () => {
         let formApi = null;
         let getFormApi = api => {

--- a/packages/semi-ui/form/baseForm.tsx
+++ b/packages/semi-ui/form/baseForm.tsx
@@ -155,12 +155,7 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
         this.reset = this.reset.bind(this);
         this.foundation = new FormFoundation(this.adapter);
         this.formApi = this.foundation.getFormApi();
-        
-        // 如果传入了外部 formApi，绑定真实的 FormApi
-        if (this.props.form && typeof this.props.form.__bind === 'function') {
-            this.props.form.__bind(this.formApi);
-        }
-        
+
         if (this.props.getFormApi) {
             this.props.getFormApi(this.formApi);
         }
@@ -168,6 +163,9 @@ class Form<Values extends Record<string, any> = any> extends BaseComponent<BaseF
 
     componentDidMount() {
         this.foundation.init();
+        if (this.props.form && typeof this.props.form.__bind === 'function') {
+            this.props.form.__bind(this.formApi);
+        }
     }
 
     componentWillUnmount() {


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
  [English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

  - [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

  ### PR类型 (请至少选择一个)

  - [x] Bugfix
  - [ ] Feature
  - [ ] Code style update
  - [ ] Refactor
  - [x] Test Case
  - [ ] TypeScript definition update
  - [ ] Document improve
  - [ ] CI/CD improve
  - [ ] Branch sync
  - [ ] Other, please describe:

  ### PR 描述

  React 18 StrictMode 会在开发环境中模拟组件卸载和重新挂载。

  Form 在 `componentWillUnmount` 中会解绑 `Form.useForm()` 返回的外部 FormApi，但重新挂载时没有再次绑定，导致后续调用 `getValues()` 等方法返回
  `undefined`。

  本 PR 将 FormApi 的绑定逻辑移至 `componentDidMount`，确保 StrictMode 模拟重新挂载后能够恢复绑定，同时增加对应回归测试。

  ### 更新日志

  🇨🇳 Chinese

  - Fix: 修复 React StrictMode 模拟重新挂载后 `Form.useForm()` API 失效的问题

  ---

  🇺🇸 English

  - Fix: fix `Form.useForm()` API becoming unavailable after a React StrictMode simulated remount

  ### 检查清单

  - [x] 已增加测试用例或无须增加
  - [x] 已补充文档或无须补充
  - [x] Changelog已提供或无须提供

  ### 其他要求

  - [ ] 本条 PR 不需要纳入 Changelog

  ### 附加信息

  验证结果：

  - Form test suites: 12 passed
  - Form tests: 112 passed
  - `git diff --check` passed