### PR TITLE
【Auto】Fix: DatePicker popup placement after dynamic layout

### DIFF
--- a/packages/semi-ui/tooltip/__test__/tooltip.test.js
+++ b/packages/semi-ui/tooltip/__test__/tooltip.test.js
@@ -337,10 +337,11 @@ describe(`Tooltip`, () => {
   });
 
   // https://github.com/DouyinFE/semi-design/issues/3310
-  // When portal-inner is not laid out yet at mount time (0x0), positioning must wait
-  // for ResizeObserver to report real dimensions before emitting 'portalInserted',
-  // otherwise calcPosition reads a 0x0 wrapper and the flip logic is silently skipped.
-  it(`waits for ResizeObserver layout before positioning the popup`, async () => {
+  // https://github.com/DouyinFE/semi-design/issues/3329
+  // When portal-inner is only partially laid out at mount time, positioning must wait
+  // for ResizeObserver to report both real dimensions before emitting 'portalInserted',
+  // otherwise calcPosition reads a zero-sized axis and the flip logic is silently skipped.
+  it(`waits for both popup dimensions before positioning`, async () => {
     const realResizeObserver = global.ResizeObserver;
     const offsetWidthDesc = Object.getOwnPropertyDescriptor(global.HTMLElement.prototype, 'offsetWidth');
     const offsetHeightDesc = Object.getOwnPropertyDescriptor(global.HTMLElement.prototype, 'offsetHeight');
@@ -353,8 +354,9 @@ describe(`Tooltip`, () => {
       unobserve() {}
       disconnect() {}
     };
-    // Simulate "portal-inner is 0x0 until the browser lays it out, then has real size"
-    Object.defineProperty(global.HTMLElement.prototype, 'offsetWidth', { configurable: true, get() { return laidOut ? 120 : 0; } });
+    // Simulate a portal whose width is ready before its height. The old fast-path
+    // treated either non-zero axis as fully laid out and positioned too early.
+    Object.defineProperty(global.HTMLElement.prototype, 'offsetWidth', { configurable: true, get() { return 120; } });
     Object.defineProperty(global.HTMLElement.prototype, 'offsetHeight', { configurable: true, get() { return laidOut ? 32 : 0; } });
 
     try {
@@ -365,7 +367,7 @@ describe(`Tooltip`, () => {
       );
       await sleep(10);
 
-      // Because the portal was 0x0 at mount, the slow path must have registered a ResizeObserver
+      // Because the portal height was still 0 at mount, the slow path must observe it.
       expect(observers.length).toBeGreaterThan(0);
 
       const instance = demo.find(Tooltip).instance();
@@ -378,6 +380,49 @@ describe(`Tooltip`, () => {
 
       // The layout-driven ResizeObserver callback should have triggered positioning
       expect(calcSpy.called).toBe(true);
+      calcSpy.restore();
+      demo.unmount();
+    } finally {
+      global.ResizeObserver = realResizeObserver;
+      Object.defineProperty(global.HTMLElement.prototype, 'offsetWidth', offsetWidthDesc);
+      Object.defineProperty(global.HTMLElement.prototype, 'offsetHeight', offsetHeightDesc);
+    }
+  });
+
+  it(`repositions when popup content grows after its initial layout`, async () => {
+    const realResizeObserver = global.ResizeObserver;
+    const offsetWidthDesc = Object.getOwnPropertyDescriptor(global.HTMLElement.prototype, 'offsetWidth');
+    const offsetHeightDesc = Object.getOwnPropertyDescriptor(global.HTMLElement.prototype, 'offsetHeight');
+
+    const observers = [];
+    let popupHeight = 32;
+    global.ResizeObserver = class {
+      constructor(cb) { this.cb = cb; observers.push(this); }
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+    Object.defineProperty(global.HTMLElement.prototype, 'offsetWidth', { configurable: true, get() { return 120; } });
+    Object.defineProperty(global.HTMLElement.prototype, 'offsetHeight', { configurable: true, get() { return popupHeight; } });
+
+    try {
+      const demo = mount(
+        <Tooltip motion={false} content={'Content'} visible={true} trigger={'custom'} position="bottom">
+          <Button>trigger</Button>
+        </Tooltip>
+      );
+      await sleep(10);
+
+      const instance = demo.find(Tooltip).instance();
+      const calcSpy = sinon.spy(instance.foundation, 'calcPosition');
+
+      // DatePicker-like content can grow after Tooltip has already positioned
+      // against a valid, but incomplete, initial size.
+      popupHeight = 342;
+      observers.forEach(o => o.cb && o.cb());
+      await sleep(10);
+
+      expect(calcSpy.calledOnce).toBe(true);
       calcSpy.restore();
       demo.unmount();
     } finally {

--- a/packages/semi-ui/tooltip/index.tsx
+++ b/packages/semi-ui/tooltip/index.tsx
@@ -95,7 +95,7 @@ export interface TooltipProps extends BaseProps {
      * When set to false, the tooltip will not show when triggered
      * @default true
      */
-    condition?: boolean;
+    condition?: boolean
 }
 
 interface TooltipState {
@@ -202,6 +202,8 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
     isWrapped: boolean;
     mounted: any;
     scrollHandler: any;
+    popupResizeObserver: ResizeObserver;
+    popupResizeTimer: ReturnType<typeof setTimeout>;
     getPopupContainer: () => HTMLElement;
     containerPosition: string;
     foundation: TooltipFoundation;
@@ -252,6 +254,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
             getAnimatingState: () => this.isAnimating,
             insertPortal: (content: TooltipProps['content'], { position, ...containerStyle }: { position: Position }) => {
                 this.cachedLatestTransitionState = "enter";
+                this.disconnectPopupResizeObserver();
                 this.setState(
                     {
                         isInsert: true,
@@ -274,39 +277,64 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
                             }
                         };
                         const el = this.containerEl?.current;
-                        // Fast path: DOM already laid out — preserves prior behavior on simple apps
-                        if (el && (el.offsetWidth > 0 || el.offsetHeight > 0)) {
-                            emit();
-                            return;
-                        }
-                        // Slow path: observe portal-inner until it gets real dimensions
+                        // Keep observing while the popup is visible. Some popup content
+                        // (for example DatePicker) first lays out at a small non-zero size,
+                        // then expands after its child state commits. Positioning only at
+                        // the first non-zero size leaves the final popup overflowing.
                         if (el && typeof ResizeObserver !== 'undefined') {
                             let emitted = false;
-                            const ro = new ResizeObserver(() => {
-                                if (!emitted && el.offsetWidth > 0 && el.offsetHeight > 0) {
+                            let lastWidth = el.offsetWidth;
+                            let lastHeight = el.offsetHeight;
+                            const emitOnce = () => {
+                                if (!emitted) {
                                     emitted = true;
-                                    ro.disconnect();
                                     emit();
                                 }
+                            };
+                            const ro = new ResizeObserver(() => {
+                                const width = el.offsetWidth;
+                                const height = el.offsetHeight;
+                                if (width <= 0 || height <= 0) {
+                                    return;
+                                }
+                                const sizeChanged = width !== lastWidth || height !== lastHeight;
+                                lastWidth = width;
+                                lastHeight = height;
+                                if (!emitted) {
+                                    emitOnce();
+                                } else if (sizeChanged && this.cachedLatestTransitionState === 'enter') {
+                                    clearTimeout(this.popupResizeTimer);
+                                    this.popupResizeTimer = setTimeout(() => {
+                                        if (this.cachedLatestTransitionState === 'enter') {
+                                            this.foundation.calcPosition();
+                                        }
+                                    }, 0);
+                                }
                             });
+                            this.popupResizeObserver = ro;
                             ro.observe(el);
+                            if (lastWidth > 0 && lastHeight > 0) {
+                                emitOnce();
+                            }
                             // Safety net: bail out after 50ms even if RO never fires
                             setTimeout(() => {
                                 if (!emitted) {
-                                    emitted = true;
-                                    ro.disconnect();
-                                    emit();
+                                    emitOnce();
                                 }
                             }, 50);
                             return;
                         }
-                        // Final fallback (no containerEl yet, or no ResizeObserver):
-                        // preserve original setTimeout(0) behavior
-                        setTimeout(emit, 0);
+                        // Fallback for browsers without ResizeObserver.
+                        if (el && el.offsetWidth > 0 && el.offsetHeight > 0) {
+                            emit();
+                        } else {
+                            setTimeout(emit, 0);
+                        }
                     }
                 );
             },
             removePortal: () => {
+                this.disconnectPopupResizeObserver();
                 this.setState({ isInsert: false, isPositionUpdated: false });
             },
             getEventName: () => ({
@@ -552,8 +580,15 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
 
     componentWillUnmount() {
         this.mounted = false;
+        this.disconnectPopupResizeObserver();
         this.foundation.destroy();
     }
+
+    disconnectPopupResizeObserver = () => {
+        clearTimeout(this.popupResizeTimer);
+        this.popupResizeObserver?.disconnect();
+        this.popupResizeObserver = null;
+    };
 
     /**
      * focus on tooltip trigger
@@ -592,6 +627,7 @@ export default class Tooltip extends BaseComponent<TooltipProps, TooltipState> {
     // };
 
     didLeave = () => {
+        this.disconnectPopupResizeObserver();
         if (this.props.keepDOM) {
             this.foundation.setDisplayNone(true);
         } else {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:

### PR description

Fixes #3329

DatePicker 放在自定义弹层容器中时，popup 会先以较小的非零尺寸完成初次布局，再随着日期面板渲染扩展到最终高度。Tooltip 原有的 ResizeObserver 在首次得到非零尺寸后即停止观察，因此自动翻转只基于中间尺寸计算，最终 popup 仍可能被视口裁剪，并在页面尺寸变化触发重新计算时发生跳动。

本 PR 在 popup 展示期间持续观察 `portal-inner` 的尺寸变化：首次获得完整的宽高后触发定位，后续尺寸变化会合并到下一个任务中重新计算位置；隐藏、卸载或重新插入 popup 时断开旧观察器。同时修正仅单轴非零就走快速路径的问题。

Reviewers 可重点关注 Tooltip/Popover 及基于它们实现的 DatePicker、Select 等浮层在动态内容尺寸变化时的定位时机，以及观察器的清理逻辑。

### Changelog
🇨🇳 Chinese
- Fix: 修复 DatePicker 等动态尺寸弹层初次展示时定位异常及被视口裁剪的问题

---

🇺🇸 English
- Fix: fix incorrect initial placement and viewport clipping for dynamically sized popups such as DatePicker

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- Tooltip unit tests: 10/10 passed, including partial-axis layout and post-mount popup growth regressions.
- Real-browser reproduction: before the fix the DatePicker remained `bottomLeft` and overflowed below the viewport; after the fix it recalculates to `topLeft`, which minimizes clipping in the constrained viewport.
- `git diff --check` passed.
