### PR TITLE
fix(datepicker): exclude rangeSeparatorNode from DOM spread in DateInput

### DIFF
--- a/packages/semi-ui/datePicker/dateInput.tsx
+++ b/packages/semi-ui/datePicker/dateInput.tsx
@@ -37,9 +37,9 @@ export interface DateInputProps extends DateInputFoundationProps, BaseProps {
     inputRef?: React.RefObject<HTMLInputElement>;
     rangeInputStartRef?: React.RefObject<HTMLInputElement>;
     rangeInputEndRef?: React.RefObject<HTMLInputElement>;
-    showClearIgnoreDisabled?: boolean
+    showClearIgnoreDisabled?: boolean;
     /** Only affects rendering of the separator between range inputs */
-    rangeSeparatorNode?: React.ReactNode;
+    rangeSeparatorNode?: React.ReactNode
 }
 
 // eslint-disable-next-line @typescript-eslint/ban-types
@@ -419,6 +419,7 @@ export default class DateInput extends BaseComponent<DateInputProps, {}> {
             onRangeEndTabPress,
             rangeInputFocus,
             rangeSeparator,
+            rangeSeparatorNode,
             insetInput,
             insetInputValue,
             defaultPickerValue,


### PR DESCRIPTION

In `DateInput.renderTriggerInput()`, `rangeSeparatorNode` was not destructured from `this.props`, so it fell into `...rest` and was spread onto the native `<Input>` DOM element. Adding it to the destructuring list fixes the issue, consistent with how `rangeSeparator` and other range-related props are already handled.

### Changelog

🇨🇳 Chinese
- Fix: 修复 DatePicker 组件 `rangeSeparatorNode` 属性被意外传递到原生 DOM 元素导致 React 警告的问题

---

🇺🇸 English
- Fix: fix `rangeSeparatorNode` prop being spread onto native DOM element in DatePicker, causing React unknown prop warning

### Checklist
- [ ] Test or no need
- [ ] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information

N/A
