### PR TITLE
【Auto】Fix: Upload 批量 beforeUpload autoRemove 文件残留（React 18 批处理）

### DIFF
--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -137,6 +137,11 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         this._latestFileList = newFileList;
         this._adapter.updateFileList(newFileList, callback);
     }
+
+    /** Keep the synchronous snapshot aligned with an externally controlled fileList. */
+    syncLatestFileList(fileList: Array<BaseFileItem>): void {
+        this._latestFileList = fileList.slice();
+    }
     constructor(adapter: UploadAdapter<P, S>) {
         super({ ...adapter });
     }
@@ -144,6 +149,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     init(): void {
         // make sure state reset, otherwise may cause upload abort in React StrictMode, like https://github.com/DouyinFE/semi-design/pull/843
         this.destroyState = false;
+        this.syncLatestFileList(this.getState('fileList'));
         // In controlled mode, parent may keep and pass back fileList with blob url.
         // Sync them into internal map so later remove/clear can revoke correctly.
         this._syncLocalUrlsFromFileList();
@@ -187,6 +193,8 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         if (!disabled) {
             this.unbindPastingHandler();
         }
+        this._batchFileList = null;
+        this._latestFileList = null;
         this.destroyState = true;
     }
 

--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -134,6 +134,9 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
      * setState (React 18 automatic batching). (#3335)
      */
     updateFileListInternal(newFileList: Array<BaseFileItem>, callback?: () => void): void {
+        if (this._batchFileList) {
+            this._batchFileList = newFileList;
+        }
         this._latestFileList = newFileList;
         this._adapter.updateFileList(newFileList, callback);
     }
@@ -141,6 +144,10 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     /** Keep the synchronous snapshot aligned with an externally controlled fileList. */
     syncLatestFileList(fileList: Array<BaseFileItem>): void {
         this._latestFileList = fileList.slice();
+    }
+
+    getLatestFileList(): Array<BaseFileItem> {
+        return this._batchFileList || this._latestFileList || this.getState('fileList');
     }
     constructor(adapter: UploadAdapter<P, S>) {
         super({ ...adapter });
@@ -551,7 +558,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     /* istanbul ignore next */
     manualUpload(): void {
         // find the list of files that have not been uploaded
-        const waitToUploadFileList = this.getState('fileList').filter((item: BaseFileItem) => item.status === FILE_STATUS_WAIT_UPLOAD);
+        const waitToUploadFileList = this.getLatestFileList().filter((item: BaseFileItem) => item.status === FILE_STATUS_WAIT_UPLOAD);
         this.startUpload(waitToUploadFileList);
     }
 
@@ -560,7 +567,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         // (e.g. several files returning autoRemove) compose correctly instead of each
         // reading a stale React state snapshot and overwriting earlier removals. (#3335)
         // try/finally guarantees the working copy is cleared even if beforeUpload throws.
-        this._batchFileList = this.getState('fileList').slice();
+        this._batchFileList = this.getLatestFileList().slice();
         try {
             fileList.forEach(file => {
                 if (!file._sizeInvalid) {
@@ -579,7 +586,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
             return;
         }
         if (typeof beforeUpload === 'function') {
-            const { fileList } = this.getStates();
+            const fileList = this.getLatestFileList();
             const buResult = this._adapter.notifyBeforeUpload({ file, fileList });
             switch (true) {
                 // sync validate - boolean
@@ -632,7 +639,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         // (promise) results read from the most recent synchronous snapshot, falling back
         // to React state. This keeps mixed sync + async beforeUpload results composing
         // correctly under React 18 automatic batching. (#3335)
-        let newFileList: Array<BaseFileItem> = (this._batchFileList || this._latestFileList || this.getState('fileList')).slice();
+        let newFileList: Array<BaseFileItem> = this.getLatestFileList().slice();
         if (autoRemove) {
             this._releaseFileUrl(file.uid);
             newFileList = newFileList.filter(item => item.uid !== file.uid);
@@ -653,12 +660,6 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
                 newFileList[index].url = this._createURL(fileInstance, file.uid);
             }
             newFileList[index].shouldUpload = shouldUpload;
-        }
-
-        // Keep the batch working copy in sync so the next beforeUpload result
-        // in the same batch builds on this result. (#3335)
-        if (this._batchFileList) {
-            this._batchFileList = newFileList;
         }
 
         this.updateFileListInternal(newFileList);
@@ -757,8 +758,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     }
 
     handleProgress({ e, fileInstance }: { e?: ProgressEvent; fileInstance: File }): void {
-        const { fileList } = this.getStates();
-        const newFileList = fileList.slice();
+        const newFileList = this.getLatestFileList().slice();
         let percent = 0;
         if (e.total > 0) {
             percent = Number(((e.loaded / e.total) * 100 * numbers.PROGRESS_COEFFICIENT).toFixed(0)) || 0;
@@ -768,7 +768,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
             return;
         }
         newFileList[index].percent = percent;
-        newFileList[index].status = FILE_STATUS_UPLOADING;
+        newFileList[index].status = FILE_STATUS_UPLOADING as FileItemStatus;
 
         this._adapter.notifyProgress(percent, fileInstance, newFileList);
         this.updateFileListInternal(newFileList);
@@ -776,7 +776,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     }
 
     handleOnLoad({ e, xhr, fileInstance }: { e?: ProgressEvent; xhr: XMLHttpRequest; fileInstance: File }): void {
-        const { fileList } = this.getStates();
+        const fileList = this.getLatestFileList();
         const index = this._getFileIndex(fileInstance, fileList);
         if (index < 0) {
             return;
@@ -789,7 +789,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     }
 
     handleSuccess({ e, fileInstance, isCustomRequest = false, xhr, response }: { e?: ProgressEvent; fileInstance: CustomFile; isCustomRequest?: boolean; xhr?: XMLHttpRequest; response?: any }): void {
-        const { fileList } = this.getStates();
+        const fileList = this.getLatestFileList();
         let body: any = null;
         const index = this._getFileIndex(fileInstance, fileList);
         if (index < 0) {
@@ -804,7 +804,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         const newFileList = fileList.slice();
         const { afterUpload } = this.getProps();
 
-        newFileList[index].status = FILE_STATUS_SUCCESS;
+        newFileList[index].status = FILE_STATUS_SUCCESS as FileItemStatus;
         newFileList[index].percent = 100;
         this._adapter.notifyProgress(100, fileInstance, newFileList);
         newFileList[index].response = body;
@@ -817,7 +817,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
                     file: newFileList[index],
                     fileList: newFileList,
                 }) || {};
-            status ? (newFileList[index].status = status) : null;
+            status ? (newFileList[index].status = status as FileItemStatus) : null;
             validateMessage ? (newFileList[index].validateMessage = validateMessage) : null;
             name ? (newFileList[index].name = name) : null;
             if (url) {
@@ -868,7 +868,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     }
 
     handleError({ e, xhr, fileInstance }: { e?: ProgressEvent;xhr: XMLHttpRequest;fileInstance: CustomFile }): void {
-        const { fileList } = this.getStates();
+        const fileList = this.getLatestFileList();
         const index = this._getFileIndex(fileInstance, fileList);
         if (index < 0) {
             return;
@@ -877,7 +877,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         const newFileList = fileList.slice();
         const error = this.getError({ action, xhr, fileName: fileInstance.name });
 
-        newFileList[index].status = FILE_STATUS_UPLOAD_FAIL;
+        newFileList[index].status = FILE_STATUS_UPLOAD_FAIL as FileItemStatus;
         newFileList[index].response = error;
         newFileList[index].event = e;
 

--- a/packages/semi-foundation/upload/foundation.ts
+++ b/packages/semi-foundation/upload/foundation.ts
@@ -110,6 +110,33 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
      * When paste event is successfully handled, we ignore the subsequent keydown event.
      */
     _pasteHandled: boolean = false;
+    /**
+     * Working copy of fileList used during a synchronous startUpload batch.
+     * Do NOT rely on React state fileList here: setState is async (batched in React 18),
+     * so reading getState('fileList') between iterations of a sync loop returns a stale
+     * snapshot and earlier removals get overwritten by later ones (see #3335).
+     * Seeded at the start of startUpload and cleared when the sync loop finishes (see
+     * try/finally in startUpload); async (promise) results fall back to _latestFileList
+     * then React state.
+     */
+    _batchFileList: Array<BaseFileItem> | null = null;
+    /**
+     * The most recent fileList produced by handleBeforeUploadResultInObject.
+     * Unlike React state (which is flushed asynchronously under React 18 automatic
+     * batching), this is updated synchronously, so a later async beforeUpload result
+     * composes with earlier sync removals of the same batch instead of reading a stale
+     * snapshot (mixed sync + async beforeUpload results, see #3335).
+     */
+    _latestFileList: Array<BaseFileItem> | null = null;
+    /**
+     * Unify all fileList commits: keep _latestFileList in sync synchronously so async
+     * beforeUpload results compose with recent mutations even before React flushes
+     * setState (React 18 automatic batching). (#3335)
+     */
+    updateFileListInternal(newFileList: Array<BaseFileItem>, callback?: () => void): void {
+        this._latestFileList = newFileList;
+        this._adapter.updateFileList(newFileList, callback);
+    }
     constructor(adapter: UploadAdapter<P, S>) {
         super({ ...adapter });
     }
@@ -363,7 +390,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         }
         newFileList.splice(replaceIdx, 1, newFileItem);
         this._adapter.notifyChange({ currentFile: newFileItem, fileList: newFileList });
-        this._adapter.updateFileList(newFileList, () => {
+        this.updateFileListInternal(newFileList, () => {
             this._adapter.resetReplaceInput();
             if (!newFileItem._sizeInvalid) {
                 this.upload(newFileItem);
@@ -405,7 +432,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         const { uploadTrigger } = this.getProps();
         const currentFiles = files.map(item => this.buildFileItem(item, uploadTrigger));
         this._adapter.notifyChange({ fileList: currentFiles, currentFile: currentFiles[0] });
-        this._adapter.updateFileList(currentFiles, () => {
+        this.updateFileListInternal(currentFiles, () => {
             if (uploadTrigger === TRIGGER_AUTO) {
                 this.startUpload(currentFiles);
             }
@@ -425,7 +452,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
                 this._adapter.notifyChange({ fileList, currentFile: file });
             }
         });
-        this._adapter.updateFileList(fileList, () => {
+        this.updateFileListInternal(fileList, () => {
             if (uploadTrigger === TRIGGER_AUTO) {
                 this.startUpload(currentFiles);
             }
@@ -506,7 +533,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
 
         this._adapter.notifyFileSelect(currentFileList);
         this._adapter.notifyChange({ fileList: newFileList, currentFile: null });
-        this._adapter.updateFileList(newFileList, () => {
+        this.updateFileListInternal(newFileList, () => {
             if (uploadTrigger === TRIGGER_AUTO) {
                 this.startUpload(fileItemList);
             }
@@ -521,11 +548,20 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     }
 
     startUpload(fileList: Array<BaseFileItem>): void {
-        fileList.forEach(file => {
-            if (!file._sizeInvalid) {
-                this.upload(file);
-            }
-        });
+        // Seed a working copy so multiple synchronous beforeUpload results
+        // (e.g. several files returning autoRemove) compose correctly instead of each
+        // reading a stale React state snapshot and overwriting earlier removals. (#3335)
+        // try/finally guarantees the working copy is cleared even if beforeUpload throws.
+        this._batchFileList = this.getState('fileList').slice();
+        try {
+            fileList.forEach(file => {
+                if (!file._sizeInvalid) {
+                    this.upload(file);
+                }
+            });
+        } finally {
+            this._batchFileList = null;
+        }
     }
 
     upload(file: BaseFileItem): void {
@@ -584,7 +620,11 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
     // handle beforeUpload result when it's an object
     handleBeforeUploadResultInObject(buResult: Partial<BeforeUploadObjectResult>, file: BaseFileItem): void {
         const { shouldUpload, status, autoRemove, validateMessage, fileInstance } = buResult;
-        let newFileList: Array<BaseFileItem> = this.getState('fileList').slice();
+        // During a synchronous startUpload batch, read from the working copy; for async
+        // (promise) results read from the most recent synchronous snapshot, falling back
+        // to React state. This keeps mixed sync + async beforeUpload results composing
+        // correctly under React 18 automatic batching. (#3335)
+        let newFileList: Array<BaseFileItem> = (this._batchFileList || this._latestFileList || this.getState('fileList')).slice();
         if (autoRemove) {
             this._releaseFileUrl(file.uid);
             newFileList = newFileList.filter(item => item.uid !== file.uid);
@@ -607,7 +647,13 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
             newFileList[index].shouldUpload = shouldUpload;
         }
 
-        this._adapter.updateFileList(newFileList);
+        // Keep the batch working copy in sync so the next beforeUpload result
+        // in the same batch builds on this result. (#3335)
+        if (this._batchFileList) {
+            this._batchFileList = newFileList;
+        }
+
+        this.updateFileListInternal(newFileList);
         this._adapter.notifyChange({ fileList: newFileList, currentFile: file });
 
         if (shouldUpload) {
@@ -717,7 +763,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         newFileList[index].status = FILE_STATUS_UPLOADING;
 
         this._adapter.notifyProgress(percent, fileInstance, newFileList);
-        this._adapter.updateFileList(newFileList);
+        this.updateFileListInternal(newFileList);
         this._adapter.notifyChange({ fileList: newFileList, currentFile: newFileList[index] });
     }
 
@@ -778,7 +824,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         }
         this._adapter.notifySuccess(body, fileInstance, newFileList);
         this._adapter.notifyChange({ fileList: newFileList, currentFile: newFileList[index] });
-        this._adapter.updateFileList(newFileList);
+        this.updateFileListInternal(newFileList);
     }
 
     _getFileIndex(file: CustomFile | BaseFileItem, fileList: Array<BaseFileItem>): number {
@@ -808,7 +854,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
             this._releaseFileUrl(file.uid);
 
             this._adapter.notifyRemove(file.fileInstance, newFileList, file);
-            this._adapter.updateFileList(newFileList);
+            this.updateFileListInternal(newFileList);
             this._adapter.notifyChange({ fileList: newFileList, currentFile: file });
         });
     }
@@ -828,7 +874,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
         newFileList[index].event = e;
 
         this._adapter.notifyError(error, fileInstance, newFileList, xhr);
-        this._adapter.updateFileList(newFileList);
+        this.updateFileListInternal(newFileList);
         this._adapter.notifyChange({ currentFile: newFileList[index], fileList: newFileList });
     }
 
@@ -844,7 +890,7 @@ class UploadFoundation<P = Record<string, any>, S = Record<string, any>> extends
                 return;
             }
             this._releaseAllFileUrls();
-            this._adapter.updateFileList([]);
+            this.updateFileListInternal([]);
             this._adapter.notifyClear();
             this._adapter.notifyChange({ fileList: [] } as any);
         }).catch(error => {

--- a/packages/semi-ui/datePicker/__test__/datePicker.test.js
+++ b/packages/semi-ui/datePicker/__test__/datePicker.test.js
@@ -5060,13 +5060,25 @@ describe(`DatePicker`, () => {
         await sleep();
         const popup = document.querySelector(popupSelector);
         if (popup) {
-            const days = popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day`);
-            if (days.length >= 15) {
+            // 只选择「当前显示月份且未禁用」的真实日期：
+            // - 空白占位格没有 aria-label，需排除
+            // - 上月/下月的补位日期带 aria-label 且默认非 disabled，点击会触发月份切换导致后续点击失效，需排除
+            // - disabled 日期点击无效，需排除
+            // 首日偏移随"今天"的星期变化，不能用绝对下标（如 days[5]/days[15]），否则会偶发踩到补位/禁用日期。
+            const now = new Date();
+            const monthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+            const days = Array.from(
+                popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day[aria-label]`)
+            ).filter(day => {
+                const label = day.getAttribute('aria-label');
+                return label && label.startsWith(monthPrefix) && day.getAttribute('aria-disabled') !== 'true';
+            });
+            if (days.length >= 2) {
                 // Click start date
-                days[5].click();
+                days[0].click();
                 await sleep(100);
                 // Click end date
-                days[15].click();
+                days[days.length - 1].click();
                 await sleep(100);
                 expect(onChange.called).toBe(true);
             }
@@ -5088,11 +5100,19 @@ describe(`DatePicker`, () => {
         await sleep();
         const popup = document.querySelector(popupSelector);
         if (popup) {
-            const days = popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day`);
-            if (days.length >= 10) {
-                days[3].click();
+            // 与 dateRange 用例同理：只选当前月份且未禁用的日期，避免补位/禁用日期
+            const now = new Date();
+            const monthPrefix = `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+            const days = Array.from(
+                popup.querySelectorAll(`.${BASE_CLASS_PREFIX}-datepicker-day[aria-label]`)
+            ).filter(day => {
+                const label = day.getAttribute('aria-label');
+                return label && label.startsWith(monthPrefix) && day.getAttribute('aria-disabled') !== 'true';
+            });
+            if (days.length >= 2) {
+                days[0].click();
                 await sleep(100);
-                days[8].click();
+                days[days.length - 1].click();
                 await sleep(100);
             }
         }

--- a/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
+++ b/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
@@ -1,0 +1,143 @@
+import UploadFoundation from '../../../semi-foundation/upload/foundation';
+
+/**
+ * Regression tests for #3335:
+ * When multiple files are uploaded at once and `beforeUpload` returns
+ * `{ shouldUpload: false, autoRemove: true }` for several of them, every file
+ * should be removed from fileList.
+ *
+ * The bug only reproduces when setState is batched (React 18 automatic batching):
+ * `startUpload` iterates synchronously and each `autoRemove` used to read the
+ * React state snapshot, which is not flushed between iterations, so later
+ * removals overwrite earlier ones and some files "revive".
+ *
+ * Semi's own test harness runs on React 16 (synchronous flush), so we drive the
+ * foundation directly with a mock adapter that simulates batching: updateFileList
+ * does NOT reflect into getState synchronously; only the last update is committed
+ * when the synchronous batch finishes.
+ */
+describe('Upload foundation - batched autoRemove (#3335)', () => {
+    function createFoundation({ initialFileList, beforeUpload }) {
+        // committed React state; getState/getStates read this
+        let committedFileList = initialFileList.slice();
+        // pending (batched) update; not visible via getState until flushed
+        let pendingFileList = null;
+        const changes = [];
+
+        const adapter = {
+            getContext: () => undefined,
+            getContexts: () => ({}),
+            getProp: key => ({ beforeUpload })[key],
+            getProps: () => ({ beforeUpload }),
+            getState: key => ({ fileList: committedFileList })[key],
+            getStates: () => ({ fileList: committedFileList }),
+            updateFileList: (fileList) => {
+                // simulate React 18 batching: keep the latest scheduled value but
+                // do NOT flush it into committed state during the synchronous loop
+                pendingFileList = fileList;
+            },
+            notifyChange: ({ fileList }) => changes.push(fileList),
+            updateLocalUrls: () => {},
+            notifyBeforeUpload: ({ file, fileList }) => beforeUpload({ file, fileList }),
+        };
+
+        const foundation = new UploadFoundation(adapter);
+        // flush the last batched update, mimicking React committing setState
+        const flush = () => {
+            if (pendingFileList !== null) {
+                committedFileList = pendingFileList;
+                pendingFileList = null;
+            }
+            return committedFileList;
+        };
+        return { foundation, flush, getChanges: () => changes };
+    }
+
+    const makeFile = uid => ({ uid, name: `${uid}.png`, size: '10KB', status: 'wait', fileInstance: {} });
+
+    it('removes every file when multiple files return autoRemove synchronously', () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+
+        const beforeUpload = () => ({ shouldUpload: false, autoRemove: true });
+        const { foundation, flush } = createFoundation({ initialFileList: [fileA, fileB], beforeUpload });
+
+        foundation.startUpload([fileA, fileB]);
+
+        // after the synchronous batch is committed, no file should remain
+        expect(flush()).toEqual([]);
+    });
+
+    it('keeps only the non-autoRemove file when removals are interleaved', () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+        const fileC = makeFile('c');
+
+        // remove a and c, keep b
+        const beforeUpload = ({ file }) =>
+            file.uid === 'b'
+                ? { shouldUpload: false, autoRemove: false }
+                : { shouldUpload: false, autoRemove: true };
+        const { foundation, flush } = createFoundation({ initialFileList: [fileA, fileB, fileC], beforeUpload });
+
+        foundation.startUpload([fileA, fileB, fileC]);
+
+        const result = flush();
+        expect(result.map(f => f.uid)).toEqual(['b']);
+    });
+
+    it('falls back to React state outside a startUpload batch and clears the working copy', () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+
+        const beforeUpload = () => ({ shouldUpload: false, autoRemove: true });
+        const { foundation, flush } = createFoundation({ initialFileList: [fileA, fileB], beforeUpload });
+
+        // a single upload (e.g. the replace flow) is not part of a startUpload batch
+        foundation.upload(fileA);
+        expect(flush().map(f => f.uid)).toEqual(['b']);
+        // the batch working copy must not leak outside startUpload
+        expect(foundation._batchFileList).toBeNull();
+    });
+
+    it('composes mixed sync + async beforeUpload results (sync remove then async remove)', async () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+
+        // file A: synchronous autoRemove; file B: async autoRemove
+        const beforeUpload = ({ file }) => {
+            if (file.uid === 'a') {
+                return { shouldUpload: false, autoRemove: true };
+            }
+            return Promise.resolve({ shouldUpload: false, autoRemove: true });
+        };
+        const { foundation, flush } = createFoundation({ initialFileList: [fileA, fileB], beforeUpload });
+
+        foundation.startUpload([fileA, fileB]);
+        // sync part of the batch is done; flush what React would have committed so far
+        expect(flush().map(f => f.uid)).toEqual(['b']);
+
+        // async result resolves later, must build on the latest snapshot ([b]) not a stale one
+        await Promise.resolve();
+        await Promise.resolve();
+        expect(flush()).toEqual([]);
+    });
+
+    it('clears the working copy even when beforeUpload throws', () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+
+        const beforeUpload = ({ file }) => {
+            if (file.uid === 'b') {
+                throw new Error('boom');
+            }
+            return { shouldUpload: false, autoRemove: true };
+        };
+        const { foundation, flush } = createFoundation({ initialFileList: [fileA, fileB], beforeUpload });
+
+        expect(() => foundation.startUpload([fileA, fileB])).toThrow('boom');
+        // working copy must be cleared by try/finally even on exception
+        expect(foundation._batchFileList).toBeNull();
+        expect(flush().map(f => f.uid)).toEqual(['b']);
+    });
+});

--- a/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
+++ b/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
@@ -50,7 +50,11 @@ describe('Upload foundation - batched autoRemove (#3335)', () => {
             }
             return committedFileList;
         };
-        return { foundation, flush, getChanges: () => changes };
+        const setCommittedFileList = fileList => {
+            committedFileList = fileList.slice();
+            pendingFileList = null;
+        };
+        return { foundation, flush, setCommittedFileList, getChanges: () => changes };
     }
 
     const makeFile = uid => ({ uid, name: `${uid}.png`, size: '10KB', status: 'wait', fileInstance: {} });
@@ -121,6 +125,40 @@ describe('Upload foundation - batched autoRemove (#3335)', () => {
         await Promise.resolve();
         await Promise.resolve();
         expect(flush()).toEqual([]);
+    });
+
+    it('does not resurrect files replaced by an externally controlled fileList', async () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+        const externalFile = makeFile('external');
+        let resolveFileB;
+
+        const beforeUpload = ({ file }) => {
+            if (file.uid === 'a') {
+                return { shouldUpload: false, autoRemove: true };
+            }
+            return new Promise(resolve => {
+                resolveFileB = resolve;
+            });
+        };
+        const { foundation, flush, setCommittedFileList, getChanges } = createFoundation({
+            initialFileList: [fileA, fileB],
+            beforeUpload,
+        });
+
+        foundation.startUpload([fileA, fileB]);
+        expect(flush().map(f => f.uid)).toEqual(['b']);
+
+        // Simulate getDerivedStateFromProps + componentDidUpdate after the parent
+        // replaces the controlled list while file B's beforeUpload is pending.
+        setCommittedFileList([externalFile]);
+        foundation.syncLatestFileList([externalFile]);
+        resolveFileB({ shouldUpload: false, status: 'uploadFail' });
+        await Promise.resolve();
+        await Promise.resolve();
+
+        expect(flush().map(f => f.uid)).toEqual(['external']);
+        expect(getChanges()).toHaveLength(1);
     });
 
     it('clears the working copy even when beforeUpload throws', () => {

--- a/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
+++ b/packages/semi-ui/upload/__test__/uploadBatchAutoRemove.test.js
@@ -17,7 +17,7 @@ import UploadFoundation from '../../../semi-foundation/upload/foundation';
  * when the synchronous batch finishes.
  */
 describe('Upload foundation - batched autoRemove (#3335)', () => {
-    function createFoundation({ initialFileList, beforeUpload }) {
+    function createFoundation({ initialFileList, beforeUpload, ...uploadProps }) {
         // committed React state; getState/getStates read this
         let committedFileList = initialFileList.slice();
         // pending (batched) update; not visible via getState until flushed
@@ -27,8 +27,8 @@ describe('Upload foundation - batched autoRemove (#3335)', () => {
         const adapter = {
             getContext: () => undefined,
             getContexts: () => ({}),
-            getProp: key => ({ beforeUpload })[key],
-            getProps: () => ({ beforeUpload }),
+            getProp: key => ({ beforeUpload, ...uploadProps })[key],
+            getProps: () => ({ beforeUpload, ...uploadProps }),
             getState: key => ({ fileList: committedFileList })[key],
             getStates: () => ({ fileList: committedFileList }),
             updateFileList: (fileList) => {
@@ -37,6 +37,7 @@ describe('Upload foundation - batched autoRemove (#3335)', () => {
                 pendingFileList = fileList;
             },
             notifyChange: ({ fileList }) => changes.push(fileList),
+            notifyProgress: () => {},
             updateLocalUrls: () => {},
             notifyBeforeUpload: ({ file, fileList }) => beforeUpload({ file, fileList }),
         };
@@ -57,7 +58,7 @@ describe('Upload foundation - batched autoRemove (#3335)', () => {
         return { foundation, flush, setCommittedFileList, getChanges: () => changes };
     }
 
-    const makeFile = uid => ({ uid, name: `${uid}.png`, size: '10KB', status: 'wait', fileInstance: {} });
+    const makeFile = uid => ({ uid, name: `${uid}.png`, size: '10KB', status: 'wait', fileInstance: { uid } });
 
     it('removes every file when multiple files return autoRemove synchronously', () => {
         const fileA = makeFile('a');
@@ -159,6 +160,36 @@ describe('Upload foundation - batched autoRemove (#3335)', () => {
 
         expect(flush().map(f => f.uid)).toEqual(['external']);
         expect(getChanges()).toHaveLength(1);
+    });
+
+    it('does not resurrect a removed file when customRequest reports progress synchronously', () => {
+        const fileA = makeFile('a');
+        const fileB = makeFile('b');
+        const beforeUpload = ({ file }) =>
+            file.uid === 'a' ? { shouldUpload: false, autoRemove: true } : true;
+        const customRequest = ({ onProgress }) => {
+            onProgress({ total: 100, loaded: 50 });
+        };
+        const originalXMLHttpRequest = global.XMLHttpRequest;
+        const originalFormData = global.FormData;
+        global.XMLHttpRequest = jest.fn();
+        global.FormData = jest.fn();
+        try {
+            const { foundation, flush } = createFoundation({
+                initialFileList: [fileA, fileB],
+                beforeUpload,
+                customRequest,
+            });
+
+            foundation.startUpload([fileA, fileB]);
+
+            const result = flush();
+            expect(result.map(f => f.uid)).toEqual(['b']);
+            expect(result[0]).toMatchObject({ status: 'uploading', percent: 48 });
+        } finally {
+            global.XMLHttpRequest = originalXMLHttpRequest;
+            global.FormData = originalFormData;
+        }
     });
 
     it('clears the working copy even when beforeUpload throws', () => {

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -491,8 +491,8 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
         this.foundation.init();
     }
 
-    componentDidUpdate(prevProps: UploadProps): void {
-        if ('fileList' in this.props && (!('fileList' in prevProps) || prevProps.fileList !== this.props.fileList)) {
+    componentDidUpdate(): void {
+        if ('fileList' in this.props) {
             this.foundation.syncLatestFileList(this.props.fileList || []);
         }
     }

--- a/packages/semi-ui/upload/index.tsx
+++ b/packages/semi-ui/upload/index.tsx
@@ -491,6 +491,12 @@ class Upload extends BaseComponent<UploadProps, UploadState> {
         this.foundation.init();
     }
 
+    componentDidUpdate(prevProps: UploadProps): void {
+        if ('fileList' in this.props && (!('fileList' in prevProps) || prevProps.fileList !== this.props.fileList)) {
+            this.foundation.syncLatestFileList(this.props.fileList || []);
+        }
+    }
+
     componentWillUnmount(): void {
         this.foundation.destroy();
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->
[中文模板 / Chinese Template](https://github.com/DouyinFE/semi-design/blob/main/.github/PULL_REQUEST_TEMPLATE.zh-CN.md)

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.


### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:


### PR description
Fixes #3335

**问题背景：**
多文件上传时 `beforeUpload` 返回 `{ shouldUpload: false, autoRemove: true }` 会有文件残留。根因：`startUpload` 同步遍历文件，每次 `autoRemove` 都读 React state 快照，React 18 自动批处理下 `setState` 不会在循环迭代间 flush，后一次移除基于过期快照覆盖前一次结果（如 A、B 均移除时最终只移除 B，A"复活"）。

**解决方案：**
1. `_batchFileList` 工作副本：`startUpload` 开始时基于 state 播种，同步批量期间各文件结果基于工作副本正确串联（与 `_localUrls` 同类问题的既有处理方式一致）
2. `try/finally` 清理：`beforeUpload` 抛异常时工作副本也能被清理，不泄漏到下一次批量
3. `_latestFileList` 同步快照（`updateFileListInternal` 统一维护）：异步 promise 类型的 `beforeUpload` 结果与同一批次的同步移除正确组合，并与受控 `fileList` 保持同步
4. 所有批次内写入同步回工作副本，避免同步 `customRequest` progress/success 回调从陈旧 React state 复活已移除文件
5. 新增 7 个专项回归测试（mock adapter 模拟 React 18 batching）：同步批量、交错保留、批量外 fallback、混合 sync+async、受控列表外部替换、同步 customRequest、异常清理

**审查关注点：**
- `_latestFileList` 与 React state / 受控 fileList 的一致性
- 与现有 `_localUrls` 模式的一致性

### Changelog
🇨🇳 Chinese
- Fix: 修复 Upload 多文件上传时 beforeUpload 返回 autoRemove 后文件残留的问题（React 18 批处理下 state 快照过期）

---

🇺🇸 English
- Fix: fix Upload leftover files when multiple beforeUpload results return autoRemove under React 18 automatic batching

### Checklist
- [x] Test or no need
- [x] Document or no need
- [x] Changelog or no need

### Other
- [ ] Skip Changelog

### Additional information
- 本地验证：Upload 全量与 7 个专项回归用例通过，semi-ui build / TypeScript 检查通过
