### PR TITLE
docs: fix AI Icon links

### DIFF
--- a/content/ai/aiComponent/index-en-US.md
+++ b/content/ai/aiComponent/index-en-US.md
@@ -30,7 +30,7 @@ For `AI Icon`, single-color, dual-color, and multi-color icons are supported, to
 
 For AI-style `Button`, `Tag`, and `FloatButton`, the `Colorful` property of the component can be enabled.
 
-Below are some examples of basic AI components. For more examples and use cases, please see [AI Token](/en-US/basic/tokens), [AI Icon](en-US/basic/icon), [AI Button](/en-US/basic/button#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%8C%89%E9%92%AE), [AI Tag](/en-US/show/tag#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%A0%87%E7%AD%BE), [AI FloatButton](/en-US/basic/floatbutton#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%82%AC%E6%B5%AE%E6%8C%89%E9%92%AE).
+Below are some examples of basic AI components. For more examples and use cases, please see [AI Token](/en-US/basic/tokens), [AI Icon](/en-US/basic/icon), [AI Button](/en-US/basic/button#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%8C%89%E9%92%AE), [AI Tag](/en-US/show/tag#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%A0%87%E7%AD%BE), [AI FloatButton](/en-US/basic/floatbutton#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%82%AC%E6%B5%AE%E6%8C%89%E9%92%AE).
 
 ```jsx live=true dir="column"
 import React from 'react';

--- a/content/ai/aiComponent/index.md
+++ b/content/ai/aiComponent/index.md
@@ -29,7 +29,7 @@ AI 基础组件包括 `AI Icon`、AI 风格的 `Button` / `Tag` / `FloatButton`�
 
 对于 AI 风格的 `Button / Tag / FloatButton`，可通过组件的 `Colorful` 属性开启。
 
-以下是 AI 基础组件的一些示例，更多示例及使用场景详见 [AI Token](/zh-CN/basic/tokens)、[AI Icon](zh-CN/basic/icon)、[AI Button](/zh-CN/basic/button#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%8C%89%E9%92%AE)、[AI Tag](/zh-CN/show/tag#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%A0%87%E7%AD%BE)、[AI FloatButton](/zh-CN/basic/floatbutton#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%82%AC%E6%B5%AE%E6%8C%89%E9%92%AE)。
+以下是 AI 基础组件的一些示例，更多示例及使用场景详见 [AI Token](/zh-CN/basic/tokens)、[AI Icon](/zh-CN/basic/icon)、[AI Button](/zh-CN/basic/button#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%8C%89%E9%92%AE)、[AI Tag](/zh-CN/show/tag#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%A0%87%E7%AD%BE)、[AI FloatButton](/zh-CN/basic/floatbutton#AI%20%E9%A3%8E%E6%A0%BC%20-%20%E5%A4%9A%E5%BD%A9%E6%82%AC%E6%B5%AE%E6%8C%89%E9%92%AE)。
  
 
 ```jsx live=true dir="column"


### PR DESCRIPTION
- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update
- [ ] Refactor
- [ ] Test Case
- [ ] TypeScript definition update
- [x] Document improve
- [ ] CI/CD improve
- [ ] Branch sync
- [ ] Other, please describe:

### PR description

Add the missing leading slash to the English and Chinese `AI Icon` links on the AI Component introduction pages. This prevents the documentation site from resolving them under the current `/ai/aiComponent` route and directs readers to the existing localized Icon documentation.

Fixes #3341

### Changelog

🇨🇳 Chinese
- Fix: 修复 AI Component 文档中 AI Icon 链接跳转至 404 页的问题

---

🇺🇸 English
- Fix: fix the AI Icon links in the AI Component documentation

### Checklist

- [x] Test or no need — documentation-only link correction; both destination routes were verified on semi.design
- [x] Document or no need
- [x] Changelog or no need

### Other

- [ ] Skip Changelog

### Additional information

Validation:

- `git diff --check`
- `https://semi.design/en-US/basic/icon` returns the English Icon documentation
- `https://semi.design/zh-CN/basic/icon` returns the Chinese Icon documentation