### PR TITLE
fix: [Button] inherit the configured font family

### DIFF
--- a/packages/semi-foundation/button/button.scss
+++ b/packages/semi-foundation/button/button.scss
@@ -19,6 +19,7 @@ $module: #{$prefix}-button;
     padding-right: $spacing-button_default-paddingRight;
     padding-top: $spacing-button_default-paddingTop;
     padding-bottom: $spacing-button_default-paddingTop;
+    font-family: inherit;
     font-size: $font-button-fontSize;
     line-height: $font-button-lineHeight;
     font-weight: $font-button-fontWeight;


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

- [x] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Test Case
- [ ] TypeScript definition update
- [ ] Document improve
- [ ] CI/CD improve
- [ ] Branch sync
- [ ] Other, please describe:

### PR description

Related to #2809.

#2809 replaced the `font-size-regular` mixin on Button with component-specific font size, line height, and font weight tokens. The mixin also supplied `font-family`, so native `button` elements now fall back to the browser's user-agent font instead of using the font configured by the application.

This change adds `font-family: inherit` to `.semi-button`. It overrides the native button UA style while preserving application-level and locale-specific font stacks.

### Changelog

🇨🇳 Chinese
- Fix: 修复 Button 未继承应用字体的问题

---

🇺🇸 English
- Fix: Fix Button not inheriting the application font family

### Checklist

- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other

- [ ] Skip Changelog

### Additional information

Validation:
- `git diff --check`
- Compiled Button SCSS successfully with Dart Sass
