### PR TITLE
【Auto】Fix: DragMove relative positioning for centered Modal

### DIFF
--- a/content/plus/dragMove/index-en-US.md
+++ b/content/plus/dragMove/index-en-US.md
@@ -28,7 +28,7 @@ Elements wrapped by `DragMove` will be able to change their position by dragging
 
 ***Notice***
 
-1. DragMove will set the draggable element to absolute positioning
+1. DragMove uses absolute positioning by default. Set `positionStrategy="relative"` when the element should keep its original layout position, such as a centered Modal
 2. DragMove needs to apply DOM event listeners to children. If the child element is a custom component, you need to ensure that it can pass properties to the underlying DOM element. The following types of children are supported:
     1. Class Component, it is not mandatory to bind ref, but you need to ensure that props can be transparently transmitted to the real DOM node 
     2. Use the functional component wrapped by forwardRef to transparently transmit props and ref to the real DOM node in children 
@@ -226,6 +226,7 @@ function CustomMove() {
 | constrainer | Returns the element that limits the draggable range. | () => HTMLElement \| 'parent' | - |
 | customMove | Customize position processing after dragging| (element: HTMLElement, top: number, left: number) => void | -|
 | handler | Returns the element that triggers dragging. | () => HTMLElement | - |
+| positionStrategy | Positioning strategy for the draggable element. Relative preserves its original layout position. | 'absolute' \| 'relative' | 'absolute' |
 | onMouseDown | Callback when mouse is pressed | (e: MouseEvent) => void | - |
 | onMouseMove | Callback when mouse moves | (e: MouseEvent) => void | - |
 | onMouseUp | Callback when mouse is raised | (e: MouseEvent) => void | - |

--- a/content/plus/dragMove/index.md
+++ b/content/plus/dragMove/index.md
@@ -28,7 +28,7 @@ import { DragMove } from '@douyinfe/semi-ui';
 
 ***注意***
 
-1. DragMove 会将可拖拽的元素设置为 absolute 定位
+1. DragMove 默认会将可拖拽的元素设置为 absolute 定位；需要保留元素原有布局位置（例如居中的 Modal）时，可设置 `positionStrategy="relative"`
 2. DragMove 需要将 DOM 事件监听器应用到 children 中，如果子元素是自定义的组件，你需要确保它能将属性传递至底层的 DOM 元素。支持以下类型的 children：
     1. Class Component，不强制绑定ref，但需要确保 props 可被透传至真实的 DOM 节点上
     2. 使用 forwardRef 包裹后的函数式组件，将 props 与 ref 透传到 children 内真实的 DOM 节点上
@@ -227,6 +227,7 @@ function CustomMove() {
 | constrainer | 返回限制可拖拽的范围的元素 | () => HTMLElement \| 'parent' | - |
 | customMove | 自定义拖动后的位置处理| (element: HTMLElement, top: number, left: number) => void | -|
 | handler | 返回触发拖动的元素 | () => HTMLElement | - |
+| positionStrategy | 拖拽元素的定位策略，relative 可保留元素原有布局位置 | 'absolute' \| 'relative' | 'absolute' |
 | onMouseDown | 鼠标按下时的回调 | (e: MouseEvent) => void | - |
 | onMouseMove | 鼠标移动时的回调 | (e: MouseEvent) => void | - |
 | onMouseUp | 鼠标抬起时的回调 | (e: MouseEvent) => void | - |

--- a/content/show/modal/index-en-US.md
+++ b/content/show/modal/index-en-US.md
@@ -521,9 +521,10 @@ function Demo(props = {}) {
             <Modal
                 title="Draggable Modal"
                 visible={visible}
+                centered
                 onCancel={() => setVisible(false)}
                 modalRender={(modal) => (
-                    <DragMove>{modal}</DragMove>
+                    <DragMove positionStrategy="relative">{modal}</DragMove>
                 )}
             >
                 <p>This is the content of a basic sidesheet.</p>

--- a/content/show/modal/index.md
+++ b/content/show/modal/index.md
@@ -543,9 +543,10 @@ function Demo(props = {}) {
             <Modal
                 title="可拖拽Modal"
                 visible={visible}
+                centered
                 onCancel={() => setVisible(false)}
                 modalRender={(modal) => (
-                    <DragMove>{modal}</DragMove>
+                    <DragMove positionStrategy="relative">{modal}</DragMove>
                 )}
             >
                 <p>This is the content of a basic sidesheet.</p>

--- a/packages/semi-foundation/dragMove/foundation.ts
+++ b/packages/semi-foundation/dragMove/foundation.ts
@@ -25,6 +25,10 @@ export default class DragMoveFoundation<P = Record<string, any>, S = Record<stri
     yMin: number;
     startOffsetX: number;
     startOffsetY: number;
+    startClientX: number;
+    startClientY: number;
+    startLeft: number;
+    startTop: number;
 
     get constrainer() {
         return this._adapter.getConstrainer();
@@ -44,9 +48,13 @@ export default class DragMoveFoundation<P = Record<string, any>, S = Record<stri
             throw new Error('drag element must be a valid element');
         }
         this.element = element;
-        this.element.style.position = 'absolute';
+        this.updatePositionStrategy();
         this.handler.style.cursor = 'move';
         this._registerStartEvent();
+    }
+
+    updatePositionStrategy = () => {
+        this.element.style.position = this.getProp('positionStrategy') === 'relative' ? 'relative' : 'absolute';
     }
 
     _registerStartEvent = () => {
@@ -95,6 +103,18 @@ export default class DragMoveFoundation<P = Record<string, any>, S = Record<stri
     _calcMoveRange() {
         // Calculate the range within which an element can move
         if (this.constrainer) {
+            if (this.getProp('positionStrategy') === 'relative') {
+                const elementRect = this.element.getBoundingClientRect();
+                const constrainerRect = this.constrainer.getBoundingClientRect();
+                const style = window.getComputedStyle(this.element);
+                const currentLeft = parseFloat(style.left) || 0;
+                const currentTop = parseFloat(style.top) || 0;
+                this.xMin = currentLeft + constrainerRect.left - elementRect.left;
+                this.xMax = currentLeft + constrainerRect.right - elementRect.right;
+                this.yMin = currentTop + constrainerRect.top - elementRect.top;
+                this.yMax = currentTop + constrainerRect.bottom - elementRect.bottom;
+                return;
+            }
             let node = this.element.offsetParent as HTMLElement;
             let startX = 0;
             let startY = 0;
@@ -126,6 +146,14 @@ export default class DragMoveFoundation<P = Record<string, any>, S = Record<stri
     }
 
     _calcOffset = (e: Touch | MouseEvent) => {
+        if (this.getProp('positionStrategy') === 'relative') {
+            const style = window.getComputedStyle(this.element);
+            this.startClientX = e.clientX;
+            this.startClientY = e.clientY;
+            this.startLeft = parseFloat(style.left) || 0;
+            this.startTop = parseFloat(style.top) || 0;
+            return;
+        }
         this.startOffsetX = e.clientX - this.element.offsetLeft;
         this.startOffsetY = e.clientY - this.element.offsetTop;
     }
@@ -161,8 +189,13 @@ export default class DragMoveFoundation<P = Record<string, any>, S = Record<stri
 
     _changePos = (e: Touch | MouseEvent) => {
         const { customMove } = this.getProps();
-        let newLeft = e.clientX - this.startOffsetX;
-        let newTop = e.clientY - this.startOffsetY;
+        const useRelativePosition = this.getProp('positionStrategy') === 'relative';
+        let newLeft = useRelativePosition ?
+            this.startLeft + e.clientX - this.startClientX :
+            e.clientX - this.startOffsetX;
+        let newTop = useRelativePosition ?
+            this.startTop + e.clientY - this.startClientY :
+            e.clientY - this.startOffsetY;
         if (this.constrainer) {
             newLeft = clampValueInRange(newLeft, this.xMin, this.xMax);
             newTop = clampValueInRange(newTop, this.yMin, this.yMax); 

--- a/packages/semi-ui/dragMove/__test__/dragMove.test.js
+++ b/packages/semi-ui/dragMove/__test__/dragMove.test.js
@@ -1,0 +1,97 @@
+import React from 'react';
+import { DragMove } from '../../index';
+
+describe('DragMove', () => {
+    const realRequestAnimationFrame = global.requestAnimationFrame;
+
+    beforeEach(() => {
+        global.requestAnimationFrame = callback => callback();
+    });
+
+    afterEach(() => {
+        global.requestAnimationFrame = realRequestAnimationFrame;
+        document.body.innerHTML = '';
+    });
+
+    it('keeps absolute positioning as the default strategy', () => {
+        const wrapper = mount(
+            <DragMove>
+                <div>Drag me</div>
+            </DragMove>
+        );
+
+        expect(wrapper.getDOMNode().style.position).toBe('absolute');
+        wrapper.unmount();
+    });
+
+    it('uses relative offsets without removing the element from layout', () => {
+        const wrapper = mount(
+            <DragMove positionStrategy="relative">
+                <div style={{ left: 12, top: 8 }}>Drag me</div>
+            </DragMove>
+        );
+        const element = wrapper.getDOMNode();
+
+        element.dispatchEvent(new MouseEvent('mousedown', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 100,
+            clientY: 100,
+        }));
+        document.dispatchEvent(new MouseEvent('mousemove', {
+            bubbles: true,
+            clientX: 130,
+            clientY: 140,
+        }));
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+
+        expect(element.style.position).toBe('relative');
+        expect(element.style.left).toBe('42px');
+        expect(element.style.top).toBe('48px');
+        wrapper.unmount();
+    });
+
+    it('clamps relative offsets to the constrainer bounds', () => {
+        const wrapper = mount(
+            <DragMove positionStrategy="relative" constrainer="parent">
+                <div style={{ left: 10, top: 5 }}>Drag me</div>
+            </DragMove>,
+            { attachTo: document.body.appendChild(document.createElement('div')) }
+        );
+        const element = wrapper.getDOMNode();
+        const constrainer = element.parentNode;
+        element.getBoundingClientRect = () => ({
+            left: 40,
+            top: 30,
+            right: 140,
+            bottom: 80,
+            width: 100,
+            height: 50,
+        });
+        constrainer.getBoundingClientRect = () => ({
+            left: 0,
+            top: 0,
+            right: 200,
+            bottom: 100,
+            width: 200,
+            height: 100,
+        });
+
+        element.dispatchEvent(new MouseEvent('mousedown', {
+            bubbles: true,
+            cancelable: true,
+            clientX: 100,
+            clientY: 100,
+        }));
+        document.dispatchEvent(new MouseEvent('mousemove', {
+            bubbles: true,
+            clientX: 300,
+            clientY: 300,
+        }));
+        document.dispatchEvent(new MouseEvent('mouseup', { bubbles: true }));
+
+        expect(element.style.left).toBe('70px');
+        expect(element.style.top).toBe('25px');
+        wrapper.unmount();
+    });
+});

--- a/packages/semi-ui/dragMove/index.ts
+++ b/packages/semi-ui/dragMove/index.ts
@@ -23,7 +23,9 @@ export interface DragMoveProps {
     // Return true to trigger dragging. Return false to not trigger dragging.
     allowMove?: (e: MouseEvent | TouchEvent, element: HTMLElement) => boolean;
     // customize move behavior
-    customMove?: (e: HTMLElement, top: number, left: number) => void
+    customMove?: (e: HTMLElement, top: number, left: number) => void;
+    // Use relative positioning to preserve the element's original layout position.
+    positionStrategy?: 'absolute' | 'relative'
 }
 
 export default class DragMove extends BaseComponent<DragMoveProps> {
@@ -36,6 +38,7 @@ export default class DragMove extends BaseComponent<DragMoveProps> {
         constrainer: PropTypes.oneOfType([PropTypes.func, PropTypes.oneOf(['parent'])]),
         allowMove: PropTypes.func,
         customMove: PropTypes.func,
+        positionStrategy: PropTypes.oneOf(['absolute', 'relative']),
         onMouseDown: PropTypes.func,
         onMouseMove: PropTypes.func,
         onMouseUp: PropTypes.func,
@@ -49,6 +52,7 @@ export default class DragMove extends BaseComponent<DragMoveProps> {
 
     static defaultProps = {
         allowInputDrag: false,
+        positionStrategy: 'absolute',
     };
 
     constructor(props: DragMoveProps) {
@@ -120,6 +124,12 @@ export default class DragMove extends BaseComponent<DragMoveProps> {
         this.foundation.destroy();
     }
 
+    componentDidUpdate(prevProps: DragMoveProps): void {
+        if (prevProps.positionStrategy !== this.props.positionStrategy) {
+            this.foundation.updatePositionStrategy();
+        }
+    }
+
     render() {
         const { children } = this.props;
         const newChildren = React.cloneElement(children, {
@@ -136,4 +146,3 @@ export default class DragMove extends BaseComponent<DragMoveProps> {
         return newChildren;
     }
 }
- 

--- a/packages/semi-ui/modal/_story/modal.stories.jsx
+++ b/packages/semi-ui/modal/_story/modal.stories.jsx
@@ -350,9 +350,10 @@ export const DraggableModal = () => {
             <Modal
                 title="可拖拽Modal"
                 visible={visible}
+                centered
                 onCancel={() => setVisible(false)}
                 modalRender={(modal) => (
-                    <DragMove>{modal}</DragMove>
+                    <DragMove positionStrategy="relative">{modal}</DragMove>
                 )}
             >
                 <p>This is the content of a basic sidesheet.</p>


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [x] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [x] TypeScript definition update
 - [x] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:

### PR description

Fixes #3323

DragMove 当前会无条件把被拖拽元素设置为 `position: absolute`。当它通过 `modalRender` 包裹 `centered={true}` 的 Modal 时，Modal 会脱离 flex 布局，外层居中容器高度变为 0，结果是 Modal 顶边落在视口中心，而不是整体垂直居中。

本 PR 新增 `positionStrategy`：

- 默认值仍为 `absolute`，保持所有现有用法和行为兼容。
- 设置为 `relative` 时，元素保留原有布局位置，拖动通过相对 `top` / `left` 偏移完成。
- 相对定位路径基于指针增量计算，支持连续拖动、`customMove` 和 `constrainer` 边界限制。
- 中英文 DragMove 文档及可拖拽 Modal 示例已更新为 `centered + positionStrategy="relative"`。

Reviewers 可重点关注默认 absolute 路径无行为变化，以及 relative 模式下重复拖动和约束范围的计算。

### Changelog
🇨🇳 Chinese
- Fix: 为 DragMove 增加 relative 定位策略，修复可拖拽居中 Modal 向下偏移的问题

---

🇺🇸 English
- Fix: add a relative positioning strategy to DragMove so centered draggable Modals keep their layout position

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- DragMove + Modal unit tests: 22/22 passed.
- DragMove regressions cover default absolute behavior, relative drag offsets, and relative constrainer clamping.
- Real-browser verification at 1280×720: the 236px-high Modal is positioned at y=242, exactly `(720 - 236) / 2`, and the draggable element keeps `position: relative`.
- Pre-commit lint and `git diff --check` passed.
