### PR TITLE
fix(timePicker): escape regExp special characters in format separator to avoid SyntaxError

### DIFF
--- a/packages/semi-foundation/timePicker/utils/index.ts
+++ b/packages/semi-foundation/timePicker/utils/index.ts
@@ -131,7 +131,8 @@ export const isTimeFormatLike = (time: string, formatToken: string) => {
     const hmsReg = /[H|m|s]{1,2}/;
     const formatSplitted = formatToken.split(formatNotSupportChReg); // => ['HH', 'mm'];
     const timeSeparator = formatToken.replace(formatSupportChReg, ''); // => :
-    const timeReg = new RegExp(`[${timeSeparator}]`, 'g'); // => /[:]/g
+    const escapedTimeSeparator = timeSeparator.replace(/[\-\[\]\/\{\}\(\)\*\+\?\.\\\^\$\|]/g, '\\$&'); // escape regExp special characters to avoid invalid regExp, e.g. format="HH\\mm"
+    const timeReg = new RegExp(`[${escapedTimeSeparator}]`, 'g'); // => /[:]/g
     const timeSplitted = time.split(timeReg); // => ['12', '0]
 
     if (formatSplitted.length !== timeSplitted.length) {

--- a/packages/semi-ui/timePicker/__test__/timePicker.test.js
+++ b/packages/semi-ui/timePicker/__test__/timePicker.test.js
@@ -300,6 +300,11 @@ describe(`TimePicker`, () => {
             ['上午 12:00:02', 'a h:mm:ss', true],
             ['上午 12:00:0', 'a h:mm:ss', false],
             ['上午 12:0:00', 'a h:mm:ss', false],
+            // format separator containing a regExp-special character should not throw (regression test,
+            // previously threw "SyntaxError: Invalid regular expression" because the separator was
+            // interpolated into a RegExp character class without escaping)
+            ['12\\00', 'HH\\mm', true],
+            ['12.00', 'HH.mm', true],
         ];
 
         testCases.forEach(test => {


### PR DESCRIPTION
<!-- Thanks so much for your PR 💗 -->

- [x] I have read and followed [Pull Request Guidelines](https://github.com/DouyinFE/semi-design/blob/main/CONTRIBUTING-en-US.md#pull-request-guidelines) of the contributing guide.

### What kind of change does this PR introduce? (check at least one)

 - [x] Bugfix
 - [ ] Feature
 - [ ] Code style update
 - [ ] Refactor
 - [ ] Test Case
 - [ ] TypeScript definition update
 - [ ] Document improve
 - [ ] CI/CD improve
 - [ ] Branch sync
 - [ ] Other, please describe:

### PR description

`isTimeFormatLike()` in `packages/semi-foundation/timePicker/utils/index.ts` builds a `RegExp` character class directly from characters extracted from the `format` prop, without escaping them. If `format` contains a character that has special meaning inside a regex character class (e.g. a backslash, as in `format="HH\\mm"`), `new RegExp` throws an uncaught `SyntaxError` on every keystroke in the `TimePicker` input — the exception propagates all the way up through `handleInputChange` with no `try/catch` anywhere in the call chain.

Reproduced with a standalone Node script mirroring the exact source logic:

```
formatToken: "HH\\mm"
timeSeparator: "\\"
ERROR: Invalid regular expression: /[\]/g: Unterminated character class
```

Fix: escape regex-special characters in `timeSeparator` before interpolating it into the character class (same escaping approach already used by `escapeRegExpFn` in `packages/semi-foundation/highlight/foundation.ts`).

Re-ran the same reproduction against the patched code: no error is thrown, the constructed RegExp is valid (`/[\\]/g`), and the split result is correct (`['12','00']`); also re-checked that the normal `format="HH:mm"` case still splits correctly, so this doesn't change existing behavior for well-formed formats.

Fixes: (no existing issue filed for this — found via an automated code review pass on this file)

### Changelog
🇨🇳 Chinese
- Fix: 修复 TimePicker 组件在 `format` 属性包含正则特殊字符（如反斜杠）时输入会抛出未捕获异常导致组件崩溃的问题

---

🇺🇸 English
- Fix: fix TimePicker throwing an uncaught SyntaxError when `format` contains a regex-special character

### Checklist
- [ ] Test or no need — no dedicated unit test added; verified via the standalone reproduction shown above (before/after). Happy to add a Jest test under the component's `__test__` directory if a maintainer confirms the expected location/pattern.
- [ ] Document or no need — no user-facing behavior/API change, no doc update needed
- [ ] Changelog or no need — included above

### Other
- [ ] Skip Changelog

### Additional information

> Disclosure: this fix was produced by an automated code-review + fix pipeline (clone → static analysis → reproduce the bug with a real script → minimal patch → re-run the same reproduction to confirm it's fixed). Every claim above (the error, the fix, the re-verification) was actually executed, not inferred — happy to share the reproduction script if useful for review.

<!-- audit-metadata-begin
{"version": 1, "findings": [{"fingerprint": "sha256:8911f7d1ee502eb1031aff0fb7f4b1edae45ca12fd20ea02081d769997e93687"}]}
audit-metadata-end -->
