### PR TITLE
fix: 修复 Typography ellipsis.showTooltip 因 clientWidth 取整导致的亚像素误判，短文本错误显示 tooltip

### DIFF
--- a/packages/semi-ui/typography/__test__/typography.test.js
+++ b/packages/semi-ui/typography/__test__/typography.test.js
@@ -83,6 +83,88 @@ describe(`Typography`, () => {
         expect(typographyParagraph.find('semi-typography-ellipsis').length).toEqual(0);
     });
 
+    it('ellipsis showTooltip 亚像素取整误差不应误判溢出（回归用例）', async () => {
+        // 背景：compareSingleRow 用整数 clientWidth 与精确浮点 Range 宽度比较，
+        // 当文本实际宽度小数部分 ∈ (0, 0.5) 时（如 32.3046875px），clientWidth 取整为 32，
+        // 32.3046875 > 32 会虚报溢出，导致未溢出的短文本也错误显示 tooltip。
+        // 修复：容器宽度改用 getBoundingClientRect().width（与 contentWidth 同精度，小数参与比较）。
+        // jsdom 无 document.createRange，这里整体 mock 测量 API。
+        const makeRect = width => ({
+            width,
+            height: 20,
+            left: 0,
+            right: width,
+            top: 0,
+            bottom: 20,
+            x: 0,
+            y: 0,
+            toJSON: () => ({}),
+        });
+
+        const originalCreateRange = document.createRange;
+        const originalElRect = HTMLElement.prototype.getBoundingClientRect;
+        const originalClientWidth = Object.getOwnPropertyDescriptor(HTMLElement.prototype, 'clientWidth');
+
+        const mockRangeWidth = rangeWidth => {
+            document.createRange = () => ({
+                selectNodeContents: () => {},
+                detach: () => {},
+                getBoundingClientRect: () => makeRect(rangeWidth),
+            });
+        };
+
+        const mockSubPixel = () => {
+            // 文本精确宽度 32.3046875（小数部分 < 0.5，clientWidth 取整为 32）→ 未真正溢出
+            mockRangeWidth(32.3046875);
+            HTMLElement.prototype.getBoundingClientRect = jest.fn(() => makeRect(32.3046875));
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 32 });
+        };
+
+        const mockRealOverflow = () => {
+            // 容器被宽度限制为 100，文本内容 250 → 真实溢出
+            mockRangeWidth(250);
+            HTMLElement.prototype.getBoundingClientRect = jest.fn(() => makeRect(100));
+            Object.defineProperty(HTMLElement.prototype, 'clientWidth', { configurable: true, get: () => 100 });
+        };
+
+        const waitEllipsisCalc = () => new Promise(resolve => setTimeout(resolve, 100));
+
+        try {
+            // 场景一：亚像素差异（32.3046875 vs 32），文本并未真正溢出 → 不应渲染 Tooltip
+            mockSubPixel();
+            const text1 = mount(
+                <Typography.Text ellipsis={{ showTooltip: true }} style={{ maxWidth: 220 }}>
+                    testa
+                </Typography.Text>
+            );
+            await waitEllipsisCalc();
+            text1.update();
+            expect(text1.find('[data-popupid]').length).toEqual(0);
+            text1.unmount();
+
+            // 场景二：真实溢出（250 > 100）→ 应正常渲染 Tooltip
+            mockRealOverflow();
+            const text2 = mount(
+                <Typography.Text ellipsis={{ showTooltip: true }} style={{ maxWidth: 100 }}>
+                    This is a very very long text that should be truncated for sure
+                </Typography.Text>
+            );
+            await waitEllipsisCalc();
+            text2.update();
+            // hostNodes: 只统计真实 DOM 节点（排除 React 组件节点的重复匹配）
+            expect(text2.find('[data-popupid]').hostNodes().length).toEqual(1);
+            text2.unmount();
+        } finally {
+            document.createRange = originalCreateRange;
+            HTMLElement.prototype.getBoundingClientRect = originalElRect;
+            if (originalClientWidth) {
+                Object.defineProperty(HTMLElement.prototype, 'clientWidth', originalClientWidth);
+            } else {
+                delete HTMLElement.prototype.clientWidth;
+            }
+        }
+    });
+
     it('typography Numeral', () => {
         let numeral = mount(
             <Typography.Numeral rule={'numbers'} truncate={'ceil'} precision={2}>

--- a/packages/semi-ui/typography/base.tsx
+++ b/packages/semi-ui/typography/base.tsx
@@ -289,7 +289,7 @@ export default class Base extends Component<BaseTypographyProps, BaseTypographyS
         // - For CSS ellipsis, truncation happens in the content box (excluding padding).
         // - clientWidth excludes border/scrollbar, but includes padding.
         //   So we use: contentBoxWidth = clientWidth - paddingLeft - paddingRight
-        const containerClientWidth = containerNode.clientWidth;
+        const containerClientWidth = containerNode.getBoundingClientRect().width;
         // Get computed style to account for padding
         // CSS text-overflow: ellipsis truncates text in the content area (excluding padding)
         // So we need to compare contentWidth with the actual content area width


### PR DESCRIPTION
<!-- 非常感谢您的PR 💗 -->
[English Template / 英文模板](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.md)

- [x] 我已阅读并遵循了贡献文档中的[PR指南](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING.md#pull-request-%E6%8C%87%E5%8D%97).

### PR类型 (请至少选择一个)

 - [x] Bugfix

### PR 描述

**背景**

`Typography` 开启 `ellipsis={{ showTooltip: true }}` 时，短文本（未溢出）hover 有时也会错误出现 tooltip，且与文本内容"随机"相关（如 `testa` 出现、`test a` 不出现、`testaa` 出现、`testxx` 不出现），和字符串长度无单调关系。

**根因**

`packages/semi-ui/typography/base.tsx` 的 `compareSingleRow()` 判断溢出时，两侧精度不一致：

- `containerNode.clientWidth`：整数（浏览器把实际渲染宽度四舍五入）
- `range.getBoundingClientRect().width`：精确浮点数（如 32.3046875）

当文本精确宽度的小数部分 ∈ (0, 0.5) 时（如 32.3046875px → clientWidth 取整为 32），会得到 `32.3046875 > 32` 的假溢出，从而错误挂载 Tooltip。具体哪个字符串命中，取决于字体/浏览器渲染出的亚像素宽度，与内容语义无关。

**修复**

容器可用宽度改用 `containerNode.getBoundingClientRect().width`（与 contentWidth 同精度，小数参与比较），保留 #2350 引入的 padding 扣除逻辑：

```js
const containerClientWidth = containerNode.getBoundingClientRect().width;
```

**验证**

- 用 playground 实测：修复前 `testa / test a / testxx / abcd / abcde` 均误报溢出；修复后全部正确判定为未溢出，真实溢出（573px > 220px）仍正确报 true
- 补充回归单测（mock Range 测量 + clientWidth/getBoundingClientRect）：亚像素场景不渲染 Tooltip，真实溢出场景正常渲染 Tooltip
- `packages/semi-ui/typography` 全部 8 个单测通过；临时回退修复时回归用例失败，证明测试有效

### 更新日志
🇨🇳 Chinese
- Fix: 修复 Typography ellipsis.showTooltip 因 clientWidth 取整导致的亚像素误判，短文本错误显示 tooltip

---

🇺🇸 English
- Fix: fix Typography ellipsis.showTooltip false positive caused by sub-pixel rounding (clientWidth integer vs exact Range width)

### 检查清单
- [x] 已增加测试用例或无须增加
- [x] 已补充文档或无须补充
- [x] Changelog已提供或无须提供

### 其他要求
- [ ] 本条 PR 不需要纳入 Changelog

### 附加信息
<!-- 你可以提供一些 截图/录屏 或者其他的信息 -->