### PR TITLE
fix(Resizable): recalculate ResizeGroup item sizes after it becomes visible (#3336)

### DIFF
--- a/packages/semi-foundation/resizable/group/index.ts
+++ b/packages/semi-foundation/resizable/group/index.ts
@@ -73,6 +73,9 @@ export class ResizeGroupFoundation<P = Record<string, any>, S = Record<string, a
     totalMinus: number;
     itemPercentMap: Map<number, number>; // 内部维护一个百分比数组，消除浮点计算误差
     type?: ResizeEventType;
+    // 首次 initSpace 时 group 是否可测量（非 display:none）。
+    // Whether the group was measurable (not inside display:none) on the first initSpace run. #3336
+    sizeInitialized: boolean = false;
 
 
     init(): void {
@@ -80,6 +83,19 @@ export class ResizeGroupFoundation<P = Record<string, any>, S = Record<string, a
         this.itemMinusMap = new Map();
         this.itemPercentMap = new Map();
         this.initSpace();
+    }
+
+    /**
+     * When the group is initially mounted inside a display:none container, its own size
+     * and the handler sizes are all 0, so item sizes are computed with a `- 0px` handler
+     * offset and never corrected once the container becomes visible. Recalculate the layout
+     * the first time the group becomes measurable. Once it has a valid size, later resizes
+     * must NOT re-run initSpace, otherwise the user's manual drag results would be reset. #3336
+     */
+    handleGroupResize = () => {
+        if (!this.sizeInitialized && this.groupSize > 0) {
+            this.initSpace();
+        }
     }
     get window(): Window | null {
         return this.groupRef.ownerDocument.defaultView as Window ?? null;
@@ -231,6 +247,9 @@ export class ResizeGroupFoundation<P = Record<string, any>, S = Record<string, a
         // calculate accurate space for group item
         let handlerSizes = new Array(this._adapter.getHandlerCount()).fill(0);
         let parentSize = this.groupSize;
+        // Mark whether the group is measurable now; if not (e.g. inside display:none),
+        // handleGroupResize will re-run initSpace once it becomes visible. #3336
+        this.sizeInitialized = parentSize > 0;
         this.totalMinus = 0;
         for (let i = 0; i < this._adapter.getHandlerCount(); i++) {
             let handlerSize = direction === 'horizontal' ? this._adapter.getHandler(i).offsetWidth : this._adapter.getHandler(i).offsetHeight;

--- a/packages/semi-ui/resizable/__test__/resizeGroupFoundation.test.js
+++ b/packages/semi-ui/resizable/__test__/resizeGroupFoundation.test.js
@@ -1,0 +1,90 @@
+import { ResizeGroupFoundation } from '../../../semi-foundation/resizable/group';
+
+/**
+ * Reproduces #3336 at the foundation level: when a ResizeGroup is mounted inside a
+ * display:none container, the group and its handlers report offset size 0, so item
+ * sizes are computed with a `- 0px` handler offset. After the container becomes
+ * visible the sizes must be recalculated (handleGroupResize), otherwise the two items
+ * plus the handler overflow the group by the handler size.
+ *
+ * The jsdom ResizeObserver mock never fires a callback, so we drive handleGroupResize
+ * directly to emulate the group becoming measurable.
+ */
+function createMockAdapter({ groupEl, handlerEls, itemEls, direction }) {
+    return {
+        getProp: key => ({ direction }[key]),
+        getProps: () => ({ direction }),
+        getState: () => undefined,
+        getStates: () => ({}),
+        getContext: () => undefined,
+        getContexts: () => ({}),
+        getGroupRef: () => groupEl,
+        getHandler: i => handlerEls[i],
+        getHandlerCount: () => handlerEls.length,
+        getItem: i => itemEls[i],
+        getItemCount: () => itemEls.length,
+        getItemMin: () => undefined,
+        getItemMax: () => undefined,
+        getItemDefaultSize: () => undefined,
+        getItemStart: () => undefined,
+        getItemChange: () => undefined,
+        getItemEnd: () => undefined,
+        registerEvents: () => {},
+        unregisterEvents: () => {},
+    };
+}
+
+const makeEl = size => ({ offsetWidth: size, offsetHeight: size, style: {} });
+
+describe('ResizeGroupFoundation - recalc after becoming visible (#3336)', () => {
+    it('recalculates item sizes with the handler offset once the group is measurable', () => {
+        // vertical group, 2 items + 1 handler, mounted inside display:none => all sizes 0
+        const groupEl = makeEl(0);
+        const handlerEls = [makeEl(0)];
+        const itemEls = [makeEl(0), makeEl(0)];
+        const adapter = createMockAdapter({ groupEl, handlerEls, itemEls, direction: 'vertical' });
+        const foundation = new ResizeGroupFoundation(adapter);
+
+        foundation.init();
+
+        // initial (hidden) layout: 50% each, handler offset 0 => `- 0px`
+        expect(foundation.sizeInitialized).toBe(false);
+        expect(itemEls[0].style.height).toContain('- 0px');
+        expect(itemEls[1].style.height).toContain('- 0px');
+
+        // become visible: group 100px tall, handler 10px
+        groupEl.offsetHeight = 100;
+        groupEl.offsetWidth = 100;
+        handlerEls[0].offsetHeight = 10;
+        handlerEls[0].offsetWidth = 10;
+
+        foundation.handleGroupResize();
+
+        // recalculated: each item reserves half of the handler (10 / 2 = 5px)
+        expect(foundation.sizeInitialized).toBe(true);
+        expect(itemEls[0].style.height).toBe('calc(50% - 5px)');
+        expect(itemEls[1].style.height).toBe('calc(50% - 5px)');
+    });
+
+    it('does not re-run initSpace on later resizes (keeps user drag results)', () => {
+        const groupEl = makeEl(100);
+        const handlerEls = [makeEl(10)];
+        const itemEls = [makeEl(50), makeEl(50)];
+        const adapter = createMockAdapter({ groupEl, handlerEls, itemEls, direction: 'vertical' });
+        const foundation = new ResizeGroupFoundation(adapter);
+
+        foundation.init();
+        expect(foundation.sizeInitialized).toBe(true);
+
+        // simulate the user having dragged item 0
+        itemEls[0].style.height = 'calc(70% - 5px)';
+        itemEls[1].style.height = 'calc(30% - 5px)';
+
+        // a later group resize must not reset the layout back to the default 50/50
+        groupEl.offsetHeight = 200;
+        foundation.handleGroupResize();
+
+        expect(itemEls[0].style.height).toBe('calc(70% - 5px)');
+        expect(itemEls[1].style.height).toBe('calc(30% - 5px)');
+    });
+});

--- a/packages/semi-ui/resizable/group/resizeGroup.tsx
+++ b/packages/semi-ui/resizable/group/resizeGroup.tsx
@@ -72,6 +72,7 @@ class ResizeGroup extends BaseComponent<ResizeGroupProps, ResizeGroupState> {
     groupRef: React.RefObject<HTMLDivElement>;
     groupSize: number;
     availableSize: number;
+    resizeObserver: ResizeObserver | null = null;
     static contextType = ResizeContext;
     context: ResizeGroupProps;
     // 在context中使用的属性需要考虑在strictMode下会执行两次，所以用Map来维护
@@ -89,6 +90,14 @@ class ResizeGroup extends BaseComponent<ResizeGroupProps, ResizeGroupState> {
         this.foundation.init();
         // 监听窗口大小变化，保证一些限制仍生效
         window.addEventListener('resize', this.foundation.ensureConstraint);
+        // 当 group 初次挂载在 display:none 容器内时 offset 尺寸为 0，item 尺寸会以 0px handler 计算且不再更新；
+        // 监听 group 自身尺寸变化，待其可见（可测量）后重新计算一次布局。#3336
+        if (typeof ResizeObserver !== 'undefined' && this.groupRef.current) {
+            this.resizeObserver = new ResizeObserver(() => {
+                this.foundation.handleGroupResize();
+            });
+            this.resizeObserver.observe(this.groupRef.current);
+        }
     }
 
     componentDidUpdate(prevProps: ResizeGroupProps) {
@@ -108,6 +117,10 @@ class ResizeGroup extends BaseComponent<ResizeGroupProps, ResizeGroupState> {
     componentWillUnmount() {
         this.foundation.destroy();
         window.removeEventListener('resize', this.foundation.ensureConstraint);
+        if (this.resizeObserver) {
+            this.resizeObserver.disconnect();
+            this.resizeObserver = null;
+        }
     }
 
     get adapter(): ResizeGroupAdapter<ResizeGroupProps, ResizeGroupState> {


### PR DESCRIPTION
### Fixes #3336

#### Problem
When a `ResizeGroup` is initially mounted inside a `display: none` container, its `ResizeHandler` has an `offsetHeight`/`offsetWidth` of 0 during `initSpace`. Item sizes are therefore computed with a `- 0px` handler offset, e.g. `height: calc(39.77% + 0px)`. After the container becomes visible the handler has its real size (e.g. 10px), but the item sizes are never recalculated, so the two items plus the handler overflow the group by the handler size.

#### Fix
- Track whether the group was measurable on the first `initSpace` run (`sizeInitialized`).
- Add `handleGroupResize`, which re-runs `initSpace` the first time the group becomes measurable, driven by a `ResizeObserver` on the group element (wired in `resizeGroup.tsx`, disconnected on unmount).
- Once the group has a valid size, later resizes do **not** re-run `initSpace`, so a user's manual drag results are preserved.

#### Tests
Added `packages/semi-ui/resizable/__test__/resizeGroupFoundation.test.js`. The jsdom `ResizeObserver` mock never fires, so the test drives `ResizeGroupFoundation` directly: it initializes with a 0-size (hidden) group, asserts the `- 0px` offset, then simulates the group becoming measurable via `handleGroupResize` and asserts the item sizes are recalculated with the real handler offset. A second test asserts later resizes do not reset user drag results. Verified the tests fail without the fix and pass with it.

### Changelog
🇨🇳 Chinese
- Fix: 修复 ResizeGroup 在 display:none 容器中挂载后变为可见时，未重新计算内部尺寸导致内容溢出的问题

---

🇺🇸 English
- Fix: fix ResizeGroup item sizes not being recalculated after it becomes visible from a display:none container
