### PR TITLE
【Auto】Fix: Tree flicker when toggling filtered results

### DIFF
--- a/packages/semi-foundation/tree/foundation.ts
+++ b/packages/semi-foundation/tree/foundation.ts
@@ -711,7 +711,10 @@ export default class TreeFoundation extends BaseFoundation<TreeAdapter, BasicTre
                 keyMaps,
                 isSearching && showFilteredOnly && filteredShownKeys
             );
-            const motionKeys = this._isAnimated() ? getMotionKeys(eventKey, expandedKeys, keyEntities) : [];
+            let motionKeys = this._isAnimated() ? getMotionKeys(eventKey, expandedKeys, keyEntities) : [];
+            if (isSearching && showFilteredOnly) {
+                motionKeys = motionKeys.filter(key => filteredShownKeys.has(key));
+            }
             const newState = {
                 [expandedStateKey]: expandedKeys,
                 flattenNodes,

--- a/packages/semi-ui/tree/__test__/tree.test.js
+++ b/packages/semi-ui/tree/__test__/tree.test.js
@@ -630,6 +630,26 @@ describe('Tree', () => {
         expect(tree.find(`.${BASE_CLASS_PREFIX}-tree-option-highlight`).length).toEqual(2);
     });
 
+    it('filterTreeNode + showFilteredOnly only animates visible descendants', () => {
+        const tree = getTree({
+            filterTreeNode: true,
+            showFilteredOnly: true,
+        });
+        const searchWrapper = tree.find(`.${BASE_CLASS_PREFIX}-tree-search-wrapper`);
+        searchWrapper.find('input').simulate('change', { target: { value: '北' } });
+
+        const chinaNode = tree.find(
+            `.${BASE_CLASS_PREFIX}-tree-option.${BASE_CLASS_PREFIX}-tree-option-level-2`
+        ).at(0);
+        const expandIcon = chinaNode.find(`.${BASE_CLASS_PREFIX}-tree-option-expand-icon`).at(0);
+        expandIcon.simulate('click', { nativeEvent: { stopImmediatePropagation: () => { } } });
+
+        // "上海" is a descendant of 中国 but is hidden by the active filter.
+        // Including it in motionKeys inserts the transition wrapper at the wrong
+        // list position and makes the visible result flicker.
+        expect(tree.state().motionKeys).toEqual(new Set(['beijing']));
+    });
+
     it('filterTreeNode as a func', () => {
         let tree = getTree({
             filterTreeNode: (inputValue, treeNode) => treeNode === inputValue,


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:

### PR description

Fixes #3325

Tree 开启 `filterTreeNode` 与 `showFilteredOnly` 后，搜索态下展开或折叠节点时，交互路径生成的 `motionKeys` 仍包含被过滤隐藏的后代节点。NodeList 会使用第一个 motion key 计算动画插入位置；当该 key 对应隐藏节点时，动画容器会被插入到错误位置，造成可见列表闪烁。

本 PR 在搜索且仅展示过滤结果时，将交互产生的 `motionKeys` 限制为 `filteredShownKeys`。这样动画范围与当前渲染列表完全一致，也与受控属性更新路径中已有的过滤逻辑保持一致。

Reviewers 可重点关注搜索态的展开/折叠动画，以及非搜索态和 `showFilteredOnly={false}` 的行为保持不变。

### Changelog
🇨🇳 Chinese
- Fix: 修复 Tree 仅展示搜索结果时展开或折叠节点的动画闪烁问题

---

🇺🇸 English
- Fix: fix Tree expand and collapse flicker when only filtered search results are shown

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- Tree unit tests: 46/46 passed, including a regression that excludes hidden descendants from `motionKeys`.
- Real-browser reproduction: filtering `008`, collapsing and expanding `合同7` keeps only `项目7` / `合同7` / the visible `008` result in the rendered sequence.
- Foundation lint and `git diff --check` passed.
