### PR TITLE
fix(Upload): keep all files removed when multiple beforeUpload results autoRemove in one batch (#3335)

### DIFF
--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -110,6 +110,15 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
      * When paste event is successfully handled, we ignore the subsequent keydown event.
      */
     _pasteHandled: boolean = false;
+    /**
+     * Working copy of fileList used during a synchronous startUpload batch.
+     * Do NOT rely on React state fileList here: setState is async (batched in React 18),
+     * so reading getState('fileList') between iterations of a sync loop returns a stale
+     * snapshot and earlier removals get overwritten by later ones (see #3335).
+     * Seeded at the start of startUpload and cleared when the sync loop finishes;
+     * async (promise) results fall back to React state.
+     */
+    _batchFileList: Array<BaseFileItem> | null = null;
     constructor(adapter: UploadAdapter<P, S>) {
         super({ ...adapter });
     }
@@ -521,11 +530,16 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     }
 
     startUpload(fileList: Array<BaseFileItem>): void {
+        // Seed a working copy so multiple synchronous beforeUpload results
+        // (e.g. several files returning autoRemove) compose correctly instead of each
+        // reading a stale React state snapshot and overwriting earlier removals. (#3335)
+        this._batchFileList = this.getState('fileList').slice();
         fileList.forEach(file => {
             if (!file._sizeInvalid) {
                 this.upload(file);
             }
         });
+        this._batchFileList = null;
     }
 
     upload(file: BaseFileItem): void {
@@ -584,7 +598,9 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     // handle beforeUpload result when it's an object
     handleBeforeUploadResultInObject(buResult: Partial<BeforeUploadObjectResult>, file: BaseFileItem): void {
         const { shouldUpload, status, autoRemove, validateMessage, fileInstance } = buResult;
-        let newFileList: Array<BaseFileItem> = this.getState('fileList').slice();
+        // During a synchronous startUpload batch, read from the working copy instead of
+        // React state so removals/mutations from earlier files in the same loop are kept. (#3335)
+        let newFileList: Array<BaseFileItem> = (this._batchFileList || this.getState('fileList')).slice();
         if (autoRemove) {
             this._releaseFileUrl(file.uid);
             newFileList = newFileList.filter(item => item.uid !== file.uid);
@@ -605,6 +621,12 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
                 newFileList[index].url = this._createURL(fileInstance, file.uid);
             }
             newFileList[index].shouldUpload = shouldUpload;
+        }
+
+        // Keep the batch working copy in sync so the next file in the same synchronous
+        // loop builds on this result rather than a stale React state snapshot. (#3335)
+        if (this._batchFileList) {
+            this._batchFileList = newFileList;
         }
 
         this._adapter.updateFileList(newFileList);

--- a/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
+++ b/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
@@ -1,0 +1,100 @@
+import UploadFoundation from '../../../semi-foundation/upload/foundation';
+
+/**
+ * Regression test for #3335:
+ * When multiple files are uploaded at once and `beforeUpload` returns
+ * `{ shouldUpload: false, autoRemove: true }` for several of them, every file
+ * should be removed from fileList.
+ *
+ * The bug only reproduces when setState is batched (React 18 automatic batching):
+ * `startUpload` iterates synchronously and each `autoRemove` used to read the
+ * React state snapshot, which is not flushed between iterations, so later
+ * removals overwrite earlier ones and some files "revive".
+ *
+ * Semi's own test harness runs on React 16 (synchronous flush), so we drive the
+ * foundation directly with a mock adapter that simulates batching: updateFileList
+ * does NOT reflect into getState synchronously; only the last update is committed
+ * when the synchronous batch finishes.
+ */
+describe('Upload foundation - batched autoRemove (#3335)', () => {
+    function createFoundation(initialFileList, beforeUpload) {
+        // committed React state; getState/getStates read this
+        let committedFileList = initialFileList.slice();
+        // pending (batched) update; not visible via getState until flushed
+        let pendingFileList = null;
+        const changes = [];
+
+        const adapter = {
+            getContext: () => undefined,
+            getContexts: () => ({}),
+            getProp: key => ({ beforeUpload })[key],
+            getProps: () => ({ beforeUpload }),
+            getState: key => ({ fileList: committedFileList })[key],
+            getStates: () => ({ fileList: committedFileList }),
+            updateFileList: (fileList) => {
+                // simulate React 18 batching: keep the latest scheduled value but
+                // do NOT flush it into committed state during the synchronous loop
+                pendingFileList = fileList;
+            },
+            notifyChange: ({ fileList }) => changes.push(fileList),
+            updateLocalUrls: () => {},
+            notifyBeforeUpload: ({ file, fileList }) => beforeUpload({ file, fileList }),
+        };
+
+        const foundation = new UploadFoundation(adapter);
+        // flush the last batched update, mimicking React committing setState
+        const flush = () => {
+            if (pendingFileList !== null) {
+                committedFileList = pendingFileList;
+                pendingFileList = null;
+            }
+            return committedFileList;
+        };
+        return { foundation, flush, getChanges: () => changes };
+    }
+
+    it('removes every file when multiple files return autoRemove synchronously', () => {
+        const fileA = { uid: 'a', name: 'a.png', size: '10KB', status: 'wait', fileInstance: {} };
+        const fileB = { uid: 'b', name: 'b.png', size: '10KB', status: 'wait', fileInstance: {} };
+
+        const beforeUpload = () => ({ shouldUpload: false, autoRemove: true });
+        const { foundation, flush } = createFoundation([fileA, fileB], beforeUpload);
+
+        foundation.startUpload([fileA, fileB]);
+
+        // after the synchronous batch is committed, no file should remain
+        expect(flush()).toEqual([]);
+    });
+
+    it('keeps only the non-autoRemove file when removals are interleaved', () => {
+        const fileA = { uid: 'a', name: 'a.png', size: '10KB', status: 'wait', fileInstance: {} };
+        const fileB = { uid: 'b', name: 'b.png', size: '10KB', status: 'wait', fileInstance: {} };
+        const fileC = { uid: 'c', name: 'c.png', size: '10KB', status: 'wait', fileInstance: {} };
+
+        // remove a and c, keep b
+        const beforeUpload = ({ file }) =>
+            file.uid === 'b'
+                ? { shouldUpload: false, autoRemove: false }
+                : { shouldUpload: false, autoRemove: true };
+        const { foundation, flush } = createFoundation([fileA, fileB, fileC], beforeUpload);
+
+        foundation.startUpload([fileA, fileB, fileC]);
+
+        const result = flush();
+        expect(result.map(f => f.uid)).toEqual(['b']);
+    });
+
+    it('falls back to React state outside a startUpload batch and clears the working copy', () => {
+        const fileA = { uid: 'a', name: 'a.png', size: '10KB', status: 'wait', fileInstance: {} };
+        const fileB = { uid: 'b', name: 'b.png', size: '10KB', status: 'wait', fileInstance: {} };
+
+        const beforeUpload = () => ({ shouldUpload: false, autoRemove: true });
+        const { foundation, flush } = createFoundation([fileA, fileB], beforeUpload);
+
+        // a single upload (e.g. the replace flow) is not part of a startUpload batch
+        foundation.upload(fileA);
+        expect(flush().map(f => f.uid)).toEqual(['b']);
+        // the batch working copy must not leak outside startUpload
+        expect(foundation._batchFileList).toBeNull();
+    });
+});


### PR DESCRIPTION
### Fixes #3335

#### Problem
When multiple files are uploaded at once and `beforeUpload` returns `{ shouldUpload: false, autoRemove: true }` for more than one of them, some rejected files remain in `fileList`.

`startUpload` iterates the files synchronously, and each `autoRemove` in `handleBeforeUploadResultInObject` reads the `fileList` React state snapshot. Under **React 18 automatic batching**, `setState` is not flushed between iterations, so every removal starts from the same stale `[A, B]` snapshot and the last `setState` wins:

```
file A: read [A, B] -> filter A -> setState([B])
file B: read [A, B] -> filter B -> setState([A])   // stale
flush:  state = [A]                                 // A "revived"
```

#### Fix
Maintain a batch-scoped working copy of `fileList` (`_batchFileList`) during the synchronous `startUpload` loop, so each file's removal/mutation builds on the previous result instead of a stale snapshot. It is seeded at the start of `startUpload` and cleared when the loop finishes; async (promise) `beforeUpload` results fall back to React state as before.

This mirrors the existing `_localUrls` field in the same file, which already exists to work around the same class of "setState is async in a sync loop" race.

#### Tests
Added `packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js`. Because Semi's unit tests run on React 16 (synchronous flush), the batching race cannot be reproduced through a mounted component, so the test drives `UploadFoundation` directly with a mock adapter that simulates React 18 batching. Verified the tests fail without the fix and pass with it; the full existing Upload suite (206 tests) still passes.