### PR TITLE
【Auto】Fix: Form.PinCode crashes when value is cleared

### DIFF
--- a/packages/semi-ui/pincode/index.tsx
+++ b/packages/semi-ui/pincode/index.tsx
@@ -59,7 +59,7 @@ class PinCode extends BaseComponent<PinCodeProps, PinCodeState> {
     componentDidUpdate(prevProps: Readonly<PinCodeProps>, prevState: Readonly<PinCodeState>, snapshot?: any) {
 
         if (prevProps.value !== this.props.value) {
-            this.foundation.updateValueList(this.props.value.split(""));
+            this.foundation.updateValueList((this.props.value || '').split(""));
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3317

修复了 Form.PinCode 组件在值被完全清空时崩溃的问题。当用户使用 Backspace 键逐个删除验证码数字，删除最后一个数字后，`componentDidUpdate` 方法中直接调用 `this.props.value.split("")` 会导致 TypeError，因为此时 `value` 可能为 `undefined`、`null` 或空字符串。

解决方案：在 `packages/semi-ui/pincode/index.tsx` 的 `componentDidUpdate` 方法中，对 `value` 进行空值保护，使用 `(this.props.value || '').split("")` 代替直接使用 `this.props.value.split("")`，确保在值为空时也能正常调用 split 方法，返回空数组而不是崩溃。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Form.PinCode 组件在值完全清空时崩溃的问题（TypeError: Cannot read properties of undefined reading 'split'）

---

🇺🇸 English
- Fix: Fixed Form.PinCode crash when value is fully cleared (TypeError: Cannot read properties of undefined reading 'split')


### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
已在测试环境中验证：
- 输入 6 位验证码后，使用 Backspace 逐个删除所有数字，应用不再崩溃
- 使用 `formApi.setValue('Code', '')` 清空值，组件正常工作
- 使用 `formApi.setValue('Code', undefined)` 清空值，组件正常工作