### PR TITLE
docs: fix broken star history chart in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,10 +195,10 @@ Semi UI is [MIT Licensed](LICENSE)
 
 ## Star History
 
-<a href="https://www.star-history.com/?repos=DouyinFE%2Fsemi-design&type=date&legend=top-left">
+<a href="https://star-history.dera.page/#DouyinFE/semi-design&type=date&legend=top-left">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DouyinFE/semi-design&type=date&theme=dark&legend=top-left" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DouyinFE/semi-design&type=date&legend=top-left" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DouyinFE/semi-design&type=date&legend=top-left" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=DouyinFE/semi-design&type=date&theme=dark&legend=top-left" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=DouyinFE/semi-design&type=date&legend=top-left" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=DouyinFE/semi-design&type=date&legend=top-left" />
  </picture>
 </a>


### PR DESCRIPTION
The star history chart in the README is currently broken and does not render, because the upstream service relies on the GitHub stargazer API which now restricts access. This change moves the chart to a working source so visitors can still see the project growth at a glance.