### PR TITLE
【Auto】Fix: datePicker 单测偶发失败（点击补位/禁用日期）

### DIFF
--- a/packages/semi-ui/datePicker/__test__/datePicker.test.js
+++ b/packages/semi-ui/datePicker/__test__/datePicker.test.js
@@ -5060,13 +5060,25 @@ describe(`DatePicker`, () => {
         await sleep();
         const popup = document.querySelector(popupSelector);
         if (popup) {
-            const days = popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day`);
-            if (days.length >= 15) {
+            // 只选择「当前显示月份且未禁用」的真实日期：
+            // - 空白占位格没有 aria-label，需排除
+            // - 上月/下月的补位日期带 aria-label 且默认非 disabled，点击会触发月份切换导致后续点击失效，需排除
+            // - disabled 日期点击无效，需排除
+            // 首日偏移随"今天"的星期变化，不能用绝对下标（如 days[5]/days[15]），否则会偶发踩到补位/禁用日期。
+            const now = new Date();
+            const monthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+            const days = Array.from(
+                popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day[aria-label]`)
+            ).filter(day => {
+                const label = day.getAttribute('aria-label');
+                return label && label.startsWith(monthPrefix) && day.getAttribute('aria-disabled') !== 'true';
+            });
+            if (days.length >= 2) {
                 // Click start date
-                days[5].click();
+                days[0].click();
                 await sleep(100);
                 // Click end date
-                days[15].click();
+                days[days.length - 1].click();
                 await sleep(100);
                 expect(onChange.called).toBe(true);
             }
@@ -5088,11 +5100,19 @@ describe(`DatePicker`, () => {
         await sleep();
         const popup = document.querySelector(popupSelector);
         if (popup) {
-            const days = popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day`);
-            if (days.length >= 10) {
-                days[3].click();
+            // 与 dateRange 用例同理：只选当前月份且未禁用的日期，避免补位/禁用日期
+            const now = new Date();
+            const monthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+            const days = Array.from(
+                popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day[aria-label]`)
+            ).filter(day => {
+                const label = day.getAttribute('aria-label');
+                return label && label.startsWith(monthPrefix) && day.getAttribute('aria-disabled') !== 'true';
+            });
+            if (days.length >= 2) {
+                days[0].click();
                 await sleep(100);
-                days[8].click();
+                days[days.length - 1].click();
                 await sleep(100);
             }
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description

**问题背景：**
`datePicker.test.js` 的 `test dateRange select both start and end to trigger onChange` 偶发失败（如 CI 上多次出现 `Expected: true / Received: false` on `onChange.called`），导致无关 PR 的 jest 检查被误伤。

根因：日历面板首行偏移随"今天"的星期变化（如当月 1 号是周六时，面板首行前 6 格是上月补位日期），测试用绝对下标 `days[5]` / `days[15]` 选日期，会偶发点到：
- 上月/下月补位日期：点击会触发月份切换，旧 DOM 卸载后后续点击失效
- disabled 日期（`aria-disabled="true"`）：`onClick` 被守卫直接忽略

两种情况下第二次点击都不生效，`onChange` 未被调用 → 断言失败。已实测：2026-08（8/1 为周六）本地复现失败，修复后通过。

**解决方案：**
- 只选择「当前显示月份且未禁用」的日期（过滤空白占位格、补位日期、disabled 日期），取第一个和最后一个（同月内首尾，无月份偏移依赖）
- 同样的加固应用于 `test dateTimeRange select dates to trigger range selection flow`
- 移除调试残留的 `DEBUG_DATE_DAYS` console.log

**审查关注点：**
- 是否还有其他用例存在同类「绝对下标点击日期」的隐患（已排查相邻 dateRange/dateTimeRange 用例）
- 过滤条件是否覆盖所有 disabled 场景

### Changelog
🇨🇳 Chinese
- Fix: 修复 datePicker 单测偶发失败（绝对下标点击到补位/禁用日期导致 onChange 未触发）

---

🇺🇸 English
- Fix: fix flaky datePicker unit tests that clicked offset/disabled days by absolute index

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- 本地验证：完整 `datePicker.test.js` 套件 345 passed / 2 skipped；修复前用例在当前日期下复现失败、修复后通过
